### PR TITLE
Add internal/reflect package

### DIFF
--- a/internal/reflect/helpers.go
+++ b/internal/reflect/helpers.go
@@ -1,0 +1,96 @@
+package reflect
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// trueReflectValue returns the reflect.Value for `in` after derefencing all
+// the pointers and unwrapping all the interfaces. It's the concrete value
+// beneath it all.
+func trueReflectValue(val reflect.Value) reflect.Value {
+	kind := val.Type().Kind()
+	for kind == reflect.Interface || kind == reflect.Ptr {
+		innerVal := val.Elem()
+		if !innerVal.IsValid() {
+			break
+		}
+		val = innerVal
+		kind = val.Type().Kind()
+	}
+	return val
+}
+
+// commaSeparatedString returns an English joining of the strings in `in`,
+// using "and" and commas as appropriate.
+func commaSeparatedString(in []string) string {
+	switch len(in) {
+	case 0:
+		return ""
+	case 1:
+		return in[0]
+	case 2:
+		return strings.Join(in, " and ")
+	default:
+		in[len(in)-1] = "and " + in[len(in)-1]
+		return strings.Join(in, ", ")
+	}
+}
+
+// getStructTags returns a map of Terraform field names to their position in
+// the tags of the struct `in`. `in` must be a struct.
+func getStructTags(ctx context.Context, in reflect.Value, path *tftypes.AttributePath) (map[string]int, error) {
+	tags := map[string]int{}
+	typ := trueReflectValue(in).Type()
+	if typ.Kind() != reflect.Struct {
+		return nil, path.NewErrorf("can't get struct tags of %s, is not a struct", in.Type())
+	}
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		if field.PkgPath != "" {
+			// skip unexported fields
+			continue
+		}
+		tag := field.Tag.Get(`tfsdk`)
+		if tag == "-" {
+			// skip explicitly excluded fields
+			continue
+		}
+		if tag == "" {
+			return nil, path.NewErrorf(`need a struct tag for "tfsdk" on %s`, field.Name)
+		}
+		path := path.WithAttributeName(tag)
+		if !isValidFieldName(tag) {
+			return nil, path.NewError(errors.New("invalid field name, must only use lowercase letters, underscores, and numbers, and must start with a letter"))
+		}
+		if other, ok := tags[tag]; ok {
+			return nil, path.NewErrorf("can't use field name for both %s and %s", typ.Field(other).Name, field.Name)
+		}
+		tags[tag] = i
+	}
+	return tags, nil
+}
+
+// isValidFieldName returns true if `name` can be used as a field name in a
+// Terraform resource or data source.
+func isValidFieldName(name string) bool {
+	re := regexp.MustCompile("^[a-z][a-z0-9_]*$")
+	return re.MatchString(name)
+}
+
+// canBeNil returns true if `target`'s type can hold a nil value
+func canBeNil(target reflect.Value) bool {
+	switch target.Kind() {
+	case reflect.Ptr, reflect.Slice, reflect.Map, reflect.Interface:
+		// these types can all hold nils
+		return true
+	default:
+		// nothing else can be set to nil
+		return false
+	}
+}

--- a/internal/reflect/helpers_test.go
+++ b/internal/reflect/helpers_test.go
@@ -1,0 +1,258 @@
+package reflect
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func TestTrueReflectValue(t *testing.T) {
+	t.Parallel()
+
+	var iface, otherIface interface{}
+	var stru struct{}
+
+	// test that when nothing needs unwrapped, we get the right answer
+	if got := trueReflectValue(reflect.ValueOf(stru)).Kind(); got != reflect.Struct {
+		t.Errorf("Expected %s, got %s", reflect.Struct, got)
+	}
+
+	// test that we can unwrap pointers
+	if got := trueReflectValue(reflect.ValueOf(&stru)).Kind(); got != reflect.Struct {
+		t.Errorf("Expected %s, got %s", reflect.Struct, got)
+	}
+
+	// test that we can unwrap interfaces
+	iface = stru
+	if got := trueReflectValue(reflect.ValueOf(iface)).Kind(); got != reflect.Struct {
+		t.Errorf("Expected %s, got %s", reflect.Struct, got)
+	}
+
+	// test that we can unwrap pointers inside interfaces, and pointers to
+	// interfaces with pointers inside them
+	iface = &stru
+	if got := trueReflectValue(reflect.ValueOf(iface)).Kind(); got != reflect.Struct {
+		t.Errorf("Expected %s, got %s", reflect.Struct, got)
+	}
+	if got := trueReflectValue(reflect.ValueOf(&iface)).Kind(); got != reflect.Struct {
+		t.Errorf("Expected %s, got %s", reflect.Struct, got)
+	}
+
+	// test that we can unwrap pointers to interfaces inside other
+	// interfaces, and pointers to interfaces inside pointers to
+	// interfaces.
+	otherIface = &iface
+	if got := trueReflectValue(reflect.ValueOf(otherIface)).Kind(); got != reflect.Struct {
+		t.Errorf("Expected %s, got %s", reflect.Struct, got)
+	}
+	if got := trueReflectValue(reflect.ValueOf(&otherIface)).Kind(); got != reflect.Struct {
+		t.Errorf("Expected %s, got %s", reflect.Struct, got)
+	}
+}
+
+func TestCommaSeparatedString(t *testing.T) {
+	t.Parallel()
+	type testCase struct {
+		input    []string
+		expected string
+	}
+	tests := map[string]testCase{
+		"empty": {
+			input:    []string{},
+			expected: "",
+		},
+		"oneWord": {
+			input:    []string{"red"},
+			expected: "red",
+		},
+		"twoWords": {
+			input:    []string{"red", "blue"},
+			expected: "red and blue",
+		},
+		"threeWords": {
+			input:    []string{"red", "blue", "green"},
+			expected: "red, blue, and green",
+		},
+		"fourWords": {
+			input:    []string{"red", "blue", "green", "purple"},
+			expected: "red, blue, green, and purple",
+		},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got := commaSeparatedString(test.input)
+			if got != test.expected {
+				t.Errorf("Expected %q, got %q", test.expected, got)
+			}
+		})
+	}
+}
+
+func TestGetStructTags_success(t *testing.T) {
+	t.Parallel()
+
+	type testStruct struct {
+		ExportedAndTagged   string `tfsdk:"exported_and_tagged"`
+		unexported          string //nolint:structcheck,unused
+		unexportedAndTagged string `tfsdk:"unexported_and_tagged"`
+		ExportedAndExcluded string `tfsdk:"-"`
+	}
+
+	res, err := getStructTags(context.Background(), reflect.ValueOf(testStruct{}), tftypes.NewAttributePath())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	if len(res) != 1 {
+		t.Errorf("Unexpected result: %v", res)
+	}
+	if res["exported_and_tagged"] != 0 {
+		t.Errorf("Unexpected result: %v", res)
+	}
+}
+
+func TestGetStructTags_untagged(t *testing.T) {
+	t.Parallel()
+	type testStruct struct {
+		ExportedAndUntagged string
+	}
+	_, err := getStructTags(context.Background(), reflect.ValueOf(testStruct{}), tftypes.NewAttributePath())
+	if err == nil {
+		t.Error("Expected error, got nil")
+	}
+	expected := `: need a struct tag for "tfsdk" on ExportedAndUntagged`
+	if err.Error() != expected {
+		t.Errorf("Expected error to be %q, got %q", expected, err.Error())
+	}
+}
+
+func TestGetStructTags_invalidTag(t *testing.T) {
+	t.Parallel()
+	type testStruct struct {
+		InvalidTag string `tfsdk:"invalidTag"`
+	}
+	_, err := getStructTags(context.Background(), reflect.ValueOf(testStruct{}), tftypes.NewAttributePath())
+	if err == nil {
+		t.Errorf("Expected error, got nil")
+	}
+	expected := `AttributeName("invalidTag"): invalid field name, must only use lowercase letters, underscores, and numbers, and must start with a letter`
+	if err.Error() != expected {
+		t.Errorf("Expected error to be %q, got %q", expected, err.Error())
+	}
+}
+
+func TestGetStructTags_duplicateTag(t *testing.T) {
+	t.Parallel()
+	type testStruct struct {
+		Field1 string `tfsdk:"my_field"`
+		Field2 string `tfsdk:"my_field"`
+	}
+	_, err := getStructTags(context.Background(), reflect.ValueOf(testStruct{}), tftypes.NewAttributePath())
+	if err == nil {
+		t.Errorf("Expected error, got nil")
+	}
+	expected := `AttributeName("my_field"): can't use field name for both Field1 and Field2`
+	if err.Error() != expected {
+		t.Errorf("Expected error to be %q, got %q", expected, err.Error())
+	}
+}
+
+func TestGetStructTags_notAStruct(t *testing.T) {
+	t.Parallel()
+	var testStruct string
+
+	_, err := getStructTags(context.Background(), reflect.ValueOf(testStruct), tftypes.NewAttributePath())
+	if err == nil {
+		t.Errorf("Expected error, got nil")
+	}
+	expected := `: can't get struct tags of string, is not a struct`
+	if err.Error() != expected {
+		t.Errorf("Expected error to be %q, got %q", expected, err.Error())
+	}
+}
+
+func TestIsValidFieldName(t *testing.T) {
+	t.Parallel()
+	tests := map[string]bool{
+		"":    false,
+		"a":   true,
+		"1":   false,
+		"1a":  false,
+		"a1":  true,
+		"A":   false,
+		"a-b": false,
+		"a_b": true,
+	}
+	for in, expected := range tests {
+		in, expected := in, expected
+		t.Run(fmt.Sprintf("input=%q", in), func(t *testing.T) {
+			t.Parallel()
+
+			result := isValidFieldName(in)
+			if result != expected {
+				t.Errorf("Expected %v, got %v", expected, result)
+			}
+		})
+	}
+}
+
+func TestCanBeNil_struct(t *testing.T) {
+	t.Parallel()
+
+	var stru struct{}
+
+	got := canBeNil(reflect.ValueOf(stru))
+	if got {
+		t.Error("Expected structs to not be nillable, but canBeNil said they were")
+	}
+}
+
+func TestCanBeNil_structPointer(t *testing.T) {
+	t.Parallel()
+
+	var stru struct{}
+	struPtr := &stru
+
+	got := canBeNil(reflect.ValueOf(struPtr))
+	if !got {
+		t.Error("Expected pointers to structs to be nillable, but canBeNil said they weren't")
+	}
+}
+
+func TestCanBeNil_slice(t *testing.T) {
+	t.Parallel()
+
+	slice := []string{}
+	got := canBeNil(reflect.ValueOf(slice))
+	if !got {
+		t.Errorf("Expected slices to be nillable, but canBeNil said they weren't")
+	}
+}
+
+func TestCanBeNil_map(t *testing.T) {
+	t.Parallel()
+
+	m := map[string]string{}
+	got := canBeNil(reflect.ValueOf(m))
+	if !got {
+		t.Errorf("Expected maps to be nillable, but canBeNil said they weren't")
+	}
+}
+
+func TestCanBeNil_interface(t *testing.T) {
+	t.Parallel()
+
+	type myStruct struct {
+		Value interface{}
+	}
+
+	var s myStruct
+	got := canBeNil(reflect.ValueOf(s).FieldByName("Value"))
+	if !got {
+		t.Errorf("Expected interfaces to be nillable, but canBeNil said they weren't")
+	}
+}

