### PR TITLE
Implement State, State.Get, State.GetAttribute

### DIFF
--- a/attr/type.go
+++ b/attr/type.go
@@ -26,6 +26,19 @@ type Type interface {
 	// Equal must return true if the Type is considered semantically equal
 	// to the Type passed as an argument.
 	Equal(Type) bool
+
+	tftypes.AttributePathStepper
+}
+
+// ObjectType extends the Type interface to include a method returning a copy
+// of the type with its "attribute types" filled in. Attribute types are
+// part of the definition of an object type.
+type ObjectType interface {
+	Type
+
+	// Equal must return true if the Type is considered semantically equal
+	// to the Type passed as an argument.
+	Equal(Type) bool
 }
 
 // TypeWithValidate extends the Type interface to include a Validate method,

--- a/schema/attribute.go
+++ b/schema/attribute.go
@@ -1,6 +1,9 @@
 package schema
 
-import "github.com/hashicorp/terraform-plugin-framework/attr"
+import (
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
 
 // Attribute defines the constraints and behaviors of a single field in a
 // schema. Attributes are the fields that show up in Terraform state files and
@@ -59,4 +62,13 @@ type Attribute struct {
 	// using this attribute, warning them that it is deprecated and
 	// instructing them on what upgrade steps to take.
 	DeprecationMessage string
+}
+
+func (a Attribute) ApplyTerraform5AttributePathStep(step tftypes.AttributePathStep) (interface{}, error) {
+	if a.Type != nil {
+		return a.Type.ApplyTerraform5AttributePathStep(step)
+	}
+	if a.Attributes != nil {
+		return a.Attributes.ApplyTerraform5AttributePathStep(step)
+	}
 }

--- a/schema/nested_attributes.go
+++ b/schema/nested_attributes.go
@@ -34,6 +34,7 @@ const (
 type NestedAttributes interface {
 	getNestingMode() nestingMode
 	getAttributes() map[string]Attribute
+	tftypes.AttributePathStepper
 }
 
 type nestedAttributes map[string]Attribute
@@ -86,6 +87,14 @@ type ListNestedAttributesOptions struct {
 
 func (l listNestedAttributes) getNestingMode() nestingMode {
 	return nestingModeList
+}
+
+func (l listNestedAttributes) ApplyTerraform5AttributePathStep(step tftypes.AttributePathStep) (interface{}, error) {
+	if _, ok := step.(tftypes.ElementKeyInt); !ok {
+		return nil, fmt.Errorf("cannot apply step %T to ListNestedAttributes", step)
+	}
+
+	return l.nestedAttributes, nil
 }
 
 // SetNestedAttributes nests `attributes` under another attribute, allowing

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1,5 +1,11 @@
 package schema
 
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
 // Schema is used to define the shape of practitioner-provider information,
 // like resources, data sources, and providers. Think of it as a type
 // definition, but for Terraform.
@@ -16,4 +22,16 @@ type Schema struct {
 	// changing an attribute type, that needs manual upgrade handling.
 	// Versions should only be incremented by one each release.
 	Version int64
+}
+
+func (s Schema) ApplyTerraform5AttributePathStep(step tftypes.AttributePathStep) (interface{}, error) {
+	if v, ok := step.(tftypes.AttributeName); ok {
+		if attr, ok := s.Attributes[string(v)]; ok {
+			return attr, nil
+		} else {
+			return nil, fmt.Errorf("could not find attribute %q in schema", v)
+		}
+	} else {
+		return nil, fmt.Errorf("cannot apply AttributePathStep %T to schema", step)
+	}
 }

--- a/state.go
+++ b/state.go
@@ -1,0 +1,43 @@
+package tfsdk
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	tfReflect "github.com/hashicorp/terraform-plugin-framework/internal/reflect"
+	"github.com/hashicorp/terraform-plugin-framework/schema"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+var attributeValueReflectType = reflect.TypeOf(new(attr.Value)).Elem()
+
+type State struct {
+	Raw    tftypes.Value
+	Schema schema.Schema
+}
+
+func isValidFieldName(name string) bool {
+	re := regexp.MustCompile("^[a-z][a-z0-9_]*$")
+	return re.MatchString(name)
+}
+
+// Get populates the struct passed as `target` with the entire state. No type assertion necessary.
+func (s State) Get(ctx context.Context, target interface{}) error {
+	return tfReflect.Into(ctx, s.Raw, target, tfReflect.Options{}, tftypes.NewAttributePath())
+}
+
+// GetAttribute retrieves the attribute found at `path` and returns it as an attr.Value,
+// which provider developers need to assert the type of
+func (s State) GetAttribute(ctx context.Context, path tftypes.AttributePath) (attr.Value, error) {
+
+}
+
+// MustGetAttribute retrieves the attribute as GetAttribute does, but populates target using As,
+// using the simplified representation without Unknown. Errors if Unknown present
+func (s State) MustGetAttribute(ctx context.Context, path tftypes.AttributePath, target interface{}) error {
+	return nil
+}

--- a/state_test.go
+++ b/state_test.go
@@ -1,0 +1,81 @@
+package tfsdk
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func TestStateGet(t *testing.T) {
+	schema := schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"foo": {
+				Type:     types.StringType,
+				Required: true,
+			},
+			"bar": {
+				Type: types.ListType{
+					ElemType: types.StringType,
+				},
+				Required: true,
+			},
+		},
+	}
+	state := State{
+		Raw: tftypes.NewValue(tftypes.Object{
+			AttributeTypes: map[string]tftypes.Type{
+				"foo": tftypes.String,
+				"bar": tftypes.List{ElementType: tftypes.String},
+			},
+		}, map[string]tftypes.Value{
+			"foo": tftypes.NewValue(tftypes.String, "hello, world"),
+			"bar": tftypes.NewValue(tftypes.List{
+				ElementType: tftypes.String,
+			}, []tftypes.Value{
+				tftypes.NewValue(tftypes.String, "red"),
+				tftypes.NewValue(tftypes.String, "blue"),
+				tftypes.NewValue(tftypes.String, "green"),
+			}),
+		}),
+		Schema: schema,
+	}
+	type myType struct {
+		Foo types.String `tfsdk:"foo"`
+		Bar types.List   `tfsdk:"bar"`
+	}
+	var val myType
+	err := state.Get(context.Background(), &val)
+	if err != nil {
+		t.Errorf("Error running As: %s", err)
+	}
+	if val.Foo.Unknown {
+		t.Error("Expected Foo to be known")
+	}
+	if val.Foo.Null {
+		t.Error("Expected Foo to be non-null")
+	}
+	if val.Foo.Value != "hello, world" {
+		t.Errorf("Expected Foo to be %q, got %q", "hello, world", val.Foo.Value)
+	}
+	if val.Bar.Unknown {
+		t.Error("Expected Bar to be known")
+	}
+	if val.Bar.Null {
+		t.Errorf("Expected Bar to be non-null")
+	}
+	if len(val.Bar.Elems) != 3 {
+		t.Errorf("Expected Bar to have 3 elements, had %d", len(val.Bar.Elems))
+	}
+	if val.Bar.Elems[0].(types.String).Value != "red" {
+		t.Errorf("Expected Bar's first element to be %q, got %q", "red", val.Bar.Elems[0].(types.String).Value)
+	}
+	if val.Bar.Elems[1].(types.String).Value != "blue" {
+		t.Errorf("Expected Bar's second element to be %q, got %q", "blue", val.Bar.Elems[1].(types.String).Value)
+	}
+	if val.Bar.Elems[2].(types.String).Value != "green" {
+		t.Errorf("Expected Bar's third element to be %q, got %q", "green", val.Bar.Elems[2].(types.String).Value)
+	}
+}

--- a/types/list.go
+++ b/types/list.go
@@ -187,3 +187,23 @@ func (l *List) SetTerraformValue(ctx context.Context, in tftypes.Value) error {
 	l.Elems = elems
 	return nil
 }
+
+// ListOf returns a new list with an ElemType of tftypes.Object, whose elements
+// are the values passed in. The struct type must have struct tags TODO
+// func ListOf(values []interface{}) List {
+// 	// make the list
+// 	// populate the list with tftypes.Objects
+
+// 	// to make the object type:
+// 	// reflect to get the type of the passed in struct
+// 	// need to get map[string]tftypes.Type
+
+// 	l := List{
+// 		ElemType: tftypes.Object,
+// 	}
+
+// 	for _, v := range values {
+// 		objType :=
+// 		l.Elems = append(l.Elems, )
+// 	}
+// }

--- a/types/list.go
+++ b/types/list.go
@@ -85,17 +85,9 @@ type List struct {
 func (l *List) ElementsAs(ctx context.Context, target interface{}, allowUnhandled bool) error {
 	// we need a tftypes.Value for this List to be able to use it with our
 	// reflection code
-	values := make([]tftypes.Value, 0, len(l.Elems))
-	for pos, elem := range l.Elems {
-		val, err := elem.ToTerraformValue(ctx)
-		if err != nil {
-			return fmt.Errorf("error getting Terraform value for element %d: %w", pos, err)
-		}
-		err = tftypes.ValidateValue(l.ElemType.TerraformType(ctx), val)
-		if err != nil {
-			return fmt.Errorf("error using created Terraform value for element %d: %w", pos, err)
-		}
-		values = append(values, tftypes.NewValue(l.ElemType.TerraformType(ctx), val))
+	values, err := l.ToTerraformValue(ctx)
+	if err != nil {
+		return err
 	}
 	return reflect.Into(ctx, tftypes.NewValue(tftypes.List{
 		ElementType: l.ElemType.TerraformType(ctx),

--- a/types/primitive.go
+++ b/types/primitive.go
@@ -88,3 +88,7 @@ func (p primitive) Equal(o attr.Type) bool {
 		return false
 	}
 }
+
+func (p primitive) ApplyTerraform5AttributePathStep(step tftypes.AttributePathStep) (interface{}, error) {
+	return nil, fmt.Errorf("cannot apply AttributePathStep %T to %s", step, p.String())
+}


### PR DESCRIPTION
WIP. The main work here is the addition of `ApplyTerraform5AttributePathStep` to all schema types, implementing the `tftypes.AttributePathStepper` interface so that we can traverse the schema with [`tftypes.WalkAttributePath`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-go@v0.3.0/tftypes#WalkAttributePath).