### PR TITLE
Default to prior state in responses.

### DIFF
--- a/.changelog/74.txt
+++ b/.changelog/74.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+Responses now default to returning the current state, meaning state will only change when provider developers actively change it. Previously, an empty state value would be returned, which caused problems.
+```

--- a/tfsdk/serve.go
+++ b/tfsdk/serve.go
@@ -723,7 +723,6 @@ func (s *server) ApplyResourceChange(ctx context.Context, req *tfprotov6.ApplyRe
 		})
 		return resp, nil
 	}
-	return resp, nil
 }
 
 func (s *server) ImportResourceState(ctx context.Context, _ *tfprotov6.ImportResourceStateRequest) (*tfprotov6.ImportResourceStateResponse, error) {

--- a/tfsdk/serve.go
+++ b/tfsdk/serve.go
@@ -348,6 +348,7 @@ func (s *server) ReadResource(ctx context.Context, req *tfprotov6.ReadResourceRe
 	}
 	readResp := ReadResourceResponse{
 		State: State{
+			Raw:    state,
 			Schema: resourceSchema,
 		},
 		Diagnostics: resp.Diagnostics,
@@ -583,15 +584,12 @@ func (s *server) ApplyResourceChange(ctx context.Context, req *tfprotov6.ApplyRe
 		createResp := CreateResourceResponse{
 			State: State{
 				Schema: resourceSchema,
+				Raw:    priorState,
 			},
 			Diagnostics: resp.Diagnostics,
 		}
 		resource.Create(ctx, createReq, &createResp)
 		resp.Diagnostics = createResp.Diagnostics
-		// TODO: set partial state before returning error
-		if diagsHasErrors(resp.Diagnostics) {
-			return resp, nil
-		}
 		newState, err := tfprotov6.NewDynamicValue(resourceSchema.TerraformType(ctx), createResp.State.Raw)
 		if err != nil {
 			resp.Diagnostics = append(resp.Diagnostics, &tfprotov6.Diagnostic{
@@ -647,15 +645,12 @@ func (s *server) ApplyResourceChange(ctx context.Context, req *tfprotov6.ApplyRe
 		updateResp := UpdateResourceResponse{
 			State: State{
 				Schema: resourceSchema,
+				Raw:    priorState,
 			},
 			Diagnostics: resp.Diagnostics,
 		}
 		resource.Update(ctx, updateReq, &updateResp)
 		resp.Diagnostics = updateResp.Diagnostics
-		// TODO: set partial state before returning error
-		if diagsHasErrors(resp.Diagnostics) {
-			return resp, nil
-		}
 		newState, err := tfprotov6.NewDynamicValue(resourceSchema.TerraformType(ctx), updateResp.State.Raw)
 		if err != nil {
 			resp.Diagnostics = append(resp.Diagnostics, &tfprotov6.Diagnostic{
@@ -666,6 +661,7 @@ func (s *server) ApplyResourceChange(ctx context.Context, req *tfprotov6.ApplyRe
 			return resp, nil
 		}
 		resp.NewState = &newState
+		return resp, nil
 	case !create && !update && destroy:
 		destroyReq := DeleteResourceRequest{
 			State: State{
@@ -702,15 +698,12 @@ func (s *server) ApplyResourceChange(ctx context.Context, req *tfprotov6.ApplyRe
 		destroyResp := DeleteResourceResponse{
 			State: State{
 				Schema: resourceSchema,
+				Raw:    priorState,
 			},
 			Diagnostics: resp.Diagnostics,
 		}
 		resource.Delete(ctx, destroyReq, &destroyResp)
 		resp.Diagnostics = destroyResp.Diagnostics
-		// TODO: set partial state before returning error
-		if diagsHasErrors(resp.Diagnostics) {
-			return resp, nil
-		}
 		newState, err := tfprotov6.NewDynamicValue(resourceSchema.TerraformType(ctx), destroyResp.State.Raw)
 		if err != nil {
 			resp.Diagnostics = append(resp.Diagnostics, &tfprotov6.Diagnostic{
@@ -721,6 +714,7 @@ func (s *server) ApplyResourceChange(ctx context.Context, req *tfprotov6.ApplyRe
 			return resp, nil
 		}
 		resp.NewState = &newState
+		return resp, nil
 	default:
 		resp.Diagnostics = append(resp.Diagnostics, &tfprotov6.Diagnostic{
 			Severity: tfprotov6.DiagnosticSeverityError,
@@ -811,6 +805,10 @@ func (s *server) ReadDataSource(ctx context.Context, req *tfprotov6.ReadDataSour
 	readResp := ReadDataSourceResponse{
 		State: State{
 			Schema: dataSourceSchema,
+			// default to the config values
+			// they should be of the same type
+			// we just want SetAttribute to not find an empty value
+			Raw: config,
 		},
 		Diagnostics: resp.Diagnostics,
 	}

--- a/tfsdk/serve_test.go
+++ b/tfsdk/serve_test.go
@@ -1289,6 +1289,8 @@ func TestServerApplyResourceChange(t *testing.T) {
 				"name": tftypes.NewValue(tftypes.String, "hello, world"),
 				"favorite_colors": tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, []tftypes.Value{
 					tftypes.NewValue(tftypes.String, "red"),
+					tftypes.NewValue(tftypes.String, "orange"),
+					tftypes.NewValue(tftypes.String, "yellow"),
 				}),
 				"created_timestamp": tftypes.NewValue(tftypes.String, "right now I guess"),
 			}),


### PR DESCRIPTION
Don't pass empty state values into response types. Instead, default to
the prior or current state, which is almost always what providers will
want.

(Partially?) resolves #51.