### PR TITLE
Add support for retrieving tfprotov6.ProviderServer.

### DIFF
--- a/.changelog/72.txt
+++ b/.changelog/72.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+Added `tfsdk.NewProtocol6Server` to return a `tfprotov6.ProviderServer` implementation for testing and muxing purposes.
+```

--- a/tfsdk/serve.go
+++ b/tfsdk/serve.go
@@ -29,6 +29,14 @@ type ServeOpts struct {
 	Name string
 }
 
+// NewProtocol6Server returns a tfprotov6.ProviderServer implementation based
+// on the passed Provider implementation.
+func NewProtocol6Server(p Provider) tfprotov6.ProviderServer {
+	return &server{
+		p: p,
+	}
+}
+
 // Serve serves a provider, blocking until the context is canceled.
 func Serve(ctx context.Context, factory func() Provider, opts ServeOpts) error {
 	return tf6server.Serve(opts.Name, func() tfprotov6.ProviderServer {


### PR DESCRIPTION
We need access to the tfprotov6.ProviderServer underlying `tfsdk.Serve`
for things like testing and muxing. Add a function that will expose it.