### PR TITLE
Add a Type method to attr.Value, add tfsdk.ValueAs.

### DIFF
--- a/.changelog/119.txt
+++ b/.changelog/119.txt
@@ -1,0 +1,7 @@
+```release-note:breaking-change
+`attr.Value` implementations must now implement a `Type(context.Context)` method that returns the `attr.Type` that created the `attr.Value`.
+```
+
+```release-note:enhancement
+Added a `tfsdk.ValueAs` helper that allows accessing an `attr.Value` without type assertion, by using the same reflection rules used in the `Config.Get`, `Plan.Get`, and `State.Get` helpers.
+```

--- a/attr/value.go
+++ b/attr/value.go
@@ -8,6 +8,9 @@ import (
 // Values allow provider developers to specify data in a convenient format, and
 // have it transparently be converted to formats Terraform understands.
 type Value interface {
+	// Type returns the Type that created the Value.
+	Type(context.Context) Type
+
 	// ToTerraformValue returns the data contained in the Value as
 	// a Go type that tftypes.NewValue will accept.
 	ToTerraformValue(context.Context) (interface{}, error)

--- a/internal/reflect/diags.go
+++ b/internal/reflect/diags.go
@@ -1,6 +1,10 @@
 package reflect
 
 import (
+	"fmt"
+	"reflect"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
@@ -35,4 +39,90 @@ func valueFromTerraformErrorDiag(err error, path *tftypes.AttributePath) diag.At
 		"Value Conversion Error",
 		"An unexpected error was encountered trying to convert the Terraform value. This is always an error in the provider. Please report the following to the provider developer:\n\n"+err.Error(),
 	)
+}
+
+type DiagIntoIncompatibleType struct {
+	Val        tftypes.Value
+	TargetType reflect.Type
+	AttrPath   *tftypes.AttributePath
+	Err        error
+}
+
+func (d DiagIntoIncompatibleType) Severity() diag.Severity {
+	return diag.SeverityError
+}
+
+func (d DiagIntoIncompatibleType) Summary() string {
+	return "Value Conversion Error"
+}
+
+func (d DiagIntoIncompatibleType) Detail() string {
+	return fmt.Sprintf("An unexpected error was encountered trying to convert %T into %s. This is always an error in the provider. Please report the following to the provider developer:\n\n%s", d.Val, d.TargetType, d.Err.Error())
+}
+
+func (d DiagIntoIncompatibleType) Equal(o diag.Diagnostic) bool {
+	od, ok := o.(DiagIntoIncompatibleType)
+	if !ok {
+		return false
+	}
+	if !d.Val.Equal(od.Val) {
+		return false
+	}
+	if d.TargetType != od.TargetType {
+		return false
+	}
+	if !d.AttrPath.Equal(od.AttrPath) {
+		return false
+	}
+	if d.Err.Error() != od.Err.Error() {
+		return false
+	}
+	return true
+}
+
+func (d DiagIntoIncompatibleType) Path() *tftypes.AttributePath {
+	return d.AttrPath
+}
+
+type DiagNewAttributeValueIntoWrongType struct {
+	ValType    reflect.Type
+	TargetType reflect.Type
+	SchemaType attr.Type
+	AttrPath   *tftypes.AttributePath
+}
+
+func (d DiagNewAttributeValueIntoWrongType) Severity() diag.Severity {
+	return diag.SeverityError
+}
+
+func (d DiagNewAttributeValueIntoWrongType) Summary() string {
+	return "Value Conversion Error"
+}
+
+func (d DiagNewAttributeValueIntoWrongType) Detail() string {
+	return fmt.Sprintf("An unexpected error was encountered trying to convert into a Terraform value. This is always an error in the provider. Please report the following to the provider developer:\n\nCannot use attr.Value %s, only %s is supported because %T is the type in the schema", d.TargetType, d.ValType, d.SchemaType)
+}
+
+func (d DiagNewAttributeValueIntoWrongType) Equal(o diag.Diagnostic) bool {
+	od, ok := o.(DiagNewAttributeValueIntoWrongType)
+	if !ok {
+		return false
+	}
+	if d.ValType != od.ValType {
+		return false
+	}
+	if d.TargetType != od.TargetType {
+		return false
+	}
+	if !d.SchemaType.Equal(od.SchemaType) {
+		return false
+	}
+	if !d.AttrPath.Equal(od.AttrPath) {
+		return false
+	}
+	return true
+}
+
+func (d DiagNewAttributeValueIntoWrongType) Path() *tftypes.AttributePath {
+	return d.AttrPath
 }

--- a/internal/reflect/interfaces.go
+++ b/internal/reflect/interfaces.go
@@ -291,12 +291,12 @@ func NewAttributeValue(ctx context.Context, typ attr.Type, val tftypes.Value, ta
 		return target, append(diags, valueFromTerraformErrorDiag(err, path))
 	}
 	if reflect.TypeOf(res) != target.Type() {
-		err := fmt.Errorf("Cannot use attr.Value %s, only %s is supported because %T is the type in the schema", target.Type(), reflect.TypeOf(res), typ)
-		diags.AddAttributeError(
-			path,
-			"Value Conversion Error",
-			"An unexpected error was encountered trying to convert into a Terraform value. This is always an error in the provider. Please report the following to the provider developer:\n\n"+err.Error(),
-		)
+		diags.Append(DiagNewAttributeValueIntoWrongType{
+			ValType:    reflect.TypeOf(res),
+			TargetType: target.Type(),
+			SchemaType: typ,
+			AttrPath:   path,
+		})
 		return target, diags
 	}
 	return reflect.ValueOf(res), diags

--- a/internal/reflect/map.go
+++ b/internal/reflect/map.go
@@ -18,31 +18,31 @@ func Map(ctx context.Context, typ attr.Type, val tftypes.Value, target reflect.V
 
 	// this only works with maps, so check that out first
 	if underlyingValue.Kind() != reflect.Map {
-		err := fmt.Errorf("expected a map type, got %s", target.Type())
-		diags.AddAttributeError(
-			path,
-			"Value Conversion Error",
-			"An unexpected error was encountered trying to convert to map value. This is always an error in the provider. Please report the following to the provider developer:\n\n"+err.Error(),
-		)
+		diags.Append(DiagIntoIncompatibleType{
+			Val:        val,
+			TargetType: target.Type(),
+			AttrPath:   path,
+			Err:        fmt.Errorf("expected a map type, got %s", target.Type()),
+		})
 		return target, diags
 	}
 	if !val.Type().Is(tftypes.Map{}) {
-		err := fmt.Errorf("cannot reflect %s into a map, must be a map", val.Type().String())
-		diags.AddAttributeError(
-			path,
-			"Value Conversion Error",
-			"An unexpected error was encountered trying to convert to map value. This is always an error in the provider. Please report the following to the provider developer:\n\n"+err.Error(),
-		)
+		diags.Append(DiagIntoIncompatibleType{
+			Val:        val,
+			TargetType: target.Type(),
+			AttrPath:   path,
+			Err:        fmt.Errorf("cannot reflect %s into a map, must be a map", val.Type().String()),
+		})
 		return target, diags
 	}
 	elemTyper, ok := typ.(attr.TypeWithElementType)
 	if !ok {
-		err := fmt.Errorf("cannot reflect map using type information provided by %T, %T must be an attr.TypeWithElementType", typ, typ)
-		diags.AddAttributeError(
-			path,
-			"Value Conversion Error",
-			"An unexpected error was encountered trying to convert to map value. This is always an error in the provider. Please report the following to the provider developer:\n\n"+err.Error(),
-		)
+		diags.Append(DiagIntoIncompatibleType{
+			Val:        val,
+			TargetType: target.Type(),
+			AttrPath:   path,
+			Err:        fmt.Errorf("cannot reflect map using type information provided by %T, %T must be an attr.TypeWithElementType", typ, typ),
+		})
 		return target, diags
 	}
 
@@ -51,11 +51,12 @@ func Map(ctx context.Context, typ attr.Type, val tftypes.Value, target reflect.V
 	values := map[string]tftypes.Value{}
 	err := val.As(&values)
 	if err != nil {
-		diags.AddAttributeError(
-			path,
-			"Value Conversion Error",
-			"An unexpected error was encountered trying to convert to map value. This is always an error in the provider. Please report the following to the provider developer:\n\n"+err.Error(),
-		)
+		diags.Append(DiagIntoIncompatibleType{
+			Val:        val,
+			TargetType: target.Type(),
+			AttrPath:   path,
+			Err:        err,
+		})
 		return target, diags
 	}
 

--- a/internal/reflect/number.go
+++ b/internal/reflect/number.go
@@ -29,11 +29,12 @@ func Number(ctx context.Context, typ attr.Type, val tftypes.Value, target reflec
 	result := big.NewFloat(0)
 	err := val.As(&result)
 	if err != nil {
-		diags.AddAttributeError(
-			path,
-			"Value Conversion Error",
-			"An unexpected error was encountered trying to convert to number. This is always an error in the provider. Please report the following to the provider developer:\n\n"+err.Error(),
-		)
+		diags.Append(DiagIntoIncompatibleType{
+			AttrPath:   path,
+			Err:        err,
+			TargetType: target.Type(),
+			Val:        val,
+		})
 		return target, diags
 	}
 	roundingError := fmt.Errorf("cannot store %s in %s", result.String(), target.Type())

--- a/internal/reflect/number_test.go
+++ b/internal/reflect/number_test.go
@@ -1198,8 +1198,11 @@ func TestFromInt(t *testing.T) {
 		"WithValidateWarning": {
 			val: 1,
 			typ: testtypes.NumberTypeWithValidateWarning{},
-			expected: types.Number{
-				Value: big.NewFloat(1),
+			expected: testtypes.Number{
+				Number: types.Number{
+					Value: big.NewFloat(1),
+				},
+				CreatedBy: testtypes.NumberType{},
 			},
 			expectedDiags: diag.Diagnostics{
 				testtypes.TestWarningDiagnostic(tftypes.NewAttributePath()),
@@ -1257,8 +1260,11 @@ func TestFromUint(t *testing.T) {
 		"WithValidateWarning": {
 			val: 1,
 			typ: testtypes.NumberTypeWithValidateWarning{},
-			expected: types.Number{
-				Value: big.NewFloat(1),
+			expected: testtypes.Number{
+				Number: types.Number{
+					Value: big.NewFloat(1),
+				},
+				CreatedBy: testtypes.NumberType{},
 			},
 			expectedDiags: diag.Diagnostics{
 				testtypes.TestWarningDiagnostic(tftypes.NewAttributePath()),
@@ -1323,8 +1329,11 @@ func TestFromFloat(t *testing.T) {
 		"WithValidateWarning": {
 			val: 1,
 			typ: testtypes.NumberTypeWithValidateWarning{},
-			expected: types.Number{
-				Value: big.NewFloat(1),
+			expected: testtypes.Number{
+				Number: types.Number{
+					Value: big.NewFloat(1),
+				},
+				CreatedBy: testtypes.NumberType{},
 			},
 			expectedDiags: diag.Diagnostics{
 				testtypes.TestWarningDiagnostic(tftypes.NewAttributePath()),
@@ -1389,8 +1398,11 @@ func TestFromBigFloat(t *testing.T) {
 		"WithValidateWarning": {
 			val: big.NewFloat(1),
 			typ: testtypes.NumberTypeWithValidateWarning{},
-			expected: types.Number{
-				Value: big.NewFloat(1),
+			expected: testtypes.Number{
+				Number: types.Number{
+					Value: big.NewFloat(1),
+				},
+				CreatedBy: testtypes.NumberType{},
 			},
 			expectedDiags: diag.Diagnostics{
 				testtypes.TestWarningDiagnostic(tftypes.NewAttributePath()),
@@ -1448,8 +1460,11 @@ func TestFromBigInt(t *testing.T) {
 		"WithValidateWarning": {
 			val: big.NewInt(1),
 			typ: testtypes.NumberTypeWithValidateWarning{},
-			expected: types.Number{
-				Value: big.NewFloat(1),
+			expected: testtypes.Number{
+				Number: types.Number{
+					Value: big.NewFloat(1),
+				},
+				CreatedBy: testtypes.NumberTypeWithValidateWarning{},
 			},
 			expectedDiags: diag.Diagnostics{
 				testtypes.TestWarningDiagnostic(tftypes.NewAttributePath()),

--- a/internal/reflect/pointer.go
+++ b/internal/reflect/pointer.go
@@ -18,12 +18,12 @@ func Pointer(ctx context.Context, typ attr.Type, val tftypes.Value, target refle
 	var diags diag.Diagnostics
 
 	if target.Kind() != reflect.Ptr {
-		err := fmt.Errorf("cannot dereference pointer, not a pointer, is a %s (%s)", target.Type(), target.Kind())
-		diags.AddAttributeError(
-			path,
-			"Value Conversion Error",
-			"An unexpected error was encountered trying to convert to pointer value. This is always an error in the provider. Please report the following to the provider developer:\n\n"+err.Error(),
-		)
+		diags.Append(DiagIntoIncompatibleType{
+			Val:        val,
+			TargetType: target.Type(),
+			AttrPath:   path,
+			Err:        fmt.Errorf("cannot dereference pointer, not a pointer, is a %s (%s)", target.Type(), target.Kind()),
+		})
 		return target, diags
 	}
 	// we may have gotten a nil pointer, so we need to create our own that

--- a/internal/reflect/pointer_test.go
+++ b/internal/reflect/pointer_test.go
@@ -115,8 +115,11 @@ func TestFromPointer(t *testing.T) {
 		"WithValidateWarning": {
 			typ: testtypes.StringTypeWithValidateWarning{},
 			val: reflect.ValueOf(strPtr("hello, world")),
-			expected: types.String{
-				Value: "hello, world",
+			expected: testtypes.String{
+				String: types.String{
+					Value: "hello, world",
+				},
+				CreatedBy: testtypes.StringTypeWithValidateWarning{},
 			},
 			expectedDiags: diag.Diagnostics{
 				testtypes.TestWarningDiagnostic(tftypes.NewAttributePath()),

--- a/internal/reflect/pointer_test.go
+++ b/internal/reflect/pointer_test.go
@@ -2,6 +2,7 @@ package reflect_test
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -20,11 +21,12 @@ func TestPointer_notAPointer(t *testing.T) {
 
 	var s string
 	expectedDiags := diag.Diagnostics{
-		diag.NewAttributeErrorDiagnostic(
-			tftypes.NewAttributePath(),
-			"Value Conversion Error",
-			"An unexpected error was encountered trying to convert to pointer value. This is always an error in the provider. Please report the following to the provider developer:\n\ncannot dereference pointer, not a pointer, is a string (string)",
-		),
+		refl.DiagIntoIncompatibleType{
+			Val:        tftypes.NewValue(tftypes.String, "hello"),
+			TargetType: reflect.TypeOf(s),
+			AttrPath:   tftypes.NewAttributePath(),
+			Err:        fmt.Errorf("cannot dereference pointer, not a pointer, is a %s (%s)", reflect.TypeOf(s), reflect.TypeOf(s).Kind()),
+		},
 	}
 
 	_, diags := refl.Pointer(context.Background(), types.StringType, tftypes.NewValue(tftypes.String, "hello"), reflect.ValueOf(s), refl.Options{}, tftypes.NewAttributePath())

--- a/internal/reflect/primitive.go
+++ b/internal/reflect/primitive.go
@@ -2,7 +2,7 @@ package reflect
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"reflect"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -22,11 +22,12 @@ func Primitive(ctx context.Context, typ attr.Type, val tftypes.Value, target ref
 		var b bool
 		err := val.As(&b)
 		if err != nil {
-			diags.AddAttributeError(
-				path,
-				"Value Conversion Error",
-				"An unexpected error was encountered trying to convert to boolean. This is always an error in the provider. Please report the following to the provider developer:\n\n"+err.Error(),
-			)
+			diags.Append(DiagIntoIncompatibleType{
+				Val:        val,
+				TargetType: target.Type(),
+				AttrPath:   path,
+				Err:        err,
+			})
 			return target, diags
 		}
 		return reflect.ValueOf(b).Convert(target.Type()), nil
@@ -34,21 +35,22 @@ func Primitive(ctx context.Context, typ attr.Type, val tftypes.Value, target ref
 		var s string
 		err := val.As(&s)
 		if err != nil {
-			diags.AddAttributeError(
-				path,
-				"Value Conversion Error",
-				"An unexpected error was encountered trying to convert to string. This is always an error in the provider. Please report the following to the provider developer:\n\n"+err.Error(),
-			)
+			diags.Append(DiagIntoIncompatibleType{
+				Val:        val,
+				TargetType: target.Type(),
+				AttrPath:   path,
+				Err:        err,
+			})
 			return target, diags
 		}
 		return reflect.ValueOf(s).Convert(target.Type()), nil
 	default:
-		err := fmt.Errorf("unrecognized type: %s", target.Kind())
-		diags.AddAttributeError(
-			path,
-			"Value Conversion Error",
-			"An unexpected error was encountered trying to convert to primitive. This is always an error in the provider. Please report the following to the provider developer:\n\n"+err.Error(),
-		)
+		diags.Append(DiagIntoIncompatibleType{
+			Val:        val,
+			TargetType: target.Type(),
+			AttrPath:   path,
+			Err:        errors.New("unknown type"),
+		})
 		return target, diags
 	}
 }

--- a/internal/reflect/primitive_test.go
+++ b/internal/reflect/primitive_test.go
@@ -95,8 +95,11 @@ func TestFromString(t *testing.T) {
 		"WithValidateWarning": {
 			val: "mystring",
 			typ: testtypes.StringTypeWithValidateWarning{},
-			expected: types.String{
-				Value: "mystring",
+			expected: testtypes.String{
+				String: types.String{
+					Value: "mystring",
+				},
+				CreatedBy: testtypes.StringTypeWithValidateWarning{},
 			},
 			expectedDiags: diag.Diagnostics{
 				testtypes.TestWarningDiagnostic(tftypes.NewAttributePath()),
@@ -155,8 +158,11 @@ func TestFromBool(t *testing.T) {
 		"WithValidateWarning": {
 			val: true,
 			typ: testtypes.BoolTypeWithValidateWarning{},
-			expected: types.Bool{
-				Value: true,
+			expected: testtypes.Bool{
+				Bool: types.Bool{
+					Value: true,
+				},
+				CreatedBy: testtypes.BoolTypeWithValidateWarning{},
 			},
 			expectedDiags: diag.Diagnostics{
 				testtypes.TestWarningDiagnostic(tftypes.NewAttributePath()),

--- a/internal/reflect/slice.go
+++ b/internal/reflect/slice.go
@@ -17,23 +17,23 @@ func reflectSlice(ctx context.Context, typ attr.Type, val tftypes.Value, target 
 
 	// this only works with slices, so check that out first
 	if target.Kind() != reflect.Slice {
-		err := fmt.Errorf("expected a slice type, got %s", target.Type())
-		diags.AddAttributeError(
-			path,
-			"Value Conversion Error",
-			"An unexpected error was encountered trying to convert to slice. This is always an error in the provider. Please report the following to the provider developer:\n\n"+err.Error(),
-		)
+		diags.Append(DiagIntoIncompatibleType{
+			Val:        val,
+			TargetType: target.Type(),
+			AttrPath:   path,
+			Err:        fmt.Errorf("expected a slice type, got %s", target.Type()),
+		})
 		return target, diags
 	}
 	// TODO: check that the val is a list or set or tuple
 	elemTyper, ok := typ.(attr.TypeWithElementType)
 	if !ok {
-		err := fmt.Errorf("cannot reflect %s using type information provided by %T, %T must be an attr.TypeWithElementType", val.Type(), typ, typ)
-		diags.AddAttributeError(
-			path,
-			"Value Conversion Error",
-			"An unexpected error was encountered trying to convert to slice. This is always an error in the provider. Please report the following to the provider developer:\n\n"+err.Error(),
-		)
+		diags.Append(DiagIntoIncompatibleType{
+			Val:        val,
+			TargetType: target.Type(),
+			AttrPath:   path,
+			Err:        fmt.Errorf("cannot reflect %s using type information provided by %T, %T must be an attr.TypeWithElementType", val.Type(), typ, typ),
+		})
 		return target, diags
 	}
 
@@ -42,11 +42,12 @@ func reflectSlice(ctx context.Context, typ attr.Type, val tftypes.Value, target 
 	var values []tftypes.Value
 	err := val.As(&values)
 	if err != nil {
-		diags.AddAttributeError(
-			path,
-			"Value Conversion Error",
-			"An unexpected error was encountered trying to convert to slice. This is always an error in the provider. Please report the following to the provider developer:\n\n"+err.Error(),
-		)
+		diags.Append(DiagIntoIncompatibleType{
+			Val:        val,
+			TargetType: target.Type(),
+			AttrPath:   path,
+			Err:        err,
+		})
 		return target, diags
 	}
 

--- a/internal/reflect/struct.go
+++ b/internal/reflect/struct.go
@@ -30,31 +30,31 @@ func Struct(ctx context.Context, typ attr.Type, object tftypes.Value, target ref
 	// this only works with object values, so make sure that constraint is
 	// met
 	if target.Kind() != reflect.Struct {
-		err := fmt.Errorf("expected a struct type, got %s", target.Type())
-		diags.AddAttributeError(
-			path,
-			"Value Conversion Error",
-			"An unexpected error was encountered trying to convert to struct. This is always an error in the provider. Please report the following to the provider developer:\n\n"+err.Error(),
-		)
+		diags.Append(DiagIntoIncompatibleType{
+			Val:        object,
+			TargetType: target.Type(),
+			AttrPath:   path,
+			Err:        fmt.Errorf("expected a struct type, got %s", target.Type()),
+		})
 		return target, diags
 	}
 	if !object.Type().Is(tftypes.Object{}) {
-		err := fmt.Errorf("cannot reflect %s into a struct, must be an object", object.Type().String())
-		diags.AddAttributeError(
-			path,
-			"Value Conversion Error",
-			"An unexpected error was encountered trying to convert to struct. This is always an error in the provider. Please report the following to the provider developer:\n\n"+err.Error(),
-		)
+		diags.Append(DiagIntoIncompatibleType{
+			Val:        object,
+			TargetType: target.Type(),
+			AttrPath:   path,
+			Err:        fmt.Errorf("cannot reflect %s into a struct, must be an object", object.Type().String()),
+		})
 		return target, diags
 	}
 	attrsType, ok := typ.(attr.TypeWithAttributeTypes)
 	if !ok {
-		err := fmt.Errorf("cannot reflect object using type information provided by %T, %T must be an attr.TypeWithAttributeTypes", typ, typ)
-		diags.AddAttributeError(
-			path,
-			"Value Conversion Error",
-			"An unexpected error was encountered trying to convert to struct. This is always an error in the provider. Please report the following to the provider developer:\n\n"+err.Error(),
-		)
+		diags.Append(DiagIntoIncompatibleType{
+			Val:        object,
+			TargetType: target.Type(),
+			AttrPath:   path,
+			Err:        fmt.Errorf("cannot reflect object using type information provided by %T, %T must be an attr.TypeWithAttributeTypes", typ, typ),
+		})
 		return target, diags
 	}
 
@@ -62,11 +62,12 @@ func Struct(ctx context.Context, typ attr.Type, object tftypes.Value, target ref
 	var objectFields map[string]tftypes.Value
 	err := object.As(&objectFields)
 	if err != nil {
-		diags.AddAttributeError(
-			path,
-			"Value Conversion Error",
-			"An unexpected error was encountered trying to convert to struct. This is always an error in the provider. Please report the following to the provider developer:\n\n"+err.Error(),
-		)
+		diags.Append(DiagIntoIncompatibleType{
+			Val:        object,
+			TargetType: target.Type(),
+			AttrPath:   path,
+			Err:        err,
+		})
 		return target, diags
 	}
 
@@ -74,12 +75,12 @@ func Struct(ctx context.Context, typ attr.Type, object tftypes.Value, target ref
 	// passed in
 	targetFields, err := getStructTags(ctx, target, path)
 	if err != nil {
-		err = fmt.Errorf("error retrieving field names from struct tags: %w", err)
-		diags.AddAttributeError(
-			path,
-			"Value Conversion Error",
-			"An unexpected error was encountered trying to convert to struct. This is always an error in the provider. Please report the following to the provider developer:\n\n"+err.Error(),
-		)
+		diags.Append(DiagIntoIncompatibleType{
+			Val:        object,
+			TargetType: target.Type(),
+			AttrPath:   path,
+			Err:        fmt.Errorf("error retrieving field names from struct tags: %w", err),
+		})
 		return target, diags
 	}
 
@@ -105,12 +106,12 @@ func Struct(ctx context.Context, typ attr.Type, object tftypes.Value, target ref
 		if len(targetMissing) > 0 {
 			missing = append(missing, fmt.Sprintf("Object defines fields not found in struct: %s.", commaSeparatedString(targetMissing)))
 		}
-		err := fmt.Errorf("mismatch between struct and object: %s", strings.Join(missing, " "))
-		diags.AddAttributeError(
-			path,
-			"Value Conversion Error",
-			"An unexpected error was encountered trying to convert to struct. This is always an error in the provider. Please report the following to the provider developer:\n\n"+err.Error(),
-		)
+		diags.Append(DiagIntoIncompatibleType{
+			Val:        object,
+			TargetType: target.Type(),
+			AttrPath:   path,
+			Err:        fmt.Errorf("mismatch between struct and object: %s", strings.Join(missing, " ")),
+		})
 		return target, diags
 	}
 
@@ -122,12 +123,12 @@ func Struct(ctx context.Context, typ attr.Type, object tftypes.Value, target ref
 	for field, structFieldPos := range targetFields {
 		attrType, ok := attrTypes[field]
 		if !ok {
-			err := fmt.Errorf("could not find type information for attribute in supplied attr.Type %T", typ)
-			diags.AddAttributeError(
-				path.WithAttributeName(field),
-				"Value Conversion Error",
-				"An unexpected error was encountered trying to convert to struct. This is always an error in the provider. Please report the following to the provider developer:\n\n"+err.Error(),
-			)
+			diags.Append(DiagIntoIncompatibleType{
+				Val:        object,
+				TargetType: target.Type(),
+				AttrPath:   path,
+				Err:        fmt.Errorf("could not find type information for attribute in supplied attr.Type %T", typ),
+			})
 			return target, diags
 		}
 		structField := result.Field(structFieldPos)

--- a/internal/testing/types/bool.go
+++ b/internal/testing/types/bool.go
@@ -39,13 +39,15 @@ func (t BoolType) TerraformType(_ context.Context) tftypes.Type {
 
 func (t BoolType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
 	if in.IsNull() {
-		return types.Bool{
-			Null: true,
+		return Bool{
+			Bool:      types.Bool{Null: true},
+			CreatedBy: t,
 		}, nil
 	}
 	if !in.IsKnown() {
-		return types.Bool{
-			Unknown: true,
+		return Bool{
+			Bool:      types.Bool{Unknown: true},
+			CreatedBy: t,
 		}, nil
 	}
 	var b bool
@@ -53,5 +55,22 @@ func (t BoolType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (att
 	if err != nil {
 		return nil, err
 	}
-	return types.Bool{Value: b}, nil
+	return Bool{Bool: types.Bool{Value: b}, CreatedBy: t}, nil
+}
+
+type Bool struct {
+	types.Bool
+	CreatedBy attr.Type
+}
+
+func (b Bool) Type(_ context.Context) attr.Type {
+	return b.CreatedBy
+}
+
+func (b Bool) Equal(o attr.Value) bool {
+	ob, ok := o.(Bool)
+	if !ok {
+		return false
+	}
+	return b.Bool.Equal(ob.Bool)
 }

--- a/internal/testing/types/boolwithvalidate.go
+++ b/internal/testing/types/boolwithvalidate.go
@@ -17,12 +17,32 @@ type BoolTypeWithValidateError struct {
 	BoolType
 }
 
+func (b BoolTypeWithValidateError) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	res, err := b.BoolType.ValueFromTerraform(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	newBool := res.(Bool)
+	newBool.CreatedBy = b
+	return newBool, nil
+}
+
 type BoolTypeWithValidateWarning struct {
 	BoolType
 }
 
+func (b BoolTypeWithValidateWarning) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	res, err := b.BoolType.ValueFromTerraform(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	newBool := res.(Bool)
+	newBool.CreatedBy = b
+	return newBool, nil
+}
+
 func (t BoolTypeWithValidateError) Validate(ctx context.Context, in tftypes.Value, path *tftypes.AttributePath) diag.Diagnostics {
-	return diag.Diagnostics{TestErrorDiagnostic(path)}
+	return diag.Diagnostics{TestErrorDiagnostic}
 }
 
 func (t BoolTypeWithValidateWarning) Validate(ctx context.Context, in tftypes.Value, path *tftypes.AttributePath) diag.Diagnostics {

--- a/internal/testing/types/boolwithvalidate.go
+++ b/internal/testing/types/boolwithvalidate.go
@@ -42,7 +42,7 @@ func (b BoolTypeWithValidateWarning) ValueFromTerraform(ctx context.Context, in 
 }
 
 func (t BoolTypeWithValidateError) Validate(ctx context.Context, in tftypes.Value, path *tftypes.AttributePath) diag.Diagnostics {
-	return diag.Diagnostics{TestErrorDiagnostic}
+	return diag.Diagnostics{TestErrorDiagnostic(path)}
 }
 
 func (t BoolTypeWithValidateWarning) Validate(ctx context.Context, in tftypes.Value, path *tftypes.AttributePath) diag.Diagnostics {

--- a/internal/testing/types/number.go
+++ b/internal/testing/types/number.go
@@ -40,15 +40,42 @@ func (t NumberType) TerraformType(_ context.Context) tftypes.Type {
 
 func (t NumberType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
 	if !in.IsKnown() {
-		return types.Number{Unknown: true}, nil
+		return Number{
+			Number:    types.Number{Unknown: true},
+			CreatedBy: t,
+		}, nil
 	}
 	if in.IsNull() {
-		return types.Number{Null: true}, nil
+		return Number{
+			Number:    types.Number{Null: true},
+			CreatedBy: t,
+		}, nil
 	}
 	n := big.NewFloat(0)
 	err := in.As(&n)
 	if err != nil {
 		return nil, err
 	}
-	return types.Number{Value: n}, nil
+	return Number{
+		Number:    types.Number{Value: n},
+		CreatedBy: t,
+	}, nil
+}
+
+type Number struct {
+	types.Number
+
+	CreatedBy attr.Type
+}
+
+func (n Number) Type(_ context.Context) attr.Type {
+	return n.CreatedBy
+}
+
+func (n Number) Equal(o attr.Value) bool {
+	on, ok := o.(Number)
+	if !ok {
+		return false
+	}
+	return n.Number.Equal(on.Number)
 }

--- a/internal/testing/types/numberwithvalidate.go
+++ b/internal/testing/types/numberwithvalidate.go
@@ -28,3 +28,23 @@ func (t NumberTypeWithValidateError) Validate(ctx context.Context, in tftypes.Va
 func (t NumberTypeWithValidateWarning) Validate(ctx context.Context, in tftypes.Value, path *tftypes.AttributePath) diag.Diagnostics {
 	return diag.Diagnostics{TestWarningDiagnostic(path)}
 }
+
+func (n NumberTypeWithValidateError) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	res, err := n.NumberType.ValueFromTerraform(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	newNumber := res.(Number)
+	newNumber.CreatedBy = n
+	return newNumber, nil
+}
+
+func (n NumberTypeWithValidateWarning) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	res, err := n.NumberType.ValueFromTerraform(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	newNumber := res.(Number)
+	newNumber.CreatedBy = n
+	return newNumber, nil
+}

--- a/internal/testing/types/string.go
+++ b/internal/testing/types/string.go
@@ -39,15 +39,41 @@ func (t StringType) TerraformType(_ context.Context) tftypes.Type {
 
 func (t StringType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
 	if !in.IsKnown() {
-		return types.String{Unknown: true}, nil
+		return String{
+			String:    types.String{Unknown: true},
+			CreatedBy: t,
+		}, nil
 	}
 	if in.IsNull() {
-		return types.String{Null: true}, nil
+		return String{
+			String:    types.String{Null: true},
+			CreatedBy: t,
+		}, nil
 	}
 	var s string
 	err := in.As(&s)
 	if err != nil {
 		return nil, err
 	}
-	return types.String{Value: s}, nil
+	return String{
+		String:    types.String{Value: s},
+		CreatedBy: t,
+	}, nil
+}
+
+type String struct {
+	types.String
+	CreatedBy attr.Type
+}
+
+func (s String) Type(_ context.Context) attr.Type {
+	return s.CreatedBy
+}
+
+func (s String) Equal(o attr.Value) bool {
+	os, ok := o.(String)
+	if !ok {
+		return false
+	}
+	return s.String.Equal(os.String)
 }

--- a/internal/testing/types/stringwithvalidate.go
+++ b/internal/testing/types/stringwithvalidate.go
@@ -17,6 +17,24 @@ type StringTypeWithValidateError struct {
 	StringType
 }
 
+func (t StringTypeWithValidateError) Equal(o attr.Type) bool {
+	other, ok := o.(StringTypeWithValidateError)
+	if !ok {
+		return false
+	}
+	return t == other
+}
+
+func (s StringTypeWithValidateError) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	res, err := s.StringType.ValueFromTerraform(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	newString := res.(String)
+	newString.CreatedBy = s
+	return newString, nil
+}
+
 type StringTypeWithValidateWarning struct {
 	StringType
 }
@@ -25,6 +43,24 @@ func (t StringTypeWithValidateError) Validate(ctx context.Context, in tftypes.Va
 	return diag.Diagnostics{TestErrorDiagnostic(path)}
 }
 
+func (t StringTypeWithValidateWarning) Equal(o attr.Type) bool {
+	other, ok := o.(StringTypeWithValidateWarning)
+	if !ok {
+		return false
+	}
+	return t == other
+}
+
+func (s StringTypeWithValidateWarning) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	res, err := s.StringType.ValueFromTerraform(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	newString := res.(String)
+	newString.CreatedBy = s
+	return newString, nil
+}
+
 func (t StringTypeWithValidateWarning) Validate(ctx context.Context, in tftypes.Value, path *tftypes.AttributePath) diag.Diagnostics {
-	return diag.Diagnostics{TestWarningDiagnostic(path)}
+	return diag.Diagnostics{TestWarningDiagnostic}
 }

--- a/internal/testing/types/stringwithvalidate.go
+++ b/internal/testing/types/stringwithvalidate.go
@@ -62,5 +62,5 @@ func (s StringTypeWithValidateWarning) ValueFromTerraform(ctx context.Context, i
 }
 
 func (t StringTypeWithValidateWarning) Validate(ctx context.Context, in tftypes.Value, path *tftypes.AttributePath) diag.Diagnostics {
-	return diag.Diagnostics{TestWarningDiagnostic}
+	return diag.Diagnostics{TestWarningDiagnostic(path)}
 }

--- a/tfsdk/attribute_plan_modification.go
+++ b/tfsdk/attribute_plan_modification.go
@@ -90,7 +90,7 @@ func RequiresReplaceIf(f RequiresReplaceIfFunc, description, markdownDescription
 
 // RequiresReplaceIfFunc is a conditional function used in the RequiresReplaceIf
 // plan modifier to determine whether the attribute requires replacement.
-type RequiresReplaceIfFunc func(ctx context.Context, state, config attr.Value) (bool, error)
+type RequiresReplaceIfFunc func(ctx context.Context, state, config attr.Value, path *tftypes.AttributePath) (bool, diag.Diagnostics)
 
 // RequiresReplaceIfModifier is an AttributePlanModifier that sets RequiresReplace
 // on the attribute if the conditional function returns true.
@@ -103,10 +103,8 @@ type RequiresReplaceIfModifier struct {
 // Modify sets RequiresReplace on the response to true if the conditional
 // RequiresReplaceIfFunc returns true.
 func (r RequiresReplaceIfModifier) Modify(ctx context.Context, req ModifyAttributePlanRequest, resp *ModifyAttributePlanResponse) {
-	res, err := r.f(ctx, req.AttributeState, req.AttributeConfig)
-	if err != nil {
-		resp.AddError("Error running RequiresReplaceIf func for attribute", err.Error())
-	}
+	res, diags := r.f(ctx, req.AttributeState, req.AttributeConfig, req.AttributePath)
+	resp.Diagnostics.Append(diags...)
 	resp.RequiresReplace = res
 }
 

--- a/tfsdk/serve.go
+++ b/tfsdk/serve.go
@@ -315,8 +315,6 @@ func (s *server) validateProviderConfig(ctx context.Context, req *tfprotov6.Vali
 	schema.validate(ctx, validateSchemaReq, &validateSchemaResp)
 
 	resp.Diagnostics = validateSchemaResp.Diagnostics
-
-	return
 }
 
 // configureProviderResponse is a thin abstraction to allow native Diagnostics usage

--- a/tfsdk/state_test.go
+++ b/tfsdk/state_test.go
@@ -1643,7 +1643,3 @@ func TestStateSetAttribute(t *testing.T) {
 		})
 	}
 }
-
-func strPtr(s string) *string {
-	return &s
-}

--- a/tfsdk/state_test.go
+++ b/tfsdk/state_test.go
@@ -34,7 +34,7 @@ func TestStateGet(t *testing.T) {
 
 	type testCase struct {
 		state         State
-		expected      interface{}
+		expected      testStateGetData
 		expectedDiags diag.Diagnostics
 	}
 
@@ -209,6 +209,55 @@ func TestStateGet(t *testing.T) {
 				},
 			},
 		},
+	}
+
+	for name, tc := range testCases {
+		name, tc := name, tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var val testStateGetData
+
+			diags := tc.state.Get(context.Background(), &val)
+
+			if diff := cmp.Diff(diags, tc.expectedDiags); diff != "" {
+				t.Errorf("unexpected diagnostics (+wanted, -got): %s", diff)
+			}
+
+			if diff := cmp.Diff(val, tc.expected); diff != "" {
+				t.Errorf("unexpected value (+wanted, -got): %s", diff)
+			}
+		})
+	}
+}
+
+func TestStateGet_testTypes(t *testing.T) {
+	t.Parallel()
+
+	type testStateGetDataTestTypes struct {
+		Name        testtypes.String `tfsdk:"name"`
+		MachineType string           `tfsdk:"machine_type"`
+		Tags        types.List       `tfsdk:"tags"`
+		Disks       []struct {
+			ID                 string `tfsdk:"id"`
+			DeleteWithInstance bool   `tfsdk:"delete_with_instance"`
+		} `tfsdk:"disks"`
+		BootDisk struct {
+			ID                 string `tfsdk:"id"`
+			DeleteWithInstance bool   `tfsdk:"delete_with_instance"`
+		} `tfsdk:"boot_disk"`
+		ScratchDisk struct {
+			Interface string `tfsdk:"interface"`
+		} `tfsdk:"scratch_disk"`
+	}
+
+	type testCase struct {
+		state         State
+		expected      testStateGetDataTestTypes
+		expectedDiags diag.Diagnostics
+	}
+
+	testCases := map[string]testCase{
 		"AttrTypeWithValidateError": {
 			state: State{
 				Raw: tftypes.NewValue(tftypes.Object{
@@ -341,8 +390,8 @@ func TestStateGet(t *testing.T) {
 					},
 				},
 			},
-			expected: testStateGetData{
-				Name:        types.String{Value: ""},
+			expected: testStateGetDataTestTypes{
+				Name:        testtypes.String{String: types.String{Value: ""}, CreatedBy: testtypes.StringTypeWithValidateError{}},
 				MachineType: "",
 				Tags:        types.List{},
 				Disks:       nil,
@@ -493,8 +542,8 @@ func TestStateGet(t *testing.T) {
 					},
 				},
 			},
-			expected: testStateGetData{
-				Name:        types.String{Value: "namevalue"},
+			expected: testStateGetDataTestTypes{
+				Name:        testtypes.String{String: types.String{Value: "namevalue"}, CreatedBy: testtypes.StringTypeWithValidateWarning{}},
 				MachineType: "e2-medium",
 				Tags: types.List{
 					ElemType: types.StringType,
@@ -539,11 +588,14 @@ func TestStateGet(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			var val testStateGetData
+			var val testStateGetDataTestTypes
 
 			diags := tc.state.Get(context.Background(), &val)
 
 			if diff := cmp.Diff(diags, tc.expectedDiags); diff != "" {
+				for _, diag := range diags {
+					t.Log(diag)
+				}
 				t.Errorf("unexpected diagnostics (+wanted, -got): %s", diff)
 			}
 
@@ -848,7 +900,7 @@ func TestStateGetAttribute(t *testing.T) {
 				},
 			},
 			path:          tftypes.NewAttributePath().WithAttributeName("name"),
-			expected:      types.String{Value: "namevalue"},
+			expected:      testtypes.String{String: types.String{Value: "namevalue"}, CreatedBy: testtypes.StringTypeWithValidateWarning{}},
 			expectedDiags: diag.Diagnostics{testtypes.TestWarningDiagnostic(tftypes.NewAttributePath().WithAttributeName("name"))},
 		},
 	}

--- a/tfsdk/value_as.go
+++ b/tfsdk/value_as.go
@@ -1,0 +1,30 @@
+package tfsdk
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/internal/reflect"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// ValueAs populates the Go value passed as `target` with
+// the contents of `val`, using the reflection rules
+// defined for `Get` and `GetAttribute`.
+func ValueAs(ctx context.Context, val attr.Value, target interface{}) diag.Diagnostics {
+	raw, err := val.ToTerraformValue(ctx)
+	if err != nil {
+		return diag.Diagnostics{diag.NewErrorDiagnostic("Error converting value",
+			fmt.Sprintf("An unexpected error was encountered converting a %T to its equivalent Terraform representation. This is always a bug in the provider.\n\nError: %s", val, err))}
+	}
+	typ := val.Type(ctx).TerraformType(ctx)
+	err = tftypes.ValidateValue(typ, raw)
+	if err != nil {
+		return diag.Diagnostics{diag.NewErrorDiagnostic("Invalid value conversion",
+			fmt.Sprintf("An unexpected error was encountered converting a %T to its equivalent Terraform representation. This is always a bug in the provider.\n\nError: %s", val, err))}
+	}
+	v := tftypes.NewValue(typ, raw)
+	return reflect.Into(ctx, val.Type(ctx), v, target, reflect.Options{})
+}

--- a/tfsdk/value_as_test.go
+++ b/tfsdk/value_as_test.go
@@ -1,0 +1,85 @@
+package tfsdk
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	goreflect "reflect"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/internal/reflect"
+	testtypes "github.com/hashicorp/terraform-plugin-framework/internal/testing/types"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func newStringPointer(in string) *string {
+	return &in
+}
+
+func newInt64Pointer(in int64) *int64 {
+	return &in
+}
+
+func TestValueAs(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		val           attr.Value
+		target        interface{}
+		expected      interface{}
+		expectedDiags diag.Diagnostics
+	}
+
+	tests := map[string]testCase{
+		"primitive": {
+			val:      types.String{Value: "hello"},
+			target:   newStringPointer(""),
+			expected: newStringPointer("hello"),
+		},
+		"incompatible-type": {
+			val:    types.String{Value: "hello"},
+			target: newInt64Pointer(0),
+			expectedDiags: diag.Diagnostics{reflect.DiagIntoIncompatibleType{
+				Val:        tftypes.NewValue(tftypes.String, "hello"),
+				TargetType: goreflect.TypeOf(int64(0)),
+				Err:        fmt.Errorf("can't unmarshal %s into %T, expected *big.Float", tftypes.String, big.NewFloat(0)),
+				AttrPath:   tftypes.NewAttributePath(),
+			}},
+		},
+		"different-type": {
+			val:    types.String{Value: "hello"},
+			target: &testtypes.String{},
+			expectedDiags: diag.Diagnostics{reflect.DiagNewAttributeValueIntoWrongType{
+				ValType:    goreflect.TypeOf(types.String{Value: "hello"}),
+				TargetType: goreflect.TypeOf(testtypes.String{}),
+				AttrPath:   tftypes.NewAttributePath(),
+				SchemaType: types.StringType,
+			}},
+		},
+	}
+
+	for name, tc := range tests {
+		name, tc := name, tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			diags := ValueAs(context.Background(), tc.val, tc.target)
+
+			if diff := cmp.Diff(tc.expectedDiags, diags); diff != "" {
+				t.Fatalf("Unexpected diff in diagnostics (-wanted, +got): %s", diff)
+			}
+
+			if diags.HasError() {
+				return
+			}
+
+			if diff := cmp.Diff(tc.expected, tc.target); diff != "" {
+				t.Fatalf("Unexpected diff in results (-wanted, +got): %s", diff)
+			}
+		})
+	}
+}

--- a/types/bool.go
+++ b/types/bool.go
@@ -42,6 +42,11 @@ type Bool struct {
 	Value bool
 }
 
+// Type returns a BoolType.
+func (b Bool) Type(_ context.Context) attr.Type {
+	return BoolType
+}
+
 // ToTerraformValue returns the data contained in the *Bool as a bool. If
 // Unknown is true, it returns a tftypes.UnknownValue. If Null is true, it
 // returns nil.

--- a/types/list.go
+++ b/types/list.go
@@ -147,6 +147,11 @@ func (l List) ElementsAs(ctx context.Context, target interface{}, allowUnhandled
 	})
 }
 
+// Type returns a ListType with the same element type as `l`.
+func (l List) Type(ctx context.Context) attr.Type {
+	return ListType{ElemType: l.ElemType}
+}
+
 // ToTerraformValue returns the data contained in the AttributeValue as
 // a Go type that tftypes.NewValue will accept.
 func (l List) ToTerraformValue(ctx context.Context) (interface{}, error) {

--- a/types/map.go
+++ b/types/map.go
@@ -160,6 +160,11 @@ func (m Map) ElementsAs(ctx context.Context, target interface{}, allowUnhandled 
 	})
 }
 
+// Type returns a MapType with the same element type as `m`.
+func (m Map) Type(ctx context.Context) attr.Type {
+	return MapType{ElemType: m.ElemType}
+}
+
 // ToTerraformValue returns the data contained in the AttributeValue as a Go
 // type that tftypes.NewValue will accept.
 func (m Map) ToTerraformValue(ctx context.Context) (interface{}, error) {

--- a/types/number.go
+++ b/types/number.go
@@ -40,6 +40,11 @@ type Number struct {
 	Value *big.Float
 }
 
+// Type returns a NumberType.
+func (n Number) Type(_ context.Context) attr.Type {
+	return NumberType
+}
+
 // ToTerraformValue returns the data contained in the *Number as a *big.Float.
 // If Unknown is true, it returns a tftypes.UnknownValue. If Null is true, it
 // returns nil.

--- a/types/object.go
+++ b/types/object.go
@@ -179,6 +179,11 @@ func (o Object) As(ctx context.Context, target interface{}, opts ObjectAsOptions
 	})
 }
 
+// Type returns an ObjectType with the same attribute types as `o`.
+func (o Object) Type(_ context.Context) attr.Type {
+	return ObjectType{AttrTypes: o.AttrTypes}
+}
+
 // ToTerraformValue returns the data contained in the AttributeValue as
 // a Go type that tftypes.NewValue will accept.
 func (o Object) ToTerraformValue(ctx context.Context) (interface{}, error) {

--- a/types/string.go
+++ b/types/string.go
@@ -38,6 +38,11 @@ type String struct {
 	Value string
 }
 
+// Type returns a StringType.
+func (s String) Type(_ context.Context) attr.Type {
+	return StringType
+}
+
 // ToTerraformValue returns the data contained in the *String as a string. If
 // Unknown is true, it returns a tftypes.UnknownValue. If Null is true, it
 // returns nil.


### PR DESCRIPTION
Implement a new `tfsdk.ValueAs` helper that uses the same reflection
found in `Get` and `GetAttribute` to coerce an `attr.Value` to a
concrete Go type. It would be `attr.ValueAs`, but we can't do that, as
it would create an import cycle between `internal/reflect` and `attr`.
Adding this functionality allows people to avoid type-asserting on their
`attr.Value`s, instead using a less-brittle approach.

To achieve this, we needed to supply the `attr.Type` of the `attr.Value`
to `reflect.Into`, because it needs that if it's going to be able to
reflect into `attr.Value`s (because not all of them can be modified in
place, meaning we need to defensively re-create them, meaning we need to
know the `attr.Type` used to generate them). Rather than making users
supply the `attr.Type` when calling `tfsdk.ValueAs`, a `Type` method was
added to `attr.Value`, returning the `attr.Type` that generates that
`attr.Value`.

This involved a lot of updates to the tests, because they assumed that
the test types could generate non-test values, but the non-test values
weren't pointing to the right types, then. So when they were reflected,
they threw errors, because the new generated `attr.Value` wasn't the
same Go type as the `attr.Value` they were being reflected into. A mess
all around, but it was fixed to have test versions of the `attr.Value`s
that return the appropriate types for `attr.Value.Type`.

This `attr.Value` interface change _does_ make it harder to compose new
`attr.Type` and `attr.Value` implementations on top of older ones,
because it kinda requires the `attr.Value` to know about the `attr.Type`
that produced it. It's not _much_ extra work--the `Equal` and `Type`
methods need to be overridden--but it is still extra work. I'm not sure
how to avoid this, however, without pushing the complexity onto the
provider developer when `tfsdk.ValueAs` is used, by making them specify
the `attr.Type`. And that (intuitively, not evidenced in data) seems
like a more frequent paper cut than the paper cut of composing
`attr.Type` and `attr.Value` implementations, outside the relatively
bizarre case of the framework tests.

Fixes #88.