--- a/internal/reflect/interfaces.go
+++ b/internal/reflect/interfaces.go
@@ -1,0 +1,85 @@
+package reflect
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+type setUnknownable interface {
+	SetUnknown(context.Context, bool) error
+}
+
+// call the SetUnknown method on types that support it.
+func reflectUnknownable(ctx context.Context, val tftypes.Value, target reflect.Value, opts Options, path *tftypes.AttributePath) (reflect.Value, error) {
+	receiver := pointerSafeZeroValue(ctx, target)
+	method := receiver.MethodByName("SetUnknown")
+	if !method.IsValid() {
+		return target, path.NewErrorf("unexpectedly couldn't find SetUnknown method on type %s", receiver.Type().String())
+	}
+	results := method.Call([]reflect.Value{
+		reflect.ValueOf(ctx),
+		reflect.ValueOf(!val.IsKnown()),
+	})
+	err := results[0].Interface()
+	if err != nil {
+		return target, path.NewError(err.(error))
+	}
+	return receiver, nil
+}
+
+type setNullable interface {
+	SetNull(context.Context, bool) error
+}
+
+// call the SetNull method on types that support it.
+func reflectNullable(ctx context.Context, val tftypes.Value, target reflect.Value, opts Options, path *tftypes.AttributePath) (reflect.Value, error) {
+	receiver := pointerSafeZeroValue(ctx, target)
+	method := receiver.MethodByName("SetNull")
+	if !method.IsValid() {
+		return target, path.NewErrorf("unexpectedly couldn't find SetUnknown method on type %s", receiver.Type().String())
+	}
+	results := method.Call([]reflect.Value{
+		reflect.ValueOf(ctx),
+		reflect.ValueOf(val.IsNull()),
+	})
+	err := results[0].Interface()
+	if err != nil {
+		return target, path.NewError(err.(error))
+	}
+	return receiver, nil
+}
+
+// call the FromTerraform5Value method on types that support it.
+func reflectValueConverter(ctx context.Context, val tftypes.Value, target reflect.Value, opts Options, path *tftypes.AttributePath) (reflect.Value, error) {
+	receiver := pointerSafeZeroValue(ctx, target)
+	method := receiver.MethodByName("FromTerraform5Value")
+	if !method.IsValid() {
+		return target, path.NewErrorf("unexpectedly couldn't find FromTerraform5Type method on type %s", receiver.Type().String())
+	}
+	results := method.Call([]reflect.Value{reflect.ValueOf(val)})
+	err := results[0].Interface()
+	if err != nil {
+		return target, path.NewError(err.(error))
+	}
+	return receiver, nil
+}
+
+// call the SetTerraformValue method on attr.Values.
+func reflectAttributeValue(ctx context.Context, val tftypes.Value, target reflect.Value, opts Options, path *tftypes.AttributePath) (reflect.Value, error) {
+	receiver := pointerSafeZeroValue(ctx, target)
+	method := receiver.MethodByName("SetTerraformValue")
+	if !method.IsValid() {
+		return target, path.NewErrorf("unexpectedly couldn't find SetTeraformValue method on type %s", receiver.Type().String())
+	}
+	results := method.Call([]reflect.Value{
+		reflect.ValueOf(ctx),
+		reflect.ValueOf(val),
+	})
+	err := results[0].Interface()
+	if err != nil {
+		return target, path.NewError(err.(error))
+	}
+	return receiver, nil
+}

--- a/internal/reflect/interfaces_test.go
+++ b/internal/reflect/interfaces_test.go
@@ -1,0 +1,355 @@
+package reflect
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+type unknownableString struct {
+	String  string
+	Unknown bool
+}
+
+func (u *unknownableString) SetUnknown(_ context.Context, unknown bool) error {
+	u.Unknown = unknown
+	return nil
+}
+
+var _ setUnknownable = &unknownableString{}
+
+type unknownableStringError struct {
+	String  string
+	Unknown bool
+}
+
+func (u *unknownableStringError) SetUnknown(_ context.Context, unknown bool) error {
+	return errors.New("this is an error")
+}
+
+var _ setUnknownable = &unknownableStringError{}
+
+type nullableString struct {
+	String string
+	Null   bool
+}
+
+var _ setNullable = &nullableString{}
+
+func (n *nullableString) SetNull(_ context.Context, null bool) error {
+	n.Null = null
+	return nil
+}
+
+type nullableStringError struct {
+	String string
+	Null   bool
+}
+
+func (n *nullableStringError) SetNull(_ context.Context, null bool) error {
+	return errors.New("this is an error")
+}
+
+var _ setNullable = &nullableStringError{}
+
+type attributeValue struct {
+	Value   string
+	Null    bool
+	Unknown bool
+}
+
+func (a *attributeValue) ToTerraformValue(_ context.Context) (interface{}, error) {
+	var val interface{}
+	if a.Null {
+		val = nil
+	}
+	if a.Value != "" {
+		val = a.Value
+	}
+	if a.Unknown {
+		val = tftypes.UnknownValue
+	}
+	return val, nil
+}
+
+func (a *attributeValue) SetTerraformValue(_ context.Context, val tftypes.Value) error {
+	a.Value = ""
+	a.Null = false
+	a.Unknown = false
+	if val.IsNull() {
+		a.Null = true
+		return nil
+	}
+	if !val.IsKnown() {
+		a.Unknown = true
+		return nil
+	}
+	err := val.As(&a.Value)
+	return err
+}
+
+func (a *attributeValue) Equal(o attr.Value) bool {
+	other, ok := o.(*attributeValue)
+	if !ok {
+		return false
+	}
+	return a.Value == other.Value && a.Null == other.Null && a.Unknown == other.Unknown
+}
+
+var _ attr.Value = &attributeValue{}
+
+type attributeValueError struct {
+	*attributeValue
+}
+
+func (a *attributeValueError) SetTerraformValue(_ context.Context, _ tftypes.Value) error {
+	return errors.New("this is an error")
+}
+
+var _ attr.Value = &attributeValueError{}
+
+type valueConverter struct {
+	value   string
+	unknown bool
+	null    bool
+}
+
+func (v *valueConverter) FromTerraform5Value(in tftypes.Value) error {
+	v.value = ""
+	v.unknown = false
+	v.null = false
+	if !in.IsKnown() {
+		v.unknown = true
+		return nil
+	}
+	if in.IsNull() {
+		v.null = true
+		return nil
+	}
+	return in.As(&v.value)
+}
+
+func (v *valueConverter) Equal(o *valueConverter) bool {
+	if v == nil && o == nil {
+		return true
+	}
+	if v == nil {
+		return false
+	}
+	if o == nil {
+		return false
+	}
+	if v.unknown != o.unknown {
+		return false
+	}
+	if v.null != o.null {
+		return false
+	}
+	return v.value == o.value
+}
+
+var _ tftypes.ValueConverter = &valueConverter{}
+
+type valueConverterError struct {
+	*valueConverter
+}
+
+func (v *valueConverterError) FromTerraform5Value(_ tftypes.Value) error {
+	return errors.New("this is an error")
+}
+
+var _ tftypes.ValueConverter = &valueConverterError{}
+
+func TestReflectUnknownable_known(t *testing.T) {
+	t.Parallel()
+
+	unknownable := &unknownableString{
+		Unknown: true,
+	}
+	res, err := reflectUnknownable(context.Background(), tftypes.NewValue(tftypes.String, "hello"), reflect.ValueOf(unknownable), Options{}, tftypes.NewAttributePath())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err.Error())
+	}
+	got := res.Interface().(*unknownableString)
+	if got.Unknown != false {
+		t.Errorf("Expected %v, got %v", false, got.Unknown)
+	}
+}
+
+func TestReflectUnknownable_unknown(t *testing.T) {
+	t.Parallel()
+
+	var unknownable *unknownableString
+	res, err := reflectUnknownable(context.Background(), tftypes.NewValue(tftypes.String, tftypes.UnknownValue), reflect.ValueOf(unknownable), Options{}, tftypes.NewAttributePath())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err.Error())
+	}
+	got := res.Interface().(*unknownableString)
+	if got.Unknown != true {
+		t.Errorf("Expected %v, got %v", true, got.Unknown)
+	}
+}
+
+func TestReflectUnknownable_error(t *testing.T) {
+	t.Parallel()
+
+	var unknownable *unknownableStringError
+	_, err := reflectUnknownable(context.Background(), tftypes.NewValue(tftypes.String, tftypes.UnknownValue), reflect.ValueOf(unknownable), Options{}, tftypes.NewAttributePath())
+	if expected := ": this is an error"; err == nil || err.Error() != expected {
+		t.Errorf("Expected error to be %q, got %v", expected, err)
+	}
+}
+
+func TestReflectNullable_notNull(t *testing.T) {
+	t.Parallel()
+
+	nullable := &nullableString{
+		Null: true,
+	}
+	res, err := reflectNullable(context.Background(), tftypes.NewValue(tftypes.String, "hello"), reflect.ValueOf(nullable), Options{}, tftypes.NewAttributePath())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err.Error())
+	}
+	got := res.Interface().(*nullableString)
+	if got.Null != false {
+		t.Errorf("Expected %v, got %v", false, got.Null)
+	}
+}
+
+func TestReflectNullable_null(t *testing.T) {
+	t.Parallel()
+
+	var nullable *nullableString
+	res, err := reflectNullable(context.Background(), tftypes.NewValue(tftypes.String, nil), reflect.ValueOf(nullable), Options{}, tftypes.NewAttributePath())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err.Error())
+	}
+	got := res.Interface().(*nullableString)
+	if got.Null != true {
+		t.Errorf("Expected %v, got %v", true, got.Null)
+	}
+}
+
+func TestReflectNullable_error(t *testing.T) {
+	t.Parallel()
+
+	var nullable *nullableStringError
+	_, err := reflectNullable(context.Background(), tftypes.NewValue(tftypes.String, "hello"), reflect.ValueOf(nullable), Options{}, tftypes.NewAttributePath())
+	if expected := ": this is an error"; err == nil || err.Error() != expected {
+		t.Errorf("Expected error to be %q, got %v", expected, err)
+	}
+}
+
+func TestReflectAttributeValue_unknown(t *testing.T) {
+	t.Parallel()
+
+	var av *attributeValue
+	res, err := reflectAttributeValue(context.Background(), tftypes.NewValue(tftypes.String, tftypes.UnknownValue), reflect.ValueOf(av), Options{}, tftypes.NewAttributePath())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err.Error())
+	}
+	got := res.Interface().(*attributeValue)
+	expected := &attributeValue{Unknown: true}
+	if !got.Equal(expected) {
+		t.Errorf("Expected %+v, got %+v", expected, got)
+	}
+}
+
+func TestReflectAttributeValue_null(t *testing.T) {
+	t.Parallel()
+
+	var av *attributeValue
+	res, err := reflectAttributeValue(context.Background(), tftypes.NewValue(tftypes.String, nil), reflect.ValueOf(av), Options{}, tftypes.NewAttributePath())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err.Error())
+	}
+	got := res.Interface().(*attributeValue)
+	expected := &attributeValue{Null: true}
+	if !got.Equal(expected) {
+		t.Errorf("Expected %+v, got %+v", expected, got)
+	}
+}
+
+func TestReflectAttributeValue_value(t *testing.T) {
+	t.Parallel()
+
+	var av *attributeValue
+	res, err := reflectAttributeValue(context.Background(), tftypes.NewValue(tftypes.String, "hello"), reflect.ValueOf(av), Options{}, tftypes.NewAttributePath())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err.Error())
+	}
+	got := res.Interface().(*attributeValue)
+	expected := &attributeValue{Value: "hello"}
+	if !got.Equal(expected) {
+		t.Errorf("Expected %+v, got %+v", expected, got)
+	}
+}
+
+func TestReflectAttributeValue_error(t *testing.T) {
+	t.Parallel()
+
+	var av *attributeValueError
+	_, err := reflectAttributeValue(context.Background(), tftypes.NewValue(tftypes.String, "hello"), reflect.ValueOf(av), Options{}, tftypes.NewAttributePath())
+	if expected := ": this is an error"; err == nil || err.Error() != expected {
+		t.Errorf("Expected error to be %q, got %v", expected, err)
+	}
+}
+
+func TestReflectValueConverter_unknown(t *testing.T) {
+	t.Parallel()
+
+	var vc *valueConverter
+	res, err := reflectValueConverter(context.Background(), tftypes.NewValue(tftypes.String, tftypes.UnknownValue), reflect.ValueOf(vc), Options{}, tftypes.NewAttributePath())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err.Error())
+	}
+	got := res.Interface().(*valueConverter)
+	expected := &valueConverter{unknown: true}
+	if !got.Equal(expected) {
+		t.Errorf("Expected %+v, got %+v", expected, got)
+	}
+}
+
+func TestReflectValueConverter_null(t *testing.T) {
+	t.Parallel()
+
+	var vc *valueConverter
+	res, err := reflectValueConverter(context.Background(), tftypes.NewValue(tftypes.String, nil), reflect.ValueOf(vc), Options{}, tftypes.NewAttributePath())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err.Error())
+	}
+	got := res.Interface().(*valueConverter)
+	expected := &valueConverter{null: true}
+	if !got.Equal(expected) {
+		t.Errorf("Expected %+v, got %+v", expected, got)
+	}
+}
+
+func TestReflectValueConverter_value(t *testing.T) {
+	t.Parallel()
+
+	var vc *valueConverter
+	res, err := reflectValueConverter(context.Background(), tftypes.NewValue(tftypes.String, "hello"), reflect.ValueOf(vc), Options{}, tftypes.NewAttributePath())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err.Error())
+	}
+	got := res.Interface().(*valueConverter)
+	expected := &valueConverter{value: "hello"}
+	if !got.Equal(expected) {
+		t.Errorf("Expected %+v, got %+v", expected, got)
+	}
+}
+
+func TestReflectValueConverter_error(t *testing.T) {
+	t.Parallel()
+
+	var vc *valueConverterError
+	_, err := reflectValueConverter(context.Background(), tftypes.NewValue(tftypes.String, "hello"), reflect.ValueOf(vc), Options{}, tftypes.NewAttributePath())
+	if expected := ": this is an error"; err == nil || err.Error() != expected {
+		t.Errorf("Expected error to be %q, got %v", expected, err)
+	}
+}

