### PR TITLE
Implement State, State.Get, State.GetAttribute, Config, Plan

### DIFF
--- a/attr/type.go
+++ b/attr/type.go
@@ -26,6 +26,8 @@ type Type interface {
 	// Equal must return true if the Type is considered semantically equal
 	// to the Type passed as an argument.
 	Equal(Type) bool
+
+	tftypes.AttributePathStepper
 }
 
 // TypeWithAttributeTypes extends the Type interface to include information about

--- a/config.go
+++ b/config.go
@@ -1,0 +1,51 @@
+package tfsdk
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/internal/reflect"
+	"github.com/hashicorp/terraform-plugin-framework/schema"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// Config represents a Terraform config.
+type Config struct {
+	Raw    tftypes.Value
+	Schema schema.Schema
+}
+
+// Get populates the struct passed as `target` with the entire config.
+func (c Config) Get(ctx context.Context, target interface{}) error {
+	return reflect.Into(ctx, c.Schema.AttributeType(), c.Raw, target, reflect.Options{})
+}
+
+// GetAttribute retrieves the attribute found at `path` and returns it as an
+// attr.Value. Consumers should assert the type of the returned value with the
+// desired attr.Type.
+func (c Config) GetAttribute(ctx context.Context, path *tftypes.AttributePath) (attr.Value, error) {
+	attrType, err := c.Schema.AttributeTypeAtPath(path)
+	if err != nil {
+		return nil, fmt.Errorf("error walking schema: %w", err)
+	}
+
+	attrValue, err := c.terraformValueAtPath(path)
+	if err != nil {
+		return nil, fmt.Errorf("error walking config: %w", err)
+	}
+
+	return attrType.ValueFromTerraform(ctx, *attrValue)
+}
+
+func (c Config) terraformValueAtPath(path *tftypes.AttributePath) (*tftypes.Value, error) {
+	rawValue, remaining, err := tftypes.WalkAttributePath(c.Raw, path)
+	if err != nil {
+		return nil, fmt.Errorf("%v still remains in the path: %w", remaining, err)
+	}
+	attrValue, ok := rawValue.(tftypes.Value)
+	if !ok {
+		return nil, fmt.Errorf("got non-tftypes.Value result %v", rawValue)
+	}
+	return &attrValue, err
+}

--- a/config.go
+++ b/config.go
@@ -35,17 +35,17 @@ func (c Config) GetAttribute(ctx context.Context, path *tftypes.AttributePath) (
 		return nil, fmt.Errorf("error walking config: %w", err)
 	}
 
-	return attrType.ValueFromTerraform(ctx, *attrValue)
+	return attrType.ValueFromTerraform(ctx, attrValue)
 }
 
-func (c Config) terraformValueAtPath(path *tftypes.AttributePath) (*tftypes.Value, error) {
+func (c Config) terraformValueAtPath(path *tftypes.AttributePath) (tftypes.Value, error) {
 	rawValue, remaining, err := tftypes.WalkAttributePath(c.Raw, path)
 	if err != nil {
-		return nil, fmt.Errorf("%v still remains in the path: %w", remaining, err)
+		return tftypes.Value{}, fmt.Errorf("%v still remains in the path: %w", remaining, err)
 	}
 	attrValue, ok := rawValue.(tftypes.Value)
 	if !ok {
-		return nil, fmt.Errorf("got non-tftypes.Value result %v", rawValue)
+		return tftypes.Value{}, fmt.Errorf("got non-tftypes.Value result %v", rawValue)
 	}
-	return &attrValue, err
+	return attrValue, err
 }

--- a/plan.go
+++ b/plan.go
@@ -35,17 +35,17 @@ func (p Plan) GetAttribute(ctx context.Context, path *tftypes.AttributePath) (at
 		return nil, fmt.Errorf("error walking plan: %w", err)
 	}
 
-	return attrType.ValueFromTerraform(ctx, *attrValue)
+	return attrType.ValueFromTerraform(ctx, attrValue)
 }
 
