### PR TITLE
Implement ResourceWithModifyPlan interface

### DIFF
--- a/.changelog/90.txt
+++ b/.changelog/90.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+Added support for ModifyPlan functions on Resources.
+```

--- a/tfsdk/data_source.go
+++ b/tfsdk/data_source.go
@@ -17,7 +17,8 @@ type DataSourceType interface {
 	NewDataSource(context.Context, Provider) (DataSource, []*tfprotov6.Diagnostic)
 }
 
-// DataSource implements a data source instance.
+// DataSource represents a data source instance. This is the core interface that
+// all data sources must implement.
 type DataSource interface {
 	// Read is called when the provider must read data source values in
 	// order to update state. Config values should be read from the

--- a/tfsdk/request.go
+++ b/tfsdk/request.go
@@ -83,6 +83,26 @@ type DeleteResourceRequest struct {
 	ProviderMeta Config
 }
 
+// ModifyResourcePlanRequest represents a request for the provider to modify the
+// planned new state that Terraform has generated for the resource.
+type ModifyResourcePlanRequest struct {
+	// Config is the configuration the user supplied for the resource.
+	//
+	// This configuration may contain unknown values if a user uses
+	// interpolation or other functionality that would prevent Terraform
+	// from knowing the value at request time.
+	Config Config
+
+	// State is the current state of the resource.
+	State State
+
+	// Plan is the planned new state for the resource.
+	Plan Plan
+
+	// ProviderMeta is metadata from the provider_meta block of the module.
+	ProviderMeta Config
+}
+
 // ReadDataSourceRequest represents a request for the provider to read a data
 // source, i.e., update values in state according to the real state of the
 // data source. An instance of this request struct is supplied as an argument

--- a/tfsdk/resource.go
+++ b/tfsdk/resource.go
@@ -42,3 +42,27 @@ type Resource interface {
 	// values may be read from the DeleteResourceRequest.
 	Delete(context.Context, DeleteResourceRequest, *DeleteResourceResponse)
 }
+
+// ResourceWithModifyPlan represents a resource instance with a ModifyPlan
+// function.
+type ResourceWithModifyPlan interface {
+	Resource
+
+	// ModifyPlan is called when the provider has an opportunity to modify
+	// the plan: once during the plan phase when Terraform is determining
+	// the diff that should be shown to the user for approval, and once
+	// during the apply phase with any unknown values from configuration
+	// filled in with their final values.
+	//
+	// The planned new state is represented by
+	// ModifyResourcePlanResponse.Plan. It must meet the following
+	// constraints:
+	// 1. Any non-Computed attribute set in config must preserve the exact
+	// config value or return the corresponding attribute value from the
+	// prior state (ModifyResourcePlanRequest.State).
+	// 2. Any attribute with a known value must not have its value changed
+	// in subsequent calls to ModifyPlan or Create/Read/Update.
+	// 3. Any attribute with an unknown value may either remain unknown
+	// or take on any value of the expected type.
+	ModifyPlan(context.Context, ModifyResourcePlanRequest, *ModifyResourcePlanResponse)
+}

--- a/tfsdk/response.go
+++ b/tfsdk/response.go
@@ -290,6 +290,69 @@ func (r *DeleteResourceResponse) AddAttributeError(attributePath *tftypes.Attrib
 	})
 }
 
+// ModifyResourcePlanResponse represents a response to a
+// ModifyResourcePlanRequest. An instance of this response struct is supplied
+// as an argument to the resource's ModifyPlan function, in which the provider
+// should modify the Plan and populate the RequiresReplace field as appropriate.
+type ModifyResourcePlanResponse struct {
+	// Plan is the planned new state for the resource.
+	Plan Plan
+
+	// RequiresReplace is a list of tftypes.AttributePaths that require the
+	// resource to be replaced. They should point to the specific field
+	// that changed that requires the resource to be destroyed and
+	// recreated.
+	RequiresReplace []*tftypes.AttributePath
+
+	// Diagnostics report errors or warnings related to determining the
+	// planned state of the requested resource. Returning an empty slice
+	// indicates a successful validation with no warnings or errors
+	// generated.
+	Diagnostics []*tfprotov6.Diagnostic
+}
+
+// AddWarning appends a warning diagnostic to the response. If the warning
+// concerns a particular attribute, AddAttributeWarning should be used instead.
+func (r *ModifyResourcePlanResponse) AddWarning(summary, detail string) {
+	r.Diagnostics = append(r.Diagnostics, &tfprotov6.Diagnostic{
+		Summary:  summary,
+		Detail:   detail,
+		Severity: tfprotov6.DiagnosticSeverityWarning,
+	})
+}
+
+// AddAttributeWarning appends a warning diagnostic to the response and labels
+// it with a specific attribute.
+func (r *ModifyResourcePlanResponse) AddAttributeWarning(attributePath *tftypes.AttributePath, summary, detail string) {
+	r.Diagnostics = append(r.Diagnostics, &tfprotov6.Diagnostic{
+		Attribute: attributePath,
+		Summary:   summary,
+		Detail:    detail,
+		Severity:  tfprotov6.DiagnosticSeverityWarning,
+	})
+}
+
+// AddError appends an error diagnostic to the response. If the error concerns a
+// particular attribute, AddAttributeError should be used instead.
+func (r *ModifyResourcePlanResponse) AddError(summary, detail string) {
+	r.Diagnostics = append(r.Diagnostics, &tfprotov6.Diagnostic{
+		Summary:  summary,
+		Detail:   detail,
+		Severity: tfprotov6.DiagnosticSeverityError,
+	})
+}
+
+// AddAttributeError appends an error diagnostic to the response and labels it
+// with a specific attribute.
+func (r *ModifyResourcePlanResponse) AddAttributeError(attributePath *tftypes.AttributePath, summary, detail string) {
+	r.Diagnostics = append(r.Diagnostics, &tfprotov6.Diagnostic{
+		Attribute: attributePath,
+		Summary:   summary,
+		Detail:    detail,
+		Severity:  tfprotov6.DiagnosticSeverityError,
+	})
+}
+
 // ReadDataSourceResponse represents a response to a ReadDataSourceRequest. An
 // instance of this response struct is supplied as an argument to the data
 // source's Read function, in which the provider should set values on the
@@ -303,4 +366,46 @@ type ReadDataSourceResponse struct {
 	// source. An empty slice indicates a successful operation with no
 	// warnings or errors generated.
 	Diagnostics []*tfprotov6.Diagnostic
+}
+
+// AddWarning appends a warning diagnostic to the response. If the warning
+// concerns a particular attribute, AddAttributeWarning should be used instead.
+func (r *ReadDataSourceResponse) AddWarning(summary, detail string) {
+	r.Diagnostics = append(r.Diagnostics, &tfprotov6.Diagnostic{
+		Summary:  summary,
+		Detail:   detail,
+		Severity: tfprotov6.DiagnosticSeverityWarning,
+	})
+}
+
+// AddAttributeWarning appends a warning diagnostic to the response and labels
+// it with a specific attribute.
+func (r *ReadDataSourceResponse) AddAttributeWarning(attributePath *tftypes.AttributePath, summary, detail string) {
+	r.Diagnostics = append(r.Diagnostics, &tfprotov6.Diagnostic{
+		Attribute: attributePath,
+		Summary:   summary,
+		Detail:    detail,
+		Severity:  tfprotov6.DiagnosticSeverityWarning,
+	})
+}
+
+// AddError appends an error diagnostic to the response. If the error concerns a
+// particular attribute, AddAttributeError should be used instead.
+func (r *ReadDataSourceResponse) AddError(summary, detail string) {
+	r.Diagnostics = append(r.Diagnostics, &tfprotov6.Diagnostic{
+		Summary:  summary,
+		Detail:   detail,
+		Severity: tfprotov6.DiagnosticSeverityError,
+	})
+}
+
+// AddAttributeError appends an error diagnostic to the response and labels it
+// with a specific attribute.
+func (r *ReadDataSourceResponse) AddAttributeError(attributePath *tftypes.AttributePath, summary, detail string) {
+	r.Diagnostics = append(r.Diagnostics, &tfprotov6.Diagnostic{
+		Attribute: attributePath,
+		Summary:   summary,
+		Detail:    detail,
+		Severity:  tfprotov6.DiagnosticSeverityError,
+	})
 }

--- a/tfsdk/serve.go
+++ b/tfsdk/serve.go
@@ -462,7 +462,7 @@ func (s *server) PlanResourceChange(ctx context.Context, req *tfprotov6.PlanReso
 	}
 
 	var modifiedPlan tftypes.Value
-
+	var modifyPlanResp ModifyResourcePlanResponse
 	if resource, ok := resource.(ResourceWithModifyPlan); ok {
 		modifyPlanReq := ModifyResourcePlanRequest{
 			Config: Config{
@@ -505,7 +505,7 @@ func (s *server) PlanResourceChange(ctx context.Context, req *tfprotov6.PlanReso
 			}
 		}
 
-		modifyPlanResp := ModifyResourcePlanResponse{
+		modifyPlanResp = ModifyResourcePlanResponse{
 			Plan: Plan{
 				Schema: resourceSchema,
 				Raw:    plan,
@@ -546,6 +546,7 @@ func (s *server) PlanResourceChange(ctx context.Context, req *tfprotov6.PlanReso
 		return resp, nil
 	}
 	resp.PlannedState = &plannedState
+	resp.RequiresReplace = modifyPlanResp.RequiresReplace
 
 	return resp, nil
 }

--- a/tfsdk/serve.go
+++ b/tfsdk/serve.go
@@ -453,8 +453,6 @@ func (s *server) PlanResourceChange(ctx context.Context, req *tfprotov6.PlanReso
 	}
 	resp.PlannedState = &plannedState
 
-	// TODO: implement customizable plan modifications later
-	// TODO: implement RequiresReplace behavior later
 	return resp, nil
 }
 

--- a/tfsdk/serve.go
+++ b/tfsdk/serve.go
@@ -514,7 +514,7 @@ func (s *server) PlanResourceChange(ctx context.Context, req *tfprotov6.PlanReso
 			Diagnostics:     resp.Diagnostics,
 		}
 		resource.ModifyPlan(ctx, modifyPlanReq, &modifyPlanResp)
-		resp.Diagnostics = modifyPlanResp.Diagnostics
+		resp.Diagnostics = append(resp.Diagnostics, modifyPlanResp.Diagnostics...)
 		modifiedPlan, err = tftypes.Transform(modifyPlanResp.Plan.Raw, markComputedNilsAsUnknown(ctx, resourceSchema))
 		if err != nil {
 			resp.Diagnostics = append(resp.Diagnostics, &tfprotov6.Diagnostic{

--- a/tfsdk/serve_provider_test.go
+++ b/tfsdk/serve_provider_test.go
@@ -27,13 +27,13 @@ type testServeProvider struct {
 	planResourceChangeCalledResourceType     string
 	planResourceChangeCalledAction           string
 	planResourceChangePriorStateValue        tftypes.Value
-	planResourceChangePriorStateSchema       schema.Schema
+	planResourceChangePriorStateSchema       Schema
 	planResourceChangeProposedNewStateValue  tftypes.Value
-	planResourceChangeProposedNewStateSchema schema.Schema
+	planResourceChangeProposedNewStateSchema Schema
 	planResourceChangeConfigValue            tftypes.Value
-	planResourceChangeConfigSchema           schema.Schema
+	planResourceChangeConfigSchema           Schema
 	planResourceChangeProviderMetaValue      tftypes.Value
-	planResourceChangeProviderMetaSchema     schema.Schema
+	planResourceChangeProviderMetaSchema     Schema
 	modifyPlanFunc                           func(context.Context, ModifyResourcePlanRequest, *ModifyResourcePlanResponse)
 
 	// apply resource change

--- a/tfsdk/serve_provider_test.go
+++ b/tfsdk/serve_provider_test.go
@@ -23,6 +23,19 @@ type testServeProvider struct {
 	readResourceImpl               func(context.Context, ReadResourceRequest, *ReadResourceResponse)
 	readResourceCalledResourceType string
 
+	// plan resource change
+	planResourceChangeCalledResourceType     string
+	planResourceChangeCalledAction           string
+	planResourceChangePriorStateValue        tftypes.Value
+	planResourceChangePriorStateSchema       schema.Schema
+	planResourceChangeProposedNewStateValue  tftypes.Value
+	planResourceChangeProposedNewStateSchema schema.Schema
+	planResourceChangeConfigValue            tftypes.Value
+	planResourceChangeConfigSchema           schema.Schema
+	planResourceChangeProviderMetaValue      tftypes.Value
+	planResourceChangeProviderMetaSchema     schema.Schema
+	modifyPlanFunc                           func(context.Context, ModifyResourcePlanRequest, *ModifyResourcePlanResponse)
+
 	// apply resource change
 	applyResourceChangeCalledResourceType string
 	applyResourceChangeCalledAction       string

--- a/tfsdk/serve_resource_two_test.go
+++ b/tfsdk/serve_resource_two_test.go
@@ -154,3 +154,17 @@ func (r testServeResourceTwo) Delete(ctx context.Context, req DeleteResourceRequ
 	r.provider.applyResourceChangeCalledAction = "delete"
 	r.provider.deleteFunc(ctx, req, resp)
 }
+
+func (r testServeResourceTwo) ModifyPlan(ctx context.Context, req ModifyResourcePlanRequest, resp *ModifyResourcePlanResponse) {
+	r.provider.planResourceChangePriorStateValue = req.State.Raw
+	r.provider.planResourceChangePriorStateSchema = req.State.Schema
+	r.provider.planResourceChangeProposedNewStateValue = req.Plan.Raw
+	r.provider.planResourceChangeProposedNewStateSchema = req.Plan.Schema
+	r.provider.planResourceChangeConfigValue = req.Config.Raw
+	r.provider.planResourceChangeConfigSchema = req.Config.Schema
+	r.provider.planResourceChangeProviderMetaValue = req.ProviderMeta.Raw
+	r.provider.planResourceChangeProviderMetaSchema = req.ProviderMeta.Schema
+	r.provider.planResourceChangeCalledResourceType = "test_two"
+	r.provider.planResourceChangeCalledAction = "modify_plan"
+	r.provider.modifyPlanFunc(ctx, req, resp)
+}

--- a/tfsdk/serve_test.go
+++ b/tfsdk/serve_test.go
@@ -1154,6 +1154,148 @@ func TestServerPlanResourceChange(t *testing.T) {
 			},
 			expectedRequiresReplace: []*tftypes.AttributePath{tftypes.NewAttributePath().WithAttributeName("id")},
 		},
+		"two_modify_diags_warning": {
+			priorState: tftypes.NewValue(testServeResourceTypeTwoType, map[string]tftypes.Value{
+				"id": tftypes.NewValue(tftypes.String, "123456"),
+				"disks": tftypes.NewValue(tftypes.List{ElementType: tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+					"name":    tftypes.String,
+					"size_gb": tftypes.Number,
+					"boot":    tftypes.Bool,
+				}}}, []tftypes.Value{
+					tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+						"name":    tftypes.String,
+						"size_gb": tftypes.Number,
+						"boot":    tftypes.Bool,
+					}}, map[string]tftypes.Value{
+						"name":    tftypes.NewValue(tftypes.String, "my-disk"),
+						"size_gb": tftypes.NewValue(tftypes.Number, 10),
+						"boot":    tftypes.NewValue(tftypes.Bool, false),
+					}),
+				}),
+			}),
+			proposedNewState: tftypes.NewValue(testServeResourceTypeTwoType, map[string]tftypes.Value{
+				"id": tftypes.NewValue(tftypes.String, "123456"),
+				"disks": tftypes.NewValue(tftypes.List{ElementType: tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+					"name":    tftypes.String,
+					"size_gb": tftypes.Number,
+					"boot":    tftypes.Bool,
+				}}}, []tftypes.Value{
+					tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+						"name":    tftypes.String,
+						"size_gb": tftypes.Number,
+						"boot":    tftypes.Bool,
+					}}, map[string]tftypes.Value{
+						"name":    tftypes.NewValue(tftypes.String, "my-disk"),
+						"size_gb": tftypes.NewValue(tftypes.Number, 10),
+						"boot":    tftypes.NewValue(tftypes.Bool, false),
+					}),
+				}),
+			}),
+			config:       tftypes.NewValue(testServeResourceTypeTwoType, nil),
+			resource:     "test_two",
+			resourceType: testServeResourceTypeTwoType,
+			expectedPlannedState: tftypes.NewValue(testServeResourceTypeTwoType, map[string]tftypes.Value{
+				"id": tftypes.NewValue(tftypes.String, "123456"),
+				"disks": tftypes.NewValue(tftypes.List{ElementType: tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+					"name":    tftypes.String,
+					"size_gb": tftypes.Number,
+					"boot":    tftypes.Bool,
+				}}}, []tftypes.Value{
+					tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+						"name":    tftypes.String,
+						"size_gb": tftypes.Number,
+						"boot":    tftypes.Bool,
+					}}, map[string]tftypes.Value{
+						"name":    tftypes.NewValue(tftypes.String, "my-disk"),
+						"size_gb": tftypes.NewValue(tftypes.Number, 10),
+						"boot":    tftypes.NewValue(tftypes.Bool, false),
+					}),
+				}),
+			}),
+			modifyPlanFunc: func(ctx context.Context, req ModifyResourcePlanRequest, resp *ModifyResourcePlanResponse) {
+				resp.RequiresReplace = []*tftypes.AttributePath{tftypes.NewAttributePath().WithAttributeName("id")}
+				resp.AddWarning("I'm warning you", "You have been warned")
+			},
+			expectedRequiresReplace: []*tftypes.AttributePath{tftypes.NewAttributePath().WithAttributeName("id")},
+			expectedDiags: []*tfprotov6.Diagnostic{
+				&tfprotov6.Diagnostic{
+					Severity: tfprotov6.DiagnosticSeverityWarning,
+					Summary:  "I'm warning you",
+					Detail:   "You have been warned",
+				},
+			},
+		},
+		"two_modify_diags_error": {
+			priorState: tftypes.NewValue(testServeResourceTypeTwoType, map[string]tftypes.Value{
+				"id": tftypes.NewValue(tftypes.String, "123456"),
+				"disks": tftypes.NewValue(tftypes.List{ElementType: tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+					"name":    tftypes.String,
+					"size_gb": tftypes.Number,
+					"boot":    tftypes.Bool,
+				}}}, []tftypes.Value{
+					tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+						"name":    tftypes.String,
+						"size_gb": tftypes.Number,
+						"boot":    tftypes.Bool,
+					}}, map[string]tftypes.Value{
+						"name":    tftypes.NewValue(tftypes.String, "my-disk"),
+						"size_gb": tftypes.NewValue(tftypes.Number, 10),
+						"boot":    tftypes.NewValue(tftypes.Bool, false),
+					}),
+				}),
+			}),
+			proposedNewState: tftypes.NewValue(testServeResourceTypeTwoType, map[string]tftypes.Value{
+				"id": tftypes.NewValue(tftypes.String, "123456"),
+				"disks": tftypes.NewValue(tftypes.List{ElementType: tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+					"name":    tftypes.String,
+					"size_gb": tftypes.Number,
+					"boot":    tftypes.Bool,
+				}}}, []tftypes.Value{
+					tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+						"name":    tftypes.String,
+						"size_gb": tftypes.Number,
+						"boot":    tftypes.Bool,
+					}}, map[string]tftypes.Value{
+						"name":    tftypes.NewValue(tftypes.String, "my-disk"),
+						"size_gb": tftypes.NewValue(tftypes.Number, 10),
+						"boot":    tftypes.NewValue(tftypes.Bool, false),
+					}),
+				}),
+			}),
+			config:       tftypes.NewValue(testServeResourceTypeTwoType, nil),
+			resource:     "test_two",
+			resourceType: testServeResourceTypeTwoType,
+			expectedPlannedState: tftypes.NewValue(testServeResourceTypeTwoType, map[string]tftypes.Value{
+				"id": tftypes.NewValue(tftypes.String, "123456"),
+				"disks": tftypes.NewValue(tftypes.List{ElementType: tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+					"name":    tftypes.String,
+					"size_gb": tftypes.Number,
+					"boot":    tftypes.Bool,
+				}}}, []tftypes.Value{
+					tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+						"name":    tftypes.String,
+						"size_gb": tftypes.Number,
+						"boot":    tftypes.Bool,
+					}}, map[string]tftypes.Value{
+						"name":    tftypes.NewValue(tftypes.String, "my-disk"),
+						"size_gb": tftypes.NewValue(tftypes.Number, 10),
+						"boot":    tftypes.NewValue(tftypes.Bool, false),
+					}),
+				}),
+			}),
+			modifyPlanFunc: func(ctx context.Context, req ModifyResourcePlanRequest, resp *ModifyResourcePlanResponse) {
+				resp.RequiresReplace = []*tftypes.AttributePath{tftypes.NewAttributePath().WithAttributeName("id")}
+				resp.AddError("This is an error", "More details about the error")
+			},
+			expectedRequiresReplace: []*tftypes.AttributePath{tftypes.NewAttributePath().WithAttributeName("id")},
+			expectedDiags: []*tfprotov6.Diagnostic{
+				&tfprotov6.Diagnostic{
+					Severity: tfprotov6.DiagnosticSeverityError,
+					Summary:  "This is an error",
+					Detail:   "More details about the error",
+				},
+			},
+		},
 	}
 
 	for name, tc := range tests {

--- a/tfsdk/serve_test.go
+++ b/tfsdk/serve_test.go
@@ -1098,7 +1098,9 @@ func TestServerPlanResourceChange(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			s := &testServeProvider{}
+			s := &testServeProvider{
+				modifyPlanFunc: tc.modifyPlanFunc,
+			}
 			testServer := &server{
 				p: s,
 			}

--- a/tfsdk/serve_test.go
+++ b/tfsdk/serve_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
@@ -1090,6 +1091,69 @@ func TestServerPlanResourceChange(t *testing.T) {
 				})
 			},
 		},
+		"two_modify_requires_replace": {
+			priorState: tftypes.NewValue(testServeResourceTypeTwoType, map[string]tftypes.Value{
+				"id": tftypes.NewValue(tftypes.String, "123456"),
+				"disks": tftypes.NewValue(tftypes.List{ElementType: tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+					"name":    tftypes.String,
+					"size_gb": tftypes.Number,
+					"boot":    tftypes.Bool,
+				}}}, []tftypes.Value{
+					tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+						"name":    tftypes.String,
+						"size_gb": tftypes.Number,
+						"boot":    tftypes.Bool,
+					}}, map[string]tftypes.Value{
+						"name":    tftypes.NewValue(tftypes.String, "my-disk"),
+						"size_gb": tftypes.NewValue(tftypes.Number, 10),
+						"boot":    tftypes.NewValue(tftypes.Bool, false),
+					}),
+				}),
+			}),
+			proposedNewState: tftypes.NewValue(testServeResourceTypeTwoType, map[string]tftypes.Value{
+				"id": tftypes.NewValue(tftypes.String, "123456"),
+				"disks": tftypes.NewValue(tftypes.List{ElementType: tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+					"name":    tftypes.String,
+					"size_gb": tftypes.Number,
+					"boot":    tftypes.Bool,
+				}}}, []tftypes.Value{
+					tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+						"name":    tftypes.String,
+						"size_gb": tftypes.Number,
+						"boot":    tftypes.Bool,
+					}}, map[string]tftypes.Value{
+						"name":    tftypes.NewValue(tftypes.String, "my-disk"),
+						"size_gb": tftypes.NewValue(tftypes.Number, 10),
+						"boot":    tftypes.NewValue(tftypes.Bool, false),
+					}),
+				}),
+			}),
+			config:       tftypes.NewValue(testServeResourceTypeTwoType, nil),
+			resource:     "test_two",
+			resourceType: testServeResourceTypeTwoType,
+			expectedPlannedState: tftypes.NewValue(testServeResourceTypeTwoType, map[string]tftypes.Value{
+				"id": tftypes.NewValue(tftypes.String, "123456"),
+				"disks": tftypes.NewValue(tftypes.List{ElementType: tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+					"name":    tftypes.String,
+					"size_gb": tftypes.Number,
+					"boot":    tftypes.Bool,
+				}}}, []tftypes.Value{
+					tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+						"name":    tftypes.String,
+						"size_gb": tftypes.Number,
+						"boot":    tftypes.Bool,
+					}}, map[string]tftypes.Value{
+						"name":    tftypes.NewValue(tftypes.String, "my-disk"),
+						"size_gb": tftypes.NewValue(tftypes.Number, 10),
+						"boot":    tftypes.NewValue(tftypes.Bool, false),
+					}),
+				}),
+			}),
+			modifyPlanFunc: func(ctx context.Context, req ModifyResourcePlanRequest, resp *ModifyResourcePlanResponse) {
+				resp.RequiresReplace = []*tftypes.AttributePath{tftypes.NewAttributePath().WithAttributeName("id")}
+			},
+			expectedRequiresReplace: []*tftypes.AttributePath{tftypes.NewAttributePath().WithAttributeName("id")},
+		},
 	}
 
 	for name, tc := range tests {
@@ -1156,7 +1220,7 @@ func TestServerPlanResourceChange(t *testing.T) {
 				t.Errorf("Expected planned private to be %q, got %q", tc.expectedPlannedPrivate, got.PlannedPrivate)
 				return
 			}
-			if diff := cmp.Diff(got.RequiresReplace, tc.expectedRequiresReplace); diff != "" {
+			if diff := cmp.Diff(got.RequiresReplace, tc.expectedRequiresReplace, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("Unexpected diff in requires replace (+wanted, -got): %s", diff)
 				return
 			}

--- a/tfsdk/serve_test.go
+++ b/tfsdk/serve_test.go
@@ -1218,7 +1218,7 @@ func TestServerPlanResourceChange(t *testing.T) {
 			},
 			expectedRequiresReplace: []*tftypes.AttributePath{tftypes.NewAttributePath().WithAttributeName("id")},
 			expectedDiags: []*tfprotov6.Diagnostic{
-				&tfprotov6.Diagnostic{
+				{
 					Severity: tfprotov6.DiagnosticSeverityWarning,
 					Summary:  "I'm warning you",
 					Detail:   "You have been warned",
@@ -1289,7 +1289,7 @@ func TestServerPlanResourceChange(t *testing.T) {
 			},
 			expectedRequiresReplace: []*tftypes.AttributePath{tftypes.NewAttributePath().WithAttributeName("id")},
 			expectedDiags: []*tfprotov6.Diagnostic{
-				&tfprotov6.Diagnostic{
+				{
 					Severity: tfprotov6.DiagnosticSeverityError,
 					Summary:  "This is an error",
 					Detail:   "More details about the error",

--- a/tfsdk/serve_test.go
+++ b/tfsdk/serve_test.go
@@ -901,6 +901,8 @@ func TestServerPlanResourceChange(t *testing.T) {
 		resource         string
 		resourceType     tftypes.Type
 
+		modifyPlanFunc func(context.Context, ModifyResourcePlanRequest, *ModifyResourcePlanResponse)
+
 		// response expectations
 		expectedPlannedState    tftypes.Value
 		expectedRequiresReplace []*tftypes.AttributePath
@@ -990,6 +992,103 @@ func TestServerPlanResourceChange(t *testing.T) {
 				"favorite_colors":   tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, nil),
 				"created_timestamp": tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
 			}),
+		},
+		"two_modify_add_list_elem": {
+			priorState: tftypes.NewValue(testServeResourceTypeTwoType, map[string]tftypes.Value{
+				"id": tftypes.NewValue(tftypes.String, "123456"),
+				"disks": tftypes.NewValue(tftypes.List{ElementType: tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+					"name":    tftypes.String,
+					"size_gb": tftypes.Number,
+					"boot":    tftypes.Bool,
+				}}}, []tftypes.Value{
+					tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+						"name":    tftypes.String,
+						"size_gb": tftypes.Number,
+						"boot":    tftypes.Bool,
+					}}, map[string]tftypes.Value{
+						"name":    tftypes.NewValue(tftypes.String, "my-disk"),
+						"size_gb": tftypes.NewValue(tftypes.Number, 10),
+						"boot":    tftypes.NewValue(tftypes.Bool, false),
+					}),
+				}),
+			}),
+			proposedNewState: tftypes.NewValue(testServeResourceTypeTwoType, map[string]tftypes.Value{
+				"id": tftypes.NewValue(tftypes.String, "123456"),
+				"disks": tftypes.NewValue(tftypes.List{ElementType: tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+					"name":    tftypes.String,
+					"size_gb": tftypes.Number,
+					"boot":    tftypes.Bool,
+				}}}, []tftypes.Value{
+					tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+						"name":    tftypes.String,
+						"size_gb": tftypes.Number,
+						"boot":    tftypes.Bool,
+					}}, map[string]tftypes.Value{
+						"name":    tftypes.NewValue(tftypes.String, "my-disk"),
+						"size_gb": tftypes.NewValue(tftypes.Number, 10),
+						"boot":    tftypes.NewValue(tftypes.Bool, false),
+					}),
+				}),
+			}),
+			config:       tftypes.NewValue(testServeResourceTypeTwoType, nil),
+			resource:     "test_two",
+			resourceType: testServeResourceTypeTwoType,
+			expectedPlannedState: tftypes.NewValue(testServeResourceTypeTwoType, map[string]tftypes.Value{
+				"id": tftypes.NewValue(tftypes.String, "123456"),
+				"disks": tftypes.NewValue(tftypes.List{ElementType: tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+					"name":    tftypes.String,
+					"size_gb": tftypes.Number,
+					"boot":    tftypes.Bool,
+				}}}, []tftypes.Value{
+					tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+						"name":    tftypes.String,
+						"size_gb": tftypes.Number,
+						"boot":    tftypes.Bool,
+					}}, map[string]tftypes.Value{
+						"name":    tftypes.NewValue(tftypes.String, "my-disk"),
+						"size_gb": tftypes.NewValue(tftypes.Number, 10),
+						"boot":    tftypes.NewValue(tftypes.Bool, false),
+					}),
+					tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+						"name":    tftypes.String,
+						"size_gb": tftypes.Number,
+						"boot":    tftypes.Bool,
+					}}, map[string]tftypes.Value{
+						"name":    tftypes.NewValue(tftypes.String, "auto-boot-disk"),
+						"size_gb": tftypes.NewValue(tftypes.Number, 1),
+						"boot":    tftypes.NewValue(tftypes.Bool, true),
+					}),
+				}),
+			}),
+			modifyPlanFunc: func(ctx context.Context, req ModifyResourcePlanRequest, resp *ModifyResourcePlanResponse) {
+				resp.Plan.Raw = tftypes.NewValue(testServeResourceTypeTwoType, map[string]tftypes.Value{
+					"id": tftypes.NewValue(tftypes.String, "123456"),
+					"disks": tftypes.NewValue(tftypes.List{ElementType: tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+						"name":    tftypes.String,
+						"size_gb": tftypes.Number,
+						"boot":    tftypes.Bool,
+					}}}, []tftypes.Value{
+						tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+							"name":    tftypes.String,
+							"size_gb": tftypes.Number,
+							"boot":    tftypes.Bool,
+						}}, map[string]tftypes.Value{
+							"name":    tftypes.NewValue(tftypes.String, "my-disk"),
+							"size_gb": tftypes.NewValue(tftypes.Number, 10),
+							"boot":    tftypes.NewValue(tftypes.Bool, false),
+						}),
+						tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+							"name":    tftypes.String,
+							"size_gb": tftypes.Number,
+							"boot":    tftypes.Bool,
+						}}, map[string]tftypes.Value{
+							"name":    tftypes.NewValue(tftypes.String, "auto-boot-disk"),
+							"size_gb": tftypes.NewValue(tftypes.Number, 1),
+							"boot":    tftypes.NewValue(tftypes.Bool, true),
+						}),
+					}),
+				})
+			},
 		},
 	}
 


### PR DESCRIPTION
Epic: #34 

Design doc: #64 

Plan modification functionality has two parts:
1. The `ResourceWithModifyPlan` interface (this PR)
2. `schema.Attribute.PlanModifiers` (future PR)

This PR adds the `ResourceWithModifyPlan` interface, allowing resources to define an optional `ModifyPlan` function.
```go
type ResourceWithModifyPlan interface {
 	Resource
 
 	ModifyPlan(context.Context, ModifyResourcePlanRequest, *ModifyResourcePlanResponse)
}
```