--- a/internal/reflect/map.go
+++ b/internal/reflect/map.go
@@ -1,0 +1,54 @@
+package reflect
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// create a map value that matches the type of `target`, and populate it with
+// the contents of `val`.
+func reflectMap(ctx context.Context, val tftypes.Value, target reflect.Value, opts Options, path *tftypes.AttributePath) (reflect.Value, error) {
+	underlyingValue := trueReflectValue(target)
+
+	// this only works with maps, so check that out first
+	if underlyingValue.Kind() != reflect.Map {
+		return target, path.NewErrorf("expected a map type, got %s", target.Type())
+	}
+	if !val.Type().Is(tftypes.Map{}) {
+		return target, path.NewErrorf("can't reflect %s into a map, must be a map", val.Type().String())
+	}
+
+	// we need our value to become a map of values so we can iterate over
+	// them and handle them individually
+	values := map[string]tftypes.Value{}
+	err := val.As(&values)
+	if err != nil {
+		return target, path.NewError(err)
+	}
+
+	// we need to know the type the slice is wrapping
+	elemType := underlyingValue.Type().Elem()
+
+	// we want an empty version of the map
+	m := reflect.MakeMapWithSize(underlyingValue.Type(), len(values))
+
+	// go over each of the values passed in, create a Go value of the right
+	// type for them, and add it to our new map
+	for key, value := range values {
+		// create a new Go value of the type that can go in the map
+		targetValue := reflect.Zero(elemType)
+
+		// update our path so we can have nice errors
+		path := path.WithElementKeyString(key)
+
+		// reflect the value into our new target
+		result, err := buildReflectValue(ctx, value, targetValue, opts, path)
+		if err != nil {
+			return target, err
+		}
+		m.SetMapIndex(reflect.ValueOf(key), result)
+	}
+	return m, nil
+}

--- a/internal/reflect/map_test.go
+++ b/internal/reflect/map_test.go
@@ -1,0 +1,40 @@
+package reflect
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func TestReflectMap_string(t *testing.T) {
+	t.Parallel()
+
+	var m map[string]string
+
+	expected := map[string]string{
+		"a": "red",
+		"b": "blue",
+		"c": "green",
+	}
+
+	result, err := reflectMap(context.Background(), tftypes.NewValue(tftypes.Map{
+		AttributeType: tftypes.String,
+	}, map[string]tftypes.Value{
+		"a": tftypes.NewValue(tftypes.String, "red"),
+		"b": tftypes.NewValue(tftypes.String, "blue"),
+		"c": tftypes.NewValue(tftypes.String, "green"),
+	}), reflect.ValueOf(m), Options{}, tftypes.NewAttributePath())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	reflect.ValueOf(&m).Elem().Set(result)
+	for k, v := range expected {
+		if got, ok := m[k]; !ok {
+			t.Errorf("Expected %q to be set to %q, wasn't set", k, v)
+		} else if got != v {
+			t.Errorf("Expected %q to be %q, got %q", k, v, got)
+		}
+	}
+}

--- a/internal/reflect/number.go
+++ b/internal/reflect/number.go
@@ -1,0 +1,185 @@
+package reflect
+
+import (
+	"context"
+	"math"
+	"math/big"
+	"reflect"
+	"strconv"
+
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// create a number and populate it with the data in val. Numbers will use
+// whatever type `target` is, as long as it's a valid number type: any of the
+// builtin int, uint, or float types, or *big.Float or *big.Int. reflectNumber
+// will loudly fail when a number cannot be losslessly represented using the
+// target type, unless opts.AllowRoundingNumbers is set to true, which you
+// should consider not doing because Terraform does not like when you round
+// things, as a general rule of thumb.
+func reflectNumber(ctx context.Context, val tftypes.Value, target reflect.Value, opts Options, path *tftypes.AttributePath) (reflect.Value, error) {
+	result := big.NewFloat(0)
+	err := val.As(&result)
+	if err != nil {
+		return target, path.NewError(err)
+	}
+	roundingError := path.NewErrorf("can't store %s in %s", result.String(), target.Type())
+	switch target.Type() {
+	case reflect.TypeOf(big.NewFloat(0)):
+		return reflect.ValueOf(result), nil
+	case reflect.TypeOf(big.NewInt(0)):
+		intResult, acc := result.Int(nil)
+		if acc != big.Exact && !opts.AllowRoundingNumbers {
+			return reflect.ValueOf(result), roundingError
+		}
+		return reflect.ValueOf(intResult), nil
+	}
+	switch target.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32,
+		reflect.Int64:
+		intResult, acc := result.Int64()
+		if acc != big.Exact && !opts.AllowRoundingNumbers {
+			return target, roundingError
+		}
+		switch target.Kind() {
+		case reflect.Int:
+			if strconv.IntSize == 32 && intResult > math.MaxInt32 {
+				if !opts.AllowRoundingNumbers {
+					return target, roundingError
+				}
+				intResult = math.MaxInt32
+			}
+			if strconv.IntSize == 32 && intResult < math.MinInt32 {
+				if !opts.AllowRoundingNumbers {
+					return target, roundingError
+				}
+				intResult = math.MinInt32
+			}
+			return reflect.ValueOf(int(intResult)), nil
+		case reflect.Int8:
+			if intResult > math.MaxInt8 {
+				if !opts.AllowRoundingNumbers {
+					return target, roundingError
+				}
+				intResult = math.MaxInt8
+			}
+			if intResult < math.MinInt8 {
+				if !opts.AllowRoundingNumbers {
+					return target, roundingError
+				}
+				intResult = math.MinInt8
+			}
+			return reflect.ValueOf(int8(intResult)), nil
+		case reflect.Int16:
+			if intResult > math.MaxInt16 {
+				if !opts.AllowRoundingNumbers {
+					return target, roundingError
+				}
+				intResult = math.MaxInt16
+			}
+			if intResult < math.MinInt16 {
+				if !opts.AllowRoundingNumbers {
+					return target, roundingError
+				}
+				intResult = math.MinInt16
+			}
+			return reflect.ValueOf(int16(intResult)), nil
+		case reflect.Int32:
+			if intResult > math.MaxInt32 {
+				if !opts.AllowRoundingNumbers {
+					return target, roundingError
+				}
+				intResult = math.MaxInt32
+			}
+			if intResult < math.MinInt32 {
+				if !opts.AllowRoundingNumbers {
+					return target, roundingError
+				}
+				intResult = math.MinInt32
+			}
+			return reflect.ValueOf(int32(intResult)), nil
+		case reflect.Int64:
+			return reflect.ValueOf(intResult), nil
+		}
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32,
+		reflect.Uint64:
+		uintResult, acc := result.Uint64()
+		if acc != big.Exact && !opts.AllowRoundingNumbers {
+			return target, roundingError
+		}
+		switch target.Kind() {
+		case reflect.Uint:
+			if strconv.IntSize == 32 && uintResult > math.MaxUint32 {
+				if !opts.AllowRoundingNumbers {
+					return target, roundingError
+				}
+				uintResult = math.MaxUint32
+			}
+			return reflect.ValueOf(uint(uintResult)), nil
+		case reflect.Uint8:
+			if uintResult > math.MaxUint8 {
+				if !opts.AllowRoundingNumbers {
+					return target, roundingError
+				}
+				uintResult = math.MaxUint8
+			}
+			return reflect.ValueOf(uint8(uintResult)), nil
+		case reflect.Uint16:
+			if uintResult > math.MaxUint16 {
+				if !opts.AllowRoundingNumbers {
+					return target, roundingError
+				}
+				uintResult = math.MaxUint16
+			}
+			return reflect.ValueOf(uint16(uintResult)), nil
+		case reflect.Uint32:
+			if uintResult > math.MaxUint32 {
+				if !opts.AllowRoundingNumbers {
+					return target, roundingError
+				}
+				uintResult = math.MaxUint32
+			}
+			return reflect.ValueOf(uint32(uintResult)), nil
+		case reflect.Uint64:
+			return reflect.ValueOf(uintResult), nil
+		}
+	case reflect.Float32:
+		floatResult, acc := result.Float32()
+		if acc != big.Exact && !opts.AllowRoundingNumbers {
+			return target, roundingError
+		} else if acc == big.Above {
+			floatResult = math.MaxFloat32
+		} else if acc == big.Below {
+			floatResult = math.SmallestNonzeroFloat32
+		} else if acc != big.Exact {
+			return target, path.NewErrorf("unsure how to round %s and %f", acc, floatResult)
+		}
+		return reflect.ValueOf(floatResult), nil
+	case reflect.Float64:
+		floatResult, acc := result.Float64()
+		if acc != big.Exact && !opts.AllowRoundingNumbers {
+			return target, roundingError
+		}
+		if acc == big.Above {
+			if floatResult == math.Inf(1) || floatResult == math.MaxFloat64 {
+				floatResult = math.MaxFloat64
+			} else if floatResult == 0.0 || floatResult == math.SmallestNonzeroFloat64 {
+				floatResult = -math.SmallestNonzeroFloat64
+			} else {
+				return target, path.NewErrorf("not sure how to round %s and %f", acc, floatResult)
+			}
+		} else if acc == big.Below {
+			if floatResult == math.Inf(-1) || floatResult == -math.MaxFloat64 {
+				floatResult = -math.MaxFloat64
+			} else if floatResult == -0.0 || floatResult == -math.SmallestNonzeroFloat64 {
+				floatResult = math.SmallestNonzeroFloat64
+			} else {
+				return target, path.NewErrorf("not sure how to round %s and %f", acc, floatResult)
+			}
+		} else if acc != big.Exact {
+			return target, path.NewErrorf("not sure how to round %s and %f", acc, floatResult)
+		}
+		return reflect.ValueOf(floatResult), nil
+	}
+	return target, path.NewErrorf("can't convert number to %s", target.Type())
+}