-func (p Plan) terraformValueAtPath(path *tftypes.AttributePath) (*tftypes.Value, error) {
+func (p Plan) terraformValueAtPath(path *tftypes.AttributePath) (tftypes.Value, error) {
 	rawValue, remaining, err := tftypes.WalkAttributePath(p.Raw, path)
 	if err != nil {
-		return nil, fmt.Errorf("%v still remains in the path: %w", remaining, err)
+		return tftypes.Value{}, fmt.Errorf("%v still remains in the path: %w", remaining, err)
 	}
 	attrValue, ok := rawValue.(tftypes.Value)
 	if !ok {
-		return nil, fmt.Errorf("got non-tftypes.Value result %v", rawValue)
+		return tftypes.Value{}, fmt.Errorf("got non-tftypes.Value result %v", rawValue)
 	}
-	return &attrValue, err
+	return attrValue, err
 }

--- a/plan.go
+++ b/plan.go
@@ -1,0 +1,51 @@
+package tfsdk
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/internal/reflect"
+	"github.com/hashicorp/terraform-plugin-framework/schema"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// Plan represents a Terraform plan.
+type Plan struct {
+	Raw    tftypes.Value
+	Schema schema.Schema
+}
+
+// Get populates the struct passed as `target` with the entire plan.
+func (p Plan) Get(ctx context.Context, target interface{}) error {
+	return reflect.Into(ctx, p.Schema.AttributeType(), p.Raw, target, reflect.Options{})
+}
+
+// GetAttribute retrieves the attribute found at `path` and returns it as an
+// attr.Value. Consumers should assert the type of the returned value with the
+// desired attr.Type.
+func (p Plan) GetAttribute(ctx context.Context, path *tftypes.AttributePath) (attr.Value, error) {
+	attrType, err := p.Schema.AttributeTypeAtPath(path)
+	if err != nil {
+		return nil, fmt.Errorf("error walking schema: %w", err)
+	}
+
+	attrValue, err := p.terraformValueAtPath(path)
+	if err != nil {
+		return nil, fmt.Errorf("error walking plan: %w", err)
+	}
+
+	return attrType.ValueFromTerraform(ctx, *attrValue)
+}
+
+func (p Plan) terraformValueAtPath(path *tftypes.AttributePath) (*tftypes.Value, error) {
+	rawValue, remaining, err := tftypes.WalkAttributePath(p.Raw, path)
+	if err != nil {
+		return nil, fmt.Errorf("%v still remains in the path: %w", remaining, err)
+	}
+	attrValue, ok := rawValue.(tftypes.Value)
+	if !ok {
+		return nil, fmt.Errorf("got non-tftypes.Value result %v", rawValue)
+	}
+	return &attrValue, err
+}

--- a/request.go
+++ b/request.go
@@ -31,12 +31,10 @@ type CreateResourceRequest struct {
 	// This configuration may contain unknown values if a user uses
 	// interpolation or other functionality that would prevent Terraform
 	// from knowing the value at request time.
-	// TODO uncomment when implemented
-	// Config Config
+	Config Config
 
 	// Plan is the planned state for the resource.
-	// TODO uncomment when implemented
-	// Plan Plan
+	Plan Plan
 }
 
 // ReadResourceRequest represents a request for the provider to read a
@@ -46,8 +44,7 @@ type CreateResourceRequest struct {
 type ReadResourceRequest struct {
 	// State is the current state of the resource prior to the Read
 	// operation.
-	// TODO uncomment when implemented
-	// State State
+	State State
 }
 
 // UpdateResourceRequest represents a request for the provider to update a
@@ -59,17 +56,14 @@ type UpdateResourceRequest struct {
 	// This configuration may contain unknown values if a user uses
 	// interpolation or other functionality that would prevent Terraform
 	// from knowing the value at request time.
-	// TODO uncomment when implemented
-	// Config Config
+	Config Config
 
 	// Plan is the planned state for the resource.
-	// TODO uncomment when implemented
-	// Plan Plan
+	Plan Plan
 
 	// State is the current state of the resource prior to the Update
 	// operation.
-	// TODO uncomment when implemented
-	// State State
+	State State
 }
 
 // DeleteResourceRequest represents a request for the provider to delete a
@@ -81,6 +75,5 @@ type DeleteResourceRequest struct {
 	// This configuration may contain unknown values if a user uses
 	// interpolation or other functionality that would prevent Terraform
 	// from knowing the value at request time.
-	// TODO uncomment when implemented
-	// Config Config
+	Config Config
 }

--- a/response.go
+++ b/response.go
@@ -66,8 +66,7 @@ type CreateResourceResponse struct {
 	// State is the state of the resource following the Create operation.
 	// This field is pre-populated from CreateResourceRequest.Plan and
 	// should be set during the resource's Create operation.
-	// TODO uncomment when implemented
-	// State State
+	State State
 
 	// Diagnostics report errors or warnings related to creating the
 	// resource. An empty slice indicates a successful operation with no
@@ -125,8 +124,7 @@ type ReadResourceResponse struct {
 	// State is the state of the resource following the Read operation.
 	// This field is pre-populated from ReadResourceRequest.State and
 	// should be set during the resource's Read operation.
-	// TODO uncomment when implemented
-	// State State
+	State State
 
 	// Diagnostics report errors or warnings related to reading the
 	// resource. An empty slice indicates a successful operation with no
@@ -184,8 +182,7 @@ type UpdateResourceResponse struct {
 	// State is the state of the resource following the Update operation.
 	// This field is pre-populated from UpdateResourceRequest.Plan and
 	// should be set during the resource's Update operation.
-	// TODO uncomment when implemented
-	// State State
+	State State
 
 	// Diagnostics report errors or warnings related to updating the
 	// resource. An empty slice indicates a successful operation with no

--- a/schema/attribute.go
+++ b/schema/attribute.go
@@ -1,6 +1,11 @@
 package schema
 
-import "github.com/hashicorp/terraform-plugin-framework/attr"
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
 
 // Attribute defines the constraints and behaviors of a single field in a
 // schema. Attributes are the fields that show up in Terraform state files and
@@ -59,4 +64,17 @@ type Attribute struct {
 	// using this attribute, warning them that it is deprecated and
 	// instructing them on what upgrade steps to take.
 	DeprecationMessage string
+}
+
+// ApplyTerraform5AttributePathStep applies the given AttributePathStep to the
+// attribute.
+func (a Attribute) ApplyTerraform5AttributePathStep(step tftypes.AttributePathStep) (interface{}, error) {
+	if a.Type != nil {
+		return a.Type.ApplyTerraform5AttributePathStep(step)
+	}
+	if a.Attributes != nil {
+		return a.Attributes.ApplyTerraform5AttributePathStep(step)
+	}
+
+	return nil, fmt.Errorf("could not apply step %T to Attribute, because it has no Type or Attributes set", step)
 }

--- a/schema/attribute.go
+++ b/schema/attribute.go
@@ -1,10 +1,7 @@
 package schema
 
 import (
-	"fmt"
-
 	"github.com/hashicorp/terraform-plugin-framework/attr"
-	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
 // Attribute defines the constraints and behaviors of a single field in a
@@ -64,17 +61,4 @@ type Attribute struct {
 	// using this attribute, warning them that it is deprecated and
 	// instructing them on what upgrade steps to take.
 	DeprecationMessage string
-}
-
-// ApplyTerraform5AttributePathStep applies the given AttributePathStep to the
-// attribute.
-func (a Attribute) ApplyTerraform5AttributePathStep(step tftypes.AttributePathStep) (interface{}, error) {
-	if a.Type != nil {
-		return a.Type.ApplyTerraform5AttributePathStep(step)
-	}
-	if a.Attributes != nil {
-		return a.Attributes.ApplyTerraform5AttributePathStep(step)
-	}
-
-	return nil, fmt.Errorf("could not apply step %T to Attribute, because it has no Type or Attributes set", step)
 }

--- a/schema/nested_attributes.go
+++ b/schema/nested_attributes.go
@@ -1,11 +1,8 @@
 package schema
 
 import (
-	"fmt"
-
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
 type nestingMode uint8
@@ -42,7 +39,6 @@ const (
 type NestedAttributes interface {
 	getNestingMode() nestingMode
 	getAttributes() map[string]Attribute
-	tftypes.AttributePathStepper
 	AttributeType() attr.Type
 }
 
@@ -67,16 +63,6 @@ type singleNestedAttributes struct {
 
 func (s singleNestedAttributes) getNestingMode() nestingMode {
 	return nestingModeSingle
-}
-
-// ApplyTerraform5AttributePathStep applies the given AttributePathStep to the
-// nested attributes.
-func (s singleNestedAttributes) ApplyTerraform5AttributePathStep(step tftypes.AttributePathStep) (interface{}, error) {
-	if _, ok := step.(tftypes.ElementKeyString); !ok {
-		return nil, fmt.Errorf("cannot apply step %T to SingleNestedAttributes", step)
-	}
-
-	return s.nestedAttributes, nil
 }
 
 // AttributeType returns an attr.Type corresponding to the nested attributes.
@@ -122,16 +108,6 @@ type ListNestedAttributesOptions struct {
 
 func (l listNestedAttributes) getNestingMode() nestingMode {
 	return nestingModeList
-}
-
-// ApplyTerraform5AttributePathStep applies the given AttributePathStep to the
-// nested attributes.
-func (l listNestedAttributes) ApplyTerraform5AttributePathStep(step tftypes.AttributePathStep) (interface{}, error) {
-	if _, ok := step.(tftypes.ElementKeyInt); !ok {
-		return nil, fmt.Errorf("cannot apply step %T to ListNestedAttributes", step)
-	}
-
-	return l.nestedAttributes, nil
 }
 
 // AttributeType returns an attr.Type corresponding to the nested attributes.
@@ -182,30 +158,10 @@ func (s setNestedAttributes) getNestingMode() nestingMode {
 	return nestingModeSet
 }
 
-// ApplyTerraform5AttributePathStep applies the given AttributePathStep to the
-// nested attributes.
-func (s setNestedAttributes) ApplyTerraform5AttributePathStep(step tftypes.AttributePathStep) (interface{}, error) {
-	if _, ok := step.(tftypes.ElementKeyInt); !ok {
-		return nil, fmt.Errorf("cannot apply step %T to SetNestedAttributes", step)
-	}
-
-	return s.nestedAttributes, nil
-}
-
 // AttributeType returns an attr.Type corresponding to the nested attributes.
 func (s setNestedAttributes) AttributeType() attr.Type {
-	attrTypes := map[string]attr.Type{}
-	for name, attr := range s.getAttributes() {
-		if attr.Type != nil {
-			attrTypes[name] = attr.Type
-		}
-		if attr.Attributes != nil {
-			attrTypes[name] = attr.Attributes.AttributeType()
-		}
-	}
-	return types.ObjectType{
-		AttrTypes: attrTypes,
-	}
+	// TODO fill in implementation when types.SetType is available
+	return nil
 }
 
 // MapNestedAttributes nests `attributes` under another attribute, allowing
@@ -238,28 +194,8 @@ func (m mapNestedAttributes) getNestingMode() nestingMode {
 	return nestingModeMap
 }
 
-// ApplyTerraform5AttributePathStep applies the given AttributePathStep to the
-// nested attributes.
-func (m mapNestedAttributes) ApplyTerraform5AttributePathStep(step tftypes.AttributePathStep) (interface{}, error) {
-	if _, ok := step.(tftypes.ElementKeyString); !ok {
-		return nil, fmt.Errorf("cannot apply step %T to MapNestedAttributes", step)
-	}
-
-	return m.nestedAttributes, nil
-}
-
 // AttributeType returns an attr.Type corresponding to the nested attributes.
 func (m mapNestedAttributes) AttributeType() attr.Type {
-	attrTypes := map[string]attr.Type{}
-	for name, attr := range m.getAttributes() {
-		if attr.Type != nil {
-			attrTypes[name] = attr.Type
-		}
-		if attr.Attributes != nil {
-			attrTypes[name] = attr.Attributes.AttributeType()
-		}
-	}
-	return types.ObjectType{
-		AttrTypes: attrTypes,
-	}
+	// TODO fill in implementation when types.MapType is available
+	return nil
 }

--- a/schema/nested_attributes.go
+++ b/schema/nested_attributes.go
@@ -149,7 +149,7 @@ func (s setNestedAttributes) getNestingMode() nestingMode {
 // nested attributes.
 func (s setNestedAttributes) ApplyTerraform5AttributePathStep(step tftypes.AttributePathStep) (interface{}, error) {
 	if _, ok := step.(tftypes.ElementKeyInt); !ok {
-		return nil, fmt.Errorf("cannot apply step %T to ListNestedAttributes", step)
+		return nil, fmt.Errorf("cannot apply step %T to SetNestedAttributes", step)
 	}
 
 	return s.nestedAttributes, nil
@@ -189,7 +189,7 @@ func (m mapNestedAttributes) getNestingMode() nestingMode {
 // nested attributes.
 func (m mapNestedAttributes) ApplyTerraform5AttributePathStep(step tftypes.AttributePathStep) (interface{}, error) {
 	if _, ok := step.(tftypes.ElementKeyString); !ok {
-		return nil, fmt.Errorf("cannot apply step %T to SingleNestedAttributes", step)
+		return nil, fmt.Errorf("cannot apply step %T to MapNestedAttributes", step)
 	}
 
 	return m.nestedAttributes, nil

--- a/schema/nested_attributes.go
+++ b/schema/nested_attributes.go
@@ -3,6 +3,8 @@ package schema
 import (
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
@@ -41,6 +43,7 @@ type NestedAttributes interface {
 	getNestingMode() nestingMode
 	getAttributes() map[string]Attribute
 	tftypes.AttributePathStepper
+	AttributeType() attr.Type
 }
 
 type nestedAttributes map[string]Attribute
@@ -74,6 +77,22 @@ func (s singleNestedAttributes) ApplyTerraform5AttributePathStep(step tftypes.At
 	}
 
 	return s.nestedAttributes, nil
+}
+
+// AttributeType returns an attr.Type corresponding to the nested attributes.
+func (s singleNestedAttributes) AttributeType() attr.Type {
+	attrTypes := map[string]attr.Type{}
+	for name, attr := range s.getAttributes() {
+		if attr.Type != nil {
+			attrTypes[name] = attr.Type
+		}
+		if attr.Attributes != nil {
+			attrTypes[name] = attr.Attributes.AttributeType()
+		}
+	}
+	return types.ObjectType{
+		AttrTypes: attrTypes,
+	}
 }
 
 // ListNestedAttributes nests `attributes` under another attribute, allowing
@@ -113,6 +132,24 @@ func (l listNestedAttributes) ApplyTerraform5AttributePathStep(step tftypes.Attr
 	}
 
 	return l.nestedAttributes, nil
+}
+
+// AttributeType returns an attr.Type corresponding to the nested attributes.
+func (l listNestedAttributes) AttributeType() attr.Type {
+	attrTypes := map[string]attr.Type{}
+	for name, attr := range l.getAttributes() {
+		if attr.Type != nil {
+			attrTypes[name] = attr.Type
+		}
+		if attr.Attributes != nil {
+			attrTypes[name] = attr.Attributes.AttributeType()
+		}
+	}
+	return types.ListType{
+		ElemType: types.ObjectType{
+			AttrTypes: attrTypes,
+		},
+	}
 }
 
 // SetNestedAttributes nests `attributes` under another attribute, allowing
@@ -155,6 +192,22 @@ func (s setNestedAttributes) ApplyTerraform5AttributePathStep(step tftypes.Attri
 	return s.nestedAttributes, nil
 }
 
+// AttributeType returns an attr.Type corresponding to the nested attributes.
+func (s setNestedAttributes) AttributeType() attr.Type {
+	attrTypes := map[string]attr.Type{}
+	for name, attr := range s.getAttributes() {
+		if attr.Type != nil {
+			attrTypes[name] = attr.Type
+		}
+		if attr.Attributes != nil {
+			attrTypes[name] = attr.Attributes.AttributeType()
+		}
+	}
+	return types.ObjectType{
+		AttrTypes: attrTypes,
+	}
+}
+
 // MapNestedAttributes nests `attributes` under another attribute, allowing
 // multiple instances of that group of attributes to appear in the
 // configuration. Each group will need to be associated with a unique string by
@@ -193,4 +246,20 @@ func (m mapNestedAttributes) ApplyTerraform5AttributePathStep(step tftypes.Attri
 	}
 
 	return m.nestedAttributes, nil
+}
+
+// AttributeType returns an attr.Type corresponding to the nested attributes.
+func (m mapNestedAttributes) AttributeType() attr.Type {
+	attrTypes := map[string]attr.Type{}
+	for name, attr := range m.getAttributes() {
+		if attr.Type != nil {
+			attrTypes[name] = attr.Type
+		}
+		if attr.Attributes != nil {
+			attrTypes[name] = attr.Attributes.AttributeType()
+		}
+	}
+	return types.ObjectType{
+		AttrTypes: attrTypes,
+	}
 }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -46,7 +46,7 @@ func (s Schema) AttributeType() attr.Type {
 			attrTypes[name] = attr.Type
 		}
 		if attr.Attributes != nil {
-			// TODO: handle nested attributes
+			attrTypes[name] = attr.Attributes.AttributeType()
 		}
 	}
 	return types.ObjectType{AttrTypes: attrTypes}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -31,7 +31,12 @@ type Schema struct {
 func (s Schema) ApplyTerraform5AttributePathStep(step tftypes.AttributePathStep) (interface{}, error) {
 	if v, ok := step.(tftypes.AttributeName); ok {
 		if attr, ok := s.Attributes[string(v)]; ok {
-			return attr.Type, nil
+			if attr.Type != nil {
+				return attr.Type, nil
+			}
+			if attr.Attributes != nil {
+				return attr.Attributes.AttributeType(), nil
+			}
 		}
 		return nil, fmt.Errorf("could not find attribute %q in schema", v)
 	}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1,5 +1,13 @@
 package schema
 
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
 // Schema is used to define the shape of practitioner-provider information,
 // like resources, data sources, and providers. Think of it as a type
 // definition, but for Terraform.
@@ -16,4 +24,45 @@ type Schema struct {
 	// changing an attribute type, that needs manual upgrade handling.
 	// Versions should only be incremented by one each release.
 	Version int64
+}
+
+// ApplyTerraform5AttributePathStep applies the given AttributePathStep to the
+// schema.
+func (s Schema) ApplyTerraform5AttributePathStep(step tftypes.AttributePathStep) (interface{}, error) {
+	if v, ok := step.(tftypes.AttributeName); ok {
+		if attr, ok := s.Attributes[string(v)]; ok {
+			return attr.Type, nil
+		}
+		return nil, fmt.Errorf("could not find attribute %q in schema", v)
+	}
+	return nil, fmt.Errorf("cannot apply AttributePathStep %T to schema", step)
+}
+
+// AttributeType returns a types.ObjectType composed from the schema types.
+func (s Schema) AttributeType() attr.Type {
+	attrTypes := map[string]attr.Type{}
+	for name, attr := range s.Attributes {
+		if attr.Type != nil {
+			attrTypes[name] = attr.Type
+		}
+		if attr.Attributes != nil {
+			// TODO: handle nested attributes
+		}
+	}
+	return types.ObjectType{AttrTypes: attrTypes}
+}
+
+// AttributeTypeAtPath returns the attr.Type of the attribute at the given path.
+func (s Schema) AttributeTypeAtPath(path *tftypes.AttributePath) (attr.Type, error) {
+	rawType, remaining, err := tftypes.WalkAttributePath(s, path)
+	if err != nil {
+		return nil, fmt.Errorf("%v still remains in the path: %w", remaining, err)
+	}
+
+	attrType, ok := rawType.(attr.Type)
+	if !ok {
+		return nil, fmt.Errorf("got non-attr.Type result %v with type %T", rawType, rawType)
+	}
+
+	return attrType, nil
 }

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -1,0 +1,63 @@
+package schema
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestSchemaAttributeType(t *testing.T) {
+	testSchema := Schema{
+		Attributes: map[string]Attribute{
+			"foo": {
+				Type:     types.StringType,
+				Required: true,
+			},
+			"bar": {
+				Type: types.ListType{
+					ElemType: types.StringType,
+				},
+				Required: true,
+			},
+			"disks": {
+				Attributes: ListNestedAttributes(map[string]Attribute{
+					"id": {
+						Type:     types.StringType,
+						Required: true,
+					},
+					"delete_with_instance": {
+						Type:     types.BoolType,
+						Optional: true,
+					},
+				}, ListNestedAttributesOptions{}),
+				Optional: true,
+				Computed: true,
+			},
+		},
+	}
+
+	expectedType := types.ObjectType{
+		AttrTypes: map[string]attr.Type{
+			"foo": types.StringType,
+			"bar": types.ListType{
+				ElemType: types.StringType,
+			},
+			"disks": types.ListType{
+				ElemType: types.ObjectType{
+					AttrTypes: map[string]attr.Type{
+						"id":                   types.StringType,
+						"delete_with_instance": types.BoolType,
+					},
+				},
+			},
+		},
+	}
+
+	actualType := testSchema.AttributeType()
+
+	if !expectedType.Equal(actualType) {
+		t.Fatalf("types not equal (+wanted, -got): %s", cmp.Diff(expectedType, actualType))
+	}
+}

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -35,6 +35,17 @@ func TestSchemaAttributeType(t *testing.T) {
 				Optional: true,
 				Computed: true,
 			},
+			"boot_disk": {
+				Attributes: SingleNestedAttributes(map[string]Attribute{
+					"id": {
+						Type:     types.StringType,
+						Required: true,
+					},
+					"delete_with_instance": {
+						Type: types.BoolType,
+					},
+				}),
+			},
 		},
 	}
 
@@ -50,6 +61,12 @@ func TestSchemaAttributeType(t *testing.T) {
 						"id":                   types.StringType,
 						"delete_with_instance": types.BoolType,
 					},
+				},
+			},
+			"boot_disk": types.ObjectType{
+				AttrTypes: map[string]attr.Type{
+					"id":                   types.StringType,
+					"delete_with_instance": types.BoolType,
 				},
 			},
 		},

--- a/state.go
+++ b/state.go
@@ -35,17 +35,17 @@ func (s State) GetAttribute(ctx context.Context, path *tftypes.AttributePath) (a
 		return nil, fmt.Errorf("error walking state: %w", err)
 	}
 
-	return attrType.ValueFromTerraform(ctx, *attrValue)
+	return attrType.ValueFromTerraform(ctx, attrValue)
 }
 
-func (s State) terraformValueAtPath(path *tftypes.AttributePath) (*tftypes.Value, error) {
+func (s State) terraformValueAtPath(path *tftypes.AttributePath) (tftypes.Value, error) {
 	rawValue, remaining, err := tftypes.WalkAttributePath(s.Raw, path)
 	if err != nil {
-		return nil, fmt.Errorf("%v still remains in the path: %w", remaining, err)
+		return tftypes.Value{}, fmt.Errorf("%v still remains in the path: %w", remaining, err)
 	}
 	attrValue, ok := rawValue.(tftypes.Value)
 	if !ok {
-		return nil, fmt.Errorf("got non-tftypes.Value result %v", rawValue)
+		return tftypes.Value{}, fmt.Errorf("got non-tftypes.Value result %v", rawValue)
 	}
-	return &attrValue, err
+	return attrValue, err
 }

--- a/state.go
+++ b/state.go
@@ -1,0 +1,57 @@
+package tfsdk
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/internal/reflect"
+	"github.com/hashicorp/terraform-plugin-framework/schema"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// State represents a Terraform state.
+type State struct {
+	Raw    tftypes.Value
+	Schema schema.Schema
+}
+
+// Get populates the struct passed as `target` with the entire state.
+func (s State) Get(ctx context.Context, target interface{}) error {
+	return reflect.Into(ctx, s.Schema.AttributeType(), s.Raw, target, reflect.Options{})
+}
+
+// GetAttribute retrieves the attribute found at `path` and returns it as an
+// attr.Value. Consumers should assert the type of the returned value with the
+// desired attr.Type.
+func (s State) GetAttribute(ctx context.Context, path *tftypes.AttributePath) (attr.Value, error) {
+	attrType, err := s.Schema.AttributeTypeAtPath(path)
+	if err != nil {
+		return nil, fmt.Errorf("error walking schema: %w", err)
+	}
+
+	attrValue, err := s.terraformValueAtPath(path)
+	if err != nil {
+		return nil, fmt.Errorf("error walking state: %w", err)
+	}
+
+	return attrType.ValueFromTerraform(ctx, *attrValue)
+}
+
+// MustGetAttribute retrieves the attribute as GetAttribute does, but populates target using As,
+// using the simplified representation without Unknown. Errors if Unknown present
+// func (s State) MustGetAttribute(ctx context.Context, path tftypes.AttributePath, target interface{}) error {
+// 	return nil
+// }
+
+func (s State) terraformValueAtPath(path *tftypes.AttributePath) (*tftypes.Value, error) {
+	rawValue, remaining, err := tftypes.WalkAttributePath(s.Raw, path)
+	if err != nil {
+		return nil, fmt.Errorf("%v still remains in the path: %w", remaining, err)
+	}
+	attrValue, ok := rawValue.(tftypes.Value)
+	if !ok {
+		return nil, fmt.Errorf("got non-tftypes.Value result %v", rawValue)
+	}
+	return &attrValue, err
+}

--- a/state.go
+++ b/state.go
@@ -38,12 +38,6 @@ func (s State) GetAttribute(ctx context.Context, path *tftypes.AttributePath) (a
 	return attrType.ValueFromTerraform(ctx, *attrValue)
 }
 
-// MustGetAttribute retrieves the attribute as GetAttribute does, but populates target using As,
-// using the simplified representation without Unknown. Errors if Unknown present
-// func (s State) MustGetAttribute(ctx context.Context, path tftypes.AttributePath, target interface{}) error {
-// 	return nil
-// }
-
 func (s State) terraformValueAtPath(path *tftypes.AttributePath) (*tftypes.Value, error) {
 	rawValue, remaining, err := tftypes.WalkAttributePath(s.Raw, path)
 	if err != nil {

--- a/state_test.go
+++ b/state_test.go
@@ -1,0 +1,215 @@
+package tfsdk
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func TestStateGet(t *testing.T) {
+	schema := schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"foo": {
+				Type:     types.StringType,
+				Required: true,
+			},
+			"bar": {
+				Type: types.ListType{
+					ElemType: types.StringType,
+				},
+				Required: true,
+			},
+		},
+	}
+	state := State{
+		Raw: tftypes.NewValue(tftypes.Object{
+			AttributeTypes: map[string]tftypes.Type{
+				"foo": tftypes.String,
+				"bar": tftypes.List{ElementType: tftypes.String},
+			},
+		}, map[string]tftypes.Value{
+			"foo": tftypes.NewValue(tftypes.String, "hello, world"),
+			"bar": tftypes.NewValue(tftypes.List{
+				ElementType: tftypes.String,
+			}, []tftypes.Value{
+				tftypes.NewValue(tftypes.String, "red"),
+				tftypes.NewValue(tftypes.String, "blue"),
+				tftypes.NewValue(tftypes.String, "green"),
+			}),
+		}),
+		Schema: schema,
+	}
+	type myType struct {
+		Foo types.String `tfsdk:"foo"`
+		Bar types.List   `tfsdk:"bar"`
+	}
+	var val myType
+	err := state.Get(context.Background(), &val)
+	if err != nil {
+		t.Errorf("Error running Get: %s", err)
+	}
+	if val.Foo.Unknown {
+		t.Error("Expected Foo to be known")
+	}
+	if val.Foo.Null {
+		t.Error("Expected Foo to be non-null")
+	}
+	if val.Foo.Value != "hello, world" {
+		t.Errorf("Expected Foo to be %q, got %q", "hello, world", val.Foo.Value)
+	}
+	if val.Bar.Unknown {
+		t.Error("Expected Bar to be known")
+	}
+	if val.Bar.Null {
+		t.Errorf("Expected Bar to be non-null")
+	}
+	if len(val.Bar.Elems) != 3 {
+		t.Errorf("Expected Bar to have 3 elements, had %d", len(val.Bar.Elems))
+	}
+	if val.Bar.Elems[0].(types.String).Value != "red" {
+		t.Errorf("Expected Bar's first element to be %q, got %q", "red", val.Bar.Elems[0].(types.String).Value)
+	}
+	if val.Bar.Elems[1].(types.String).Value != "blue" {
+		t.Errorf("Expected Bar's second element to be %q, got %q", "blue", val.Bar.Elems[1].(types.String).Value)
+	}
+	if val.Bar.Elems[2].(types.String).Value != "green" {
+		t.Errorf("Expected Bar's third element to be %q, got %q", "green", val.Bar.Elems[2].(types.String).Value)
+	}
+}
+
+func TestStateGetAttribute(t *testing.T) {
+	schema := schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"foo": {
+				Type:     types.StringType,
+				Required: true,
+			},
+			"bar": {
+				Type: types.ListType{
+					ElemType: types.StringType,
+				},
+				Required: true,
+			},
+		},
+	}
+	state := State{
+		Raw: tftypes.NewValue(tftypes.Object{
+			AttributeTypes: map[string]tftypes.Type{
+				"foo": tftypes.String,
+				"bar": tftypes.List{ElementType: tftypes.String},
+			},
+		}, map[string]tftypes.Value{
+			"foo": tftypes.NewValue(tftypes.String, "hello, world"),
+			"bar": tftypes.NewValue(tftypes.List{
+				ElementType: tftypes.String,
+			}, []tftypes.Value{
+				tftypes.NewValue(tftypes.String, "red"),
+				tftypes.NewValue(tftypes.String, "blue"),
+				tftypes.NewValue(tftypes.String, "green"),
+			}),
+		}),
+		Schema: schema,
+	}
+
+	fooVal, err := state.GetAttribute(context.Background(), tftypes.NewAttributePath().WithAttributeName("foo"))
+	if err != nil {
+		t.Errorf("Error running GetAttribute for foo: %s", err)
+	}
+	foo, ok := fooVal.(types.String)
+	if !ok {
+		t.Errorf("expected foo to have type String, but it was %T", fooVal)
+	}
+	if foo.Unknown {
+		t.Error("Expected Foo to be known")
+	}
+	if foo.Null {
+		t.Error("Expected Foo to be non-null")
+	}
+	if foo.Value != "hello, world" {
+		t.Errorf("Expected Foo to be %q, got %q", "hello, world", foo.Value)
+	}
+
+	barVal, err := state.GetAttribute(context.Background(), tftypes.NewAttributePath().WithAttributeName("bar"))
+	if err != nil {
+		t.Errorf("Error running GetAttribute for bar: %s", err)
+	}
+	bar, ok := barVal.(types.List)
+	if !ok {
+		t.Errorf("expected bar to have type List, but it was %T", barVal)
+	}
+	if bar.Unknown {
+		t.Error("Expected Bar to be known")
+	}
+	if bar.Null {
+		t.Errorf("Expected Bar to be non-null")
+	}
+	if len(bar.Elems) != 3 {
+		t.Errorf("Expected Bar to have 3 elements, had %d", len(bar.Elems))
+	}
+	if bar.Elems[0].(types.String).Value != "red" {
+		t.Errorf("Expected Bar's first element to be %q, got %q", "red", bar.Elems[0].(types.String).Value)
+	}
+	if bar.Elems[1].(types.String).Value != "blue" {
+		t.Errorf("Expected Bar's second element to be %q, got %q", "blue", bar.Elems[1].(types.String).Value)
+	}
+	if bar.Elems[2].(types.String).Value != "green" {
+		t.Errorf("Expected Bar's third element to be %q, got %q", "green", bar.Elems[2].(types.String).Value)
+	}
+
+	bar0Val, err := state.GetAttribute(context.Background(), tftypes.NewAttributePath().WithAttributeName("bar").WithElementKeyInt(0))
+	if err != nil {
+		t.Errorf("Error running GetAttribute for bar[0]: %s", err)
+	}
+	bar0, ok := bar0Val.(types.String)
+	if !ok {
+		t.Errorf("expected bar[0] to have type String, but it was %T", bar0Val)
+	}
+	if bar0.Unknown {
+		t.Error("expected bar[0] to be known")
+	}
+	if bar0.Null {
+		t.Error("expected bar[0] to be non-null")
+	}
+	if bar0.Value != "red" {
+		t.Errorf("Expected bar[0] to be %q, got %q", "red", bar0.Value)
+	}
+
+	bar1Val, err := state.GetAttribute(context.Background(), tftypes.NewAttributePath().WithAttributeName("bar").WithElementKeyInt(1))
+	if err != nil {
+		t.Errorf("Error running GetAttribute for bar[1]: %s", err)
+	}
+	bar1, ok := bar1Val.(types.String)
+	if !ok {
+		t.Errorf("expected bar[1] to have type String, but it was %T", bar1Val)
+	}
+	if bar1.Unknown {
+		t.Error("expected bar[1] to be known")
+	}
+	if bar1.Null {
+		t.Error("expected bar[1] to be non-null")
+	}
+	if bar1.Value != "blue" {
+		t.Errorf("Expected bar[1] to be %q, got %q", "red", bar1.Value)
+	}
+
+	bar2Val, err := state.GetAttribute(context.Background(), tftypes.NewAttributePath().WithAttributeName("bar").WithElementKeyInt(2))
+	if err != nil {
+		t.Errorf("Error running GetAttribute for bar[2]: %s", err)
+	}
+	bar2, ok := bar2Val.(types.String)
+	if !ok {
+		t.Errorf("expected bar[2] to have type String, but it was %T", bar2Val)
+	}
+	if bar2.Unknown {
+		t.Error("expected bar[2] to be known")
+	}
+	if bar2.Null {
+		t.Error("expected bar[2] to be non-null")
+	}
+	if bar2.Value != "green" {
+		t.Errorf("Expected bar[2] to be %q, got %q", "red", bar2.Value)
+	}
+}

--- a/state_test.go
+++ b/state_test.go
@@ -51,32 +51,19 @@ func TestStateGet(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error running Get: %s", err)
 	}
-	if val.Foo.Unknown {
-		t.Error("Expected Foo to be known")
+	expected := myType{
+	  Foo: types.String{Value: "hello, world"},
+	  Bar: types.List{
+	    ElemType: types.StringType,
+	    Elems: []attr.Value{
+	      types.String{Value: "red"},
+	      types.String{Value: "blue"},
+	      types.String{Value: "green"},
+	    },
+	  },
 	}
-	if val.Foo.Null {
-		t.Error("Expected Foo to be non-null")
-	}
-	if val.Foo.Value != "hello, world" {
-		t.Errorf("Expected Foo to be %q, got %q", "hello, world", val.Foo.Value)
-	}
-	if val.Bar.Unknown {
-		t.Error("Expected Bar to be known")
-	}
-	if val.Bar.Null {
-		t.Errorf("Expected Bar to be non-null")
-	}
-	if len(val.Bar.Elems) != 3 {
-		t.Errorf("Expected Bar to have 3 elements, had %d", len(val.Bar.Elems))
-	}
-	if val.Bar.Elems[0].(types.String).Value != "red" {
-		t.Errorf("Expected Bar's first element to be %q, got %q", "red", val.Bar.Elems[0].(types.String).Value)
-	}
-	if val.Bar.Elems[1].(types.String).Value != "blue" {
-		t.Errorf("Expected Bar's second element to be %q, got %q", "blue", val.Bar.Elems[1].(types.String).Value)
-	}
-	if val.Bar.Elems[2].(types.String).Value != "green" {
-		t.Errorf("Expected Bar's third element to be %q, got %q", "green", val.Bar.Elems[2].(types.String).Value)
+	diff := cmp.Diff(expected, val); diff != "" {
+	  t.Errorf("unexpected diff (+wanted, -got): %s", diff)
 	}
 }
 

--- a/types/list.go
+++ b/types/list.go
@@ -120,17 +120,9 @@ type List struct {
 func (l List) ElementsAs(ctx context.Context, target interface{}, allowUnhandled bool) error {
 	// we need a tftypes.Value for this List to be able to use it with our
 	// reflection code
-	values := make([]tftypes.Value, 0, len(l.Elems))
-	for pos, elem := range l.Elems {
-		val, err := elem.ToTerraformValue(ctx)
-		if err != nil {
-			return fmt.Errorf("error getting Terraform value for element %d: %w", pos, err)
-		}
-		err = tftypes.ValidateValue(l.ElemType.TerraformType(ctx), val)
-		if err != nil {
-			return fmt.Errorf("error using created Terraform value for element %d: %w", pos, err)
-		}
-		values = append(values, tftypes.NewValue(l.ElemType.TerraformType(ctx), val))
+	values, err := l.ToTerraformValue(ctx)
+	if err != nil {
+		return err
 	}
 	return reflect.Into(ctx, ListType{ElemType: l.ElemType}, tftypes.NewValue(tftypes.List{
 		ElementType: l.ElemType.TerraformType(ctx),

--- a/types/list.go
+++ b/types/list.go
@@ -91,6 +91,16 @@ func (l ListType) Equal(o attr.Type) bool {
 	return l.ElemType.Equal(other.ElemType)
 }
 
+// ApplyTerraform5AttributePathStep applies the given AttributePathStep to the
+// list.
+func (l ListType) ApplyTerraform5AttributePathStep(step tftypes.AttributePathStep) (interface{}, error) {
+	if _, ok := step.(tftypes.ElementKeyInt); !ok {
+		return nil, fmt.Errorf("cannot apply step %T to ListType", step)
+	}
+
+	return l.ElemType, nil
+}
+
 // List represents a list of AttributeValues, all of the same type, indicated
 // by ElemType.
 type List struct {

--- a/types/object.go
+++ b/types/object.go
@@ -101,6 +101,16 @@ func (o ObjectType) Equal(candidate attr.Type) bool {
 	return true
 }
 
+// ApplyTerraform5AttributePathStep applies the given AttributePathStep to the
+// object.
+func (o ObjectType) ApplyTerraform5AttributePathStep(step tftypes.AttributePathStep) (interface{}, error) {
+	if _, ok := step.(tftypes.ElementKeyString); !ok {
+		return nil, fmt.Errorf("cannot apply step %T to ObjectType", step)
+	}
+
+	return o.AttrTypes[string(step.(tftypes.ElementKeyString))], nil
+}
+
 // Object represents an object
 type Object struct {
 	// Unknown will be set to true if the entire object is an unknown value.

--- a/types/object.go
+++ b/types/object.go
@@ -104,11 +104,11 @@ func (o ObjectType) Equal(candidate attr.Type) bool {
 // ApplyTerraform5AttributePathStep applies the given AttributePathStep to the
 // object.
 func (o ObjectType) ApplyTerraform5AttributePathStep(step tftypes.AttributePathStep) (interface{}, error) {
-	if _, ok := step.(tftypes.ElementKeyString); !ok {
+	if _, ok := step.(tftypes.AttributeName); !ok {
 		return nil, fmt.Errorf("cannot apply step %T to ObjectType", step)
 	}
 
-	return o.AttrTypes[string(step.(tftypes.ElementKeyString))], nil
+	return o.AttrTypes[string(step.(tftypes.AttributeName))], nil
 }
 
 // Object represents an object

--- a/types/primitive.go
+++ b/types/primitive.go
@@ -88,3 +88,9 @@ func (p primitive) Equal(o attr.Type) bool {
 		return false
 	}
 }
+
+// ApplyTerraform5AttributePathStep applies the given AttributePathStep to the
+// type.
+func (p primitive) ApplyTerraform5AttributePathStep(step tftypes.AttributePathStep) (interface{}, error) {
+	return nil, fmt.Errorf("cannot apply AttributePathStep %T to %s", step, p.String())
+}

--- a/types/primitive_test.go
+++ b/types/primitive_test.go
@@ -67,6 +67,10 @@ func (t testAttributeType) Equal(_ attr.Type) bool {
 	panic("not implemented")
 }
 
+func (t testAttributeType) ApplyTerraform5AttributePathStep(_ tftypes.AttributePathStep) (interface{}, error) {
+	panic("not implemented")
+}
+
 func TestPrimitiveEqual(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
The changes to `internal/reflect` on `main` made rather a mess of `katystate3`. We're up to `katystate5` now.

The main work here is the addition of `ApplyTerraform5AttributePathStep` to all schema types, implementing the `tftypes.AttributePathStepper` interface so that we can traverse the schema with [`tftypes.WalkAttributePath`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-go@v0.3.0/tftypes#WalkAttributePath).