### PR TITLE
return nil when GetAttribute called on nil state

### DIFF
--- a/tfsdk/config.go
+++ b/tfsdk/config.go
@@ -38,6 +38,12 @@ func (c Config) GetAttribute(ctx context.Context, path *tftypes.AttributePath) (
 		})
 	}
 
+	// if the whole config is nil, the value of a valid attribute is also
+	// nil
+	if c.Raw.IsNull() {
+		return nil, nil
+	}
+
 	tfValue, err := c.terraformValueAtPath(path)
 	if err != nil {
 		return nil, append(diags, &tfprotov6.Diagnostic{

--- a/tfsdk/plan.go
+++ b/tfsdk/plan.go
@@ -39,6 +39,11 @@ func (p Plan) GetAttribute(ctx context.Context, path *tftypes.AttributePath) (at
 		})
 	}
 
+	// if the whole plan is nil, the value of a valid attribute is also nil
+	if p.Raw.IsNull() {
+		return nil, nil
+	}
+
 	tfValue, err := p.terraformValueAtPath(path)
 	if err != nil {
 		return nil, append(diags, &tfprotov6.Diagnostic{

--- a/tfsdk/serve_test.go
+++ b/tfsdk/serve_test.go
@@ -1527,6 +1527,22 @@ func TestServerPlanResourceChange(t *testing.T) {
 				"created_timestamp": tftypes.NewValue(tftypes.String, "when the earth was young"),
 			}),
 		},
+		"one_nil_state_and_config": {
+			priorState:           tftypes.NewValue(testServeResourceTypeOneType, nil),
+			proposedNewState:     tftypes.NewValue(testServeResourceTypeOneType, nil),
+			config:               tftypes.NewValue(testServeResourceTypeOneType, nil),
+			resource:             "test_one",
+			resourceType:         testServeResourceTypeOneType,
+			expectedPlannedState: tftypes.NewValue(testServeResourceTypeOneType, nil),
+		},
+		"two_nil_state_and_config": {
+			priorState:           tftypes.NewValue(testServeResourceTypeOneType, nil),
+			proposedNewState:     tftypes.NewValue(testServeResourceTypeOneType, nil),
+			config:               tftypes.NewValue(testServeResourceTypeOneType, nil),
+			resource:             "test_two",
+			resourceType:         testServeResourceTypeOneType,
+			expectedPlannedState: tftypes.NewValue(testServeResourceTypeOneType, nil),
+		},
 		"two_delete": {
 			priorState: tftypes.NewValue(testServeResourceTypeTwoType, map[string]tftypes.Value{
 				"id": tftypes.NewValue(tftypes.String, "123456"),

--- a/tfsdk/state.go
+++ b/tfsdk/state.go
@@ -39,6 +39,11 @@ func (s State) GetAttribute(ctx context.Context, path *tftypes.AttributePath) (a
 		})
 	}
 
+	// if the whole state is nil, the value of a valid attribute is also nil
+	if s.Raw.IsNull() {
+		return nil, nil
+	}
+
 	tfValue, err := s.terraformValueAtPath(path)
 	if err != nil {
 		return nil, append(diags, &tfprotov6.Diagnostic{


### PR DESCRIPTION
Fixes #106 

Instead of returning an error when GetAttribute is called on a nil state, plan, or config, return nil, provided the attribute path is valid and appears in the schema.

In a nil state/plan/config, the value of any given schema attribute should be nil.