--- a/internal/reflect/number_test.go
+++ b/internal/reflect/number_test.go
@@ -1,0 +1,1060 @@
+package reflect
+
+import (
+	"context"
+	"math"
+	"math/big"
+	"reflect"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+var (
+	overflowInt, _, _            = big.ParseFloat("9223372036854775808", 10, 53, big.ToPositiveInf)
+	overflowUint, _, _           = big.ParseFloat("18446744073709551616", 10, 53, big.ToPositiveInf)
+	overflowFloat, _, _          = big.ParseFloat("1e10000", 10, 53, big.ToPositiveInf)
+	overflowNegativeFloat, _, _  = big.ParseFloat("-1e10000", 10, 53, big.ToPositiveInf)
+	underflowInt, _, _           = big.ParseFloat("-9223372036854775809", 10, 53, big.ToNegativeInf)
+	underflowFloat, _, _         = big.ParseFloat("1e-1000", 10, 0, big.ToNegativeInf)
+	underflowNegativeFloat, _, _ = big.ParseFloat("-1e-1000", 10, 0, big.ToNegativeInf)
+)
+
+func TestReflectNumber_bigFloat(t *testing.T) {
+	t.Parallel()
+
+	var f *big.Float
+
+	result, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, 123456), reflect.ValueOf(f), Options{}, tftypes.NewAttributePath())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	reflect.ValueOf(&f).Elem().Set(result)
+	if f == nil {
+		t.Error("Expected value, got nil")
+		return
+	}
+	if f.Cmp(big.NewFloat(123456)) != 0 {
+		t.Errorf("Expected %v, got %v", big.NewFloat(123456), f)
+	}
+}
+
+func TestReflectNumber_bigInt(t *testing.T) {
+	t.Parallel()
+
+	var n *big.Int
+
+	result, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, 123456), reflect.ValueOf(n), Options{}, tftypes.NewAttributePath())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	reflect.ValueOf(&n).Elem().Set(result)
+	if n == nil {
+		t.Error("Expected value, got nil")
+		return
+	}
+	if n.Cmp(big.NewInt(123456)) != 0 {
+		t.Errorf("Expected %v, got %v", big.NewInt(123456), n)
+	}
+}
+
+func TestReflectNumber_bigIntRounded(t *testing.T) {
+	t.Parallel()
+
+	var n *big.Int
+
+	result, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, 123456.123), reflect.ValueOf(n), Options{
+		AllowRoundingNumbers: true,
+	}, tftypes.NewAttributePath())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	reflect.ValueOf(&n).Elem().Set(result)
+	if n == nil {
+		t.Error("Expected value, got nil")
+		return
+	}
+	if n.Cmp(big.NewInt(123456)) != 0 {
+		t.Errorf("Expected %v, got %v", big.NewInt(123456), n)
+	}
+}
+
+func TestReflectNumber_bigIntRoundingError(t *testing.T) {
+	t.Parallel()
+
+	var n *big.Int
+
+	_, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, 123456.123), reflect.ValueOf(n), Options{}, tftypes.NewAttributePath())
+	if err == nil {
+		t.Error("Expected error, got none")
+		return
+	}
+	if expected := ": can't store 123456.123 in *big.Int"; expected != err.Error() {
+		t.Errorf("Expected error to be %q, got %q", expected, err.Error())
+	}
+}
+
+func TestReflectNumber_int(t *testing.T) {
+	t.Parallel()
+
+	var n int
+
+	result, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, 123), reflect.ValueOf(n), Options{}, tftypes.NewAttributePath())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	reflect.ValueOf(&n).Elem().Set(result)
+	if n != 123 {
+		t.Errorf("Expected %v, got %v", 123, n)
+	}
+}
+
+func TestReflectNumber_intOverflow(t *testing.T) {
+	t.Parallel()
+
+	var n int
+
+	result, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, overflowInt), reflect.ValueOf(n), Options{
+		AllowRoundingNumbers: true,
+	}, tftypes.NewAttributePath())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	reflect.ValueOf(&n).Elem().Set(result)
+	if strconv.IntSize == 64 && n != math.MaxInt64 {
+		t.Errorf("Expected %v, got %v", math.MaxInt64, n)
+	} else if strconv.IntSize == 32 && n != math.MaxInt32 {
+		t.Errorf("Expected %v, got %v", math.MaxInt32, n)
+	}
+}
+
+func TestReflectNumber_intOverflowError(t *testing.T) {
+	t.Parallel()
+
+	var n int
+
+	_, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, overflowInt), reflect.ValueOf(n), Options{}, tftypes.NewAttributePath())
+	if err == nil {
+		t.Error("Expected error, got none")
+		return
+	}
+	if expected := ": can't store " + overflowInt.String() + " in int"; expected != err.Error() {
+		t.Errorf("Expected error to be %q, got %q", expected, err.Error())
+	}
+}
+
+func TestReflectNumber_intUnderflow(t *testing.T) {
+	t.Parallel()
+
+	var n int
+
+	result, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, underflowInt), reflect.ValueOf(n), Options{
+		AllowRoundingNumbers: true,
+	}, tftypes.NewAttributePath())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	reflect.ValueOf(&n).Elem().Set(result)
+	if strconv.IntSize == 64 && n != math.MinInt64 {
+		t.Errorf("Expected %v, got %v", math.MinInt64, n)
+	} else if strconv.IntSize == 32 && n != math.MinInt32 {
+		t.Errorf("Expected %v, got %v", math.MinInt32, n)
+	}
+}
+
+func TestReflectNumber_intUnderflowError(t *testing.T) {
+	t.Parallel()
+
+	var n int
+
+	_, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, underflowInt), reflect.ValueOf(n), Options{}, tftypes.NewAttributePath())
+	if err == nil {
+		t.Error("Expected error, got none")
+		return
+	}
+	if expected := ": can't store " + underflowInt.String() + " in int"; expected != err.Error() {
+		t.Errorf("Expected error to be %q, got %q", expected, err.Error())
+	}
+}
+
+func TestReflectNumber_int8(t *testing.T) {
+	t.Parallel()
+
+	var n int8
+
+	result, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, 123), reflect.ValueOf(n), Options{}, tftypes.NewAttributePath())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	reflect.ValueOf(&n).Elem().Set(result)
+	if n != 123 {
+		t.Errorf("Expected %v, got %v", 123, n)
+	}
+}
+
+func TestReflectNumber_int8Overflow(t *testing.T) {
+	t.Parallel()
+
+	var n int8
+
+	result, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, math.MaxInt8+1), reflect.ValueOf(n), Options{
+		AllowRoundingNumbers: true,
+	}, tftypes.NewAttributePath())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	reflect.ValueOf(&n).Elem().Set(result)
+	if n != math.MaxInt8 {
+		t.Errorf("Expected %v, got %v", math.MaxInt8, n)
+	}
+}
+
+func TestReflectNumber_int8OverflowError(t *testing.T) {
+	t.Parallel()
+
+	var n int8
+
+	_, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, math.MaxInt8+1), reflect.ValueOf(n), Options{}, tftypes.NewAttributePath())
+	if err == nil {
+		t.Error("Expected error, got none")
+		return
+	}
+	if expected := ": can't store 128 in int8"; expected != err.Error() {
+		t.Errorf("Expected error to be %q, got %q", expected, err.Error())
+	}
+}
+
+func TestReflectNumber_int8Underflow(t *testing.T) {
+	t.Parallel()
+
+	var n int8
+
+	result, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, math.MinInt8-1), reflect.ValueOf(n), Options{
+		AllowRoundingNumbers: true,
+	}, tftypes.NewAttributePath())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	reflect.ValueOf(&n).Elem().Set(result)
+	if n != math.MinInt8 {
+		t.Errorf("Expected %v, got %v", math.MinInt8, n)
+	}
+}
+
+func TestReflectNumber_int8UnderflowError(t *testing.T) {
+	t.Parallel()
+
+	var n int8
+
+	_, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, math.MinInt8-1), reflect.ValueOf(n), Options{}, tftypes.NewAttributePath())
+	if err == nil {
+		t.Error("Expected error, got none")
+		return
+	}
+	if expected := ": can't store -129 in int8"; expected != err.Error() {
+		t.Errorf("Expected error to be %q, got %q", expected, err.Error())
+	}
+}
+
+func TestReflectNumber_int16(t *testing.T) {
+	t.Parallel()
+}
+
+func TestReflectNumber_int16Overflow(t *testing.T) {
+	t.Parallel()
+
+	var n int16
+
+	result, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, math.MaxInt16+1), reflect.ValueOf(n), Options{
+		AllowRoundingNumbers: true,
+	}, tftypes.NewAttributePath())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	reflect.ValueOf(&n).Elem().Set(result)
+	if n != math.MaxInt16 {
+		t.Errorf("Expected %v, got %v", math.MaxInt16, n)
+	}
+}
+
+func TestReflectNumber_int16OverflowError(t *testing.T) {
+	t.Parallel()
+
+	var n int16
+
+	_, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, math.MaxInt16+1), reflect.ValueOf(n), Options{}, tftypes.NewAttributePath())
+	if err == nil {
+		t.Error("Expected error, got none")
+		return
+	}
+	if expected := ": can't store 32768 in int16"; expected != err.Error() {
+		t.Errorf("Expected error to be %q, got %q", expected, err.Error())
+	}
+}
+
+func TestReflectNumber_int16Underflow(t *testing.T) {
+	t.Parallel()
+
+	var n int16
+
+	result, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, math.MinInt16-1), reflect.ValueOf(n), Options{
+		AllowRoundingNumbers: true,
+	}, tftypes.NewAttributePath())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	reflect.ValueOf(&n).Elem().Set(result)
+	if n != math.MinInt16 {
+		t.Errorf("Expected %v, got %v", math.MinInt16, n)
+	}
+}
+
+func TestReflectNumber_int16UnderflowError(t *testing.T) {
+	t.Parallel()
+
+	var n int16
+
+	_, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, math.MinInt16-1), reflect.ValueOf(n), Options{}, tftypes.NewAttributePath())
+	if err == nil {
+		t.Error("Expected error, got none")
+		return
+	}
+	if expected := ": can't store -32769 in int16"; expected != err.Error() {
+		t.Errorf("Expected error to be %q, got %q", expected, err.Error())
+	}
+}
+
+func TestReflectNumber_int32(t *testing.T) {
+	t.Parallel()
+}
+
+func TestReflectNumber_int32Overflow(t *testing.T) {
+	t.Parallel()
+
+	var n int32
+
+	result, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, math.MaxInt32+1), reflect.ValueOf(n), Options{
+		AllowRoundingNumbers: true,
+	}, tftypes.NewAttributePath())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	reflect.ValueOf(&n).Elem().Set(result)
+	if n != math.MaxInt32 {
+		t.Errorf("Expected %v, got %v", math.MaxInt32, n)
+	}
+}
+
+func TestReflectNumber_int32OverflowError(t *testing.T) {
+	t.Parallel()
+
+	var n int32
+
+	_, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, math.MaxInt32+1), reflect.ValueOf(n), Options{}, tftypes.NewAttributePath())
+	if err == nil {
+		t.Error("Expected error, got none")
+		return
+	}
+	if expected := ": can't store 2147483648 in int32"; expected != err.Error() {
+		t.Errorf("Expected error to be %q, got %q", expected, err.Error())
+	}
+}
+
+func TestReflectNumber_int32Underflow(t *testing.T) {
+	t.Parallel()
+
+	var n int32
+
+	result, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, math.MinInt32-1), reflect.ValueOf(n), Options{
+		AllowRoundingNumbers: true,
+	}, tftypes.NewAttributePath())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	reflect.ValueOf(&n).Elem().Set(result)
+	if n != math.MinInt32 {
+		t.Errorf("Expected %v, got %v", math.MinInt32, n)
+	}
+}
+
+func TestReflectNumber_int32UnderflowError(t *testing.T) {
+	t.Parallel()
+
+	var n int32
+
+	_, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, math.MinInt32-1), reflect.ValueOf(n), Options{}, tftypes.NewAttributePath())
+	if err == nil {
+		t.Error("Expected error, got none")
+		return
+	}
+	if expected := ": can't store -2147483649 in int32"; expected != err.Error() {
+		t.Errorf("Expected error to be %q, got %q", expected, err.Error())
+	}
+}
+
+func TestReflectNumber_int64(t *testing.T) {
+	t.Parallel()
+
+	var n int64
+
+	result, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, 123), reflect.ValueOf(n), Options{}, tftypes.NewAttributePath())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	reflect.ValueOf(&n).Elem().Set(result)
+	if n != 123 {
+		t.Errorf("Expected %v, got %v", 123, n)
+	}
+}
+
+func TestReflectNumber_int64Overflow(t *testing.T) {
+	t.Parallel()
+
+	var n int64
+
+	result, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, overflowInt), reflect.ValueOf(n), Options{
+		AllowRoundingNumbers: true,
+	}, tftypes.NewAttributePath())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	reflect.ValueOf(&n).Elem().Set(result)
+	if n != math.MaxInt64 {
+		t.Errorf("Expected %v, got %v", math.MaxInt64, n)
+	}
+}
+
+func TestReflectNumber_int64OverflowError(t *testing.T) {
+	t.Parallel()
+
+	var n int64
+
+	_, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, overflowInt), reflect.ValueOf(n), Options{}, tftypes.NewAttributePath())
+	if err == nil {
+		t.Error("Expected error, got none")
+		return
+	}
+	if expected := ": can't store 9.223372037e+18 in int64"; expected != err.Error() {
+		t.Errorf("Expected error to be %q, got %q", expected, err.Error())
+	}
+}
+
+func TestReflectNumber_int64Underflow(t *testing.T) {
+	t.Parallel()
+
+	var n int64
+
+	result, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, underflowInt), reflect.ValueOf(n), Options{
+		AllowRoundingNumbers: true,
+	}, tftypes.NewAttributePath())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	reflect.ValueOf(&n).Elem().Set(result)
+	if n != math.MinInt64 {
+		t.Errorf("Expected %v, got %v", math.MinInt64, n)
+	}
+}
+
+func TestReflectNumber_int64UnderflowError(t *testing.T) {
+	t.Parallel()
+
+	var n int64
+
+	_, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, underflowInt), reflect.ValueOf(n), Options{}, tftypes.NewAttributePath())
+	if err == nil {
+		t.Error("Expected error, got none")
+		return
+	}
+	if expected := ": can't store -9.223372037e+18 in int64"; expected != err.Error() {
+		t.Errorf("Expected error to be %q, got %q", expected, err.Error())
+	}
+}
+
+func TestReflectNumber_uint(t *testing.T) {
+	t.Parallel()
+
+	var n uint
+
+	result, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, 123), reflect.ValueOf(n), Options{}, tftypes.NewAttributePath())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	reflect.ValueOf(&n).Elem().Set(result)
+	if n != 123 {
+		t.Errorf("Expected %v, got %v", 123, n)
+	}
+}
+
+func TestReflectNumber_uintOverflow(t *testing.T) {
+	t.Parallel()
+
+	var n uint
+
+	result, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, overflowUint), reflect.ValueOf(n), Options{
+		AllowRoundingNumbers: true,
+	}, tftypes.NewAttributePath())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	reflect.ValueOf(&n).Elem().Set(result)
+	if strconv.IntSize == 64 && n != math.MaxUint64 {
+		t.Errorf("Expected %v, got %v", uint64(math.MaxUint64), n)
+	} else if strconv.IntSize == 32 && n != math.MaxUint32 {
+		t.Errorf("Expected %v, got %v", math.MaxUint32, n)
+	}
+}
+
+func TestReflectNumber_uintOverflowError(t *testing.T) {
+	t.Parallel()
+
+	var n uint
+
+	_, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, overflowUint), reflect.ValueOf(n), Options{}, tftypes.NewAttributePath())
+	if err == nil {
+		t.Error("Expected error, got none")
+		return
+	}
+	if expected := ": can't store " + overflowUint.String() + " in uint"; expected != err.Error() {
+		t.Errorf("Expected error to be %q, got %q", expected, err.Error())
+	}
+}
+
+func TestReflectNumber_uintUnderflow(t *testing.T) {
+	t.Parallel()
+
+	var n uint
+
+	result, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, -1), reflect.ValueOf(n), Options{
+		AllowRoundingNumbers: true,
+	}, tftypes.NewAttributePath())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	reflect.ValueOf(&n).Elem().Set(result)
+	if n != 0 {
+		t.Errorf("Expected %v, got %v", 0, n)
+	}
+}
+
+func TestReflectNumber_uintUnderflowError(t *testing.T) {
+	t.Parallel()
+
+	var n uint
+
+	_, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, -1), reflect.ValueOf(n), Options{}, tftypes.NewAttributePath())
+	if err == nil {
+		t.Error("Expected error, got none")
+		return
+	}
+	if expected := ": can't store -1 in uint"; expected != err.Error() {
+		t.Errorf("Expected error to be %q, got %q", expected, err.Error())
+	}
+}
+
+func TestReflectNumber_uint8(t *testing.T) {
+	t.Parallel()
+
+	var n uint8
+
+	result, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, 123), reflect.ValueOf(n), Options{}, tftypes.NewAttributePath())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	reflect.ValueOf(&n).Elem().Set(result)
+	if n != 123 {
+		t.Errorf("Expected %v, got %v", 123, n)
+	}
+}
+
+func TestReflectNumber_uint8Overflow(t *testing.T) {
+	t.Parallel()
+
+	var n uint8
+
+	result, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, math.MaxUint8+1), reflect.ValueOf(n), Options{
+		AllowRoundingNumbers: true,
+	}, tftypes.NewAttributePath())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	reflect.ValueOf(&n).Elem().Set(result)
+	if n != math.MaxUint8 {
+		t.Errorf("Expected %v, got %v", math.MaxUint8, n)
+	}
+}
+
+func TestReflectNumber_uint8OverflowError(t *testing.T) {
+	t.Parallel()
+
+	var n uint8
+
+	_, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, math.MaxUint8+1), reflect.ValueOf(n), Options{}, tftypes.NewAttributePath())
+	if err == nil {
+		t.Error("Expected error, got none")
+		return
+	}
+	if expected := ": can't store 256 in uint8"; expected != err.Error() {
+		t.Errorf("Expected error to be %q, got %q", expected, err.Error())
+	}
+}
+
+func TestReflectNumber_uint8Underflow(t *testing.T) {
+	t.Parallel()
+
+	var n uint8
+
+	result, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, -1), reflect.ValueOf(n), Options{
+		AllowRoundingNumbers: true,
+	}, tftypes.NewAttributePath())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	reflect.ValueOf(&n).Elem().Set(result)
+	if n != 0 {
+		t.Errorf("Expected %v, got %v", 0, n)
+	}
+}
+
+func TestReflectNumber_uint8UnderflowError(t *testing.T) {
+	t.Parallel()
+
+	var n uint8
+
+	_, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, -1), reflect.ValueOf(n), Options{}, tftypes.NewAttributePath())
+	if err == nil {
+		t.Error("Expected error, got none")
+		return
+	}
+	if expected := ": can't store -1 in uint8"; expected != err.Error() {
+		t.Errorf("Expected error to be %q, got %q", expected, err.Error())
+	}
+}
+
+func TestReflectNumber_uint16(t *testing.T) {
+	t.Parallel()
+}
+
+func TestReflectNumber_uint16Overflow(t *testing.T) {
+	t.Parallel()
+
+	var n uint16
+
+	result, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, math.MaxUint16+1), reflect.ValueOf(n), Options{
+		AllowRoundingNumbers: true,
+	}, tftypes.NewAttributePath())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	reflect.ValueOf(&n).Elem().Set(result)
+	if n != math.MaxUint16 {
+		t.Errorf("Expected %v, got %v", math.MaxUint16, n)
+	}
+}
+
+func TestReflectNumber_uint16OverflowError(t *testing.T) {
+	t.Parallel()
+
+	var n uint16
+
+	_, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, math.MaxUint16+1), reflect.ValueOf(n), Options{}, tftypes.NewAttributePath())
+	if err == nil {
+		t.Error("Expected error, got none")
+		return
+	}
+	if expected := ": can't store 65536 in uint16"; expected != err.Error() {
+		t.Errorf("Expected error to be %q, got %q", expected, err.Error())
+	}
+}
+
+func TestReflectNumber_uint16Underflow(t *testing.T) {
+	t.Parallel()
+
+	var n uint16
+
+	result, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, -1), reflect.ValueOf(n), Options{
+		AllowRoundingNumbers: true,
+	}, tftypes.NewAttributePath())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	reflect.ValueOf(&n).Elem().Set(result)
+	if n != 0 {
+		t.Errorf("Expected %v, got %v", 0, n)
+	}
+}
+
+func TestReflectNumber_uint16UnderflowError(t *testing.T) {
+	t.Parallel()
+
+	var n uint16
+
+	_, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, -1), reflect.ValueOf(n), Options{}, tftypes.NewAttributePath())
+	if err == nil {
+		t.Error("Expected error, got none")
+		return
+	}
+	if expected := ": can't store -1 in uint16"; expected != err.Error() {
+		t.Errorf("Expected error to be %q, got %q", expected, err.Error())
+	}
+}
+
+func TestReflectNumber_uint32(t *testing.T) {
+	t.Parallel()
+}
+
+func TestReflectNumber_uint32Overflow(t *testing.T) {
+	t.Parallel()
+
+	var n uint32
+
+	result, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, math.MaxUint32+1), reflect.ValueOf(n), Options{
+		AllowRoundingNumbers: true,
+	}, tftypes.NewAttributePath())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	reflect.ValueOf(&n).Elem().Set(result)
+	if n != math.MaxUint32 {
+		t.Errorf("Expected %v, got %v", math.MaxUint32, n)
+	}
+}
+
+func TestReflectNumber_uint32OverflowError(t *testing.T) {
+	t.Parallel()
+
+	var n uint32
+
+	_, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, math.MaxUint32+1), reflect.ValueOf(n), Options{}, tftypes.NewAttributePath())
+	if err == nil {
+		t.Error("Expected error, got none")
+		return
+	}
+	if expected := ": can't store 4294967296 in uint32"; expected != err.Error() {
+		t.Errorf("Expected error to be %q, got %q", expected, err.Error())
+	}
+}
+
+func TestReflectNumber_uint32Underflow(t *testing.T) {
+	t.Parallel()
+
+	var n uint32
+
+	result, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, -1), reflect.ValueOf(n), Options{
+		AllowRoundingNumbers: true,
+	}, tftypes.NewAttributePath())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	reflect.ValueOf(&n).Elem().Set(result)
+	if n != 0 {
+		t.Errorf("Expected %v, got %v", 0, n)
+	}
+}
+
+func TestReflectNumber_uint32UnderflowError(t *testing.T) {
+	t.Parallel()
+
+	var n uint32
+
+	_, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, -1), reflect.ValueOf(n), Options{}, tftypes.NewAttributePath())
+	if err == nil {
+		t.Error("Expected error, got none")
+		return
+	}
+	if expected := ": can't store -1 in uint32"; expected != err.Error() {
+		t.Errorf("Expected error to be %q, got %q", expected, err.Error())
+	}
+}
+
+func TestReflectNumber_uint64(t *testing.T) {
+	t.Parallel()
+
+	var n uint64
+
+	result, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, 123), reflect.ValueOf(n), Options{}, tftypes.NewAttributePath())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	reflect.ValueOf(&n).Elem().Set(result)
+	if n != 123 {
+		t.Errorf("Expected %v, got %v", 123, n)
+	}
+}
+
+func TestReflectNumber_uint64Overflow(t *testing.T) {
+	t.Parallel()
+
+	var n uint64
+
+	result, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, overflowUint), reflect.ValueOf(n), Options{
+		AllowRoundingNumbers: true,
+	}, tftypes.NewAttributePath())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	reflect.ValueOf(&n).Elem().Set(result)
+	if n != math.MaxUint64 {
+		t.Errorf("Expected %v, got %v", uint64(math.MaxUint64), n)
+	}
+}
+
+func TestReflectNumber_uint64OverflowError(t *testing.T) {
+	t.Parallel()
+
+	var n uint64
+
+	_, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, overflowUint), reflect.ValueOf(n), Options{}, tftypes.NewAttributePath())
+	if err == nil {
+		t.Error("Expected error, got none")
+		return
+	}
+	if expected := ": can't store 1.844674407e+19 in uint64"; expected != err.Error() {
+		t.Errorf("Expected error to be %q, got %q", expected, err.Error())
+	}
+}
+
+func TestReflectNumber_uint64Underflow(t *testing.T) {
+	t.Parallel()
+
+	var n uint64
+
+	result, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, -1), reflect.ValueOf(n), Options{
+		AllowRoundingNumbers: true,
+	}, tftypes.NewAttributePath())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	reflect.ValueOf(&n).Elem().Set(result)
+	if n != 0 {
+		t.Errorf("Expected %v, got %v", 0, n)
+	}
+}
+
+func TestReflectNumber_uint64UnderflowError(t *testing.T) {
+	t.Parallel()
+
+	var n uint64
+
+	_, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, -1), reflect.ValueOf(n), Options{}, tftypes.NewAttributePath())
+	if err == nil {
+		t.Error("Expected error, got none")
+		return
+	}
+	if expected := ": can't store -1 in uint64"; expected != err.Error() {
+		t.Errorf("Expected error to be %q, got %q", expected, err.Error())
+	}
+}
+
+func TestReflectNumber_float32(t *testing.T) {
+	t.Parallel()
+}
+
+func TestReflectNumber_float32Overflow(t *testing.T) {
+	t.Parallel()
+
+	var n float32
+
+	result, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, math.MaxFloat64), reflect.ValueOf(n), Options{
+		AllowRoundingNumbers: true,
+	}, tftypes.NewAttributePath())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	reflect.ValueOf(&n).Elem().Set(result)
+	if n != math.MaxFloat32 {
+		t.Errorf("Expected %v, got %v", math.MaxFloat32, n)
+	}
+}
+
+func TestReflectNumber_float32OverflowError(t *testing.T) {
+	t.Parallel()
+
+	var n float32
+
+	result, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, math.MaxFloat64), reflect.ValueOf(n), Options{}, tftypes.NewAttributePath())
+	if err == nil {
+		t.Error("Expected error, got none")
+		return
+	}
+	reflect.ValueOf(&n).Elem().Set(result)
+	if expected := ": can't store 1.797693135e+308 in float32"; expected != err.Error() {
+		t.Errorf("Expected error to be %q, got %q", expected, err.Error())
+	}
+}
+
+func TestReflectNumber_float32Underflow(t *testing.T) {
+	t.Parallel()
+
+	var n float32
+
+	result, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, math.SmallestNonzeroFloat64), reflect.ValueOf(n), Options{
+		AllowRoundingNumbers: true,
+	}, tftypes.NewAttributePath())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	reflect.ValueOf(&n).Elem().Set(result)
+	if n != math.SmallestNonzeroFloat32 {
+		t.Errorf("Expected %v, got %v", math.SmallestNonzeroFloat32, n)
+	}
+}
+
+func TestReflectNumber_float32UnderflowError(t *testing.T) {
+	t.Parallel()
+
+	var n float32
+
+	_, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, math.SmallestNonzeroFloat64), reflect.ValueOf(n), Options{}, tftypes.NewAttributePath())
+	if err == nil {
+		t.Error("Expected error, got none")
+		return
+	}
+	if expected := ": can't store 4.940656458e-324 in float32"; expected != err.Error() {
+		t.Errorf("Expected error to be %q, got %q", expected, err.Error())
+	}
+}
+
+func TestReflectNumber_float64(t *testing.T) {
+	t.Parallel()
+
+	var n float64
+
+	result, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, 123), reflect.ValueOf(n), Options{}, tftypes.NewAttributePath())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	reflect.ValueOf(&n).Elem().Set(result)
+	if n != 123 {
+		t.Errorf("Expected %v, got %v", 123, n)
+	}
+}
+
+func TestReflectNumber_float64Overflow(t *testing.T) {
+	t.Parallel()
+
+	var n float64
+
+	result, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, overflowFloat), reflect.ValueOf(n), Options{
+		AllowRoundingNumbers: true,
+	}, tftypes.NewAttributePath())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	reflect.ValueOf(&n).Elem().Set(result)
+	if n != math.MaxFloat64 {
+		t.Errorf("Expected %v, got %v", math.MaxFloat64, n)
+	}
+}
+
+func TestReflectNumber_float64OverflowError(t *testing.T) {
+	t.Parallel()
+
+	var n float64
+
+	_, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, overflowFloat), reflect.ValueOf(n), Options{}, tftypes.NewAttributePath())
+	if err == nil {
+		t.Error("Expected error, got none")
+		return
+	}
+	if expected := ": can't store 1e+10000 in float64"; expected != err.Error() {
+		t.Errorf("Expected error to be %q, got %q", expected, err.Error())
+	}
+}
+
+func TestReflectNumber_float64OverflowNegative(t *testing.T) {
+	t.Parallel()
+
+	var n float64
+
+	result, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, overflowNegativeFloat), reflect.ValueOf(n), Options{
+		AllowRoundingNumbers: true,
+	}, tftypes.NewAttributePath())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	reflect.ValueOf(&n).Elem().Set(result)
+	if n != -math.MaxFloat64 {
+		t.Errorf("Expected %v, got %v", -math.MaxFloat64, n)
+	}
+}
+
+func TestReflectNumber_float64OverflowNegativeError(t *testing.T) {
+	t.Parallel()
+
+	var n float64
+
+	_, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, overflowNegativeFloat), reflect.ValueOf(n), Options{}, tftypes.NewAttributePath())
+	if err == nil {
+		t.Error("Expected error, got none")
+		return
+	}
+	if expected := ": can't store -1e+10000 in float64"; expected != err.Error() {
+		t.Errorf("Expected error to be %q, got %q", expected, err.Error())
+	}
+}
+
+func TestReflectNumber_float64Underflow(t *testing.T) {
+	t.Parallel()
+
+	var n float64
+
+	result, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, underflowFloat), reflect.ValueOf(n), Options{
+		AllowRoundingNumbers: true,
+	}, tftypes.NewAttributePath())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	reflect.ValueOf(&n).Elem().Set(result)
+	if n != math.SmallestNonzeroFloat64 {
+		t.Errorf("Expected %v, got %v", math.SmallestNonzeroFloat64, n)
+	}
+}
+
+func TestReflectNumber_float64UnderflowError(t *testing.T) {
+	t.Parallel()
+
+	var n float64
+
+	_, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, underflowFloat), reflect.ValueOf(n), Options{}, tftypes.NewAttributePath())
+	if err == nil {
+		t.Error("Expected error, got none")
+		return
+	}
+	if expected := ": can't store 1e-1000 in float64"; expected != err.Error() {
+		t.Errorf("Expected error to be %q, got %q", expected, err.Error())
+	}
+}
+
+func TestReflectNumber_float64UnderflowNegative(t *testing.T) {
+	t.Parallel()
+
+	var n float64
+
+	result, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, underflowNegativeFloat), reflect.ValueOf(n), Options{
+		AllowRoundingNumbers: true,
+	}, tftypes.NewAttributePath())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	reflect.ValueOf(&n).Elem().Set(result)
+	if n != -math.SmallestNonzeroFloat64 {
+		t.Errorf("Expected %v, got %v", -math.SmallestNonzeroFloat64, n)
+	}
+}
+
+func TestReflectNumber_float64UnderflowNegativeError(t *testing.T) {
+	t.Parallel()
+
+	var n float64
+
+	_, err := reflectNumber(context.Background(), tftypes.NewValue(tftypes.Number, underflowNegativeFloat), reflect.ValueOf(n), Options{}, tftypes.NewAttributePath())
+	if err == nil {
+		t.Error("Expected error, got none")
+		return
+	}
+	if expected := ": can't store -1e-1000 in float64"; expected != err.Error() {
+		t.Errorf("Expected error to be %q, got %q", expected, err.Error())
+	}
+}

