### PR TITLE
tfsdk: Automatic detection of attribute value normalization

### DIFF
--- a/tfsdk/normalization_detect.go
+++ b/tfsdk/normalization_detect.go
@@ -1,0 +1,84 @@
+package tfsdk
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// undoNormalizationDifferences looks for situations where attribute values
+// in the new object differ from the corresponding attributes in the
+// old object only to the extent that the schema types still consider
+// the values to be equivalent, and constructs a resulting object which
+// prefers to keep the values from the configuration in that case.
+//
+// The "old" object typically represents prior state, while the "new"
+// object represents a new value that would eventually supersede it, such as
+// the result of refreshing or the "proposed new value" provided by Terraform
+// Core during planning.
+//
+// This compromise allows us to respect the higher-level definitions of
+// equality implemented by schema types while also remaining compatible with
+// Terraform Core's stricter definition of equality. The configuration value
+// must "win" in such cases, rather than the proposed (refreshed or planned)
+// value, so that a reference to an attribute from elsewhere in the Terraform
+// module will see exactly the value the module author wrote, rather than the
+// modified value the provider or remote system generated.
+func undoNormalizationDifferences(ctx context.Context, old, new tftypes.Value, schema Schema) tftypes.Value {
+	if old.IsNull() || !old.IsKnown() {
+		// No old values, so we'll just keep the new value exactly as-is.
+		return new
+	}
+
+	// We use "new" as the basis of our Transform here because if there's
+	// anything additional in "new" that wasn't present in "old" then we
+	// want to retain that unique portion of "new" verbatim, rather than
+	// discarding it to match the overall shape of "old".
+	result, _ := tftypes.Transform(new, func(path *tftypes.AttributePath, val tftypes.Value) (tftypes.Value, error) {
+		attribute, err := schema.AttributeAtPath(path)
+		if err != nil {
+			// Equality rules are only defined for entire attributes, so
+			// we have nothing to change if we're not referring to exactly
+			// an attribute.
+			return val, nil
+		}
+
+		ty := attribute.Type
+		if ty == nil {
+			// Equality rules are only for leaf attributes, which can define
+			// a custom type with its own equality rule.
+			return val, nil
+		}
+
+		oldValRaw, _, err := tftypes.WalkAttributePath(old, path)
+		if err != nil {
+			// If the old value doesn't even have this attribute then
+			// we'll just keep the new one.
+			return val, nil
+		}
+		oldVal := oldValRaw.(tftypes.Value)
+
+		// If we finally get here then that means we _do_ have corresponding
+		// old and new values for this particular attribute, and so we might
+		// possibly choose to keep oldVal instead of val.
+		schemaVal, err := ty.ValueFromTerraform(ctx, val)
+		if err != nil {
+			// The new value isn't valid for its defined type? Weird.
+			return val, nil
+		}
+
+		schemaOldVal, err := ty.ValueFromTerraform(ctx, oldVal)
+		if err != nil {
+			// The old value isn't valid for its defined type? Also weird.
+			return val, nil
+		}
+
+		// Finally, if the schema-level type considers these values to be
+		// equal then this is the one case where we will keep the old value.
+		if schemaOldVal.Equal(schemaVal) {
+			return oldVal, nil
+		}
+		return val, nil
+	})
+	return result
+}

--- a/tfsdk/serve_provider_test.go
+++ b/tfsdk/serve_provider_test.go
@@ -557,6 +557,7 @@ func (t *testServeProvider) GetResources(_ context.Context) (map[string]Resource
 		"test_attribute_plan_modifiers": testServeResourceTypeAttributePlanModifiers{},
 		"test_config_validators":        testServeResourceTypeConfigValidators{},
 		"test_import_state":             testServeResourceTypeImportState{},
+		"test_normalization":            testServeResourceTypeNormalization{},
 		"test_validate_config":          testServeResourceTypeValidateConfig{},
 	}, nil
 }

