### PR TITLE
Fix out of date guidance for GetSchema.

### DIFF
--- a/tfsdk/provider.go
+++ b/tfsdk/provider.go
@@ -10,7 +10,7 @@ import (
 // Provider is the core interface that all Terraform providers must implement.
 type Provider interface {
 	// GetSchema returns the schema for this provider's configuration. If
-	// this provider has no configuration, return nil.
+	// this provider has no configuration, return an empty schema.Schema.
 	GetSchema(context.Context) (schema.Schema, []*tfprotov6.Diagnostic)
 
 	// Configure is called at the beginning of the provider lifecycle, when


### PR DESCRIPTION
The Provider interface's GetSchema method told provider developers to
return nil, but they can't actually return nil anymore. Update to
correct the guidance.