### PR TITLE
tfsdk: Add unit testing covering attr.TypeWithValidate in (Attribute).validate()

### DIFF
--- a/tfsdk/attribute_test.go
+++ b/tfsdk/attribute_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	testtypes "github.com/hashicorp/terraform-plugin-framework/internal/testing/types"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
@@ -864,6 +865,60 @@ func TestAttributeValidate(t *testing.T) {
 				Diagnostics: []*tfprotov6.Diagnostic{
 					testErrorDiagnostic,
 					testErrorDiagnostic,
+				},
+			},
+		},
+		"type-with-validate-error": {
+			req: ValidateAttributeRequest{
+				AttributePath: tftypes.NewAttributePath().WithAttributeName("test"),
+				Config: Config{
+					Raw: tftypes.NewValue(tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"test": tftypes.String,
+						},
+					}, map[string]tftypes.Value{
+						"test": tftypes.NewValue(tftypes.String, "testvalue"),
+					}),
+					Schema: Schema{
+						Attributes: map[string]Attribute{
+							"test": {
+								Type:     testtypes.StringTypeWithValidateError{},
+								Required: true,
+							},
+						},
+					},
+				},
+			},
+			resp: ValidateAttributeResponse{
+				Diagnostics: []*tfprotov6.Diagnostic{
+					testtypes.TestErrorDiagnostic,
+				},
+			},
+		},
+		"type-with-validate-warning": {
+			req: ValidateAttributeRequest{
+				AttributePath: tftypes.NewAttributePath().WithAttributeName("test"),
+				Config: Config{
+					Raw: tftypes.NewValue(tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"test": tftypes.String,
+						},
+					}, map[string]tftypes.Value{
+						"test": tftypes.NewValue(tftypes.String, "testvalue"),
+					}),
+					Schema: Schema{
+						Attributes: map[string]Attribute{
+							"test": {
+								Type:     testtypes.StringTypeWithValidateWarning{},
+								Required: true,
+							},
+						},
+					},
+				},
+			},
+			resp: ValidateAttributeResponse{
+				Diagnostics: []*tfprotov6.Diagnostic{
+					testtypes.TestWarningDiagnostic,
 				},
 			},
 		},


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/17

This was covered already by the `(Config).GetAttribute()` call in the function, however this testing required merging the new `internal/testing/types` package.