--- a/tfsdk/serve_resource_normalization_test.go
+++ b/tfsdk/serve_resource_normalization_test.go
@@ -1,0 +1,158 @@
+package tfsdk
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+type testServeResourceTypeNormalization struct{}
+
+func (dt testServeResourceTypeNormalization) GetSchema(_ context.Context) (Schema, diag.Diagnostics) {
+	return Schema{
+		Attributes: map[string]Attribute{
+			"id": {
+				Type:     types.StringType,
+				Computed: true,
+			},
+			"name": {
+				Type:     caseInsensitiveStringType{},
+				Required: true,
+			},
+		},
+	}, nil
+}
+
+func (dt testServeResourceTypeNormalization) NewResource(_ context.Context, p Provider) (Resource, diag.Diagnostics) {
+	provider, ok := p.(*testServeProvider)
+	if !ok {
+		prov, ok := p.(*testServeProviderWithMetaSchema)
+		if !ok {
+			panic(fmt.Sprintf("unexpected provider type %T", p))
+		}
+		provider = prov.testServeProvider
+	}
+	return testServeResourceNormalization{
+		provider: provider,
+	}, nil
+}
+
+var testServeResourceTypeNormalizationSchema = &tfprotov6.Schema{
+	Block: &tfprotov6.SchemaBlock{
+		Attributes: []*tfprotov6.SchemaAttribute{
+			{
+				Name:     "id",
+				Computed: true,
+				Type:     tftypes.String,
+			},
+			{
+				Name:     "name",
+				Required: true,
+				Type:     tftypes.String,
+			},
+		},
+	},
+}
+
+var testServeResourceTypeNormalizationType = tftypes.Object{
+	AttributeTypes: map[string]tftypes.Type{
+		"id":   tftypes.String,
+		"name": tftypes.String,
+	},
+}
+
+type testServeResourceNormalization struct {
+	provider *testServeProvider
+}
+
+func (r testServeResourceNormalization) Create(ctx context.Context, req CreateResourceRequest, resp *CreateResourceResponse) {
+	r.provider.applyResourceChangeCalledResourceType = "test_normalization"
+	r.provider.applyResourceChangeCalledAction = "create"
+}
+func (r testServeResourceNormalization) Read(ctx context.Context, req ReadResourceRequest, resp *ReadResourceResponse) {
+	r.provider.readResourceCalledResourceType = "test_normalization"
+	r.provider.readResourceCurrentStateValue = req.State.Raw
+	r.provider.readResourceCurrentStateSchema = req.State.Schema
+	r.provider.readResourceImpl(ctx, req, resp)
+}
+func (r testServeResourceNormalization) Update(ctx context.Context, req UpdateResourceRequest, resp *UpdateResourceResponse) {
+	r.provider.applyResourceChangeCalledResourceType = "test_normalization"
+	r.provider.applyResourceChangeCalledAction = "update"
+}
+func (r testServeResourceNormalization) Delete(ctx context.Context, req DeleteResourceRequest, resp *DeleteResourceResponse) {
+	r.provider.applyResourceChangeCalledResourceType = "test_normalization"
+	r.provider.applyResourceChangeCalledAction = "delete"
+}
+func (r testServeResourceNormalization) ImportState(ctx context.Context, req ImportResourceStateRequest, resp *ImportResourceStateResponse) {
+	ResourceImportStateNotImplemented(ctx, "Not expected to be called during testing.", resp)
+}
+
+func (r testServeResourceNormalization) ValidateConfig(ctx context.Context, req ValidateResourceConfigRequest, resp *ValidateResourceConfigResponse) {
+	r.provider.validateResourceConfigCalledResourceType = "test_normalization"
+	r.provider.validateResourceConfigImpl(ctx, req, resp)
+}
+
+// caseInsensitiveString is an attr.Type representing a string where differences
+// in case (as defined by Unicode case-folding) are considered to be
+// normalization rather than drift.
+type caseInsensitiveStringType struct{}
+
+var _ attr.Type = caseInsensitiveStringType{}
+
+func (t caseInsensitiveStringType) TerraformType(ctx context.Context) tftypes.Type {
+	return types.StringType.TerraformType(ctx)
+}
+
+func (t caseInsensitiveStringType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if !in.IsKnown() {
+		return caseInsensitiveString{types.String{Unknown: true}}, nil
+	}
+	if in.IsNull() {
+		return caseInsensitiveString{types.String{Null: true}}, nil
+	}
+	var s string
+	err := in.As(&s)
+	if err != nil {
+		return nil, err
+	}
+	return caseInsensitiveString{types.String{Value: s}}, nil
+}
+
+func (t caseInsensitiveStringType) Equal(other attr.Type) bool {
+	_, ok := other.(caseInsensitiveStringType)
+	return ok
+}
+
+func (t caseInsensitiveStringType) String() string {
+	return "tfsdk.caseInsensitiveStringType"
+}
+
+func (t caseInsensitiveStringType) ApplyTerraform5AttributePathStep(step tftypes.AttributePathStep) (interface{}, error) {
+	return types.StringType.ApplyTerraform5AttributePathStep(step)
+}
+
+type caseInsensitiveString struct {
+	types.String
+}
+
+var _ attr.Value = caseInsensitiveString{}
+
+func (s caseInsensitiveString) Equal(other attr.Value) bool {
+	o, ok := other.(caseInsensitiveString)
+	if !ok {
+		return false
+	}
+	if s.Unknown != o.Unknown {
+		return false
+	}
+	if s.Null != o.Null {
+		return false
+	}
+	return strings.EqualFold(s.Value, o.Value)
+}

