### PR TITLE
tfsdk: Omit ImportedResource from response if error during protocol conversion

### DIFF
--- a/tfsdk/serve_import.go
+++ b/tfsdk/serve_import.go
@@ -32,9 +32,7 @@ func (r importedResource) toTfprotov6(ctx context.Context) (*tfprotov6.ImportedR
 			"Error converting imported resource response",
 			"An unexpected error was encountered when converting the imported resource response to a usable type. This is always a problem with the provider. Please give the following information to the provider developer:\n\n"+err.Error(),
 		)
-		// Do not return a nil ImportedResource, it can cause Terraform CLI
-		// to panic.
-		return irProto6, diags
+		return nil, diags
 	}
 
 	irProto6.State = &stateProto6
@@ -56,6 +54,9 @@ func (r importResourceStateResponse) toTfprotov6(ctx context.Context) *tfprotov6
 	for _, ir := range r.ImportedResources {
 		irProto6, diags := ir.toTfprotov6(ctx)
 		resp.Diagnostics = append(resp.Diagnostics, diags.ToTfprotov6Diagnostics()...)
+		if diags.HasError() {
+			continue
+		}
 		resp.ImportedResources = append(resp.ImportedResources, irProto6)
 	}
 

--- a/tfsdk/serve_import.go
+++ b/tfsdk/serve_import.go
@@ -32,7 +32,9 @@ func (r importedResource) toTfprotov6(ctx context.Context) (*tfprotov6.ImportedR
 			"Error converting imported resource response",
 			"An unexpected error was encountered when converting the imported resource response to a usable type. This is always a problem with the provider. Please give the following information to the provider developer:\n\n"+err.Error(),
 		)
-		return nil, diags
+		// Do not return a nil ImportedResource, it can cause Terraform CLI
+		// to panic.
+		return irProto6, diags
 	}
 
 	irProto6.State = &stateProto6

--- a/tfsdk/serve_import_test.go
+++ b/tfsdk/serve_import_test.go
@@ -126,6 +126,32 @@ func TestServerImportResourceState(t *testing.T) {
 				},
 			},
 		},
+		"imported_resource_conversion_error": {
+			req: &tfprotov6.ImportResourceStateRequest{
+				ID:       "test",
+				TypeName: "test_import_state",
+			},
+
+			impl: func(ctx context.Context, req ImportResourceStateRequest, resp *ImportResourceStateResponse) {
+				resp.State.Raw = tftypes.NewValue(tftypes.String, "this should never work")
+			},
+
+			resp: &tfprotov6.ImportResourceStateResponse{
+				Diagnostics: []*tfprotov6.Diagnostic{
+					{
+						Summary:  "Error converting imported resource response",
+						Severity: tfprotov6.DiagnosticSeverityError,
+						Detail: "An unexpected error was encountered when converting the imported resource response to a usable type. This is always a problem with the provider. Please give the following information to the provider developer:\n\n" +
+							`unexpected value type string, tftypes.Object["id":tftypes.String, "optional_string":tftypes.String, "required_string":tftypes.String] values must be of type map[string]tftypes.Value`,
+					},
+				},
+				ImportedResources: []*tfprotov6.ImportedResource{
+					{
+						TypeName: "test_import_state",
+					},
+				},
+			},
+		},
 		"no_state": {
 			req: &tfprotov6.ImportResourceStateRequest{
 				ID:       "test",

--- a/tfsdk/serve_import_test.go
+++ b/tfsdk/serve_import_test.go
@@ -145,11 +145,6 @@ func TestServerImportResourceState(t *testing.T) {
 							`unexpected value type string, tftypes.Object["id":tftypes.String, "optional_string":tftypes.String, "required_string":tftypes.String] values must be of type map[string]tftypes.Value`,
 					},
 				},
-				ImportedResources: []*tfprotov6.ImportedResource{
-					{
-						TypeName: "test_import_state",
-					},
-				},
 			},
 		},
 		"no_state": {


### PR DESCRIPTION
Closes #163

Prior to the code fix:

```
    --- FAIL: TestServerImportResourceState/imported_resource_conversion_error (0.00s)
        /Users/bflad/src/github.com/hashicorp/terraform-plugin-framework/tfsdk/serve_import_test.go:202: Unexpected diff in response (+wanted, -got):   &tfprotov6.ImportResourceStateResponse{
            - 	ImportedResources: []*tfprotov6.ImportedResource{nil},
            + 	ImportedResources: []*tfprotov6.ImportedResource{&{TypeName: "test_import_state"}},
              	Diagnostics:       {&{Severity: s"ERROR", Summary: "Error converting imported resource response", Detail: "An unexpected error was encountered when converting the imported"...}},
              }
```