--- a/internal/reflect/options.go
+++ b/internal/reflect/options.go
@@ -1,0 +1,20 @@
+package reflect
+
+// Options provides configuration settings for how the reflection behavior
+// works, letting callers tweak different behaviors based on their needs.
+type Options struct {
+	// UnhandledNullAsEmpty controls whether null values should be
+	// translated into empty values without provider interaction, or if
+	// they must be explicitly handled.
+	UnhandledNullAsEmpty bool
+
+	// UnhandledUnknownAsEmpty controls whether null values should be
+	// translated into empty values without provider interaction, or if
+	// they must be explicitly handled.
+	UnhandledUnknownAsEmpty bool
+
+	// AllowRoundingNumbers silently rounds numbers that don't fit
+	// perfectly in the types they're being stored in, rather than
+	// returning errors. Numbers will always be rounded towards 0.
+	AllowRoundingNumbers bool
+}

--- a/internal/reflect/pointer.go
+++ b/internal/reflect/pointer.go
@@ -1,0 +1,54 @@
+package reflect
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// build a pointer of the same type as `target`, ensuring that the data it
+// points to exists and it is not set to nil.
+func reflectPointer(ctx context.Context, val tftypes.Value, target reflect.Value, opts Options, path *tftypes.AttributePath) (reflect.Value, error) {
+	if target.Kind() != reflect.Ptr {
+		return target, path.NewErrorf("can't dereference pointer, not a pointer, is a %s (%s)", target.Type(), target.Kind())
+	}
+	// we may have gotten a nil pointer, so we need to create our own that
+	// we can set
+	pointer := reflect.New(target.Type().Elem())
+	// build out whatever the pointer is pointing to
+	pointed, err := buildReflectValue(ctx, val, pointer.Elem(), opts, path)
+	if err != nil {
+		return target, err
+	}
+	// to be able to set the pointer to our new pointer, we need to create
+	// a pointer to the pointer
+	pointerPointer := reflect.New(pointer.Type())
+	// we set the pointer we created on the pointer to the pointer
+	pointerPointer.Elem().Set(pointer)
+	// then it's settable, so we can now set the concrete value we created
+	// on the pointer
+	pointerPointer.Elem().Elem().Set(pointed)
+	// return the pointer we created
+	return pointerPointer.Elem(), nil
+}
+
+// create a zero value of concrete type underlying any number of pointers, then
+// wrap it in that number of pointers again. The end result is to wind up with
+// the same exact type, except now you can be sure it's pointing to actual data
+// and will not give you a nil pointer dereference panic unexpectedly.
+func pointerSafeZeroValue(ctx context.Context, target reflect.Value) reflect.Value {
+	pointer := target.Type()
+	var pointers int
+	for pointer.Kind() == reflect.Ptr {
+		pointer = pointer.Elem()
+		pointers++
+	}
+	receiver := reflect.Zero(pointer)
+	for i := 0; i < pointers; i++ {
+		newReceiver := reflect.New(receiver.Type())
+		newReceiver.Elem().Set(receiver)
+		receiver = newReceiver
+	}
+	return receiver
+}