--- a/types/string_specialized.go
+++ b/types/string_specialized.go
@@ -1,0 +1,159 @@
+package types
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// specializedStringType is a convenience helper for the common situation where
+// an underlying API takes a value as a string but imposes additional
+// validation and/or normalization rules on that string.
+type specializedStringType struct {
+	opts SpecializedStringOpts
+}
+
+type SpecializedStringOpts struct {
+	// NormalizeFunc is an optional function to convert a given string to the
+	// for that the underlying system would store and return it in.
+	//
+	// If you provide a NormalizeFunc then Value.Equal will return true for
+	// any pair of values that normalize to the same string.
+	NormalizeFunc func(given string) string
+	ValidateFunc  func(ctx context.Context, val string, path *tftypes.AttributePath) diag.Diagnostics
+	TypeString    string
+}
+
+func SpecializedStringType(opts SpecializedStringOpts) attr.Type {
+	return &specializedStringType{opts}
+}
+
+func (t *specializedStringType) TerraformType(ctx context.Context) tftypes.Type {
+	return tftypes.String
+}
+
+func (t *specializedStringType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if !in.IsKnown() {
+		return SpecializedString{ty: t, Unknown: true}, nil
+	}
+	if in.IsNull() {
+		return SpecializedString{ty: t, Null: true}, nil
+	}
+	var s string
+	err := in.As(&s)
+	if err != nil {
+		return nil, err
+	}
+	return SpecializedString{ty: t, Value: s}, nil
+}
+
+func (t *specializedStringType) Equal(other attr.Type) bool {
+	if other, ok := other.(*specializedStringType); ok {
+		// Two specialized string types are equal only if they came from
+		// the same call to SpecializedStringType.
+		return t == other
+	}
+	return false
+}
+
+func (t *specializedStringType) Validate(ctx context.Context, val tftypes.Value, path *tftypes.AttributePath) diag.Diagnostics {
+	var diags diag.Diagnostics
+	strDiags := StringType.Validate(ctx, val, path)
+	diags.Append(strDiags...)
+	if strDiags.HasError() {
+		return diags
+	}
+	if t.opts.ValidateFunc == nil {
+		return diags
+	}
+	// We validated the value for StringType above, so we know it must be
+	// a string.
+	if val.IsNull() || !val.IsKnown() {
+		return diags // no special validation for null or unknown strings
+	}
+	var s string
+	err := val.As(&s)
+	if err != nil {
+		// We should not get here, because we already validated that we had
+		// a known, non-null string above. This is just for robustness, then.
+		diags.AddError("Invalid string", err.Error())
+	}
+	customDiags := t.opts.ValidateFunc(ctx, s, path)
+	diags.Append(customDiags...)
+	return diags
+}
+
+func (t *specializedStringType) String() string {
+	if t.opts.TypeString != "" {
+		return t.opts.TypeString
+	}
+	return "types.SpecializedStringType"
+}
+
+func (t *specializedStringType) ApplyTerraform5AttributePathStep(step tftypes.AttributePathStep) (interface{}, error) {
+	return StringType.ApplyTerraform5AttributePathStep(step)
+}
+
+type SpecializedString struct {
+	ty *specializedStringType
+
+	// Unknown will be true if the value is not yet known.
+	Unknown bool
+
+	// Null will be true if the value was not set, or was explicitly set to
+	// null.
+	Null bool
+
+	// Value contains the set value, as long as Unknown and Null are both
+	// false.
+	Value string
+}
+
+var _ attr.Value = SpecializedString{}
+
+// Equal returns true if the given value is a SpecializedString of the same
+// type as the reciever and if the type's "NormalizeFunc" produces the same
+// value for both the receiver and for the other given value.
+//
+// If the value's type does not have a NormalizeFunc then this is equivalent
+// to String.Equal.
+func (s SpecializedString) Equal(other attr.Value) bool {
+	o, ok := other.(SpecializedString)
+	if !ok {
+		return false
+	}
+	if o.ty != s.ty {
+		return false // different specializations of String
+	}
+	if s.Unknown != o.Unknown {
+		return false
+	}
+	if s.Null != o.Null {
+		return false
+	}
+	if norm := s.ty.opts.NormalizeFunc; !(s.Null || s.Unknown) && norm != nil {
+		ss := norm(s.Value)
+		os := norm(o.Value)
+		return ss == os
+	}
+	return s.Value == o.Value
+}
+
+// Type returns the specialized string type for this value.
+func (s SpecializedString) Type(_ context.Context) attr.Type {
+	return s.ty
+}
+
+// ToTerraformValue returns the data contained in the SpecializedString as
+// a string.
+func (s SpecializedString) ToTerraformValue(_ context.Context) (interface{}, error) {
+	if s.Null {
+		return nil, nil
+	}
+	if s.Unknown {
+		return tftypes.UnknownValue, nil
+	}
+	return s.Value, nil
+}


