### PR TITLE
Migrate tfsdk package Config, Plan, and State into schema package

### DIFF
--- a/schema/config.go
+++ b/schema/config.go
@@ -1,4 +1,4 @@
-package tfsdk
+package schema
 
 import (
 	"context"
@@ -6,14 +6,13 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/internal/reflect"
-	"github.com/hashicorp/terraform-plugin-framework/schema"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
 // Config represents a Terraform config.
 type Config struct {
 	Raw    tftypes.Value
-	Schema schema.Schema
+	Schema Schema
 }
 
 // Get populates the struct passed as `target` with the entire config.

--- a/schema/plan.go
+++ b/schema/plan.go
@@ -1,4 +1,4 @@
-package tfsdk
+package schema
 
 import (
 	"context"
@@ -6,14 +6,13 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/internal/reflect"
-	"github.com/hashicorp/terraform-plugin-framework/schema"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
 // Plan represents a Terraform plan.
 type Plan struct {
 	Raw    tftypes.Value
-	Schema schema.Schema
+	Schema Schema
 }
 
 // Get populates the struct passed as `target` with the entire plan.

--- a/schema/state.go
+++ b/schema/state.go
@@ -1,4 +1,4 @@
-package tfsdk
+package schema
 
 import (
 	"context"
@@ -6,14 +6,13 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/internal/reflect"
-	"github.com/hashicorp/terraform-plugin-framework/schema"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
 // State represents a Terraform state.
 type State struct {
 	Raw    tftypes.Value
-	Schema schema.Schema
+	Schema Schema
 }
 
 // Get populates the struct passed as `target` with the entire state.

--- a/schema/state_test.go
+++ b/schema/state_test.go
@@ -1,4 +1,4 @@
-package tfsdk
+package schema
 
 import (
 	"context"
@@ -7,7 +7,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
-	"github.com/hashicorp/terraform-plugin-framework/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
@@ -15,8 +14,8 @@ import (
 var allowAllUnexported = cmp.Exporter(func(reflect.Type) bool { return true })
 
 // schema used for all tests
-var testSchema = schema.Schema{
-	Attributes: map[string]schema.Attribute{
+var testSchema = Schema{
+	Attributes: map[string]Attribute{
 		"name": {
 			Type:     types.StringType,
 			Required: true,
@@ -31,7 +30,7 @@ var testSchema = schema.Schema{
 			Required: true,
 		},
 		"disks": {
-			Attributes: schema.ListNestedAttributes(map[string]schema.Attribute{
+			Attributes: ListNestedAttributes(map[string]Attribute{
 				"id": {
 					Type:     types.StringType,
 					Required: true,
@@ -40,12 +39,12 @@ var testSchema = schema.Schema{
 					Type:     types.BoolType,
 					Optional: true,
 				},
-			}, schema.ListNestedAttributesOptions{}),
+			}, ListNestedAttributesOptions{}),
 			Optional: true,
 			Computed: true,
 		},
 		"boot_disk": {
-			Attributes: schema.SingleNestedAttributes(map[string]schema.Attribute{
+			Attributes: SingleNestedAttributes(map[string]Attribute{
 				"id": {
 					Type:     types.StringType,
 					Required: true,

--- a/tfsdk/request.go
+++ b/tfsdk/request.go
@@ -1,5 +1,9 @@
 package tfsdk
 
+import (
+	"github.com/hashicorp/terraform-plugin-framework/schema"
+)
+
 // ConfigureProviderRequest represents a request containing the values the user
 // specified for the provider configuration block, along with other runtime
 // information from Terraform or the Plugin SDK. An instance of this request
@@ -15,7 +19,7 @@ type ConfigureProviderRequest struct {
 	// information should usually be persisted to the underlying type
 	// that's implementing the Provider interface, for use in later
 	// resource CRUD operations.
-	Config Config
+	Config schema.Config
 }
 
 // CreateResourceRequest represents a request for the provider to create a
@@ -27,13 +31,13 @@ type CreateResourceRequest struct {
 	// This configuration may contain unknown values if a user uses
 	// interpolation or other functionality that would prevent Terraform
 	// from knowing the value at request time.
-	Config Config
+	Config schema.Config
 
 	// Plan is the planned state for the resource.
-	Plan Plan
+	Plan schema.Plan
 
 	// ProviderMeta is metadata from the provider_meta block of the module.
-	ProviderMeta Config
+	ProviderMeta schema.Config
 }
 
 // ReadResourceRequest represents a request for the provider to read a
@@ -43,10 +47,10 @@ type CreateResourceRequest struct {
 type ReadResourceRequest struct {
 	// State is the current state of the resource prior to the Read
 	// operation.
-	State State
+	State schema.State
 
 	// ProviderMeta is metadata from the provider_meta block of the module.
-	ProviderMeta Config
+	ProviderMeta schema.Config
 }
 
 // UpdateResourceRequest represents a request for the provider to update a
@@ -58,17 +62,17 @@ type UpdateResourceRequest struct {
 	// This configuration may contain unknown values if a user uses
 	// interpolation or other functionality that would prevent Terraform
 	// from knowing the value at request time.
-	Config Config
+	Config schema.Config
 
 	// Plan is the planned state for the resource.
-	Plan Plan
+	Plan schema.Plan
 
 	// State is the current state of the resource prior to the Update
 	// operation.
-	State State
+	State schema.State
 
 	// ProviderMeta is metadata from the provider_meta block of the module.
-	ProviderMeta Config
+	ProviderMeta schema.Config
 }
 
 // DeleteResourceRequest represents a request for the provider to delete a
@@ -77,10 +81,10 @@ type UpdateResourceRequest struct {
 type DeleteResourceRequest struct {
 	// State is the current state of the resource prior to the Delete
 	// operation.
-	State State
+	State schema.State
 
 	// ProviderMeta is metadata from the provider_meta block of the module.
-	ProviderMeta Config
+	ProviderMeta schema.Config
 }
 
 // ReadDataSourceRequest represents a request for the provider to read a data
@@ -93,8 +97,8 @@ type ReadDataSourceRequest struct {
 	// This configuration may contain unknown values if a user uses
 	// interpolation or other functionality that would prevent Terraform
 	// from knowing the value at request time.
-	Config Config
+	Config schema.Config
 
 	// ProviderMeta is metadata from the provider_meta block of the module.
-	ProviderMeta Config
+	ProviderMeta schema.Config
 }

--- a/tfsdk/response.go
+++ b/tfsdk/response.go
@@ -1,6 +1,7 @@
 package tfsdk
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework/schema"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
@@ -66,7 +67,7 @@ type CreateResourceResponse struct {
 	// State is the state of the resource following the Create operation.
 	// This field is pre-populated from CreateResourceRequest.Plan and
 	// should be set during the resource's Create operation.
-	State State
+	State schema.State
 
 	// Diagnostics report errors or warnings related to creating the
 	// resource. An empty slice indicates a successful operation with no
@@ -124,7 +125,7 @@ type ReadResourceResponse struct {
 	// State is the state of the resource following the Read operation.
 	// This field is pre-populated from ReadResourceRequest.State and
 	// should be set during the resource's Read operation.
-	State State
+	State schema.State
 
 	// Diagnostics report errors or warnings related to reading the
 	// resource. An empty slice indicates a successful operation with no
@@ -182,7 +183,7 @@ type UpdateResourceResponse struct {
 	// State is the state of the resource following the Update operation.
 	// This field is pre-populated from UpdateResourceRequest.Plan and
 	// should be set during the resource's Update operation.
-	State State
+	State schema.State
 
 	// Diagnostics report errors or warnings related to updating the
 	// resource. An empty slice indicates a successful operation with no
@@ -240,7 +241,7 @@ type DeleteResourceResponse struct {
 	// State is the state of the resource following the Delete operation.
 	// This field is pre-populated from UpdateResourceRequest.Plan and
 	// should be set during the resource's Update operation.
-	State State
+	State schema.State
 
 	// Diagnostics report errors or warnings related to deleting the
 	// resource. An empty slice indicates a successful operation with no
@@ -297,7 +298,7 @@ func (r *DeleteResourceResponse) AddAttributeError(attributePath *tftypes.Attrib
 type ReadDataSourceResponse struct {
 	// State is the state of the data source following the Read operation.
 	// This field should be set during the resource's Read operation.
-	State State
+	State schema.State
 
 	// Diagnostics report errors or warnings related to reading the data
 	// source. An empty slice indicates a successful operation with no


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform-plugin-framework/pull/76

These types are tightly coupled to Schema and Attribute handling and migrating them will allow for future enhancements with Attribute plan modifications and validations to reference these types without an import cycle.