--- a/internal/reflect/pointer_test.go
+++ b/internal/reflect/pointer_test.go
@@ -1,0 +1,117 @@
+package reflect
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func TestReflectPointer_notAPointer(t *testing.T) {
+	t.Parallel()
+
+	var s string
+	_, err := reflectPointer(context.Background(), tftypes.NewValue(tftypes.String, "hello"), reflect.ValueOf(s), Options{}, tftypes.NewAttributePath())
+	if expected := ": can't dereference pointer, not a pointer, is a string (string)"; err.Error() != expected {
+		t.Errorf("Expected error to be %q, got %q", expected, err.Error())
+	}
+}
+
+func TestReflectPointer_nilPointer(t *testing.T) {
+	t.Parallel()
+
+	var s *string
+	got, err := reflectPointer(context.Background(), tftypes.NewValue(tftypes.String, "hello"), reflect.ValueOf(s), Options{}, tftypes.NewAttributePath())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err.Error())
+	}
+	if got.Interface() == nil {
+		t.Error("Expected \"hello\", got nil")
+	}
+	if *(got.Interface().(*string)) != "hello" {
+		t.Errorf("Expected \"hello\", got %+v", *(got.Interface().(*string)))
+	}
+}
+
+func TestReflectPointer_simple(t *testing.T) {
+	t.Parallel()
+
+	var s string
+	got, err := reflectPointer(context.Background(), tftypes.NewValue(tftypes.String, "hello"), reflect.ValueOf(&s), Options{}, tftypes.NewAttributePath())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err.Error())
+	}
+	if got.Interface() == nil {
+		t.Error("Expected \"hello\", got nil")
+	}
+	if *(got.Interface().(*string)) != "hello" {
+		t.Errorf("Expected \"hello\", got %+v", *(got.Interface().(*string)))
+	}
+}
+
+func TestReflectPointer_pointerPointer(t *testing.T) {
+	t.Parallel()
+
+	var s *string
+	got, err := reflectPointer(context.Background(), tftypes.NewValue(tftypes.String, "hello"), reflect.ValueOf(&s), Options{}, tftypes.NewAttributePath())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err.Error())
+	}
+	if got.Interface() == nil {
+		t.Error("Expected \"hello\", got nil")
+	}
+	if **(got.Interface().(**string)) != "hello" {
+		t.Errorf("Expected \"hello\", got %+v", **(got.Interface().(**string)))
+	}
+}
+
+func TestPointerSafeZeroValue_zeroPointers(t *testing.T) {
+	t.Parallel()
+
+	var s string
+	got := pointerSafeZeroValue(context.Background(), reflect.ValueOf(s))
+	if got.Interface().(string) != "" {
+		t.Errorf("expected \"\", got %v", got.Interface())
+	}
+}
+
+func TestPointerSafeZeroValue_onePointer(t *testing.T) {
+	t.Parallel()
+
+	var s *string
+	got := pointerSafeZeroValue(context.Background(), reflect.ValueOf(s))
+	if got.Interface() != nil && *(got.Interface().(*string)) != "" {
+		t.Errorf("expected \"\", got %v", got.Interface())
+	}
+}
+
+func TestPointerSafeZeroValue_twoPointers(t *testing.T) {
+	t.Parallel()
+
+	var s **string
+	got := pointerSafeZeroValue(context.Background(), reflect.ValueOf(s))
+	if got.Interface() != nil && **(got.Interface().(**string)) != "" {
+		t.Errorf("expected \"\", got %v", got.Interface())
+	}
+}
+
+func TestPointerSafeZeroValue_threePointers(t *testing.T) {
+	t.Parallel()
+
+	var s ***string
+	got := pointerSafeZeroValue(context.Background(), reflect.ValueOf(s))
+	if got.Interface() != nil && ***(got.Interface().(***string)) != "" {
+		t.Errorf("expected \"\", got %v", got.Interface())
+	}
+}
+
+func TestPointerSafeZeroValue_tenPointers(t *testing.T) {
+	t.Parallel()
+
+	var s **********string
+	got := pointerSafeZeroValue(context.Background(), reflect.ValueOf(s))
+	if got.Interface() != nil && **********(got.Interface().(**********string)) != "" {
+		t.Errorf("expected \"\", got %v", got.Interface())
+	}
+}

--- a/internal/reflect/primitive.go
+++ b/internal/reflect/primitive.go
@@ -1,0 +1,31 @@
+package reflect
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// build a string or bool depending on the type of `target`, and populate it
+// with the data in `val`.
+func reflectPrimitive(ctx context.Context, val tftypes.Value, target reflect.Value, path *tftypes.AttributePath) (reflect.Value, error) {
+	switch target.Kind() {
+	case reflect.Bool:
+		var b bool
+		err := val.As(&b)
+		if err != nil {
+			return target, path.NewError(err)
+		}
+		return reflect.ValueOf(b).Convert(target.Type()), nil
+	case reflect.String:
+		var s string
+		err := val.As(&s)
+		if err != nil {
+			return target, path.NewError(err)
+		}
+		return reflect.ValueOf(s).Convert(target.Type()), nil
+	default:
+		return target, path.NewErrorf("unrecognized type %s (this should never happen)", target.Kind())
+	}
+}

