### PR TITLE
Request and response types

### DIFF
--- a/request.go
+++ b/request.go
@@ -1,0 +1,83 @@
+package tfsdk
+
+import (
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// ConfigureProviderRequest represents a request supplying the provider with
+// the values the user supplied for the provider configuration block, along with
+// other runtime information supplied by Terraform or the Plugin SDK. An
+// instance of this request struct is supplied as an argument to the provider's
+// Configure function.
+type ConfigureProviderRequest struct {
+	// TerraformVersion is the version of Terraform executing the request.
+	// This is supplied for logging, analytics, and User-Agent purposes
+	// only. Providers should not try to gate provider behavior on
+	// Terraform versions.
+	TerraformVersion string
+
+	// Config is the configuration the user supplied for the provider. This
+	// information should usually be persisted to the underlying type
+	// that's implementing the Provider interface, for use in later
+	// resource CRUD operations.
+	Config *tftypes.Value
+}
+
+// CreateResourceRequest represents a request for the provider to create a
+// resource. An instance of this request struct is supplied as an argument to
+// the resource's Create function.
+type CreateResourceRequest struct {
+	// Config is the configuration the user supplied for the resource.
+	//
+	// This configuration may contain unknown values if a user uses
+	// interpolation or other functionality that would prevent Terraform
+	// from knowing the value at request time.
+	Config Config
+
+	// Plan is the planned state for the resource.
+	Plan Plan
+}
+
+// ReadResourceRequest represents a request for the provider to read a
+// resource, i.e., update values in state according to the real state of the
+// resource. An instance of this request struct is supplied as an argument to
+// the resource's Read function.
+type ReadResourceRequest struct {
+	// tfprotov6.ReadResourceRequest has no Config field
+	// Config     Config
+
+	// State is the current state of the resource prior to the Read
+	// operation.
+	State State
+}
+
+// UpdateResourceRequest represents a request for the provider to update a
+// resource. An instance of this request struct is supplied as an argument to
+// the resource's Update function.
+type UpdateResourceRequest struct {
+	// Config is the configuration the user supplied for the resource.
+	//
+	// This configuration may contain unknown values if a user uses
+	// interpolation or other functionality that would prevent Terraform
+	// from knowing the value at request time.
+	Config Config
+
+	// Plan is the planned state for the resource.
+	Plan Plan
+
+	// State is the current state of the resource prior to the Update
+	// operation.
+	State State
+}
+
+// DeleteResourceRequest represents a request for the provider to delete a
+// resource. An instance of this request struct is supplied as an argument to
+// the resource's Delete function.
+type DeleteResourceRequest struct {
+	// Config is the configuration the user supplied for the resource.
+	//
+	// This configuration may contain unknown values if a user uses
+	// interpolation or other functionality that would prevent Terraform
+	// from knowing the value at request time.
+	Config Config
+}

--- a/request.go
+++ b/request.go
@@ -32,10 +32,12 @@ type CreateResourceRequest struct {
 	// This configuration may contain unknown values if a user uses
 	// interpolation or other functionality that would prevent Terraform
 	// from knowing the value at request time.
-	Config Config
+	// TODO uncomment when implemented
+	// Config Config
 
 	// Plan is the planned state for the resource.
-	Plan Plan
+	// TODO uncomment when implemented
+	// Plan Plan
 }
 
 // ReadResourceRequest represents a request for the provider to read a
@@ -48,7 +50,8 @@ type ReadResourceRequest struct {
 
 	// State is the current state of the resource prior to the Read
 	// operation.
-	State State
+	// TODO uncomment when implemented
+	// State State
 }
 
 // UpdateResourceRequest represents a request for the provider to update a
@@ -60,14 +63,17 @@ type UpdateResourceRequest struct {
 	// This configuration may contain unknown values if a user uses
 	// interpolation or other functionality that would prevent Terraform
 	// from knowing the value at request time.
-	Config Config
+	// TODO uncomment when implemented
+	// Config Config
 
 	// Plan is the planned state for the resource.
-	Plan Plan
+	// TODO uncomment when implemented
+	// Plan Plan
 
 	// State is the current state of the resource prior to the Update
 	// operation.
-	State State
+	// TODO uncomment when implemented
+	// State State
 }
 
 // DeleteResourceRequest represents a request for the provider to delete a
@@ -79,5 +85,6 @@ type DeleteResourceRequest struct {
 	// This configuration may contain unknown values if a user uses
 	// interpolation or other functionality that would prevent Terraform
 	// from knowing the value at request time.
-	Config Config
+	// TODO uncomment when implemented
+	// Config Config
 }

--- a/response.go
+++ b/response.go
@@ -66,7 +66,8 @@ type CreateResourceResponse struct {
 	// State is the state of the resource following the Create operation.
 	// This field is pre-populated from CreateResourceRequest.Plan and
 	// should be set during the resource's Create operation.
-	State State
+	// TODO uncomment when implemented
+	// State State
 
 	// Diagnostics report errors or warnings related to creating the
 	// resource. An empty slice indicates a successful operation with no
@@ -124,7 +125,8 @@ type ReadResourceResponse struct {
 	// State is the state of the resource following the Read operation.
 	// This field is pre-populated from ReadResourceRequest.State and
 	// should be set during the resource's Read operation.
-	State State
+	// TODO uncomment when implemented
+	// State State
 
 	// Diagnostics report errors or warnings related to reading the
 	// resource. An empty slice indicates a successful operation with no
@@ -182,7 +184,8 @@ type UpdateResourceResponse struct {
 	// State is the state of the resource following the Update operation.
 	// This field is pre-populated from UpdateResourceRequest.Plan and
 	// should be set during the resource's Update operation.
-	State State
+	// TODO uncomment when implemented
+	// State State
 
 	// Diagnostics report errors or warnings related to updating the
 	// resource. An empty slice indicates a successful operation with no

--- a/response.go
+++ b/response.go
@@ -1,0 +1,286 @@
+package tfsdk
+
+import (
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// ConfigureProviderResponse represents a response to a
+// ConfigureProviderRequest. An instance of this response struct is supplied as
+// an argument to the provider's Configure function, in which the provider
+// should set values on the ConfigureProviderResponse as appropriate.
+type ConfigureProviderResponse struct {
+	// Diagnostics report errors or warnings related to configuring the
+	// provider. An empty slice indicates success, with no warnings or
+	// errors generated.
+	Diagnostics []*tfprotov6.Diagnostic
+}
+
+// AddWarning appends a warning diagnostic to the response. If the warning
+// concerns a particular attribute, AddAttributeWarning should be used instead.
+func (r *ConfigureProviderResponse) AddWarning(summary, detail string) {
+	r.Diagnostics = append(r.Diagnostics, &tfprotov6.Diagnostic{
+		Summary:  summary,
+		Detail:   detail,
+		Severity: tfprotov6.DiagnosticSeverityWarning,
+	})
+}
+
+// AddAttributeWarning appends a warning diagnostic to the response and labels
+// it with a specific attribute.
+func (r *ConfigureProviderResponse) AddAttributeWarning(attributePath *tftypes.AttributePath, summary, detail string) {
+	r.Diagnostics = append(r.Diagnostics, &tfprotov6.Diagnostic{
+		Attribute: attributePath,
+		Summary:   summary,
+		Detail:    detail,
+		Severity:  tfprotov6.DiagnosticSeverityWarning,
+	})
+}
+
+// AddError appends an error diagnostic to the response. If the error concerns a
+// particular attribute, AddAttributeError should be used instead.
+func (r *ConfigureProviderResponse) AddError(summary, detail string) {
+	r.Diagnostics = append(r.Diagnostics, &tfprotov6.Diagnostic{
+		Summary:  summary,
+		Detail:   detail,
+		Severity: tfprotov6.DiagnosticSeverityError,
+	})
+}
+
+// AddAttributeError appends an error diagnostic to the response and labels it
+// with a specific attribute.
+func (r *ConfigureProviderResponse) AddAttributeError(attributePath *tftypes.AttributePath, summary, detail string) {
+	r.Diagnostics = append(r.Diagnostics, &tfprotov6.Diagnostic{
+		Attribute: attributePath,
+		Summary:   summary,
+		Detail:    detail,
+		Severity:  tfprotov6.DiagnosticSeverityError,
+	})
+}
+
+// CreateResourceResponse represents a response to a CreateResourceRequest. An
+// instance of this response struct is supplied as
+// an argument to the resource's Create function, in which the provider
+// should set values on the CreateResourceResponse as appropriate.
+type CreateResourceResponse struct {
+	// State is the state of the resource following the Create operation.
+	// This field is pre-populated from CreateResourceRequest.Plan and
+	// should be set during the resource's Create operation.
+	State State
+
+	// Diagnostics report errors or warnings related to creating the
+	// resource. An empty slice indicates a successful operation with no
+	// warnings or errors generated.
+	Diagnostics []*tfprotov6.Diagnostic
+}
+
+// AddWarning appends a warning diagnostic to the response. If the warning
+// concerns a particular attribute, AddAttributeWarning should be used instead.
+func (r *CreateResourceResponse) AddWarning(summary, detail string) {
+	r.Diagnostics = append(r.Diagnostics, &tfprotov6.Diagnostic{
+		Summary:  summary,
+		Detail:   detail,
+		Severity: tfprotov6.DiagnosticSeverityWarning,
+	})
+}
+
+// AddAttributeWarning appends a warning diagnostic to the response and labels
+// it with a specific attribute.
+func (r *CreateResourceResponse) AddAttributeWarning(attributePath *tftypes.AttributePath, summary, detail string) {
+	r.Diagnostics = append(r.Diagnostics, &tfprotov6.Diagnostic{
+		Attribute: attributePath,
+		Summary:   summary,
+		Detail:    detail,
+		Severity:  tfprotov6.DiagnosticSeverityWarning,
+	})
+}
+
+// AddError appends an error diagnostic to the response. If the error concerns a
+// particular attribute, AddAttributeError should be used instead.
+func (r *CreateResourceResponse) AddError(summary, detail string) {
+	r.Diagnostics = append(r.Diagnostics, &tfprotov6.Diagnostic{
+		Summary:  summary,
+		Detail:   detail,
+		Severity: tfprotov6.DiagnosticSeverityError,
+	})
+}
+
+// AddAttributeError appends an error diagnostic to the response and labels it
+// with a specific attribute.
+func (r *CreateResourceResponse) AddAttributeError(attributePath *tftypes.AttributePath, summary, detail string) {
+	r.Diagnostics = append(r.Diagnostics, &tfprotov6.Diagnostic{
+		Attribute: attributePath,
+		Summary:   summary,
+		Detail:    detail,
+		Severity:  tfprotov6.DiagnosticSeverityError,
+	})
+}
+
+// ReadResourceResponse represents a response to a ReadResourceRequest. An
+// instance of this response struct is supplied as
+// an argument to the resource's Read function, in which the provider
+// should set values on the ReadResourceResponse as appropriate.
+type ReadResourceResponse struct {
+	// State is the state of the resource following the Read operation.
+	// This field is pre-populated from ReadResourceRequest.State and
+	// should be set during the resource's Read operation.
+	State State
+
+	// Diagnostics report errors or warnings related to reading the
+	// resource. An empty slice indicates a successful operation with no
+	// warnings or errors generated.
+	Diagnostics []*tfprotov6.Diagnostic
+}
+
+// AddWarning appends a warning diagnostic to the response. If the warning
+// concerns a particular attribute, AddAttributeWarning should be used instead.
+func (r *ReadResourceResponse) AddWarning(summary, detail string) {
+	r.Diagnostics = append(r.Diagnostics, &tfprotov6.Diagnostic{
+		Summary:  summary,
+		Detail:   detail,
+		Severity: tfprotov6.DiagnosticSeverityWarning,
+	})
+}
+
+// AddAttributeWarning appends a warning diagnostic to the response and labels
+// it with a specific attribute.
+func (r *ReadResourceResponse) AddAttributeWarning(attributePath *tftypes.AttributePath, summary, detail string) {
+	r.Diagnostics = append(r.Diagnostics, &tfprotov6.Diagnostic{
+		Attribute: attributePath,
+		Summary:   summary,
+		Detail:    detail,
+		Severity:  tfprotov6.DiagnosticSeverityWarning,
+	})
+}
+
+// AddError appends an error diagnostic to the response. If the error concerns a
+// particular attribute, AddAttributeError should be used instead.
+func (r *ReadResourceResponse) AddError(summary, detail string) {
+	r.Diagnostics = append(r.Diagnostics, &tfprotov6.Diagnostic{
+		Summary:  summary,
+		Detail:   detail,
+		Severity: tfprotov6.DiagnosticSeverityError,
+	})
+}
+
+// AddAttributeError appends an error diagnostic to the response and labels it
+// with a specific attribute.
+func (r *ReadResourceResponse) AddAttributeError(attributePath *tftypes.AttributePath, summary, detail string) {
+	r.Diagnostics = append(r.Diagnostics, &tfprotov6.Diagnostic{
+		Attribute: attributePath,
+		Summary:   summary,
+		Detail:    detail,
+		Severity:  tfprotov6.DiagnosticSeverityError,
+	})
+}
+
+// UpdateResourceResponse represents a response to an UpdateResourceRequest. An
+// instance of this response struct is supplied as
+// an argument to the resource's Update function, in which the provider
+// should set values on the UpdateResourceResponse as appropriate.
+type UpdateResourceResponse struct {
+	// State is the state of the resource following the Update operation.
+	// This field is pre-populated from UpdateResourceRequest.Plan and
+	// should be set during the resource's Update operation.
+	State State
+
+	// Diagnostics report errors or warnings related to updating the
+	// resource. An empty slice indicates a successful operation with no
+	// warnings or errors generated.
+	Diagnostics []*tfprotov6.Diagnostic
+}
+
+// AddWarning appends a warning diagnostic to the response. If the warning
+// concerns a particular attribute, AddAttributeWarning should be used instead.
+func (r *UpdateResourceResponse) AddWarning(summary, detail string) {
+	r.Diagnostics = append(r.Diagnostics, &tfprotov6.Diagnostic{
+		Summary:  summary,
+		Detail:   detail,
+		Severity: tfprotov6.DiagnosticSeverityWarning,
+	})
+}
+
+// AddAttributeWarning appends a warning diagnostic to the response and labels
+// it with a specific attribute.
+func (r *UpdateResourceResponse) AddAttributeWarning(attributePath *tftypes.AttributePath, summary, detail string) {
+	r.Diagnostics = append(r.Diagnostics, &tfprotov6.Diagnostic{
+		Attribute: attributePath,
+		Summary:   summary,
+		Detail:    detail,
+		Severity:  tfprotov6.DiagnosticSeverityWarning,
+	})
+}
+
+// AddError appends an error diagnostic to the response. If the error concerns a
+// particular attribute, AddAttributeError should be used instead.
+func (r *UpdateResourceResponse) AddError(summary, detail string) {
+	r.Diagnostics = append(r.Diagnostics, &tfprotov6.Diagnostic{
+		Summary:  summary,
+		Detail:   detail,
+		Severity: tfprotov6.DiagnosticSeverityError,
+	})
+}
+
+// AddAttributeError appends an error diagnostic to the response and labels it
+// with a specific attribute.
+func (r *UpdateResourceResponse) AddAttributeError(attributePath *tftypes.AttributePath, summary, detail string) {
+	r.Diagnostics = append(r.Diagnostics, &tfprotov6.Diagnostic{
+		Attribute: attributePath,
+		Summary:   summary,
+		Detail:    detail,
+		Severity:  tfprotov6.DiagnosticSeverityError,
+	})
+}
+
+// DeleteResourceResponse represents a response to a DeleteResourceRequest. An
+// instance of this response struct is supplied as
+// an argument to the resource's Delete function, in which the provider
+// should set values on the DeleteResourceResponse as appropriate.
+type DeleteResourceResponse struct {
+	// Diagnostics report errors or warnings related to deleting the
+	// resource. An empty slice indicates a successful operation with no
+	// warnings or errors generated.
+	Diagnostics []*tfprotov6.Diagnostic
+}
+
+// AddWarning appends a warning diagnostic to the response. If the warning
+// concerns a particular attribute, AddAttributeWarning should be used instead.
+func (r *DeleteResourceResponse) AddWarning(summary, detail string) {
+	r.Diagnostics = append(r.Diagnostics, &tfprotov6.Diagnostic{
+		Summary:  summary,
+		Detail:   detail,
+		Severity: tfprotov6.DiagnosticSeverityWarning,
+	})
+}
+
+// AddAttributeWarning appends a warning diagnostic to the response and labels
+// it with a specific attribute.
+func (r *DeleteResourceResponse) AddAttributeWarning(attributePath *tftypes.AttributePath, summary, detail string) {
+	r.Diagnostics = append(r.Diagnostics, &tfprotov6.Diagnostic{
+		Attribute: attributePath,
+		Summary:   summary,
+		Detail:    detail,
+		Severity:  tfprotov6.DiagnosticSeverityWarning,
+	})
+}
+
+// AddError appends an error diagnostic to the response. If the error concerns a
+// particular attribute, AddAttributeError should be used instead.
+func (r *DeleteResourceResponse) AddError(summary, detail string) {
+	r.Diagnostics = append(r.Diagnostics, &tfprotov6.Diagnostic{
+		Summary:  summary,
+		Detail:   detail,
+		Severity: tfprotov6.DiagnosticSeverityError,
+	})
+}
+
+// AddAttributeError appends an error diagnostic to the response and labels it
+// with a specific attribute.
+func (r *DeleteResourceResponse) AddAttributeError(attributePath *tftypes.AttributePath, summary, detail string) {
+	r.Diagnostics = append(r.Diagnostics, &tfprotov6.Diagnostic{
+		Attribute: attributePath,
+		Summary:   summary,
+		Detail:    detail,
+		Severity:  tfprotov6.DiagnosticSeverityError,
+	})
+}


### PR DESCRIPTION
closes #13 

This PR defines:
* `ConfigureProviderRequest`
*  `ConfigureProviderResponse`
*  `{Create,Read,Update,Delete}ResourceRequest` 
*  `{Create,Read,Update,Delete}ResourceResponse`

Needs `State` and `Plan` types (#26) before it will compile.