### PR TITLE
Add primitive types.

### DIFF
--- a/.changelog/29.txt
+++ b/.changelog/29.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+Added support for bools, numbers, and strings.
+```

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/hashicorp/terraform-plugin-framework
 
 go 1.16
 
-require github.com/hashicorp/terraform-plugin-go v0.3.0
+require (
+	github.com/google/go-cmp v0.5.6
+	github.com/hashicorp/terraform-plugin-go v0.3.1-0.20210601164646-1df22172e56a
+)

--- a/go.sum
+++ b/go.sum
@@ -26,12 +26,13 @@ github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5a
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
+github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/hashicorp/go-hclog v0.0.0-20180709165350-ff2cf002a8dd/go.mod h1:9bjs9uLqI8l75knNv3lV1kA55veR+WUPSiKIWcQHudI=
 github.com/hashicorp/go-plugin v1.3.0/go.mod h1:F9eH4LrE/ZsRdbwhfjs9k9HoDUwAHnYtXdgmf1AVNs0=
-github.com/hashicorp/terraform-plugin-go v0.3.0 h1:AJqYzP52JFYl9NABRI7smXI1pNjgR5Q/y2WyVJ/BOZA=
-github.com/hashicorp/terraform-plugin-go v0.3.0/go.mod h1:dFHsQMaTLpON2gWhVWT96fvtlc/MF1vSy3OdMhWBzdM=
+github.com/hashicorp/terraform-plugin-go v0.3.1-0.20210601164646-1df22172e56a h1:Wc3hc/mKK1nyo1fpLAurYltTTgE6DR3vywoHvMZKZw8=
+github.com/hashicorp/terraform-plugin-go v0.3.1-0.20210601164646-1df22172e56a/go.mod h1:dFHsQMaTLpON2gWhVWT96fvtlc/MF1vSy3OdMhWBzdM=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/jhump/protoreflect v1.6.0/go.mod h1:eaTn3RZAmMBcV0fifFvlm6VHNz3wSkYyXYWUh7ymB74=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=

--- a/types/bool.go
+++ b/types/bool.go
@@ -1,0 +1,80 @@
+package types
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func boolValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	val := new(Bool)
+	err := val.SetTerraformValue(ctx, in)
+	return val, err
+}
+
+var _ attr.Value = &Bool{}
+
+// Bool represents a boolean value.
+type Bool struct {
+	// Unknown will be true if the value is not yet known.
+	Unknown bool
+
+	// Null will be true if the value was not set, or was explicitly set to
+	// null.
+	Null bool
+
+	// Value contains the set value, as long as Unknown and Null are both
+	// false.
+	Value bool
+}
+
+// ToTerraformValue returns the data contained in the *Bool as a bool. If
+// Unknown is true, it returns a tftypes.UnknownValue. If Null is true, it
+// returns nil.
+func (b *Bool) ToTerraformValue(_ context.Context) (interface{}, error) {
+	if b.Null {
+		return nil, nil
+	}
+	if b.Unknown {
+		return tftypes.UnknownValue, nil
+	}
+	return b.Value, nil
+}
+
+// Equal returns true if `other` is a *Bool and has the same value as `b`.
+func (b *Bool) Equal(other attr.Value) bool {
+	if b == nil && other == nil {
+		return true
+	}
+	if b == nil || other == nil {
+		return false
+	}
+	o, ok := other.(*Bool)
+	if !ok {
+		return false
+	}
+	if b.Unknown != o.Unknown {
+		return false
+	}
+	if b.Null != o.Null {
+		return false
+	}
+	return b.Value == o.Value
+}
+
+// SetTerraformValue updates the Bool to match the contents of `val`.
+func (b *Bool) SetTerraformValue(ctx context.Context, val tftypes.Value) error {
+	b.Unknown = false
+	b.Null = false
+	b.Value = false
+	if val.IsNull() {
+		b.Null = true
+		return nil
+	}
+	if !val.IsKnown() {
+		b.Unknown = true
+		return nil
+	}
+	return val.As(&b.Value)
+}

--- a/types/bool_test.go
+++ b/types/bool_test.go
@@ -1,0 +1,433 @@
+package types
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func TestBoolValueFromTerraform(t *testing.T) {
+	t.Parallel()
+
+	testBoolValueFromTerraform(t, true)
+}
+
+func testBoolValueFromTerraform(t *testing.T, direct bool) {
+	type testCase struct {
+		input       tftypes.Value
+		expectation attr.Value
+		expectedErr string
+	}
+	tests := map[string]testCase{
+		"true": {
+			input:       tftypes.NewValue(tftypes.Bool, true),
+			expectation: &Bool{Value: true},
+		},
+		"false": {
+			input:       tftypes.NewValue(tftypes.Bool, false),
+			expectation: &Bool{Value: false},
+		},
+		"unknown": {
+			input:       tftypes.NewValue(tftypes.Bool, tftypes.UnknownValue),
+			expectation: &Bool{Unknown: true},
+		},
+		"null": {
+			input:       tftypes.NewValue(tftypes.Bool, nil),
+			expectation: &Bool{Null: true},
+		},
+		"wrongType": {
+			input:       tftypes.NewValue(tftypes.String, "oops"),
+			expectedErr: "can't unmarshal tftypes.String into *bool, expected boolean",
+		},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+
+			f := BoolType.ValueFromTerraform
+			if direct {
+				f = boolValueFromTerraform
+			}
+			got, err := f(ctx, test.input)
+			if err != nil {
+				if test.expectedErr == "" {
+					t.Errorf("Unexpected error: %s", err)
+					return
+				}
+				if test.expectedErr != err.Error() {
+					t.Errorf("Expected error to be %q, got %q", test.expectedErr, err.Error())
+					return
+				}
+				// we have an error, and it matches our
+				// expectations, we're good
+				return
+			}
+			if err == nil && test.expectedErr != "" {
+				t.Errorf("Expected error to be %q, didn't get an error", test.expectedErr)
+				return
+			}
+			if !got.Equal(test.expectation) {
+				t.Errorf("Expected %+v, got %+v", test.expectation, got)
+			}
+		})
+	}
+}
+
+func TestBoolToTerraformValue(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		input       *Bool
+		expectation interface{}
+	}
+	tests := map[string]testCase{
+		"true": {
+			input:       &Bool{Value: true},
+			expectation: true,
+		},
+		"false": {
+			input:       &Bool{Value: false},
+			expectation: false,
+		},
+		"unknown": {
+			input:       &Bool{Unknown: true},
+			expectation: tftypes.UnknownValue,
+		},
+		"null": {
+			input:       &Bool{Null: true},
+			expectation: nil,
+		},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+
+			got, err := test.input.ToTerraformValue(ctx)
+			if err != nil {
+				t.Errorf("Unexpected error: %s", err)
+				return
+			}
+			if !cmp.Equal(got, test.expectation) {
+				t.Errorf("Expected %+v, got %+v", test.expectation, got)
+			}
+		})
+	}
+}
+
+func TestBoolEqual(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		input       *Bool
+		candidate   attr.Value
+		expectation bool
+	}
+	tests := map[string]testCase{
+		"true-true": {
+			input:       &Bool{Value: true},
+			candidate:   &Bool{Value: true},
+			expectation: true,
+		},
+		"true-false": {
+			input:       &Bool{Value: true},
+			candidate:   &Bool{Value: false},
+			expectation: false,
+		},
+		"true-unknown": {
+			input:       &Bool{Value: true},
+			candidate:   &Bool{Unknown: true},
+			expectation: false,
+		},
+		"true-null": {
+			input:       &Bool{Value: true},
+			candidate:   &Bool{Null: true},
+			expectation: false,
+		},
+		"true-wrongType": {
+			input:       &Bool{Value: true},
+			candidate:   &String{Value: "oops"},
+			expectation: false,
+		},
+		"true-nil": {
+			input:       &Bool{Value: true},
+			candidate:   nil,
+			expectation: false,
+		},
+		"false-true": {
+			input:       &Bool{Value: false},
+			candidate:   &Bool{Value: true},
+			expectation: false,
+		},
+		"false-false": {
+			input:       &Bool{Value: false},
+			candidate:   &Bool{Value: false},
+			expectation: true,
+		},
+		"false-unknown": {
+			input:       &Bool{Value: false},
+			candidate:   &Bool{Unknown: true},
+			expectation: false,
+		},
+		"false-null": {
+			input:       &Bool{Value: false},
+			candidate:   &Bool{Null: true},
+			expectation: false,
+		},
+		"false-wrongType": {
+			input:       &Bool{Value: false},
+			candidate:   &String{Value: "oops"},
+			expectation: false,
+		},
+		"false-nil": {
+			input:       &Bool{Value: false},
+			candidate:   nil,
+			expectation: false,
+		},
+		"unknown-true": {
+			input:       &Bool{Unknown: true},
+			candidate:   &Bool{Value: true},
+			expectation: false,
+		},
+		"unknown-false": {
+			input:       &Bool{Unknown: true},
+			candidate:   &Bool{Value: false},
+			expectation: false,
+		},
+		"unknown-unknown": {
+			input:       &Bool{Unknown: true},
+			candidate:   &Bool{Unknown: true},
+			expectation: true,
+		},
+		"unknown-null": {
+			input:       &Bool{Unknown: true},
+			candidate:   &Bool{Null: true},
+			expectation: false,
+		},
+		"unknown-wrongType": {
+			input:       &Bool{Unknown: true},
+			candidate:   &String{Value: "oops"},
+			expectation: false,
+		},
+		"unknown-nil": {
+			input:       &Bool{Unknown: true},
+			candidate:   nil,
+			expectation: false,
+		},
+		"null-true": {
+			input:       &Bool{Null: true},
+			candidate:   &Bool{Value: true},
+			expectation: false,
+		},
+		"null-false": {
+			input:       &Bool{Null: true},
+			candidate:   &Bool{Value: false},
+			expectation: false,
+		},
+		"null-unknown": {
+			input:       &Bool{Null: true},
+			candidate:   &Bool{Unknown: true},
+			expectation: false,
+		},
+		"null-null": {
+			input:       &Bool{Null: true},
+			candidate:   &Bool{Null: true},
+			expectation: true,
+		},
+		"null-wrongType": {
+			input:       &Bool{Null: true},
+			candidate:   &String{Value: "oops"},
+			expectation: false,
+		},
+		"null-nil": {
+			input:       &Bool{Null: true},
+			candidate:   nil,
+			expectation: false,
+		},
+		"nil-true": {
+			input:       nil,
+			candidate:   &Bool{Value: true},
+			expectation: false,
+		},
+		"nil-false": {
+			input:       nil,
+			candidate:   &Bool{Value: false},
+			expectation: false,
+		},
+		"nil-unknown": {
+			input:       nil,
+			candidate:   &Bool{Unknown: true},
+			expectation: false,
+		},
+		"nil-wrongType": {
+			input:       nil,
+			candidate:   &String{Value: "oops"},
+			expectation: false,
+		},
+		"nil-nil": {
+			input:       nil,
+			candidate:   nil,
+			expectation: true,
+		},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := test.input.Equal(test.candidate)
+			if !cmp.Equal(got, test.expectation) {
+				t.Errorf("Expected %v, got %v", test.expectation, got)
+			}
+		})
+	}
+}
+
+func TestBoolSetTerraformValue(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		start       *Bool
+		input       tftypes.Value
+		expectation *Bool
+		expectedErr string
+	}
+	tests := map[string]testCase{
+		"true-true": {
+			start:       &Bool{Value: true},
+			input:       tftypes.NewValue(tftypes.Bool, true),
+			expectation: &Bool{Value: true},
+		},
+		"true-false": {
+			start:       &Bool{Value: true},
+			input:       tftypes.NewValue(tftypes.Bool, false),
+			expectation: &Bool{Value: false},
+		},
+		"true-unknown": {
+			start:       &Bool{Value: true},
+			input:       tftypes.NewValue(tftypes.Bool, tftypes.UnknownValue),
+			expectation: &Bool{Unknown: true},
+		},
+		"true-null": {
+			start:       &Bool{Value: true},
+			input:       tftypes.NewValue(tftypes.Bool, nil),
+			expectation: &Bool{Null: true},
+		},
+		"true-wrongType": {
+			start:       &Bool{Value: true},
+			input:       tftypes.NewValue(tftypes.String, "oops"),
+			expectedErr: "can't unmarshal tftypes.String into *bool, expected boolean",
+		},
+		"false-true": {
+			start:       &Bool{Value: false},
+			input:       tftypes.NewValue(tftypes.Bool, true),
+			expectation: &Bool{Value: true},
+		},
+		"false-false": {
+			start:       &Bool{Value: false},
+			input:       tftypes.NewValue(tftypes.Bool, false),
+			expectation: &Bool{Value: false},
+		},
+		"false-unknown": {
+			start:       &Bool{Value: false},
+			input:       tftypes.NewValue(tftypes.Bool, tftypes.UnknownValue),
+			expectation: &Bool{Unknown: true},
+		},
+		"false-null": {
+			start:       &Bool{Value: false},
+			input:       tftypes.NewValue(tftypes.Bool, nil),
+			expectation: &Bool{Null: true},
+		},
+		"false-wrongType": {
+			start:       &Bool{Value: false},
+			input:       tftypes.NewValue(tftypes.String, "oops"),
+			expectedErr: "can't unmarshal tftypes.String into *bool, expected boolean",
+		},
+		"unknown-true": {
+			start:       &Bool{Unknown: true},
+			input:       tftypes.NewValue(tftypes.Bool, true),
+			expectation: &Bool{Value: true},
+		},
+		"unknown-false": {
+			start:       &Bool{Unknown: true},
+			input:       tftypes.NewValue(tftypes.Bool, false),
+			expectation: &Bool{Value: false},
+		},
+		"unknown-unknown": {
+			start:       &Bool{Unknown: true},
+			input:       tftypes.NewValue(tftypes.Bool, tftypes.UnknownValue),
+			expectation: &Bool{Unknown: true},
+		},
+		"unknown-null": {
+			start:       &Bool{Unknown: true},
+			input:       tftypes.NewValue(tftypes.Bool, nil),
+			expectation: &Bool{Null: true},
+		},
+		"unknown-wrongType": {
+			start:       &Bool{Unknown: true},
+			input:       tftypes.NewValue(tftypes.String, "oops"),
+			expectedErr: "can't unmarshal tftypes.String into *bool, expected boolean",
+		},
+		"null-true": {
+			start:       &Bool{Null: true},
+			input:       tftypes.NewValue(tftypes.Bool, true),
+			expectation: &Bool{Value: true},
+		},
+		"null-false": {
+			start:       &Bool{Null: true},
+			input:       tftypes.NewValue(tftypes.Bool, false),
+			expectation: &Bool{Value: false},
+		},
+		"null-unknown": {
+			start:       &Bool{Null: true},
+			input:       tftypes.NewValue(tftypes.Bool, tftypes.UnknownValue),
+			expectation: &Bool{Unknown: true},
+		},
+		"null-null": {
+			start:       &Bool{Null: true},
+			input:       tftypes.NewValue(tftypes.Bool, nil),
+			expectation: &Bool{Null: true},
+		},
+		"null-wrongType": {
+			start:       &Bool{Null: true},
+			input:       tftypes.NewValue(tftypes.String, "oops"),
+			expectedErr: "can't unmarshal tftypes.String into *bool, expected boolean",
+		},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+
+			err := test.start.SetTerraformValue(ctx, test.input)
+			if err != nil {
+				if test.expectedErr == "" {
+					t.Errorf("Unexpected error: %s", err)
+					return
+				}
+				if test.expectedErr != err.Error() {
+					t.Errorf("Expected error to be %q, got %q", test.expectedErr, err.Error())
+					return
+				}
+				// we have an error, and it matches our
+				// expectations, we're good
+				return
+			}
+			if err == nil && test.expectedErr != "" {
+				t.Errorf("Expected error to be %q, didn't get an error", test.expectedErr)
+				return
+			}
+			if !test.start.Equal(test.expectation) {
+				t.Errorf("Expected %+v, got %+v", test.expectation, test.start)
+			}
+		})
+	}
+}

--- a/types/number.go
+++ b/types/number.go
@@ -1,0 +1,89 @@
+package types
+
+import (
+	"context"
+	"math/big"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func numberValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	n := new(Number)
+	err := n.SetTerraformValue(ctx, in)
+	return n, err
+}
+
+var _ attr.Value = &Number{}
+
+// Number represents a number value, exposed as a *big.Float. Numbers can be
+// floats or integers.
+type Number struct {
+	// Unknown will be true if the value is not yet known.
+	Unknown bool
+
+	// Null will be true if the value was not set, or was explicitly set to
+	// null.
+	Null bool
+
+	// Value contains the set value, as long as Unknown and Null are both
+	// false.
+	Value *big.Float
+}
+
+// ToTerraformValue returns the data contained in the *Number as a *big.Float.
+// If Unknown is true, it returns a tftypes.UnknownValue. If Null is true, it
+// returns nil.
+func (n *Number) ToTerraformValue(_ context.Context) (interface{}, error) {
+	if n.Null {
+		return nil, nil
+	}
+	if n.Unknown {
+		return tftypes.UnknownValue, nil
+	}
+	return n.Value, nil
+}
+
+// Equal returns true if `other` is a *Number and has the same value as `n`.
+func (n *Number) Equal(other attr.Value) bool {
+	if n == nil && other == nil {
+		return true
+	}
+	if n == nil || other == nil {
+		return false
+	}
+	o, ok := other.(*Number)
+	if !ok {
+		return false
+	}
+	if n.Unknown != o.Unknown {
+		return false
+	}
+	if n.Null != o.Null {
+		return false
+	}
+	if n.Value == nil && o.Value == nil {
+		return true
+	}
+	if n.Value == nil || o.Value == nil {
+		return false
+	}
+	return n.Value.Cmp(o.Value) == 0
+}
+
+// SetTerraformValue updates the Number to match the contents of `val`.
+func (n *Number) SetTerraformValue(ctx context.Context, in tftypes.Value) error {
+	n.Unknown = false
+	n.Null = false
+	n.Value = nil
+	if !in.IsKnown() {
+		n.Unknown = true
+		return nil
+	}
+	if in.IsNull() {
+		n.Null = true
+		return nil
+	}
+	err := in.As(&n.Value)
+	return err
+}

--- a/types/number_test.go
+++ b/types/number_test.go
@@ -1,0 +1,420 @@
+package types
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func numberComparer(i, j *big.Float) bool {
+	return (i == nil && j == nil) || (i != nil && j != nil && i.Cmp(j) == 0)
+}
+
+func TestNumberValueFromTerraform(t *testing.T) {
+	t.Parallel()
+
+	testNumberValueFromTerraform(t, true)
+}
+
+func testNumberValueFromTerraform(t *testing.T, direct bool) {
+	type testCase struct {
+		input       tftypes.Value
+		expectation attr.Value
+		expectedErr string
+	}
+	tests := map[string]testCase{
+		"value": {
+			input:       tftypes.NewValue(tftypes.Number, 123),
+			expectation: &Number{Value: big.NewFloat(123)},
+		},
+		"unknown": {
+			input:       tftypes.NewValue(tftypes.Number, tftypes.UnknownValue),
+			expectation: &Number{Unknown: true},
+		},
+		"null": {
+			input:       tftypes.NewValue(tftypes.Number, nil),
+			expectation: &Number{Null: true},
+		},
+		"wrongType": {
+			input:       tftypes.NewValue(tftypes.String, "oops"),
+			expectedErr: "can't unmarshal tftypes.String into *big.Float, expected *big.Float",
+		},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+
+			f := NumberType.ValueFromTerraform
+			if direct {
+				f = numberValueFromTerraform
+			}
+			got, err := f(ctx, test.input)
+			if err != nil {
+				if test.expectedErr == "" {
+					t.Errorf("Unexpected error: %s", err)
+					return
+				}
+				if test.expectedErr != err.Error() {
+					t.Errorf("Expected error to be %q, got %q", test.expectedErr, err.Error())
+					return
+				}
+				// we have an error, and it matches our
+				// expectations, we're good
+				return
+			}
+			if err == nil && test.expectedErr != "" {
+				t.Errorf("Expected error to be %q, didn't get an error", test.expectedErr)
+				return
+			}
+			if !got.Equal(test.expectation) {
+				t.Errorf("Expected %+v, got %+v", test.expectation, got)
+			}
+		})
+	}
+}
+
+func TestNumberToTerraformValue(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		input       *Number
+		expectation interface{}
+	}
+	tests := map[string]testCase{
+		"value": {
+			input:       &Number{Value: big.NewFloat(123)},
+			expectation: big.NewFloat(123),
+		},
+		"unknown": {
+			input:       &Number{Unknown: true},
+			expectation: tftypes.UnknownValue,
+		},
+		"null": {
+			input:       &Number{Null: true},
+			expectation: nil,
+		},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+
+			got, err := test.input.ToTerraformValue(ctx)
+			if err != nil {
+				t.Errorf("Unexpected error: %s", err)
+				return
+			}
+			if !cmp.Equal(got, test.expectation, cmp.Comparer(numberComparer)) {
+				t.Errorf("Expected %+v, got %+v", test.expectation, got)
+			}
+		})
+	}
+}
+
+func TestNumberEqual(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		input       *Number
+		candidate   attr.Value
+		expectation bool
+	}
+	tests := map[string]testCase{
+		"value-value-same": {
+			input:       &Number{Value: big.NewFloat(123)},
+			candidate:   &Number{Value: big.NewFloat(123)},
+			expectation: true,
+		},
+		"value-value-diff": {
+			input:       &Number{Value: big.NewFloat(123)},
+			candidate:   &Number{Value: big.NewFloat(456)},
+			expectation: false,
+		},
+		"value-unknown": {
+			input:       &Number{Value: big.NewFloat(123)},
+			candidate:   &Number{Unknown: true},
+			expectation: false,
+		},
+		"value-null": {
+			input:       &Number{Value: big.NewFloat(123)},
+			candidate:   &Number{Null: true},
+			expectation: false,
+		},
+		"value-wrongType": {
+			input:       &Number{Value: big.NewFloat(123)},
+			candidate:   &String{Value: "oops"},
+			expectation: false,
+		},
+		"value-nil": {
+			input:       &Number{Value: big.NewFloat(123)},
+			candidate:   nil,
+			expectation: false,
+		},
+		"value-nilValue": {
+			input:       &Number{Value: big.NewFloat(123)},
+			candidate:   &Number{Value: nil},
+			expectation: false,
+		},
+		"unknown-value": {
+			input:       &Number{Unknown: true},
+			candidate:   &Number{Value: big.NewFloat(123)},
+			expectation: false,
+		},
+		"unknown-unknown": {
+			input:       &Number{Unknown: true},
+			candidate:   &Number{Unknown: true},
+			expectation: true,
+		},
+		"unknown-null": {
+			input:       &Number{Unknown: true},
+			candidate:   &Number{Null: true},
+			expectation: false,
+		},
+		"unknown-wrongType": {
+			input:       &Number{Unknown: true},
+			candidate:   &String{Value: "oops"},
+			expectation: false,
+		},
+		"unknown-nil": {
+			input:       &Number{Unknown: true},
+			candidate:   nil,
+			expectation: false,
+		},
+		"unknown-nilValue": {
+			input:       &Number{Unknown: true},
+			candidate:   &Number{Value: nil},
+			expectation: false,
+		},
+		"null-value": {
+			input:       &Number{Null: true},
+			candidate:   &Number{Value: big.NewFloat(123)},
+			expectation: false,
+		},
+		"null-unknown": {
+			input:       &Number{Null: true},
+			candidate:   &Number{Unknown: true},
+			expectation: false,
+		},
+		"null-null": {
+			input:       &Number{Null: true},
+			candidate:   &Number{Null: true},
+			expectation: true,
+		},
+		"null-wrongType": {
+			input:       &Number{Null: true},
+			candidate:   &String{Value: "oops"},
+			expectation: false,
+		},
+		"null-nil": {
+			input:       &Number{Null: true},
+			candidate:   nil,
+			expectation: false,
+		},
+		"null-nilValue": {
+			input:       &Number{Null: true},
+			candidate:   &Number{Value: nil},
+			expectation: false,
+		},
+		"nil-value": {
+			input:       nil,
+			candidate:   &Number{Value: big.NewFloat(123)},
+			expectation: false,
+		},
+		"nil-unknown": {
+			input:       nil,
+			candidate:   &Number{Unknown: true},
+			expectation: false,
+		},
+		"nil-wrongType": {
+			input:       nil,
+			candidate:   &String{Value: "oops"},
+			expectation: false,
+		},
+		"nil-nil": {
+			input:       nil,
+			candidate:   nil,
+			expectation: true,
+		},
+		"nil-nilValue": {
+			input:       nil,
+			candidate:   &Number{Value: nil},
+			expectation: false,
+		},
+		"nilValue-value": {
+			input:       &Number{Value: nil},
+			candidate:   &Number{Value: big.NewFloat(123)},
+			expectation: false,
+		},
+		"nilValue-unknown": {
+			input:       &Number{Value: nil},
+			candidate:   &Number{Unknown: true},
+			expectation: false,
+		},
+		"nilValue-wrongType": {
+			input:       &Number{Value: nil},
+			candidate:   &String{Value: "oops"},
+			expectation: false,
+		},
+		"nilValue-nil": {
+			input:       &Number{Value: nil},
+			candidate:   nil,
+			expectation: false,
+		},
+		"nilValue-nilValue": {
+			input:       &Number{Value: nil},
+			candidate:   &Number{Value: nil},
+			expectation: true,
+		},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := test.input.Equal(test.candidate)
+			if !cmp.Equal(got, test.expectation) {
+				t.Errorf("Expected %v, got %v", test.expectation, got)
+			}
+		})
+	}
+}
+
+func TestNumberSetTerraformValue(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		start       *Number
+		input       tftypes.Value
+		expectation *Number
+		expectedErr string
+	}
+	tests := map[string]testCase{
+		"123-123": {
+			start:       &Number{Value: big.NewFloat(123)},
+			input:       tftypes.NewValue(tftypes.Number, 123),
+			expectation: &Number{Value: big.NewFloat(123)},
+		},
+		"123-456": {
+			start:       &Number{Value: big.NewFloat(123)},
+			input:       tftypes.NewValue(tftypes.Number, 456),
+			expectation: &Number{Value: big.NewFloat(456)},
+		},
+		"123-unknown": {
+			start:       &Number{Value: big.NewFloat(123)},
+			input:       tftypes.NewValue(tftypes.Number, tftypes.UnknownValue),
+			expectation: &Number{Unknown: true},
+		},
+		"123-null": {
+			start:       &Number{Value: big.NewFloat(123)},
+			input:       tftypes.NewValue(tftypes.Number, nil),
+			expectation: &Number{Null: true},
+		},
+		"123-wrongType": {
+			start:       &Number{Value: big.NewFloat(123)},
+			input:       tftypes.NewValue(tftypes.String, "oops"),
+			expectedErr: "can't unmarshal tftypes.String into *big.Float, expected *big.Float",
+		},
+		"nilValue-123": {
+			start:       &Number{Value: nil},
+			input:       tftypes.NewValue(tftypes.Number, 123),
+			expectation: &Number{Value: big.NewFloat(123)},
+		},
+		"nilValue-456": {
+			start:       &Number{Value: nil},
+			input:       tftypes.NewValue(tftypes.Number, 456),
+			expectation: &Number{Value: big.NewFloat(456)},
+		},
+		"nilValue-unknown": {
+			start:       &Number{Value: nil},
+			input:       tftypes.NewValue(tftypes.Number, tftypes.UnknownValue),
+			expectation: &Number{Unknown: true},
+		},
+		"nilValue-null": {
+			start:       &Number{Value: nil},
+			input:       tftypes.NewValue(tftypes.Number, nil),
+			expectation: &Number{Null: true},
+		},
+		"nilValue-wrongType": {
+			start:       &Number{Value: nil},
+			input:       tftypes.NewValue(tftypes.String, "oops"),
+			expectedErr: "can't unmarshal tftypes.String into *big.Float, expected *big.Float",
+		},
+		"unknown-123": {
+			start:       &Number{Unknown: true},
+			input:       tftypes.NewValue(tftypes.Number, 123),
+			expectation: &Number{Value: big.NewFloat(123)},
+		},
+		"unknown-unknown": {
+			start:       &Number{Unknown: true},
+			input:       tftypes.NewValue(tftypes.Number, tftypes.UnknownValue),
+			expectation: &Number{Unknown: true},
+		},
+		"unknown-null": {
+			start:       &Number{Unknown: true},
+			input:       tftypes.NewValue(tftypes.Number, nil),
+			expectation: &Number{Null: true},
+		},
+		"unknown-wrongType": {
+			start:       &Number{Unknown: true},
+			input:       tftypes.NewValue(tftypes.String, "oops"),
+			expectedErr: "can't unmarshal tftypes.String into *big.Float, expected *big.Float",
+		},
+		"null-123": {
+			start:       &Number{Null: true},
+			input:       tftypes.NewValue(tftypes.Number, 123),
+			expectation: &Number{Value: big.NewFloat(123)},
+		},
+		"null-unknown": {
+			start:       &Number{Null: true},
+			input:       tftypes.NewValue(tftypes.Number, tftypes.UnknownValue),
+			expectation: &Number{Unknown: true},
+		},
+		"null-null": {
+			start:       &Number{Null: true},
+			input:       tftypes.NewValue(tftypes.Number, nil),
+			expectation: &Number{Null: true},
+		},
+		"null-wrongType": {
+			start:       &Number{Null: true},
+			input:       tftypes.NewValue(tftypes.String, "oops"),
+			expectedErr: "can't unmarshal tftypes.String into *big.Float, expected *big.Float",
+		},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+
+			err := test.start.SetTerraformValue(ctx, test.input)
+			if err != nil {
+				if test.expectedErr == "" {
+					t.Errorf("Unexpected error: %s", err)
+					return
+				}
+				if test.expectedErr != err.Error() {
+					t.Errorf("Expected error to be %q, got %q", test.expectedErr, err.Error())
+					return
+				}
+				// we have an error, and it matches our
+				// expectations, we're good
+				return
+			}
+			if err == nil && test.expectedErr != "" {
+				t.Errorf("Expected error to be %q, didn't get an error", test.expectedErr)
+				return
+			}
+			if !test.start.Equal(test.expectation) {
+				t.Errorf("Expected %+v, got %+v", test.expectation, test.start)
+			}
+		})
+	}
+}

--- a/types/primitive.go
+++ b/types/primitive.go
@@ -1,0 +1,90 @@
+package types
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+type primitive uint8
+
+const (
+	// StringType represents a UTF-8 string type.
+	StringType primitive = iota
+
+	// NumberType represents a number type, either an integer or a float.
+	NumberType
+
+	// BoolType represents a boolean type.
+	BoolType
+)
+
+var (
+	_ attr.Type = StringType
+	_ attr.Type = NumberType
+	_ attr.Type = BoolType
+)
+
+func (p primitive) String() string {
+	switch p {
+	case StringType:
+		return "types.StringType"
+	case NumberType:
+		return "types.NumberType"
+	case BoolType:
+		return "types.BoolType"
+	default:
+		return fmt.Sprintf("unknown primitive %d", p)
+	}
+}
+
+// TerraformType returns the tftypes.Type that should be used to represent this
+// type. This constrains what user input will be accepted and what kind of data
+// can be set in state. The framework will use this to translate the Type to
+// something Terraform can understand.
+func (p primitive) TerraformType(_ context.Context) tftypes.Type {
+	switch p {
+	case StringType:
+		return tftypes.String
+	case NumberType:
+		return tftypes.Number
+	case BoolType:
+		return tftypes.Bool
+	default:
+		panic(fmt.Sprintf("unknown primitive %d", p))
+	}
+}
+
+// ValueFromTerraform returns a Value given a tftypes.Value.  This is meant to
+// convert the tftypes.Value into a more convenient Go type for the provider to
+// consume the data with.
+func (p primitive) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	switch p {
+	case StringType:
+		return stringValueFromTerraform(ctx, in)
+	case NumberType:
+		return numberValueFromTerraform(ctx, in)
+	case BoolType:
+		return boolValueFromTerraform(ctx, in)
+	default:
+		panic(fmt.Sprintf("unknown primitive %d", p))
+	}
+}
+
+// Equal returns true if `o` is also a primitive, and is the same type of
+// primitive as `p`.
+func (p primitive) Equal(o attr.Type) bool {
+	other, ok := o.(primitive)
+	if !ok {
+		return false
+	}
+	switch p {
+	case StringType, NumberType, BoolType:
+		return p == other
+	default:
+		// unrecognized types are never equal to anything.
+		return false
+	}
+}

--- a/types/primitive_test.go
+++ b/types/primitive_test.go
@@ -1,0 +1,191 @@
+package types
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func TestPrimitiveTerraformType(t *testing.T) {
+	t.Parallel()
+
+	tests := map[primitive]tftypes.Type{
+		StringType: tftypes.String,
+		NumberType: tftypes.Number,
+		BoolType:   tftypes.Bool,
+	}
+	for prim, expected := range tests {
+		prim, expected := prim, expected
+		t.Run(prim.String(), func(t *testing.T) {
+			t.Parallel()
+
+			got := prim.TerraformType(context.Background())
+			if !got.Is(expected) {
+				t.Errorf("Expected %s, got %s", expected, got)
+			}
+		})
+	}
+}
+
+func TestPrimitiveValueFromTerraform(t *testing.T) {
+	t.Parallel()
+
+	t.Run(StringType.String(), func(t *testing.T) {
+		t.Parallel()
+
+		testStringValueFromTerraform(t, false)
+	})
+
+	t.Run(NumberType.String(), func(t *testing.T) {
+		t.Parallel()
+
+		testNumberValueFromTerraform(t, false)
+	})
+
+	t.Run(BoolType.String(), func(t *testing.T) {
+		t.Parallel()
+
+		testBoolValueFromTerraform(t, false)
+	})
+}
+
+// testAttributeType is a dummy attribute type to compare against with Equal to
+// make sure we can handle unexpected types being passed in.
+type testAttributeType struct{}
+
+func (t testAttributeType) TerraformType(_ context.Context) tftypes.Type {
+	panic("not implemented")
+}
+
+func (t testAttributeType) ValueFromTerraform(_ context.Context, _ tftypes.Value) (attr.Value, error) {
+	panic("not implemented")
+}
+
+func (t testAttributeType) Equal(_ attr.Type) bool {
+	panic("not implemented")
+}
+
+func TestPrimitiveEqual(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		prim      primitive
+		candidate attr.Type
+		expected  bool
+	}
+	tests := map[string]testCase{
+		"string-string": {
+			prim:      StringType,
+			candidate: StringType,
+			expected:  true,
+		},
+		"string-number": {
+			prim:      StringType,
+			candidate: NumberType,
+			expected:  false,
+		},
+		"string-bool": {
+			prim:      StringType,
+			candidate: BoolType,
+			expected:  false,
+		},
+		"string-unknown": {
+			prim:      StringType,
+			candidate: primitive(100),
+			expected:  false,
+		},
+		"string-wrongType": {
+			prim:      StringType,
+			candidate: testAttributeType{},
+			expected:  false,
+		},
+		"number-string": {
+			prim:      NumberType,
+			candidate: StringType,
+			expected:  false,
+		},
+		"number-number": {
+			prim:      NumberType,
+			candidate: NumberType,
+			expected:  true,
+		},
+		"number-bool": {
+			prim:      NumberType,
+			candidate: BoolType,
+			expected:  false,
+		},
+		"number-unknown": {
+			prim:      NumberType,
+			candidate: primitive(100),
+			expected:  false,
+		},
+		"number-wrongType": {
+			prim:      NumberType,
+			candidate: testAttributeType{},
+			expected:  false,
+		},
+		"bool-string": {
+			prim:      BoolType,
+			candidate: StringType,
+			expected:  false,
+		},
+		"bool-number": {
+			prim:      BoolType,
+			candidate: NumberType,
+			expected:  false,
+		},
+		"bool-bool": {
+			prim:      BoolType,
+			candidate: BoolType,
+			expected:  true,
+		},
+		"bool-unknown": {
+			prim:      BoolType,
+			candidate: primitive(100),
+			expected:  false,
+		},
+		"bool-wrongType": {
+			prim:      BoolType,
+			candidate: testAttributeType{},
+			expected:  false,
+		},
+		"unknown-string": {
+			prim:      100,
+			candidate: StringType,
+			expected:  false,
+		},
+		"unknown-number": {
+			prim:      100,
+			candidate: NumberType,
+			expected:  false,
+		},
+		"unknown-bool": {
+			prim:      100,
+			candidate: BoolType,
+			expected:  false,
+		},
+		"unknown-unknown": {
+			prim:      100,
+			candidate: primitive(100),
+			expected:  false,
+		},
+		"unknown-wrongType": {
+			prim:      100,
+			candidate: testAttributeType{},
+			expected:  false,
+		},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := test.prim.Equal(test.candidate)
+			if got != test.expected {
+				t.Errorf("Expected %v, got %v", test.expected, got)
+			}
+		})
+	}
+}

--- a/types/string.go
+++ b/types/string.go
@@ -1,0 +1,81 @@
+package types
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func stringValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	s := new(String)
+	err := s.SetTerraformValue(ctx, in)
+	return s, err
+}
+
+var _ attr.Value = &String{}
+
+// String represents a UTF-8 string value.
+type String struct {
+	// Unknown will be true if the value is not yet known.
+	Unknown bool
+
+	// Null will be true if the value was not set, or was explicitly set to
+	// null.
+	Null bool
+
+	// Value contains the set value, as long as Unknown and Null are both
+	// false.
+	Value string
+}
+
+// ToTerraformValue returns the data contained in the *String as a string. If
+// Unknown is true, it returns a tftypes.UnknownValue. If Null is true, it
+// returns nil.
+func (s *String) ToTerraformValue(_ context.Context) (interface{}, error) {
+	if s.Null {
+		return nil, nil
+	}
+	if s.Unknown {
+		return tftypes.UnknownValue, nil
+	}
+	return s.Value, nil
+}
+
+// Equal returns true if `other` is a *String and has the same value as `s`.
+func (s *String) Equal(other attr.Value) bool {
+	if s == nil && other == nil {
+		return true
+	}
+	if s == nil || other == nil {
+		return false
+	}
+	o, ok := other.(*String)
+	if !ok {
+		return false
+	}
+	if s.Unknown != o.Unknown {
+		return false
+	}
+	if s.Null != o.Null {
+		return false
+	}
+	return s.Value == o.Value
+}
+
+// SetTerraformValue updates the String to match the contents of `val`.
+func (s *String) SetTerraformValue(ctx context.Context, in tftypes.Value) error {
+	s.Unknown = false
+	s.Null = false
+	s.Value = ""
+	if !in.IsKnown() {
+		s.Unknown = true
+		return nil
+	}
+	if in.IsNull() {
+		s.Null = true
+		return nil
+	}
+	err := in.As(&s.Value)
+	return err
+}

--- a/types/string_test.go
+++ b/types/string_test.go
@@ -1,0 +1,346 @@
+package types
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func TestStringValueFromTerraform(t *testing.T) {
+	t.Parallel()
+
+	testStringValueFromTerraform(t, true)
+}
+
+func testStringValueFromTerraform(t *testing.T, direct bool) {
+	type testCase struct {
+		input       tftypes.Value
+		expectation attr.Value
+		expectedErr string
+	}
+	tests := map[string]testCase{
+		"true": {
+			input:       tftypes.NewValue(tftypes.String, "hello"),
+			expectation: &String{Value: "hello"},
+		},
+		"unknown": {
+			input:       tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+			expectation: &String{Unknown: true},
+		},
+		"null": {
+			input:       tftypes.NewValue(tftypes.String, nil),
+			expectation: &String{Null: true},
+		},
+		"wrongType": {
+			input:       tftypes.NewValue(tftypes.Number, 123),
+			expectedErr: "can't unmarshal tftypes.Number into *string, expected string",
+		},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+
+			f := StringType.ValueFromTerraform
+			if direct {
+				f = stringValueFromTerraform
+			}
+			got, err := f(ctx, test.input)
+			if err != nil {
+				if test.expectedErr == "" {
+					t.Errorf("Unexpected error: %s", err)
+					return
+				}
+				if test.expectedErr != err.Error() {
+					t.Errorf("Expected error to be %q, got %q", test.expectedErr, err.Error())
+					return
+				}
+				// we have an error, and it matches our
+				// expectations, we're good
+				return
+			}
+			if err == nil && test.expectedErr != "" {
+				t.Errorf("Expected error to be %q, didn't get an error", test.expectedErr)
+				return
+			}
+			if !got.Equal(test.expectation) {
+				t.Errorf("Expected %+v, got %+v", test.expectation, got)
+			}
+		})
+	}
+}
+
+func TestStringToTerraformValue(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		input       *String
+		expectation interface{}
+	}
+	tests := map[string]testCase{
+		"value": {
+			input:       &String{Value: "hello"},
+			expectation: "hello",
+		},
+		"unknown": {
+			input:       &String{Unknown: true},
+			expectation: tftypes.UnknownValue,
+		},
+		"null": {
+			input:       &String{Null: true},
+			expectation: nil,
+		},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+
+			got, err := test.input.ToTerraformValue(ctx)
+			if err != nil {
+				t.Errorf("Unexpected error: %s", err)
+				return
+			}
+			if !cmp.Equal(got, test.expectation) {
+				t.Errorf("Expected %+v, got %+v", test.expectation, got)
+			}
+		})
+	}
+}
+
+func TestStringEqual(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		input       *String
+		candidate   attr.Value
+		expectation bool
+	}
+	tests := map[string]testCase{
+		"value-value": {
+			input:       &String{Value: "hello"},
+			candidate:   &String{Value: "hello"},
+			expectation: true,
+		},
+		"value-diff": {
+			input:       &String{Value: "hello"},
+			candidate:   &String{Value: "world"},
+			expectation: false,
+		},
+		"value-unknown": {
+			input:       &String{Value: "hello"},
+			candidate:   &String{Unknown: true},
+			expectation: false,
+		},
+		"value-null": {
+			input:       &String{Value: "hello"},
+			candidate:   &String{Null: true},
+			expectation: false,
+		},
+		"value-wrongType": {
+			input:       &String{Value: "hello"},
+			candidate:   &Number{Value: big.NewFloat(123)},
+			expectation: false,
+		},
+		"value-nil": {
+			input:       &String{Value: "hello"},
+			candidate:   nil,
+			expectation: false,
+		},
+		"unknown-value": {
+			input:       &String{Unknown: true},
+			candidate:   &String{Value: "hello"},
+			expectation: false,
+		},
+		"unknown-unknown": {
+			input:       &String{Unknown: true},
+			candidate:   &String{Unknown: true},
+			expectation: true,
+		},
+		"unknown-null": {
+			input:       &String{Unknown: true},
+			candidate:   &String{Null: true},
+			expectation: false,
+		},
+		"unknown-wrongType": {
+			input:       &String{Unknown: true},
+			candidate:   &Number{Value: big.NewFloat(123)},
+			expectation: false,
+		},
+		"unknown-nil": {
+			input:       &String{Unknown: true},
+			candidate:   nil,
+			expectation: false,
+		},
+		"null-value": {
+			input:       &String{Null: true},
+			candidate:   &String{Value: "hello"},
+			expectation: false,
+		},
+		"null-unknown": {
+			input:       &String{Null: true},
+			candidate:   &String{Unknown: true},
+			expectation: false,
+		},
+		"null-null": {
+			input:       &String{Null: true},
+			candidate:   &String{Null: true},
+			expectation: true,
+		},
+		"null-wrongType": {
+			input:       &String{Null: true},
+			candidate:   &Number{Value: big.NewFloat(123)},
+			expectation: false,
+		},
+		"null-nil": {
+			input:       &String{Null: true},
+			candidate:   nil,
+			expectation: false,
+		},
+		"nil-value": {
+			input:       nil,
+			candidate:   &String{Value: "hello"},
+			expectation: false,
+		},
+		"nil-unknown": {
+			input:       nil,
+			candidate:   &String{Unknown: true},
+			expectation: false,
+		},
+		"nil-wrongType": {
+			input:       nil,
+			candidate:   &Number{Value: big.NewFloat(123)},
+			expectation: false,
+		},
+		"nil-nil": {
+			input:       nil,
+			candidate:   nil,
+			expectation: true,
+		},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := test.input.Equal(test.candidate)
+			if !cmp.Equal(got, test.expectation) {
+				t.Errorf("Expected %v, got %v", test.expectation, got)
+			}
+		})
+	}
+}
+
+func TestStringSetTerraformValue(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		start       *String
+		input       tftypes.Value
+		expectation *String
+		expectedErr string
+	}
+	tests := map[string]testCase{
+		"value-value": {
+			start:       &String{Value: "hello"},
+			input:       tftypes.NewValue(tftypes.String, "hello"),
+			expectation: &String{Value: "hello"},
+		},
+		"value-diff": {
+			start:       &String{Value: "hello"},
+			input:       tftypes.NewValue(tftypes.String, "world"),
+			expectation: &String{Value: "world"},
+		},
+		"value-unknown": {
+			start:       &String{Value: "hello"},
+			input:       tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+			expectation: &String{Unknown: true},
+		},
+		"value-null": {
+			start:       &String{Value: "hello"},
+			input:       tftypes.NewValue(tftypes.String, nil),
+			expectation: &String{Null: true},
+		},
+		"value-wrongType": {
+			start:       &String{Value: "hello"},
+			input:       tftypes.NewValue(tftypes.Number, 123),
+			expectedErr: "can't unmarshal tftypes.Number into *string, expected string",
+		},
+		"unknown-value": {
+			start:       &String{Unknown: true},
+			input:       tftypes.NewValue(tftypes.String, "hello"),
+			expectation: &String{Value: "hello"},
+		},
+		"unknown-unknown": {
+			start:       &String{Unknown: true},
+			input:       tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+			expectation: &String{Unknown: true},
+		},
+		"unknown-null": {
+			start:       &String{Unknown: true},
+			input:       tftypes.NewValue(tftypes.String, nil),
+			expectation: &String{Null: true},
+		},
+		"unknown-wrongType": {
+			start:       &String{Unknown: true},
+			input:       tftypes.NewValue(tftypes.Number, 123),
+			expectedErr: "can't unmarshal tftypes.Number into *string, expected string",
+		},
+		"null-value": {
+			start:       &String{Null: true},
+			input:       tftypes.NewValue(tftypes.String, "hello"),
+			expectation: &String{Value: "hello"},
+		},
+		"null-unknown": {
+			start:       &String{Null: true},
+			input:       tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+			expectation: &String{Unknown: true},
+		},
+		"null-null": {
+			start:       &String{Null: true},
+			input:       tftypes.NewValue(tftypes.String, nil),
+			expectation: &String{Null: true},
+		},
+		"null-wrongType": {
+			start:       &String{Null: true},
+			input:       tftypes.NewValue(tftypes.Number, 123),
+			expectedErr: "can't unmarshal tftypes.Number into *string, expected string",
+		},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+
+			err := test.start.SetTerraformValue(ctx, test.input)
+			if err != nil {
+				if test.expectedErr == "" {
+					t.Errorf("Unexpected error: %s", err)
+					return
+				}
+				if test.expectedErr != err.Error() {
+					t.Errorf("Expected error to be %q, got %q", test.expectedErr, err.Error())
+					return
+				}
+				// we have an error, and it matches our
+				// expectations, we're good
+				return
+			}
+			if err == nil && test.expectedErr != "" {
+				t.Errorf("Expected error to be %q, didn't get an error", test.expectedErr)
+				return
+			}
+			if !test.start.Equal(test.expectation) {
+				t.Errorf("Expected %+v, got %+v", test.expectation, test.start)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This adds to #28 by creating implementations of the attr.Type interface for our primitive types: bools, numbers, and strings.

This is likewise a split of code originally written for #11 that is being split out into its own PR for easier review. (Or, at least, review will be easier when #28 is merged, which should happen before this is merged.)