--- a/internal/reflect/primitive_test.go
+++ b/internal/reflect/primitive_test.go
@@ -1,0 +1,71 @@
+package reflect
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func TestReflectPrimitive_string(t *testing.T) {
+	t.Parallel()
+
+	var s string
+
+	result, err := reflectPrimitive(context.Background(), tftypes.NewValue(tftypes.String, "hello"), reflect.ValueOf(s), tftypes.NewAttributePath())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	reflect.ValueOf(&s).Elem().Set(result)
+	if s != "hello" {
+		t.Errorf("Expected %q, got %q", "hello", s)
+	}
+}
+
+func TestReflectPrimitive_stringAlias(t *testing.T) {
+	t.Parallel()
+
+	type testString string
+	var s testString
+
+	result, err := reflectPrimitive(context.Background(), tftypes.NewValue(tftypes.String, "hello"), reflect.ValueOf(s), tftypes.NewAttributePath())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	reflect.ValueOf(&s).Elem().Set(result)
+	if s != "hello" {
+		t.Errorf("Expected %q, got %q", "hello", s)
+	}
+}
+
+func TestReflectPrimitive_bool(t *testing.T) {
+	t.Parallel()
+
+	var b bool
+
+	result, err := reflectPrimitive(context.Background(), tftypes.NewValue(tftypes.Bool, true), reflect.ValueOf(b), tftypes.NewAttributePath())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	reflect.ValueOf(&b).Elem().Set(result)
+	if b != true {
+		t.Errorf("Expected %v, got %v", true, b)
+	}
+}
+
+func TestReflectPrimitive_boolAlias(t *testing.T) {
+	t.Parallel()
+
+	type testBool bool
+	var b testBool
+
+	result, err := reflectPrimitive(context.Background(), tftypes.NewValue(tftypes.Bool, true), reflect.ValueOf(b), tftypes.NewAttributePath())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	reflect.ValueOf(&b).Elem().Set(result)
+	if b != true {
+		t.Errorf("Expected %v, got %v", true, b)
+	}
+}

--- a/internal/reflect/reflection.go
+++ b/internal/reflect/reflection.go
@@ -1,0 +1,141 @@
+package reflect
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/big"
+	"reflect"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// Into uses the data in `val` to populate `target`, using the reflection
+// package to recursively reflect into structs and slices. If `target` is an
+// AttributeValue, its assignment method will be used instead of reflecting. If
+// `target` is a tftypes.ValueConverter, the FromTerraformValue method will be
+// used instead of using reflection. Primitives are set using the val.As
+// method. Structs use reflection: each exported struct field must have a
+// "tfsdk" tag with the name of the field in the tftypes.Value, and all fields
+// in the tftypes.Value must have a corresponding property in the struct. Into
+// will be called for each struct field. Slices will have Into called for each
+// element.
+func Into(ctx context.Context, val tftypes.Value, target interface{}, opts Options) error {
+	v := reflect.ValueOf(target)
+	if v.Kind() != reflect.Ptr {
+		return fmt.Errorf("target must be a pointer, got %T, which is a %s", target, v.Kind())
+	}
+	result, err := buildReflectValue(ctx, val, v.Elem(), opts, tftypes.NewAttributePath())
+	if err != nil {
+		return err
+	}
+	v.Set(result)
+	return nil
+}
+
+// buildReflectValue constructs a reflect.Value of the same type as `target`,
+// populated with the data in `val`. It will defensively instantiate new values
+// to set, making it safe for use with pointer types which may be nil. It tries
+// to give consumers the ability to override its default behaviors wherever
+// possible.
+func buildReflectValue(ctx context.Context, val tftypes.Value, target reflect.Value, opts Options, path *tftypes.AttributePath) (reflect.Value, error) {
+	// if this isn't a valid reflect.Value, bail before we accidentally
+	// panic
+	if !target.IsValid() {
+		return target, path.NewErrorf("invalid target")
+	}
+	// if this is an attr.Value, build the type from that
+	if target.Type().Implements(reflect.TypeOf((*attr.Value)(nil)).Elem()) {
+		return reflectAttributeValue(ctx, val, target, opts, path)
+	}
+	// if this tells tftypes how to build an instance of it out of a
+	// tftypes.Value, well, that's what we want, so do that instead of our
+	// default logic.
+	if target.Type().Implements(reflect.TypeOf((*tftypes.ValueConverter)(nil)).Elem()) {
+		return reflectValueConverter(ctx, val, target, opts, path)
+	}
+	// if this can explicitly be set to unknown, do that
+	if target.Type().Implements(reflect.TypeOf((*setUnknownable)(nil)).Elem()) {
+		res, err := reflectUnknownable(ctx, val, target, opts, path)
+		if err != nil {
+			return target, err
+		}
+		target = res
+		// only return if it's unknown; we want to call SetUnknown
+		// either way, but if the value is unknown, there's nothing
+		// else to do, so bail
+		if !val.IsKnown() {
+			return target, nil
+		}
+	}
+	// if this can explicitly be set to null, do that
+	if target.Type().Implements(reflect.TypeOf((*setNullable)(nil)).Elem()) {
+		res, err := reflectNullable(ctx, val, target, opts, path)
+		if err != nil {
+			return target, err
+		}
+		target = res
+		// only return if it's null; we want to call SetNull either
+		// way, but if the value is null, there's nothing else to do,
+		// so bail
+		if val.IsNull() {
+			return target, nil
+		}
+	}
+	if !val.IsKnown() {
+		// we already handled unknown the only ways we can
+		// we checked that target doesn't have a SetUnknown method we
+		// can call
+		// we checked that target isn't an AttributeValue
+		// all that's left to us now is to set it as an empty value or
+		// throw an error, depending on what's in opts
+		if !opts.UnhandledUnknownAsEmpty {
+			return target, path.NewError(errors.New("unhandled unknown value"))
+		}
+		// we want to set unhandled unknowns to the empty value
+		return reflect.Zero(target.Type()), nil
+	}
+
+	if val.IsNull() {
+		// we already handled null the only ways we can
+		// we checked that target doesn't have a SetNull method we can
+		// call
+		// we checked that target isn't an AttributeValue
+		// all that's left to us now is to set it as an empty value or
+		// throw an error, depending on what's in opts
+		if canBeNil(target) || opts.UnhandledNullAsEmpty {
+			return reflect.Zero(target.Type()), nil
+		}
+		return target, path.NewError(errors.New("unhandled null value"))
+	}
+	// *big.Float and *big.Int are technically pointers, but we want them
+	// handled as numbers
+	if target.Type() == reflect.TypeOf(big.NewFloat(0)) || target.Type() == reflect.TypeOf(big.NewInt(0)) {
+		return reflectNumber(ctx, val, target, opts, path)
+	}
+	switch target.Kind() {
+	case reflect.Struct:
+		return reflectStructFromObject(ctx, val, target, opts, path)
+	case reflect.Bool, reflect.String:
+		return reflectPrimitive(ctx, val, target, path)
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32,
+		reflect.Int64, reflect.Uint, reflect.Uint8, reflect.Uint16,
+		reflect.Uint32, reflect.Uint64, reflect.Float32, reflect.Float64:
+		// numbers are the wooooorst and need their own special handling
+		// because we can't just hand them off to tftypes and also
+		// because we can't just make people use *big.Floats, because a
+		// nil *big.Float will crash everything if we don't handle it
+		// as a special case, so let's just special case numbers and
+		// let people use the types they want
+		return reflectNumber(ctx, val, target, opts, path)
+	case reflect.Slice:
+		return reflectSlice(ctx, val, target, opts, path)
+	case reflect.Map:
+		return reflectMap(ctx, val, target, opts, path)
+	case reflect.Ptr:
+		return reflectPointer(ctx, val, target, opts, path)
+	default:
+		return target, path.NewErrorf("don't know how to reflect %s into %s", val.Type(), target.Type())
+	}
+}

--- a/internal/reflect/reflection_test.go
+++ b/internal/reflect/reflection_test.go
@@ -1,0 +1,35 @@
+package reflect
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func TestBuildReflectValue_unhandledNull(t *testing.T) {
+	t.Parallel()
+
+	var s string
+	_, err := buildReflectValue(context.Background(), tftypes.NewValue(tftypes.String, nil), reflect.ValueOf(s), Options{}, tftypes.NewAttributePath())
+	if err == nil {
+		t.Error("Expected error, didn't get one")
+	}
+	if expected := `: unhandled null value`; expected != err.Error() {
+		t.Errorf("Expected error to be %q, got %q", expected, err.Error())
+	}
+}
+
+func TestBuildReflectValue_unhandledUnknown(t *testing.T) {
+	t.Parallel()
+
+	var s string
+	_, err := buildReflectValue(context.Background(), tftypes.NewValue(tftypes.String, tftypes.UnknownValue), reflect.ValueOf(s), Options{}, tftypes.NewAttributePath())
+	if err == nil {
+		t.Error("Expected error, didn't get one")
+	}
+	if expected := `: unhandled unknown value`; expected != err.Error() {
+		t.Errorf("Expected error to be %q, got %q", expected, err.Error())
+	}
+}

--- a/internal/reflect/slice.go
+++ b/internal/reflect/slice.go
@@ -1,0 +1,52 @@
+package reflect
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// build a slice of elements, matching the type of `target`, and fill it with
+// the data in `val`.
+func reflectSlice(ctx context.Context, val tftypes.Value, target reflect.Value, opts Options, path *tftypes.AttributePath) (reflect.Value, error) {
+	// this only works with slices, so check that out first
+	if target.Kind() != reflect.Slice {
+		return target, path.NewErrorf("expected a slice type, got %s", target.Type())
+	}
+
+	// we need our value to become a list of values so we can iterate over
+	// them and handle them individually
+	var values []tftypes.Value
+	err := val.As(&values)
+	if err != nil {
+		return target, path.NewError(err)
+	}
+
+	// we need to know the type the slice is wrapping
+	elemType := target.Type().Elem()
+
+	// we want an empty version of the slice
+	slice := reflect.MakeSlice(target.Type(), 0, len(values))
+
+	// go over each of the values passed in, create a Go value of the right
+	// type for them, and add it to our new slice
+	for pos, value := range values {
+		// create a new Go value of the type that can go in the slice
+		targetValue := reflect.Zero(elemType)
+
+		// update our path so we can have nice errors
+		path := path.WithElementKeyInt(int64(pos))
+
+		// reflect the value into our new target
+		val, err := buildReflectValue(ctx, value, targetValue, opts, path)
+		if err != nil {
+			return target, err
+		}
+
+		// add the new target to our slice
+		slice = reflect.Append(slice, val)
+	}
+
+	return slice, nil
+}

--- a/internal/reflect/struct.go
+++ b/internal/reflect/struct.go
@@ -1,0 +1,80 @@
+package reflect
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// build a struct with a type matching that of `target` and populate it with
+// the values in `object`. `target` must be a struct type. The properties on
+// `target` must be tagged with a "tfsdk" label, and every property must be
+// present in the type of `object`, and all the attributes in the type of
+// `object` must have a corresponding property. Properties that don't map to
+// object attributes must have a `tfsdk:"-"` tag, explicitly defining them as
+// not part of the object.
+func reflectStructFromObject(ctx context.Context, object tftypes.Value, target reflect.Value, opts Options, path *tftypes.AttributePath) (reflect.Value, error) {
+	// this only works with object values, so make sure that constraint is
+	// met
+	if target.Kind() != reflect.Struct {
+		return target, path.NewErrorf("expected a struct type, got %s", target.Type())
+	}
+	if !object.Type().Is(tftypes.Object{}) {
+		return target, path.NewErrorf("can't reflect %s into a struct, must be an object", object.Type().String())
+	}
+
+	// collect a map of fields that are in the object passed in
+	var objectFields map[string]tftypes.Value
+	err := object.As(&objectFields)
+	if err != nil {
+		return target, path.NewErrorf("unexpected error converting object: %w", err)
+	}
+
+	// collect a map of fields that are defined in the tags of the struct
+	// passed in
+	targetFields, err := getStructTags(ctx, target, path)
+	if err != nil {
+		return target, fmt.Errorf("error retrieving field names from struct tags: %w", err)
+	}
+
+	// we require an exact, 1:1 match of these fields to avoid typos
+	// leading to surprises, so let's ensure they have the exact same
+	// fields defined
+	var objectMissing, targetMissing []string
+	for field := range targetFields {
+		if _, ok := objectFields[field]; !ok {
+			objectMissing = append(objectMissing, field)
+		}
+	}
+	for field := range objectFields {
+		if _, ok := targetFields[field]; !ok {
+			targetMissing = append(targetMissing, field)
+		}
+	}
+	if len(objectMissing) > 0 || len(targetMissing) > 0 {
+		var missing []string
+		if len(objectMissing) > 0 {
+			missing = append(missing, fmt.Sprintf("Struct defines fields not found in object: %s.", commaSeparatedString(objectMissing)))
+		}
+		if len(targetMissing) > 0 {
+			missing = append(missing, fmt.Sprintf("Object defines fields not found in struct: %s.", commaSeparatedString(targetMissing)))
+		}
+		return target, path.NewErrorf("mismatch between struct and object: %s", strings.Join(missing, " "))
+	}
+
+	// now that we know they match perfectly, fill the struct with the
+	// values in the object
+	result := reflect.New(target.Type()).Elem()
+	for field, structFieldPos := range targetFields {
+		structField := result.Field(structFieldPos)
+		fieldVal, err := buildReflectValue(ctx, objectFields[field], structField, opts, path.WithAttributeName(field))
+		if err != nil {
+			return target, err
+		}
+		structField.Set(fieldVal)
+	}
+	return result, nil
+}

