### PR TITLE
Add design doc about the factory problem.

### DIFF
--- a/docs/design/factories.md
+++ b/docs/design/factories.md
@@ -134,7 +134,7 @@ type ResourceFactory interface {
 ```
 
 Which can then be used instead of the type the factory will return when asking
-users for resources, data sources, and providers:
+consumers for resources, data sources, and providers:
 
 ```go
 type Provider struct {

--- a/docs/design/factories.md
+++ b/docs/design/factories.md
@@ -155,7 +155,7 @@ would return an interface) or by the framework.
 
 ### Documentation
 
-[sdkv2-provider-func][https://github.com/hashicorp/terraform-plugin-sdk/blob/893e7238350e1980eb2cce3303689ba59ae47490/plugin/serve.go#L28]
-[sdkv2-resource-func-call][https://github.com/hashicorp/terraform-provider-scaffolding/blob/243ba4948171e3902003f678c7c43ec3fafcdc20/internal/provider/provider.go#L33]
-[sdkv2-resource-schema][https://github.com/hashicorp/terraform-provider-scaffolding/blob/243ba4948171e3902003f678c7c43ec3fafcdc20/internal/provider/resource_scaffolding.go#L10-L29]
-[structs-interfaces][https://github.com/hashicorp/terraform-plugin-framework/blob/main/docs/design/structs-interfaces.md]
+[sdkv2-provider-func]: https://github.com/hashicorp/terraform-plugin-sdk/blob/893e7238350e1980eb2cce3303689ba59ae47490/plugin/serve.go#L28
+[sdkv2-resource-func-call]: https://github.com/hashicorp/terraform-provider-scaffolding/blob/243ba4948171e3902003f678c7c43ec3fafcdc20/internal/provider/provider.go#L33
+[sdkv2-resource-schema]: https://github.com/hashicorp/terraform-provider-scaffolding/blob/243ba4948171e3902003f678c7c43ec3fafcdc20/internal/provider/resource_scaffolding.go#L10-L29
+[structs-interfaces]: https://github.com/hashicorp/terraform-plugin-framework/blob/main/docs/design/structs-interfaces.md

--- a/docs/design/factories.md
+++ b/docs/design/factories.md
@@ -125,7 +125,7 @@ provider would need to use reflection to achieve this outcome.
 ### Factory types
 
 Instead of using functions, the framework can define an interface for a factory that
-providers define:
+can be implemented by a provider-defined type:
 
 ```go
 type ResourceFactory interface {

--- a/docs/design/factories.md
+++ b/docs/design/factories.md
@@ -144,7 +144,7 @@ type Provider struct {
 }
 ```
 
-This works whether the type is defined by the provider (the `NewResource()`
+This works whether the `Resource` type is defined by the provider (the `NewResource()`
 method would return an interface) or by the framework.
 
 ### Separating types and values

--- a/docs/design/factories.md
+++ b/docs/design/factories.md
@@ -42,7 +42,7 @@ would return an interface) or by the framework.
 
 ### Named functions
 
-Similarly to anonymous functions, we can ask for named functions:
+Similarly to anonymous functions, we can ask for functions with a named type:
 
 ```go
 type ResourceFactory func() framework.Resource

--- a/docs/design/factories.md
+++ b/docs/design/factories.md
@@ -284,6 +284,17 @@ Reflection, manual copying, and anonymous function types can only have their
 intent inferred by the name of the property they're set on, which is the
 hardest to build automation around.
 
+### Schema Access
+
+Anonymous functions, named functions, factory types, reflection, and manually
+copying all let the provider developer access the resource's schema inside the
+CRUD functions of that resource, by just calling the method.
+
+If resource types and resource instances are separated into two Go types,
+however, this avenue will no longer be available, and we'll either need to
+surface the resource type or its schema in the CRUD functions somehow, or
+decide that provider developers don't need access to it.
+
 [sdkv2-provider-func]: https://github.com/hashicorp/terraform-plugin-sdk/blob/893e7238350e1980eb2cce3303689ba59ae47490/plugin/serve.go#L28
 [sdkv2-resource-func-call]: https://github.com/hashicorp/terraform-provider-scaffolding/blob/243ba4948171e3902003f678c7c43ec3fafcdc20/internal/provider/provider.go#L33
 [sdkv2-resource-schema]: https://github.com/hashicorp/terraform-provider-scaffolding/blob/243ba4948171e3902003f678c7c43ec3fafcdc20/internal/provider/resource_scaffolding.go#L10-L29

--- a/docs/design/factories.md
+++ b/docs/design/factories.md
@@ -144,8 +144,8 @@ type Provider struct {
 }
 ```
 
-This works whether the `Resource` type is defined by the provider (the `NewResource()`
-method would return an interface) or by the framework.
+This works whether the `Resource` type is defined by the provider (the
+`NewResource()` method would return an interface) or by the framework.
 
 ### Separating types and values
 

--- a/docs/design/factories.md
+++ b/docs/design/factories.md
@@ -261,8 +261,11 @@ type myResource struct {
 }
 
 func (m *myResource) Create(ctx, req, resp) {
+  // this ensures that only one Create call can happen at a time
   reqMutex.Lock()
   defer reqMutex.Unlock()
+
+  // make API call
 }
 ```
 

--- a/docs/design/factories.md
+++ b/docs/design/factories.md
@@ -209,7 +209,7 @@ providers to want to have available to all RPC calls for every instance of
 their resources. This state usually is _used_ by RPC calls, not _created_ by
 it. An example of this we see a lot in the wild is a mutex that constrains the
 number of requests that can be made in parallel, to not provoke API rate
-limiting. Currently, the only way to keep this state is to register it at as
+limiting. Currently, the only way to keep this state is to register it as
 global mutable state. This is problematic in testing scenarios, as all provider
 servers will need to share that same state; it's not just one server's resource
 instances, it's all the resource instances for all the servers created by any

--- a/docs/design/factories.md
+++ b/docs/design/factories.md
@@ -223,7 +223,7 @@ Go types:
 ```go
 type ResourceType interface {
   GetSchema() *tfprotov5.Schema
-  NewResource() Resource
+  NewResource(p framework.Provider) Resource
 }
 
 type Resource interface {

--- a/docs/design/factories.md
+++ b/docs/design/factories.md
@@ -2,10 +2,10 @@
 
 Historically, the provider has always tried to use providers, data sources, and
 resources that are scoped to the RPC server; you can see this in the SDKv2
-[`ProviderFunc`][SDKv2-ProviderFunc] type, which is used to instantiate a
+[`ProviderFunc`][sdkv2-provider-func] type, which is used to instantiate a
 provider when the server starts up. But you can also see it in the practice of
-[using a function][SDKv2-ResourceFuncCall] to [register resource
-schemas][SDKv2-ResourceSchema], even though there's no enforced requirement
+[using a function][sdkv2-resource-func-call] to [register resource
+schemas][sdkv2-resource-schema], even though there's no enforced requirement
 that providers do this. This keeps the variables representing providers, data
 sources, and resources scoped to the gRPC server, which is very helpful when
 running multiple servers at the same time, as in the acceptance test drivers.
@@ -155,7 +155,7 @@ would return an interface) or by the framework.
 
 ### Documentation
 
-[SDKv2-ProviderFunc][https://github.com/hashicorp/terraform-plugin-sdk/blob/893e7238350e1980eb2cce3303689ba59ae47490/plugin/serve.go#L28]
-[SDKv2-ResourceFuncCall][https://github.com/hashicorp/terraform-provider-scaffolding/blob/243ba4948171e3902003f678c7c43ec3fafcdc20/internal/provider/provider.go#L33]
-[SDKv2-ResourceSchema][https://github.com/hashicorp/terraform-provider-scaffolding/blob/243ba4948171e3902003f678c7c43ec3fafcdc20/internal/provider/resource_scaffolding.go#L10-L29]
+[sdkv2-provider-func][https://github.com/hashicorp/terraform-plugin-sdk/blob/893e7238350e1980eb2cce3303689ba59ae47490/plugin/serve.go#L28]
+[sdkv2-resource-func-call][https://github.com/hashicorp/terraform-provider-scaffolding/blob/243ba4948171e3902003f678c7c43ec3fafcdc20/internal/provider/provider.go#L33]
+[sdkv2-resource-schema][https://github.com/hashicorp/terraform-provider-scaffolding/blob/243ba4948171e3902003f678c7c43ec3fafcdc20/internal/provider/resource_scaffolding.go#L10-L29]
 [structs-interfaces][https://github.com/hashicorp/terraform-plugin-framework/blob/main/docs/design/structs-interfaces.md]

--- a/docs/design/factories.md
+++ b/docs/design/factories.md
@@ -83,11 +83,44 @@ type Provider struct {
 and do the instantiation ourselves behind the scenes.
 
 This works if the type is defined by the provider, but there's not really any
-point to it if the type is defined by the framework, as the framework can then
-just use non-reflection instantiation to get to the same result. A separate
-initialization callback or other hook would need to be used to allow providers
-to define values for this new instance, to set things like the schema and CRUD
-functions on it.
+point to it if the type is defined by the framework, as the framework can just
+use manual copying to get the same result.
+
+### Manual copying
+
+If the Resource type is owned by the framework, it will be able to instantiate
+its own instances of that type, and would be able to copy over the data used to
+populate them:
+
+```go
+resource := framework.Resource{
+	Schema: map[string]*Schema{},
+	Create: createFunc,
+	Read: readFunc,
+	Update: updateFunc,
+	Delete: deleteFunc,
+}
+
+newResource := framework.Resource{}
+newResource.Schema = resource.Schema
+newResource.Create = resource.Create
+newResource.Read = resource.Read
+newResource.Update = resource.Update
+newResource.Delete = resource.Delete
+```
+
+we can use this in a helper, to do something like:
+
+```go
+type Provider struct {
+	Resources map[string]Resource
+}
+```
+
+and do the instantiation ourselves behind the scenes.
+
+This works only if the type is defined by the framework. Types defined by the
+provider would need to use reflection to achieve this outcome.
 
 ### Factory types
 
@@ -147,13 +180,47 @@ would return an interface) or by the framework.
 
 ### Mutability of data
 
+As a general rule of thumb, resources, data sources, and providers should not change at runtime. It's hard to imagine a scenario where modifying the schema, validation, or CRUD implementations while the server is running is a good idea, and we should consider that scenario out of scope for this design.
+
+Anonymous and named functions, factory types, and separating types and values may give the impression that this is possible or supported, by changing what is returned by the function based on some runtime considerations.
+
+Reflection and manual copying do not give the impression that this is possible or supported, as the creation of new values is abstracted from the provider developer and they may not even know it's happening.
+
 ### Type system gymnastics
+
+Anonymous and named functions require the user to specify a function that returns a resource, with a usually-hardcoded implementation inside the function. The user may not understand the purpose of the function, and may consider it extra verbosity. Additionally, depending on how it is used (as a value in a map, etc.) the provider developer _may_ need to cast their function implementation to the correct type if we use named functions, which is verbose and annoying.
+
+Reflection and manual copying require no extra type gymnastics other than the minimal viable work of defining the resource, which can then be used as a stamp.
+
+Factory types require the provider developer to define an entire type, likely with no state of its own, just to implement a method on it, just to return a static resource definition.
+
+Separating types and values requires the provider developer to define an entire type, just like factory types, but it perhaps _feels_ less like type system gymnastics as it also bundles in the schema information with the factory, providing some separation between the type of resource and an instance of the resource at runtime.
 
 ### Reliability
 
+Anonymous and named functions, factory types, and separating types and values are all straightforward implementations, lean heavily on the Go compiler, and are relatively reliable as implementation patterns.
+
+Reflection circumvents the Go compiler and has a lot of sharp corner cases to it, which we may or may not have enough experience to predict, and is relatively unreliable as an implementation pattern.
+
+Manually copying is a more reliable alternative, compared to reflection, that yields the same outcome, though the subtlety of things like pointers and slices in that situation still makes it a less reliable implementation than the other options, above. It also creates maintenance overhead, as we'll need to remember to update the copying implementation every time the struct changes.
+
 ### Type safety
 
+Anonymous and named functions, factory types, manually copying, and separating types and values are all type-safe implementations, working within the Go compiler and its type system.
+
+Reflection circumvents the Go compiler and its type system, and is not a type-safe implementation.
+
 ### Documentation
+
+Named functions, factory types, and separating types and values all share documentation properties. They can have the purpose of the function defined explicitly and clearly (positive) but that definition is likely to be at a distance in the documentation from the types that use it (negative).
+
+Manually copying and reflection have no special types or outward indication that the process is happening, meaning there's nowhere to hang documentation off of except where they're used, which is repetitive (negative); but also there's not much purpose for that documentation (positive)--assuming the implementation works correctly.
+
+Anonymous functions likewise have nowhere to hang documentation off of besides where they're used, which is repetitive (negative).
+
+### Automation
+
+For automation and code-analysis purposes, factory types and separating types and values are the most friendly, as their intent is explicit and checked by the compiler. Named functions are the next-most automatable, as the intent of where the function is used is explicit, but the definition of the function itself does not have any intent associated with it. Reflection, manual copying, and anonymous functions can only have their intent inferred by the name of the property they're set on, which is the hardest to build automation around.
 
 [sdkv2-provider-func]: https://github.com/hashicorp/terraform-plugin-sdk/blob/893e7238350e1980eb2cce3303689ba59ae47490/plugin/serve.go#L28
 [sdkv2-resource-func-call]: https://github.com/hashicorp/terraform-provider-scaffolding/blob/243ba4948171e3902003f678c7c43ec3fafcdc20/internal/provider/provider.go#L33

--- a/docs/design/factories.md
+++ b/docs/design/factories.md
@@ -32,6 +32,7 @@ provider developers, we can ask for them as the results of anonymous function
 types.  For example:
 
 ```go
+// in the framework
 type Provider struct {
   Resources map[string]func() framework.Resource
 }
@@ -48,6 +49,7 @@ Similarly to anonymous function types, we can ask for functions with a named
 function type:
 
 ```go
+// in the framework
 type ResourceFactory func() framework.Resource
 
 type Provider struct {
@@ -66,6 +68,7 @@ package to create new instances of the type:
 
 
 ```go
+// in the provider
 resource := computeInstanceResource{}
 
 typ := reflect.TypeOf(resource)
@@ -78,6 +81,7 @@ newResource := reflect.New(typ)
 We can use this in a helper, to do something like:
 
 ```go
+// in the framework
 type Provider struct {
   Resources map[string]Resource
 }
@@ -96,6 +100,7 @@ its own instances of that type, and would be able to copy over the data used to
 populate them:
 
 ```go
+// in the provider
 resource := framework.Resource{
   Schema: map[string]*Schema{},
   Create: createFunc,
@@ -103,7 +108,10 @@ resource := framework.Resource{
   Update: updateFunc,
   Delete: deleteFunc,
 }
+```
 
+```go
+// in the framework
 newResource := framework.Resource{}
 newResource.Schema = resource.Schema
 newResource.Create = resource.Create
@@ -115,6 +123,7 @@ newResource.Delete = resource.Delete
 we can use this in a helper, to do something like:
 
 ```go
+// in the framework
 type Provider struct {
   Resources map[string]Resource
 }
@@ -131,6 +140,7 @@ Instead of using functions, the framework can define an interface for a factory
 that can be implemented by a provider-defined type:
 
 ```go
+// in the framework
 type ResourceFactory interface {
   NewResource() Resource
 }
@@ -140,6 +150,7 @@ Which can then be used instead of the type the factory will return when asking
 consumers for resources, data sources, and providers:
 
 ```go
+// in the framework
 type Provider struct {
   Resources map[string]ResourceFactory
 }
@@ -174,6 +185,7 @@ resources, this may lead providers to try and store information generated
 during RPC calls in their `framework.Resource` implementation:
 
 ```go
+// in the provider
 type myResource struct {
   readResult tftypes.Value
 }
@@ -221,6 +233,7 @@ type. We could define the resource type and the resource instance as separate
 Go types:
 
 ```go
+// in the framework
 type ResourceType interface {
   GetSchema() *tfprotov5.Schema
   NewResource(p framework.Provider) Resource
@@ -238,6 +251,7 @@ This allows provider developers to define their resource types and thread
 through the state shared by all instances of the resource:
 
 ```go
+// in the provider
 type myResourceType struct {
   reqMutex sync.Mutex
 }
@@ -283,6 +297,7 @@ And provider developers can instantiate the state they need the resource
 instances to share:
 
 ```go
+// in the provider
 func NewProvider() *framework.Provider{
   return &framework.Provider{
     Resources: map[string]framework.ResourceType{

--- a/docs/design/factories.md
+++ b/docs/design/factories.md
@@ -23,6 +23,13 @@ provider-controlled][structs-interfaces].
 This document is meant to catalogue our available options and explore their
 benefits and trade-offs.
 
+**Note**: there are many code samples below. Code samples are meant to be
+illustrative of patterns; the specific types of arguments and return values,
+the names of things, etc. aren't meant to be part of the proposal. The purpose
+of the code is just to illustrate the pattern, not to suggest a final
+implementation that will be used. Code will be PRed, and these and other
+concerns that don't impact the pattern can be resolved at that time.
+
 ## Options
 
 ### Anonymous function types

--- a/docs/design/factories.md
+++ b/docs/design/factories.md
@@ -147,9 +147,15 @@ method would return an interface) or by the framework.
 
 ### Separating types and values
 
+The SDK currently conflates two separate ideas: the type of a resource--i.e.,
+the shape a resource takes, the general idea of a resource--and the value of a
+resource--e.g. a specific instance of that resource, a single resource
+definition in state.
+
 Rather than conflating types and values, we can separate them out into two
-different Go implementations. A type is a factory that contains information
-common to values, values are specific instances of a type:
+different Go implementations. The type can then serve as a factory that
+contains information common to values, and values can surface the
+implementations that are used for specific instances of a type:
 
 ```go
 type ResourceType interface {

--- a/docs/design/factories.md
+++ b/docs/design/factories.md
@@ -129,7 +129,7 @@ providers define:
 
 ```go
 type ResourceFactory interface {
-  NewFactory() Resource
+  NewResource() Resource
 }
 ```
 
@@ -142,7 +142,7 @@ type Provider struct {
 }
 ```
 
-This works whether the type is defined by the provider (the `NewFactory()`
+This works whether the type is defined by the provider (the `NewResource()`
 method would return an interface) or by the framework.
 
 ### Separating types and values

--- a/docs/design/factories.md
+++ b/docs/design/factories.md
@@ -262,8 +262,8 @@ type myResource struct {
 
 func (m *myResource) Create(ctx, req, resp) {
   // this ensures that only one Create call can happen at a time
-  reqMutex.Lock()
-  defer reqMutex.Unlock()
+  m.reqMutex.Lock()
+  defer m.reqMutex.Unlock()
 
   // make API call
 }

--- a/docs/design/factories.md
+++ b/docs/design/factories.md
@@ -113,7 +113,7 @@ we can use this in a helper, to do something like:
 
 ```go
 type Provider struct {
-	Resources map[string]Resource
+  Resources map[string]Resource
 }
 ```
 

--- a/docs/design/factories.md
+++ b/docs/design/factories.md
@@ -26,7 +26,7 @@ benefits and trade-offs.
 
 ### Anonymous functions
 
-Wherever we need these types from provider developers, we can ask for them as
+Wherever we need instances of provider, resource, and data source types from provider developers, we can ask for them as
 the results of anonymous functions. For example:
 
 ```go

--- a/docs/design/factories.md
+++ b/docs/design/factories.md
@@ -1,0 +1,161 @@
+# Instantiating New Provider-Controlled Types
+
+Historically, the provider has always tried to use providers, data sources, and
+resources that are scoped to the RPC server; you can see this in the SDKv2
+[`ProviderFunc`][SDKv2-ProviderFunc] type, which is used to instantiate a
+provider when the server starts up. But you can also see it in the practice of
+[using a function][SDKv2-ResourceFuncCall] to [register resource
+schemas][SDKv2-ResourceSchema], even though there's no enforced requirement
+that providers do this. This keeps the variables representing providers, data
+sources, and resources scoped to the gRPC server, which is very helpful when
+running multiple servers at the same time, as in the acceptance test drivers.
+
+There are two main goals when instantiating new instances of a type: to provide
+isolation from other instances of that type that may be running (otherwise, a
+global can just be used) and to (sometimes) allow the provider to populate some
+values on that type (e.g., filling in a schema).
+
+There are a few ways these values can be instantiated, and some of the details
+are dependent on whether the types in question are [framework-controlled or
+provider-controlled][structs-interfaces].
+
+This document is meant to catalogue our available options and explore their
+benefits and trade-offs.
+
+## Options
+
+### Anonymous functions
+
+Wherever we need these types from provider developers, we can ask for them as
+the results of anonymous functions. For example:
+
+```go
+type Provider struct {
+  Resources map[string]func() framework.Resource
+}
+```
+
+This is asking for a function that returns a `framework.Resource` when called,
+which lets the framework call the function to instantiate a new instance of the
+type. This works whether the type is defined by the provider (the function
+would return an interface) or by the framework.
+
+### Named functions
+
+Similarly to anonymous functions, we can ask for named functions:
+
+```go
+type ResourceFactory func() framework.Resource
+
+type Provider struct {
+  Resources map[string]ResourceFactory
+}
+```
+
+This also asks for a function that returns a `framework.Resource`, but gives
+the function signature a name. This works whether the type is defined by the
+provider (the function would return an interface) or by the framework.
+
+### Reflection
+
+In theory, given a single instance of the type, we can use the `reflect`
+package to create new instances of the type:
+
+
+```go
+resource := computeInstanceResource{}
+
+typ := reflect.TypeOf(resource)
+newResource := reflect.New(typ)
+
+// newResource is now a newly instantiated variable of the same type as
+// resource
+```
+
+We can use this in a helper, to do something like:
+
+```go
+type Provider struct {
+  Resources map[string]Resource
+}
+```
+
+and do the instantiation ourselves behind the scenes.
+
+This works if the type is defined by the provider, but there's not really any
+point to it if the type is defined by the framework, as the framework can then
+just use non-reflection instantiation to get to the same result. A separate
+initialization callback or other hook would need to be used to allow providers
+to define values for this new instance, to set things like the schema and CRUD
+functions on it.
+
+### Factory types
+
+Instead of using functions, we can have an interface for a factory type that
+providers define:
+
+```go
+type ResourceFactory interface {
+  NewFactory() Resource
+}
+```
+
+Which can then be used instead of the type the factory will return when asking
+users for resources, data sources, and providers:
+
+```go
+type Provider struct {
+  Resources map[string]ResourceFactory
+}
+```
+
+This works whether the type is defined by the provider (the `NewFactory()`
+method would return an interface) or by the framework.
+
+### Separating types and values
+
+Rather than conflating types and values, we can separate them out into two
+different Go implementations. A type is a factory that contains information
+common to values, values are specific instances of a type:
+
+```go
+type ResourceType interface {
+  GetSchema() *tfprotov5.Schema
+  NewValue() ResourceValue
+}
+
+type ResourceValue interface {
+  Create(ctx context.Context, *CreateResourceRequest, *CreateResourceResponse)
+  Read(ctx context.Context, *ReadResourceRequest, *ReadResourceResponse)
+  Update(ctx context.Context, *UpdateResourceRequest, *UpdateResourceResponse)
+  Delete(ctx context.Context, *DeleteResourceRequest, *DeleteResourceResponse)
+}
+```
+
+We can then use types to instantiate new values at runtime:
+
+```go
+type Provider struct {
+  Resources map[string]ResourceType
+}
+```
+
+This works whether the type is defined by the provider (the `NewValue()` method
+would return an interface) or by the framework.
+
+## Trade-offs
+
+### Mutability of data
+
+### Type system gymnastics
+
+### Reliability
+
+### Type safety
+
+### Documentation
+
+[SDKv2-ProviderFunc][https://github.com/hashicorp/terraform-plugin-sdk/blob/893e7238350e1980eb2cce3303689ba59ae47490/plugin/serve.go#L28]
+[SDKv2-ResourceFuncCall][https://github.com/hashicorp/terraform-provider-scaffolding/blob/243ba4948171e3902003f678c7c43ec3fafcdc20/internal/provider/provider.go#L33]
+[SDKv2-ResourceSchema][https://github.com/hashicorp/terraform-provider-scaffolding/blob/243ba4948171e3902003f678c7c43ec3fafcdc20/internal/provider/resource_scaffolding.go#L10-L29]
+[structs-interfaces][https://github.com/hashicorp/terraform-plugin-framework/blob/main/docs/design/structs-interfaces.md]

--- a/docs/design/factories.md
+++ b/docs/design/factories.md
@@ -1,7 +1,7 @@
 # Instantiating New Provider-Controlled Types
 
-Historically, the provider has always tried to use providers, data sources, and
-resources that are scoped to the RPC server; you can see this in the SDKv2
+Historically, the framework has always tried to use providers, data sources,
+and resources that are scoped to the RPC server; you can see this in the SDKv2
 [`ProviderFunc`][sdkv2-provider-func] type, which is used to instantiate a
 provider when the server starts up. But you can also see it in the practice of
 [using a function][sdkv2-resource-func-call] to [register resource

--- a/docs/design/factories.md
+++ b/docs/design/factories.md
@@ -124,7 +124,7 @@ provider would need to use reflection to achieve this outcome.
 
 ### Factory types
 
-Instead of using functions, we can have an interface for a factory type that
+Instead of using functions, the framework can define an interface for a factory that
 providers define:
 
 ```go

--- a/docs/design/factories.md
+++ b/docs/design/factories.md
@@ -53,7 +53,7 @@ type Provider struct {
 ```
 
 This also asks for a function that returns a `framework.Resource`, but gives
-the function signature a name. This works whether the type is defined by the
+the function signature a name. This works whether the resource type is defined by the
 provider (the function would return an interface) or by the framework.
 
 ### Reflection

--- a/docs/design/factories.md
+++ b/docs/design/factories.md
@@ -94,11 +94,11 @@ populate them:
 
 ```go
 resource := framework.Resource{
-	Schema: map[string]*Schema{},
-	Create: createFunc,
-	Read: readFunc,
-	Update: updateFunc,
-	Delete: deleteFunc,
+  Schema: map[string]*Schema{},
+  Create: createFunc,
+  Read: readFunc,
+  Update: updateFunc,
+  Delete: deleteFunc,
 }
 
 newResource := framework.Resource{}

--- a/docs/design/factories.md
+++ b/docs/design/factories.md
@@ -21,7 +21,9 @@ are dependent on whether the types in question are [framework-controlled or
 provider-controlled][structs-interfaces].
 
 This document is meant to catalogue our available options and explore their
-benefits and trade-offs.
+benefits and trade-offs. It, like all these design documents, is meant to
+explore only its specific scope; orthogonal issues are handled in separate
+design documents.
 
 **Note**: there are many code samples below. Code samples are meant to be
 illustrative of patterns; the specific types of arguments and return values,

--- a/docs/design/factories.md
+++ b/docs/design/factories.md
@@ -198,7 +198,11 @@ func (m *myResource) Create(ctx context.Context, req framework.CreateResourceReq
 This code could _sometimes_ work if we're not careful about always generating a
 new `myResource` for each RPC call we handle. But if the inner workings of the
 SDK or Terraform's graph change in any way, it's likely to break this code,
-which may not be obvious to provider developers.
+which may not be obvious to provider developers. We can mitigate this by
+requiring provider developers to register a function with the provider, not a
+value, and always calling the function to get a fresh value at the beginning of
+every RPC call, though provider developers may not understand that we're doing
+that.
 
 Second, there exists a certain kind of state that it's very reasonable for
 providers to want to have available to all RPC calls for every instance of

--- a/docs/design/factories.md
+++ b/docs/design/factories.md
@@ -24,11 +24,11 @@ benefits and trade-offs.
 
 ## Options
 
-### Anonymous functions
+### Anonymous function types
 
 Wherever we need instances of provider, resource, and data source types from
-provider developers, we can ask for them as the results of anonymous functions.
-For example:
+provider developers, we can ask for them as the results of anonymous function
+types.  For example:
 
 ```go
 type Provider struct {
@@ -41,9 +41,10 @@ which lets the framework call the function to instantiate a new instance of the
 type. This works whether the type is defined by the provider (the function
 would return an interface) or by the framework.
 
-### Named functions
+### Named function types
 
-Similarly to anonymous functions, we can ask for functions with a named type:
+Similarly to anonymous function types, we can ask for functions with a named
+function type:
 
 ```go
 type ResourceFactory func() framework.Resource
@@ -192,9 +193,9 @@ change at runtime. It's hard to imagine a scenario where modifying the schema,
 validation, or CRUD implementations while the server is running is a good idea,
 and we should consider that scenario out of scope for this design.
 
-Anonymous and named functions, factory types, and separating types and values
-may give the impression that this is possible or supported, by changing what is
-returned by the function based on some runtime considerations.
+Anonymous and named function types, factory types, and separating types and
+values may give the impression that this is possible or supported, by changing
+what is returned by the function based on some runtime considerations.
 
 Reflection and manual copying do not give the impression that this is possible
 or supported, as the creation of new values is abstracted from the provider
@@ -202,13 +203,13 @@ developer and they may not even know it's happening.
 
 ### Type system gymnastics
 
-Anonymous and named functions require the user to specify a function that
+Anonymous and named function types require the user to specify a function that
 returns a resource, with a usually-hardcoded implementation inside the
 function. The user may not understand the purpose of the function, and may
 consider it extra verbosity. Additionally, depending on how it is used (as a
 value in a map, etc.) the provider developer _may_ need to cast their function
-implementation to the correct type if we use named functions, which is verbose
-and annoying.
+implementation to the correct type if we use named function types, which is
+verbose and annoying.
 
 Reflection and manual copying require no extra type gymnastics other than the
 minimal viable work of defining the resource, which can then be used as a
@@ -226,9 +227,9 @@ resource at runtime.
 
 ### Reliability
 
-Anonymous and named functions, factory types, and separating types and values
-are all straightforward implementations, lean heavily on the Go compiler, and
-are relatively reliable as implementation patterns.
+Anonymous and named function types, factory types, and separating types and
+values are all straightforward implementations, lean heavily on the Go
+compiler, and are relatively reliable as implementation patterns.
 
 Reflection circumvents the Go compiler and has a lot of sharp corner cases to
 it, which we may or may not have enough experience to predict, and is
@@ -242,16 +243,16 @@ to update the copying implementation every time the struct changes.
 
 ### Type safety
 
-Anonymous and named functions, factory types, manually copying, and separating
-types and values are all type-safe implementations, working within the Go
-compiler and its type system.
+Anonymous and named function types, factory types, manually copying, and
+separating types and values are all type-safe implementations, working within
+the Go compiler and its type system.
 
 Reflection circumvents the Go compiler and its type system, and is not a
 type-safe implementation.
 
 ### Documentation
 
-Named functions, factory types, and separating types and values all share
+Named function types, factory types, and separating types and values all share
 documentation properties. They can have the purpose of the function defined
 explicitly and clearly (positive) but that definition is likely to be at a
 distance in the documentation from the types that use it (negative).
@@ -262,18 +263,18 @@ off of except where they're used, which is repetitive (negative); but also
 there's not much purpose for that documentation (positive)--assuming the
 implementation works correctly.
 
-Anonymous functions likewise have nowhere to hang documentation off of besides
-where they're used, which is repetitive (negative).
+Anonymous function types likewise have nowhere to hang documentation off of
+besides where they're used, which is repetitive (negative).
 
 ### Automation
 
 For automation and code-analysis purposes, factory types and separating types
 and values are the most friendly, as their intent is explicit and checked by
-the compiler. Named functions are the next-most automatable, as the intent of
-where the function is used is explicit, but the definition of the function
+the compiler. Named function types are the next-most automatable, as the intent
+of where the function is used is explicit, but the definition of the function
 itself does not have any intent associated with it. Reflection, manual copying,
-and anonymous functions can only have their intent inferred by the name of the
-property they're set on, which is the hardest to build automation around.
+and anonymous function types can only have their intent inferred by the name of
+the property they're set on, which is the hardest to build automation around.
 
 [sdkv2-provider-func]: https://github.com/hashicorp/terraform-plugin-sdk/blob/893e7238350e1980eb2cce3303689ba59ae47490/plugin/serve.go#L28
 [sdkv2-resource-func-call]: https://github.com/hashicorp/terraform-provider-scaffolding/blob/243ba4948171e3902003f678c7c43ec3fafcdc20/internal/provider/provider.go#L33


### PR DESCRIPTION
We want to instantiate new instances of resources, data sources, and
providers so that we can have some isolation at runtime, but either the
provider defined the type of the resource/data source/provider and we
don't know how to create new instance of it, or the framework defined
the type and the provider needs to supply values for it, which the
framework needs to get from the provider when creating a new instance of
it.

This document explores different ways to achieve that.