### PR TITLE
tfsdk: Exit early in TestServerPlanResourceChange on error diagnostics

### DIFF
--- a/tfsdk/serve_test.go
+++ b/tfsdk/serve_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/internal/diagnostics"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
@@ -2632,6 +2633,9 @@ func TestServerPlanResourceChange(t *testing.T) {
 			}
 			if diff := cmp.Diff(got.Diagnostics, tc.expectedDiags); diff != "" {
 				t.Errorf("Unexpected diff in diagnostics (+wanted, -got): %s", diff)
+			}
+			if diagnostics.DiagsHasErrors(got.Diagnostics) {
+				return
 			}
 			gotPlannedState, err := got.PlannedState.Unmarshal(tc.resourceType)
 			if err != nil {


### PR DESCRIPTION
Close #121

Least invasive change to fix testing race conditions.