--- a/internal/reflect/struct_test.go
+++ b/internal/reflect/struct_test.go
@@ -1,0 +1,325 @@
+package reflect
+
+import (
+	"context"
+	"math/big"
+	"reflect"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func TestReflectObjectIntoStruct_notAnObject(t *testing.T) {
+	t.Parallel()
+
+	var s struct{}
+	_, err := reflectStructFromObject(context.Background(), tftypes.NewValue(tftypes.String, "hello"), reflect.ValueOf(s), Options{}, tftypes.NewAttributePath())
+	if err == nil {
+		t.Error("Expected error, didn't get one")
+	}
+	if expected := `: can't reflect tftypes.String into a struct, must be an object`; expected != err.Error() {
+		t.Errorf("Expected error to be %q, got %q", expected, err.Error())
+	}
+}
+
+func TestReflectObjectIntoStruct_notAStruct(t *testing.T) {
+	t.Parallel()
+
+	var s string
+	_, err := reflectStructFromObject(context.Background(), tftypes.NewValue(tftypes.Object{
+		AttributeTypes: map[string]tftypes.Type{
+			"a": tftypes.String,
+		},
+	}, map[string]tftypes.Value{
+		"a": tftypes.NewValue(tftypes.String, "hello"),
+	}), reflect.ValueOf(s), Options{}, tftypes.NewAttributePath())
+	if err == nil {
+		t.Error("Expected error, didn't get one")
+	}
+	if expected := `: expected a struct type, got string`; expected != err.Error() {
+		t.Errorf("Expected error to be %q, got %q", expected, err.Error())
+	}
+}
+
+func TestReflectObjectIntoStruct_objectMissingFields(t *testing.T) {
+	t.Parallel()
+
+	var s struct {
+		A string `tfsdk:"a"`
+	}
+	_, err := reflectStructFromObject(context.Background(), tftypes.NewValue(tftypes.Object{
+		AttributeTypes: map[string]tftypes.Type{},
+	}, map[string]tftypes.Value{}), reflect.ValueOf(s), Options{}, tftypes.NewAttributePath())
+	if err == nil {
+		t.Error("Expected error, didn't get one")
+	}
+	if expected := `: mismatch between struct and object: Struct defines fields not found in object: a.`; expected != err.Error() {
+		t.Errorf("Expected error to be %q, got %q", expected, err.Error())
+	}
+}
+
+func TestReflectObjectIntoStruct_structMissingProperties(t *testing.T) {
+	t.Parallel()
+
+	var s struct{}
+	_, err := reflectStructFromObject(context.Background(), tftypes.NewValue(tftypes.Object{
+		AttributeTypes: map[string]tftypes.Type{
+			"a": tftypes.String,
+		},
+	}, map[string]tftypes.Value{
+		"a": tftypes.NewValue(tftypes.String, "hello"),
+	}), reflect.ValueOf(s), Options{}, tftypes.NewAttributePath())
+	if err == nil {
+		t.Error("Expected error, didn't get one")
+	}
+	if expected := `: mismatch between struct and object: Object defines fields not found in struct: a.`; expected != err.Error() {
+		t.Errorf("Expected error to be %q, got %q", expected, err.Error())
+	}
+}
+
+func TestReflectObjectIntoStruct_objectMissingFieldsAndStructMissingProperties(t *testing.T) {
+	t.Parallel()
+
+	var s struct {
+		A string `tfsdk:"a"`
+	}
+	_, err := reflectStructFromObject(context.Background(), tftypes.NewValue(tftypes.Object{
+		AttributeTypes: map[string]tftypes.Type{
+			"b": tftypes.String,
+		},
+	}, map[string]tftypes.Value{
+		"b": tftypes.NewValue(tftypes.String, "hello"),
+	}), reflect.ValueOf(s), Options{}, tftypes.NewAttributePath())
+	if err == nil {
+		t.Error("Expected error, didn't get one")
+	}
+	if expected := `: mismatch between struct and object: Struct defines fields not found in object: a. Object defines fields not found in struct: b.`; expected != err.Error() {
+		t.Errorf("Expected error to be %q, got %q", expected, err.Error())
+	}
+}
+
+func TestReflectObjectIntoStruct_primitives(t *testing.T) {
+	t.Parallel()
+
+	var s struct {
+		A string     `tfsdk:"a"`
+		B *big.Float `tfsdk:"b"`
+		C bool       `tfsdk:"c"`
+	}
+	result, err := reflectStructFromObject(context.Background(), tftypes.NewValue(tftypes.Object{
+		AttributeTypes: map[string]tftypes.Type{
+			"a": tftypes.String,
+			"b": tftypes.Number,
+			"c": tftypes.Bool,
+		},
+	}, map[string]tftypes.Value{
+		"a": tftypes.NewValue(tftypes.String, "hello"),
+		"b": tftypes.NewValue(tftypes.Number, 123),
+		"c": tftypes.NewValue(tftypes.Bool, true),
+	}), reflect.ValueOf(s), Options{}, tftypes.NewAttributePath())
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	reflect.ValueOf(&s).Elem().Set(result)
+	if s.A != "hello" {
+		t.Errorf("Expected s.A to be %q, was %q", "hello", s.A)
+	}
+	if s.B.Cmp(big.NewFloat(123)) != 0 {
+		t.Errorf("Expected s.B to be %v, was %v", big.NewFloat(123), s.B)
+	}
+	if s.C != true {
+		t.Errorf("Expected s.C to be %v, was %v", true, s.C)
+	}
+}
+
+func TestReflectObjectIntoStruct_complex(t *testing.T) {
+	t.Parallel()
+
+	type myStruct struct {
+		Slice          []string `tfsdk:"slice"`
+		SliceOfStructs []struct {
+			A string `tfsdk:"a"`
+			B int    `tfsdk:"b"`
+		} `tfsdk:"slice_of_structs"`
+		Struct struct {
+			A     bool      `tfsdk:"a"`
+			Slice []float64 `tfsdk:"slice"`
+		} `tfsdk:"struct"`
+		Map              map[string][]string `tfsdk:"map"`
+		Pointer          *string             `tfsdk:"pointer"`
+		Unknownable      *unknownableString  `tfsdk:"unknownable"`
+		Nullable         *nullableString     `tfsdk:"nullable"`
+		AttributeValue   *attributeValue     `tfsdk:"attribute_value"`
+		ValueConverter   *valueConverter     `tfsdk:"value_converter"`
+		UnhandledNull    string              `tfsdk:"unhandled_null"`
+		UnhandledUnknown string              `tfsdk:"unhandled_unknown"`
+	}
+	var s myStruct
+	result, err := reflectStructFromObject(context.Background(), tftypes.NewValue(tftypes.Object{
+		AttributeTypes: map[string]tftypes.Type{
+			"slice": tftypes.List{
+				ElementType: tftypes.String,
+			},
+			"slice_of_structs": tftypes.List{
+				ElementType: tftypes.Object{
+					AttributeTypes: map[string]tftypes.Type{
+						"a": tftypes.String,
+						"b": tftypes.Number,
+					},
+				},
+			},
+			"struct": tftypes.Object{
+				AttributeTypes: map[string]tftypes.Type{
+					"a": tftypes.Bool,
+					"slice": tftypes.List{
+						ElementType: tftypes.Number,
+					},
+				},
+			},
+			"map": tftypes.Map{
+				AttributeType: tftypes.List{
+					ElementType: tftypes.String,
+				},
+			},
+			"pointer":           tftypes.String,
+			"unknownable":       tftypes.String,
+			"nullable":          tftypes.String,
+			"attribute_value":   tftypes.String,
+			"value_converter":   tftypes.String,
+			"unhandled_null":    tftypes.String,
+			"unhandled_unknown": tftypes.String,
+		},
+	}, map[string]tftypes.Value{
+		"slice": tftypes.NewValue(tftypes.List{
+			ElementType: tftypes.String,
+		}, []tftypes.Value{
+			tftypes.NewValue(tftypes.String, "red"),
+			tftypes.NewValue(tftypes.String, "blue"),
+			tftypes.NewValue(tftypes.String, "green"),
+		}),
+		"slice_of_structs": tftypes.NewValue(tftypes.List{
+			ElementType: tftypes.Object{
+				AttributeTypes: map[string]tftypes.Type{
+					"a": tftypes.String,
+					"b": tftypes.Number,
+				},
+			},
+		}, []tftypes.Value{
+			tftypes.NewValue(tftypes.Object{
+				AttributeTypes: map[string]tftypes.Type{
+					"a": tftypes.String,
+					"b": tftypes.Number,
+				},
+			}, map[string]tftypes.Value{
+				"a": tftypes.NewValue(tftypes.String, "hello, world"),
+				"b": tftypes.NewValue(tftypes.Number, 123),
+			}),
+			tftypes.NewValue(tftypes.Object{
+				AttributeTypes: map[string]tftypes.Type{
+					"a": tftypes.String,
+					"b": tftypes.Number,
+				},
+			}, map[string]tftypes.Value{
+				"a": tftypes.NewValue(tftypes.String, "goodnight, moon"),
+				"b": tftypes.NewValue(tftypes.Number, 456),
+			}),
+		}),
+		"struct": tftypes.NewValue(tftypes.Object{
+			AttributeTypes: map[string]tftypes.Type{
+				"a": tftypes.Bool,
+				"slice": tftypes.List{
+					ElementType: tftypes.Number,
+				},
+			},
+		}, map[string]tftypes.Value{
+			"a": tftypes.NewValue(tftypes.Bool, true),
+			"slice": tftypes.NewValue(tftypes.List{
+				ElementType: tftypes.Number,
+			}, []tftypes.Value{
+				tftypes.NewValue(tftypes.Number, 123),
+				tftypes.NewValue(tftypes.Number, 456),
+				tftypes.NewValue(tftypes.Number, 789),
+			}),
+		}),
+		"map": tftypes.NewValue(tftypes.Map{
+			AttributeType: tftypes.List{
+				ElementType: tftypes.String,
+			},
+		}, map[string]tftypes.Value{
+			"colors": tftypes.NewValue(tftypes.List{
+				ElementType: tftypes.String,
+			}, []tftypes.Value{
+				tftypes.NewValue(tftypes.String, "red"),
+				tftypes.NewValue(tftypes.String, "orange"),
+				tftypes.NewValue(tftypes.String, "yellow"),
+			}),
+			"fruits": tftypes.NewValue(tftypes.List{
+				ElementType: tftypes.String,
+			}, []tftypes.Value{
+				tftypes.NewValue(tftypes.String, "apple"),
+				tftypes.NewValue(tftypes.String, "banana"),
+			}),
+		}),
+		"pointer":           tftypes.NewValue(tftypes.String, "pointed"),
+		"unknownable":       tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+		"nullable":          tftypes.NewValue(tftypes.String, nil),
+		"attribute_value":   tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+		"value_converter":   tftypes.NewValue(tftypes.String, nil),
+		"unhandled_null":    tftypes.NewValue(tftypes.String, nil),
+		"unhandled_unknown": tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+	}), reflect.ValueOf(s), Options{
+		UnhandledNullAsEmpty:    true,
+		UnhandledUnknownAsEmpty: true,
+	}, tftypes.NewAttributePath())
+	reflect.ValueOf(&s).Elem().Set(result)
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	str := "pointed"
+	expected := myStruct{
+		Slice: []string{"red", "blue", "green"},
+		SliceOfStructs: []struct {
+			A string `tfsdk:"a"`
+			B int    `tfsdk:"b"`
+		}{
+			{
+				A: "hello, world",
+				B: 123,
+			},
+			{
+				A: "goodnight, moon",
+				B: 456,
+			},
+		},
+		Struct: struct {
+			A     bool      `tfsdk:"a"`
+			Slice []float64 `tfsdk:"slice"`
+		}{
+			A:     true,
+			Slice: []float64{123, 456, 789},
+		},
+		Map: map[string][]string{
+			"colors": {"red", "orange", "yellow"},
+			"fruits": {"apple", "banana"},
+		},
+		Pointer: &str,
+		Unknownable: &unknownableString{
+			Unknown: true,
+		},
+		Nullable: &nullableString{
+			Null: true,
+		},
+		AttributeValue: &attributeValue{
+			Unknown: true,
+		},
+		ValueConverter: &valueConverter{
+			null: true,
+		},
+		UnhandledNull:    "",
+		UnhandledUnknown: "",
+	}
+	if diff := cmp.Diff(s, expected); diff != "" {
+		t.Errorf("Didn't get expected value. Diff (+ is expected, - is result): %s", diff)
+	}
+}


### PR DESCRIPTION
Add a package that will let us build reflect.Values from any Go type and
populate them with the data from any tftypes.Value. This culminates in
the reflect.Into function, which lets us have json.Unmarshal-esque
behavior but for tftypes.Values.

This will be used later for making aggregate types easier to work with.