### PR DESCRIPTION
This is a draft/prototype of what I was thinking about over in #70. For the moment this is just a hypothetical implementation to help with discussion over in that issue. I was mainly interested in seeing if I could achieve the effect I was describing in that issue (which I did) but I expect this probably isn't the best way to achieve that effect, if indeed that effect is even desirable in practice.

---

It's common for Terraform's very general definition of value equality to be stricter than a remote system's idea of equality. In that case, part of a provider's job is to classify each difference in value as either normalization or drift, or in other words to decide if a particular change is functionally significant to the remote system or if it's just a different way to write down what is effectively the same value.

The `attr.Value` interface already includes a method Equal, which allows defining value equality for a custom type in a more liberal way than Terraform's type system would define it.

Now we'll use that `Equal` method to automatically classify attribute value changes as normalization if the schema-defined type considers the old and new value as equal. In practice, that means that both `ReadResource` and `PlanResourceChange` will retain an attribute value from the prior state if the replacement new value is non-equal in Terraform terms but equal by
the provider's own definition.

Terraform Core's resource instance change lifecycle rules explicitly call for providers to return the prior state value if the new value from configuration is functionally-equivalent during `PlanResourceChange`. The documented rules don't discuss the expected behavior of `ReadResource` at all, but `ReadResource` also ultimately contributes to a diff (between the
prior state and the refreshed state) and it's important to use the same classification rules in both cases so that refreshing doesn't lead to situations where it takes multiple runs of `terraform apply` before the configuration and state can fully converge.
