### PR TITLE
tfsdk: Check ProposedNewState for State differences before marking unknowns for Computed-only attributes in plans

### DIFF
--- a/tfsdk/serve.go
+++ b/tfsdk/serve.go
@@ -695,8 +695,8 @@ func (s *server) planResourceChange(ctx context.Context, req *tfprotov6.PlanReso
 	//
 	// This pass is before any Computed-only attributes are marked as unknown
 	// to ensure any plan changes will trigger that behavior. These plan
-	// modifiers be run again after that marking to allow setting values and
-	// preventing extraneous plan differences.
+	// modifiers are run again after that marking to allow setting values
+	// and preventing extraneous plan differences.
 	//
 	// We only do this if there's a plan to modify; otherwise, it
 	// represents a resource being deleted and there's no point.

--- a/tfsdk/serve.go
+++ b/tfsdk/serve.go
@@ -691,15 +691,57 @@ func (s *server) planResourceChange(ctx context.Context, req *tfprotov6.PlanReso
 		return
 	}
 
-	// first, mark any computed attributes that are null in the config as
-	// unknown in the plan, so providers have the choice to update them
+	// Execute any AttributePlanModifiers.
 	//
-	// do this first so that providers can override the unknown with a
-	// known value using any plan modifiers
+	// This pass is before any Computed-only attributes are marked as unknown
+	// to ensure any plan changes will trigger that behavior. These plan
+	// modifiers be run again after that marking to allow setting values and
+	// preventing extraneous plan differences.
 	//
-	// we only do this if there's a plan to modify; otherwise, it
-	// represents a resource being deleted and there's no point
-	if !plan.IsNull() {
+	// We only do this if there's a plan to modify; otherwise, it
+	// represents a resource being deleted and there's no point.
+	//
+	// TODO: Enabling this pass will generate the following test error:
+	//
+	//     --- FAIL: TestServerPlanResourceChange/two_modifyplan_add_list_elem (0.00s)
+	// serve_test.go:3303: An unexpected error was encountered trying to read an attribute from the configuration. This is always an error in the provider. Please report the following to the provider developer:
+	//
+	// ElementKeyInt(1).AttributeName("name") still remains in the path: step cannot be applied to this value
+	//
+	// To fix this, (Config).GetAttribute() should return nil instead of the error.
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/183
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/150
+	// See also: https://github.com/hashicorp/terraform-plugin-framework/pull/167
+
+	// Execute any resource-level ModifyPlan method.
+	//
+	// This pass is before any Computed-only attributes are marked as unknown
+	// to ensure any plan changes will trigger that behavior. These plan
+	// modifiers be run again after that marking to allow setting values and
+	// preventing extraneous plan differences.
+	//
+	// TODO: Enabling this pass will generate the following test error:
+	//
+	//     --- FAIL: TestServerPlanResourceChange/two_modifyplan_add_list_elem (0.00s)
+	// serve_test.go:3303: An unexpected error was encountered trying to read an attribute from the configuration. This is always an error in the provider. Please report the following to the provider developer:
+	//
+	// ElementKeyInt(1).AttributeName("name") still remains in the path: step cannot be applied to this value
+	//
+	// To fix this, (Config).GetAttribute() should return nil instead of the error.
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/183
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/150
+	// See also: https://github.com/hashicorp/terraform-plugin-framework/pull/167
+
+	// After ensuring there are proposed changes, mark any computed attributes
+	// that are null in the config as unknown in the plan, so providers have
+	// the choice to update them.
+	//
+	// Later attribute and resource plan modifier passes can override the
+	// unknown with a known value using any plan modifiers.
+	//
+	// We only do this if there's a plan to modify; otherwise, it
+	// represents a resource being deleted and there's no point.
+	if !plan.IsNull() && !plan.Equal(state) {
 		modifiedPlan, err := tftypes.Transform(plan, markComputedNilsAsUnknown(ctx, config, resourceSchema))
 		if err != nil {
 			resp.Diagnostics.AddError(
@@ -711,8 +753,8 @@ func (s *server) planResourceChange(ctx context.Context, req *tfprotov6.PlanReso
 		plan = modifiedPlan
 	}
 
-	// next, execute any AttributePlanModifiers as long as there's a plan
-	// to modify.
+	// Execute any AttributePlanModifiers again. This allows overwriting
+	// any unknown values.
 	//
 	// We only do this if there's a plan to modify; otherwise, it
 	// represents a resource being deleted and there's no point.
@@ -766,7 +808,7 @@ func (s *server) planResourceChange(ctx context.Context, req *tfprotov6.PlanReso
 		}
 
 		resourceSchema.modifyAttributePlans(ctx, modifySchemaPlanReq, &modifySchemaPlanResp)
-		resp.RequiresReplace = modifySchemaPlanResp.RequiresReplace
+		resp.RequiresReplace = append(resp.RequiresReplace, modifySchemaPlanResp.RequiresReplace...)
 		plan = modifySchemaPlanResp.Plan.Raw
 		resp.Diagnostics = modifySchemaPlanResp.Diagnostics
 		if resp.Diagnostics.HasError() {
@@ -774,9 +816,10 @@ func (s *server) planResourceChange(ctx context.Context, req *tfprotov6.PlanReso
 		}
 	}
 
-	// third, execute any resource-level ModifyPlan method
+	// Execute any resource-level ModifyPlan method again. This allows
+	// overwriting any unknown values.
 	//
-	// we do this regardless of whether the plan is null or not, because we
+	// We do this regardless of whether the plan is null or not, because we
 	// want resources to be able to return diagnostics when planning to
 	// delete resources, e.g. to inform practitioners that the resource
 	// _can't_ be deleted in the API and will just be removed from

--- a/tfsdk/serve_resource_attribute_plan_modifiers_test.go
+++ b/tfsdk/serve_resource_attribute_plan_modifiers_test.go
@@ -92,6 +92,10 @@ func (rt testServeResourceTypeAttributePlanModifiers) GetSchema(_ context.Contex
 				Type:          types.StringType,
 				PlanModifiers: []AttributePlanModifier{testAttrDefaultValueModifier{}},
 			},
+			"computed_string_no_modifiers": {
+				Computed: true,
+				Type:     types.StringType,
+			},
 		},
 	}, nil
 }
@@ -114,6 +118,11 @@ var testServeResourceTypeAttributePlanModifiersSchema = &tfprotov6.Schema{
 	Version: 1,
 	Block: &tfprotov6.SchemaBlock{
 		Attributes: []*tfprotov6.SchemaAttribute{
+			{
+				Name:     "computed_string_no_modifiers",
+				Computed: true,
+				Type:     tftypes.String,
+			},
 			{
 				Name:     "name",
 				Required: true,
@@ -173,8 +182,9 @@ var testServeResourceTypeAttributePlanModifiersSchema = &tfprotov6.Schema{
 
 var testServeResourceTypeAttributePlanModifiersType = tftypes.Object{
 	AttributeTypes: map[string]tftypes.Type{
-		"name": tftypes.String,
-		"size": tftypes.Number,
+		"computed_string_no_modifiers": tftypes.String,
+		"name":                         tftypes.String,
+		"size":                         tftypes.Number,
 		"scratch_disk": tftypes.Object{
 			AttributeTypes: map[string]tftypes.Type{
 				"id":        tftypes.String,

--- a/tfsdk/serve_test.go
+++ b/tfsdk/serve_test.go
@@ -1705,7 +1705,46 @@ func TestServerPlanResourceChange(t *testing.T) {
 	}
 
 	tests := map[string]testCase{
-		"one_basic": {
+		"one_changed": {
+			priorState: tftypes.NewValue(testServeResourceTypeOneType, map[string]tftypes.Value{
+				"name": tftypes.NewValue(tftypes.String, "hello, world"),
+				"favorite_colors": tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, []tftypes.Value{
+					tftypes.NewValue(tftypes.String, "red"),
+					tftypes.NewValue(tftypes.String, "orange"),
+				}),
+				"created_timestamp": tftypes.NewValue(tftypes.String, "when the earth was young"),
+			}),
+			proposedNewState: tftypes.NewValue(testServeResourceTypeOneType, map[string]tftypes.Value{
+				"name": tftypes.NewValue(tftypes.String, "hello, world"),
+				"favorite_colors": tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, []tftypes.Value{
+					tftypes.NewValue(tftypes.String, "red"),
+					tftypes.NewValue(tftypes.String, "orange"),
+					tftypes.NewValue(tftypes.String, "yellow"),
+				}),
+				"created_timestamp": tftypes.NewValue(tftypes.String, "when the earth was young"),
+			}),
+			config: tftypes.NewValue(testServeResourceTypeOneType, map[string]tftypes.Value{
+				"name": tftypes.NewValue(tftypes.String, "hello, world"),
+				"favorite_colors": tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, []tftypes.Value{
+					tftypes.NewValue(tftypes.String, "red"),
+					tftypes.NewValue(tftypes.String, "orange"),
+					tftypes.NewValue(tftypes.String, "yellow"),
+				}),
+				"created_timestamp": tftypes.NewValue(tftypes.String, nil),
+			}),
+			resource:     "test_one",
+			resourceType: testServeResourceTypeOneType,
+			expectedPlannedState: tftypes.NewValue(testServeResourceTypeOneType, map[string]tftypes.Value{
+				"name": tftypes.NewValue(tftypes.String, "hello, world"),
+				"favorite_colors": tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, []tftypes.Value{
+					tftypes.NewValue(tftypes.String, "red"),
+					tftypes.NewValue(tftypes.String, "orange"),
+					tftypes.NewValue(tftypes.String, "yellow"),
+				}),
+				"created_timestamp": tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+			}),
+		},
+		"one_not_changed": {
 			priorState: tftypes.NewValue(testServeResourceTypeOneType, map[string]tftypes.Value{
 				"name": tftypes.NewValue(tftypes.String, "hello, world"),
 				"favorite_colors": tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, []tftypes.Value{
@@ -1727,7 +1766,6 @@ func TestServerPlanResourceChange(t *testing.T) {
 				"favorite_colors": tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, []tftypes.Value{
 					tftypes.NewValue(tftypes.String, "red"),
 					tftypes.NewValue(tftypes.String, "orange"),
-					tftypes.NewValue(tftypes.String, "yellow"),
 				}),
 				"created_timestamp": tftypes.NewValue(tftypes.String, nil),
 			}),
@@ -1739,7 +1777,7 @@ func TestServerPlanResourceChange(t *testing.T) {
 					tftypes.NewValue(tftypes.String, "red"),
 					tftypes.NewValue(tftypes.String, "orange"),
 				}),
-				"created_timestamp": tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+				"created_timestamp": tftypes.NewValue(tftypes.String, "when the earth was young"),
 			}),
 		},
 		"one_nil_state_and_config": {
@@ -1783,7 +1821,199 @@ func TestServerPlanResourceChange(t *testing.T) {
 			resourceType:         testServeResourceTypeTwoType,
 			expectedPlannedState: tftypes.NewValue(testServeResourceTypeTwoType, nil),
 		},
-		"three_nested_computed_unknown": {
+		"three_nested_computed_no_changes": {
+			resource:     "test_three",
+			resourceType: testServeResourceTypeThreeType,
+			priorState: tftypes.NewValue(testServeResourceTypeThreeType, map[string]tftypes.Value{
+				"name":          tftypes.NewValue(tftypes.String, "myname"),
+				"last_updated":  tftypes.NewValue(tftypes.String, "yesterday"),
+				"first_updated": tftypes.NewValue(tftypes.String, "last year"),
+				"map_nested": tftypes.NewValue(tftypes.Map{
+					ElementType: tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"computed_string": tftypes.String,
+							"string":          tftypes.String,
+						},
+					},
+				}, map[string]tftypes.Value{
+					"one": tftypes.NewValue(tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"computed_string": tftypes.String,
+							"string":          tftypes.String,
+						},
+					}, map[string]tftypes.Value{
+						"computed_string": tftypes.NewValue(tftypes.String, "mycompstring"),
+						"string":          tftypes.NewValue(tftypes.String, "mystring"),
+					}),
+				}),
+			}),
+			config: tftypes.NewValue(testServeResourceTypeThreeType, map[string]tftypes.Value{
+				"name":          tftypes.NewValue(tftypes.String, "myname"),
+				"last_updated":  tftypes.NewValue(tftypes.String, nil),
+				"first_updated": tftypes.NewValue(tftypes.String, nil),
+				"map_nested": tftypes.NewValue(tftypes.Map{
+					ElementType: tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"computed_string": tftypes.String,
+							"string":          tftypes.String,
+						},
+					},
+				}, map[string]tftypes.Value{
+					"one": tftypes.NewValue(tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"computed_string": tftypes.String,
+							"string":          tftypes.String,
+						},
+					}, map[string]tftypes.Value{
+						"computed_string": tftypes.NewValue(tftypes.String, nil),
+						"string":          tftypes.NewValue(tftypes.String, "mystring"),
+					}),
+				}),
+			}),
+			proposedNewState: tftypes.NewValue(testServeResourceTypeThreeType, map[string]tftypes.Value{
+				"name":          tftypes.NewValue(tftypes.String, "myname"),
+				"last_updated":  tftypes.NewValue(tftypes.String, "yesterday"),
+				"first_updated": tftypes.NewValue(tftypes.String, "last year"),
+				"map_nested": tftypes.NewValue(tftypes.Map{
+					ElementType: tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"computed_string": tftypes.String,
+							"string":          tftypes.String,
+						},
+					},
+				}, map[string]tftypes.Value{
+					"one": tftypes.NewValue(tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"computed_string": tftypes.String,
+							"string":          tftypes.String,
+						},
+					}, map[string]tftypes.Value{
+						"computed_string": tftypes.NewValue(tftypes.String, "mycompstring"),
+						"string":          tftypes.NewValue(tftypes.String, "mystring"),
+					}),
+				}),
+			}),
+			expectedPlannedState: tftypes.NewValue(testServeResourceTypeThreeType, map[string]tftypes.Value{
+				"name":          tftypes.NewValue(tftypes.String, "myname"),
+				"last_updated":  tftypes.NewValue(tftypes.String, "yesterday"),
+				"first_updated": tftypes.NewValue(tftypes.String, "last year"),
+				"map_nested": tftypes.NewValue(tftypes.Map{
+					ElementType: tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"computed_string": tftypes.String,
+							"string":          tftypes.String,
+						},
+					},
+				}, map[string]tftypes.Value{
+					"one": tftypes.NewValue(tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"computed_string": tftypes.String,
+							"string":          tftypes.String,
+						},
+					}, map[string]tftypes.Value{
+						"computed_string": tftypes.NewValue(tftypes.String, "mycompstring"),
+						"string":          tftypes.NewValue(tftypes.String, "mystring"),
+					}),
+				}),
+			}),
+		},
+		"three_nested_computed_configuration_change": {
+			resource:     "test_three",
+			resourceType: testServeResourceTypeThreeType,
+			priorState: tftypes.NewValue(testServeResourceTypeThreeType, map[string]tftypes.Value{
+				"name":          tftypes.NewValue(tftypes.String, "myname"),
+				"last_updated":  tftypes.NewValue(tftypes.String, "yesterday"),
+				"first_updated": tftypes.NewValue(tftypes.String, "last year"),
+				"map_nested": tftypes.NewValue(tftypes.Map{
+					ElementType: tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"computed_string": tftypes.String,
+							"string":          tftypes.String,
+						},
+					},
+				}, map[string]tftypes.Value{
+					"one": tftypes.NewValue(tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"computed_string": tftypes.String,
+							"string":          tftypes.String,
+						},
+					}, map[string]tftypes.Value{
+						"computed_string": tftypes.NewValue(tftypes.String, "mycompstring"),
+						"string":          tftypes.NewValue(tftypes.String, "mystring"),
+					}),
+				}),
+			}),
+			config: tftypes.NewValue(testServeResourceTypeThreeType, map[string]tftypes.Value{
+				"name":          tftypes.NewValue(tftypes.String, "newname"),
+				"last_updated":  tftypes.NewValue(tftypes.String, nil),
+				"first_updated": tftypes.NewValue(tftypes.String, nil),
+				"map_nested": tftypes.NewValue(tftypes.Map{
+					ElementType: tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"computed_string": tftypes.String,
+							"string":          tftypes.String,
+						},
+					},
+				}, map[string]tftypes.Value{
+					"one": tftypes.NewValue(tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"computed_string": tftypes.String,
+							"string":          tftypes.String,
+						},
+					}, map[string]tftypes.Value{
+						"computed_string": tftypes.NewValue(tftypes.String, nil),
+						"string":          tftypes.NewValue(tftypes.String, "mystring"),
+					}),
+				}),
+			}),
+			proposedNewState: tftypes.NewValue(testServeResourceTypeThreeType, map[string]tftypes.Value{
+				"name":          tftypes.NewValue(tftypes.String, "newname"),
+				"last_updated":  tftypes.NewValue(tftypes.String, nil),
+				"first_updated": tftypes.NewValue(tftypes.String, nil),
+				"map_nested": tftypes.NewValue(tftypes.Map{
+					ElementType: tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"computed_string": tftypes.String,
+							"string":          tftypes.String,
+						},
+					},
+				}, map[string]tftypes.Value{
+					"one": tftypes.NewValue(tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"computed_string": tftypes.String,
+							"string":          tftypes.String,
+						},
+					}, map[string]tftypes.Value{
+						"computed_string": tftypes.NewValue(tftypes.String, nil),
+						"string":          tftypes.NewValue(tftypes.String, "mystring"),
+					}),
+				}),
+			}),
+			expectedPlannedState: tftypes.NewValue(testServeResourceTypeThreeType, map[string]tftypes.Value{
+				"name":          tftypes.NewValue(tftypes.String, "newname"),
+				"last_updated":  tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+				"first_updated": tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+				"map_nested": tftypes.NewValue(tftypes.Map{
+					ElementType: tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"computed_string": tftypes.String,
+							"string":          tftypes.String,
+						},
+					},
+				}, map[string]tftypes.Value{
+					"one": tftypes.NewValue(tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"computed_string": tftypes.String,
+							"string":          tftypes.String,
+						},
+					}, map[string]tftypes.Value{
+						"computed_string": tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+						"string":          tftypes.NewValue(tftypes.String, "mystring"),
+					}),
+				}),
+			}),
+		},
+		"three_nested_computed_nested_configuration_change": {
 			resource:     "test_three",
 			resourceType: testServeResourceTypeThreeType,
 			priorState: tftypes.NewValue(testServeResourceTypeThreeType, map[string]tftypes.Value{
@@ -2279,8 +2509,9 @@ func TestServerPlanResourceChange(t *testing.T) {
 		},
 		"attr_plan_modifiers_requiresreplace": {
 			priorState: tftypes.NewValue(testServeResourceTypeAttributePlanModifiersType, map[string]tftypes.Value{
-				"name": tftypes.NewValue(tftypes.String, "name1"),
-				"size": tftypes.NewValue(tftypes.Number, 3),
+				"computed_string_no_modifiers": tftypes.NewValue(tftypes.String, "statevalue"),
+				"name":                         tftypes.NewValue(tftypes.String, "name1"),
+				"size":                         tftypes.NewValue(tftypes.Number, 3),
 				"scratch_disk": tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
 					"id":        tftypes.String,
 					"interface": tftypes.String,
@@ -2302,8 +2533,9 @@ func TestServerPlanResourceChange(t *testing.T) {
 				"region": tftypes.NewValue(tftypes.String, "region1"),
 			}),
 			proposedNewState: tftypes.NewValue(testServeResourceTypeAttributePlanModifiersType, map[string]tftypes.Value{
-				"name": tftypes.NewValue(tftypes.String, "name1"),
-				"size": tftypes.NewValue(tftypes.Number, 3),
+				"computed_string_no_modifiers": tftypes.NewValue(tftypes.String, "statevalue"),
+				"name":                         tftypes.NewValue(tftypes.String, "name1"),
+				"size":                         tftypes.NewValue(tftypes.Number, 3),
 				"scratch_disk": tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
 					"id":        tftypes.String,
 					"interface": tftypes.String,
@@ -2325,8 +2557,9 @@ func TestServerPlanResourceChange(t *testing.T) {
 				"region": tftypes.NewValue(tftypes.String, "region1"),
 			}),
 			config: tftypes.NewValue(testServeResourceTypeAttributePlanModifiersType, map[string]tftypes.Value{
-				"name": tftypes.NewValue(tftypes.String, "name1"),
-				"size": tftypes.NewValue(tftypes.Number, 3),
+				"computed_string_no_modifiers": tftypes.NewValue(tftypes.String, nil),
+				"name":                         tftypes.NewValue(tftypes.String, "name1"),
+				"size":                         tftypes.NewValue(tftypes.Number, 3),
 				"scratch_disk": tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
 					"id":        tftypes.String,
 					"interface": tftypes.String,
@@ -2350,8 +2583,9 @@ func TestServerPlanResourceChange(t *testing.T) {
 			resource:     "test_attribute_plan_modifiers",
 			resourceType: testServeResourceTypeAttributePlanModifiersType,
 			expectedPlannedState: tftypes.NewValue(testServeResourceTypeAttributePlanModifiersType, map[string]tftypes.Value{
-				"name": tftypes.NewValue(tftypes.String, "name1"),
-				"size": tftypes.NewValue(tftypes.Number, 3),
+				"computed_string_no_modifiers": tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+				"name":                         tftypes.NewValue(tftypes.String, "name1"),
+				"size":                         tftypes.NewValue(tftypes.Number, 3),
 				"scratch_disk": tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
 					"id":        tftypes.String,
 					"interface": tftypes.String,
@@ -2380,8 +2614,9 @@ func TestServerPlanResourceChange(t *testing.T) {
 		},
 		"attr_plan_modifiers_requiresreplaceif_true": {
 			priorState: tftypes.NewValue(testServeResourceTypeAttributePlanModifiersType, map[string]tftypes.Value{
-				"name": tftypes.NewValue(tftypes.String, "name1"),
-				"size": tftypes.NewValue(tftypes.Number, 3),
+				"computed_string_no_modifiers": tftypes.NewValue(tftypes.String, "statevalue"),
+				"name":                         tftypes.NewValue(tftypes.String, "name1"),
+				"size":                         tftypes.NewValue(tftypes.Number, 3),
 				"scratch_disk": tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
 					"id":        tftypes.String,
 					"interface": tftypes.String,
@@ -2400,8 +2635,9 @@ func TestServerPlanResourceChange(t *testing.T) {
 				"region": tftypes.NewValue(tftypes.String, "region1"),
 			}),
 			proposedNewState: tftypes.NewValue(testServeResourceTypeAttributePlanModifiersType, map[string]tftypes.Value{
-				"name": tftypes.NewValue(tftypes.String, "name1"),
-				"size": tftypes.NewValue(tftypes.Number, 999),
+				"computed_string_no_modifiers": tftypes.NewValue(tftypes.String, "statevalue"),
+				"name":                         tftypes.NewValue(tftypes.String, "name1"),
+				"size":                         tftypes.NewValue(tftypes.Number, 999),
 				"scratch_disk": tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
 					"id":        tftypes.String,
 					"interface": tftypes.String,
@@ -2420,8 +2656,9 @@ func TestServerPlanResourceChange(t *testing.T) {
 				"region": tftypes.NewValue(tftypes.String, "region1"),
 			}),
 			config: tftypes.NewValue(testServeResourceTypeAttributePlanModifiersType, map[string]tftypes.Value{
-				"name": tftypes.NewValue(tftypes.String, "name1"),
-				"size": tftypes.NewValue(tftypes.Number, 999),
+				"computed_string_no_modifiers": tftypes.NewValue(tftypes.String, nil),
+				"name":                         tftypes.NewValue(tftypes.String, "name1"),
+				"size":                         tftypes.NewValue(tftypes.Number, 999),
 				"scratch_disk": tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
 					"id":        tftypes.String,
 					"interface": tftypes.String,
@@ -2442,8 +2679,9 @@ func TestServerPlanResourceChange(t *testing.T) {
 			resource:     "test_attribute_plan_modifiers",
 			resourceType: testServeResourceTypeAttributePlanModifiersType,
 			expectedPlannedState: tftypes.NewValue(testServeResourceTypeAttributePlanModifiersType, map[string]tftypes.Value{
-				"name": tftypes.NewValue(tftypes.String, "name1"),
-				"size": tftypes.NewValue(tftypes.Number, 999),
+				"computed_string_no_modifiers": tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+				"name":                         tftypes.NewValue(tftypes.String, "name1"),
+				"size":                         tftypes.NewValue(tftypes.Number, 999),
 				"scratch_disk": tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
 					"id":        tftypes.String,
 					"interface": tftypes.String,
@@ -2465,8 +2703,9 @@ func TestServerPlanResourceChange(t *testing.T) {
 		},
 		"attr_plan_modifiers_requiresreplaceif_false": {
 			priorState: tftypes.NewValue(testServeResourceTypeAttributePlanModifiersType, map[string]tftypes.Value{
-				"name": tftypes.NewValue(tftypes.String, "name1"),
-				"size": tftypes.NewValue(tftypes.Number, 3),
+				"computed_string_no_modifiers": tftypes.NewValue(tftypes.String, "statevalue"),
+				"name":                         tftypes.NewValue(tftypes.String, "name1"),
+				"size":                         tftypes.NewValue(tftypes.Number, 3),
 				"scratch_disk": tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
 					"id":        tftypes.String,
 					"interface": tftypes.String,
@@ -2485,8 +2724,9 @@ func TestServerPlanResourceChange(t *testing.T) {
 				"region": tftypes.NewValue(tftypes.String, "region1"),
 			}),
 			proposedNewState: tftypes.NewValue(testServeResourceTypeAttributePlanModifiersType, map[string]tftypes.Value{
-				"name": tftypes.NewValue(tftypes.String, "name1"),
-				"size": tftypes.NewValue(tftypes.Number, 1),
+				"computed_string_no_modifiers": tftypes.NewValue(tftypes.String, "statevalue"),
+				"name":                         tftypes.NewValue(tftypes.String, "name1"),
+				"size":                         tftypes.NewValue(tftypes.Number, 1),
 				"scratch_disk": tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
 					"id":        tftypes.String,
 					"interface": tftypes.String,
@@ -2505,8 +2745,9 @@ func TestServerPlanResourceChange(t *testing.T) {
 				"region": tftypes.NewValue(tftypes.String, "region1"),
 			}),
 			config: tftypes.NewValue(testServeResourceTypeAttributePlanModifiersType, map[string]tftypes.Value{
-				"name": tftypes.NewValue(tftypes.String, "name1"),
-				"size": tftypes.NewValue(tftypes.Number, 1),
+				"computed_string_no_modifiers": tftypes.NewValue(tftypes.String, nil),
+				"name":                         tftypes.NewValue(tftypes.String, "name1"),
+				"size":                         tftypes.NewValue(tftypes.Number, 1),
 				"scratch_disk": tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
 					"id":        tftypes.String,
 					"interface": tftypes.String,
@@ -2527,8 +2768,9 @@ func TestServerPlanResourceChange(t *testing.T) {
 			resource:     "test_attribute_plan_modifiers",
 			resourceType: testServeResourceTypeAttributePlanModifiersType,
 			expectedPlannedState: tftypes.NewValue(testServeResourceTypeAttributePlanModifiersType, map[string]tftypes.Value{
-				"name": tftypes.NewValue(tftypes.String, "name1"),
-				"size": tftypes.NewValue(tftypes.Number, 1),
+				"computed_string_no_modifiers": tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+				"name":                         tftypes.NewValue(tftypes.String, "name1"),
+				"size":                         tftypes.NewValue(tftypes.Number, 1),
 				"scratch_disk": tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
 					"id":        tftypes.String,
 					"interface": tftypes.String,
@@ -2550,8 +2792,9 @@ func TestServerPlanResourceChange(t *testing.T) {
 		},
 		"attr_plan_modifiers_diags": {
 			priorState: tftypes.NewValue(testServeResourceTypeAttributePlanModifiersType, map[string]tftypes.Value{
-				"name": tftypes.NewValue(tftypes.String, "TESTDIAG"),
-				"size": tftypes.NewValue(tftypes.Number, 3),
+				"computed_string_no_modifiers": tftypes.NewValue(tftypes.String, "statevalue"),
+				"name":                         tftypes.NewValue(tftypes.String, "TESTDIAG"),
+				"size":                         tftypes.NewValue(tftypes.Number, 3),
 				"scratch_disk": tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
 					"id":        tftypes.String,
 					"interface": tftypes.String,
@@ -2570,8 +2813,9 @@ func TestServerPlanResourceChange(t *testing.T) {
 				"region": tftypes.NewValue(tftypes.String, "region1"),
 			}),
 			proposedNewState: tftypes.NewValue(testServeResourceTypeAttributePlanModifiersType, map[string]tftypes.Value{
-				"name": tftypes.NewValue(tftypes.String, "TESTDIAG"),
-				"size": tftypes.NewValue(tftypes.Number, 3),
+				"computed_string_no_modifiers": tftypes.NewValue(tftypes.String, "statevalue"),
+				"name":                         tftypes.NewValue(tftypes.String, "TESTDIAG"),
+				"size":                         tftypes.NewValue(tftypes.Number, 3),
 				"scratch_disk": tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
 					"id":        tftypes.String,
 					"interface": tftypes.String,
@@ -2590,8 +2834,9 @@ func TestServerPlanResourceChange(t *testing.T) {
 				"region": tftypes.NewValue(tftypes.String, "region1"),
 			}),
 			config: tftypes.NewValue(testServeResourceTypeAttributePlanModifiersType, map[string]tftypes.Value{
-				"name": tftypes.NewValue(tftypes.String, "TESTDIAG"),
-				"size": tftypes.NewValue(tftypes.Number, 3),
+				"computed_string_no_modifiers": tftypes.NewValue(tftypes.String, nil),
+				"name":                         tftypes.NewValue(tftypes.String, "TESTDIAG"),
+				"size":                         tftypes.NewValue(tftypes.Number, 3),
 				"scratch_disk": tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
 					"id":        tftypes.String,
 					"interface": tftypes.String,
@@ -2610,8 +2855,9 @@ func TestServerPlanResourceChange(t *testing.T) {
 				"region": tftypes.NewValue(tftypes.String, "region1"),
 			}),
 			expectedPlannedState: tftypes.NewValue(testServeResourceTypeAttributePlanModifiersType, map[string]tftypes.Value{
-				"name": tftypes.NewValue(tftypes.String, "TESTDIAG"),
-				"size": tftypes.NewValue(tftypes.Number, 3),
+				"computed_string_no_modifiers": tftypes.NewValue(tftypes.String, "statevalue"),
+				"name":                         tftypes.NewValue(tftypes.String, "TESTDIAG"),
+				"size":                         tftypes.NewValue(tftypes.Number, 3),
 				"scratch_disk": tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
 					"id":        tftypes.String,
 					"interface": tftypes.String,
@@ -2647,8 +2893,9 @@ func TestServerPlanResourceChange(t *testing.T) {
 		},
 		"attr_plan_modifiers_chained_modifiers": {
 			priorState: tftypes.NewValue(testServeResourceTypeAttributePlanModifiersType, map[string]tftypes.Value{
-				"name": tftypes.NewValue(tftypes.String, "name1"),
-				"size": tftypes.NewValue(tftypes.Number, 3),
+				"computed_string_no_modifiers": tftypes.NewValue(tftypes.String, "statevalue"),
+				"name":                         tftypes.NewValue(tftypes.String, "name1"),
+				"size":                         tftypes.NewValue(tftypes.Number, 3),
 				"scratch_disk": tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
 					"id":        tftypes.String,
 					"interface": tftypes.String,
@@ -2667,8 +2914,9 @@ func TestServerPlanResourceChange(t *testing.T) {
 				"region": tftypes.NewValue(tftypes.String, "region1"),
 			}),
 			proposedNewState: tftypes.NewValue(testServeResourceTypeAttributePlanModifiersType, map[string]tftypes.Value{
-				"name": tftypes.NewValue(tftypes.String, "TESTATTRONE"),
-				"size": tftypes.NewValue(tftypes.Number, 3),
+				"computed_string_no_modifiers": tftypes.NewValue(tftypes.String, "statevalue"),
+				"name":                         tftypes.NewValue(tftypes.String, "TESTATTRONE"),
+				"size":                         tftypes.NewValue(tftypes.Number, 3),
 				"scratch_disk": tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
 					"id":        tftypes.String,
 					"interface": tftypes.String,
@@ -2687,8 +2935,9 @@ func TestServerPlanResourceChange(t *testing.T) {
 				"region": tftypes.NewValue(tftypes.String, "region1"),
 			}),
 			config: tftypes.NewValue(testServeResourceTypeAttributePlanModifiersType, map[string]tftypes.Value{
-				"name": tftypes.NewValue(tftypes.String, "TESTATTRONE"),
-				"size": tftypes.NewValue(tftypes.Number, 3),
+				"computed_string_no_modifiers": tftypes.NewValue(tftypes.String, nil),
+				"name":                         tftypes.NewValue(tftypes.String, "TESTATTRONE"),
+				"size":                         tftypes.NewValue(tftypes.Number, 3),
 				"scratch_disk": tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
 					"id":        tftypes.String,
 					"interface": tftypes.String,
@@ -2707,8 +2956,9 @@ func TestServerPlanResourceChange(t *testing.T) {
 				"region": tftypes.NewValue(tftypes.String, "region1"),
 			}),
 			expectedPlannedState: tftypes.NewValue(testServeResourceTypeAttributePlanModifiersType, map[string]tftypes.Value{
-				"name": tftypes.NewValue(tftypes.String, "MODIFIED_TWO"),
-				"size": tftypes.NewValue(tftypes.Number, 3),
+				"computed_string_no_modifiers": tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+				"name":                         tftypes.NewValue(tftypes.String, "MODIFIED_TWO"),
+				"size":                         tftypes.NewValue(tftypes.Number, 3),
 				"scratch_disk": tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
 					"id":        tftypes.String,
 					"interface": tftypes.String,
@@ -2732,8 +2982,9 @@ func TestServerPlanResourceChange(t *testing.T) {
 		},
 		"attr_plan_modifiers_default_value_modifier": {
 			priorState: tftypes.NewValue(testServeResourceTypeAttributePlanModifiersType, map[string]tftypes.Value{
-				"name": tftypes.NewValue(tftypes.String, "name1"),
-				"size": tftypes.NewValue(tftypes.Number, 3),
+				"computed_string_no_modifiers": tftypes.NewValue(tftypes.String, "statevalue"),
+				"name":                         tftypes.NewValue(tftypes.String, "name1"),
+				"size":                         tftypes.NewValue(tftypes.Number, 3),
 				"scratch_disk": tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
 					"id":        tftypes.String,
 					"interface": tftypes.String,
@@ -2752,8 +3003,9 @@ func TestServerPlanResourceChange(t *testing.T) {
 				"region": tftypes.NewValue(tftypes.String, nil),
 			}),
 			proposedNewState: tftypes.NewValue(testServeResourceTypeAttributePlanModifiersType, map[string]tftypes.Value{
-				"name": tftypes.NewValue(tftypes.String, "TESTATTRONE"),
-				"size": tftypes.NewValue(tftypes.Number, 3),
+				"computed_string_no_modifiers": tftypes.NewValue(tftypes.String, "statevalue"),
+				"name":                         tftypes.NewValue(tftypes.String, "TESTATTRONE"),
+				"size":                         tftypes.NewValue(tftypes.Number, 3),
 				"scratch_disk": tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
 					"id":        tftypes.String,
 					"interface": tftypes.String,
@@ -2772,8 +3024,9 @@ func TestServerPlanResourceChange(t *testing.T) {
 				"region": tftypes.NewValue(tftypes.String, nil),
 			}),
 			config: tftypes.NewValue(testServeResourceTypeAttributePlanModifiersType, map[string]tftypes.Value{
-				"name": tftypes.NewValue(tftypes.String, "TESTATTRONE"),
-				"size": tftypes.NewValue(tftypes.Number, 3),
+				"computed_string_no_modifiers": tftypes.NewValue(tftypes.String, nil),
+				"name":                         tftypes.NewValue(tftypes.String, "TESTATTRONE"),
+				"size":                         tftypes.NewValue(tftypes.Number, 3),
 				"scratch_disk": tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
 					"id":        tftypes.String,
 					"interface": tftypes.String,
@@ -2792,8 +3045,9 @@ func TestServerPlanResourceChange(t *testing.T) {
 				"region": tftypes.NewValue(tftypes.String, nil),
 			}),
 			expectedPlannedState: tftypes.NewValue(testServeResourceTypeAttributePlanModifiersType, map[string]tftypes.Value{
-				"name": tftypes.NewValue(tftypes.String, "MODIFIED_TWO"),
-				"size": tftypes.NewValue(tftypes.Number, 3),
+				"computed_string_no_modifiers": tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+				"name":                         tftypes.NewValue(tftypes.String, "MODIFIED_TWO"),
+				"size":                         tftypes.NewValue(tftypes.Number, 3),
 				"scratch_disk": tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
 					"id":        tftypes.String,
 					"interface": tftypes.String,
@@ -2815,10 +3069,102 @@ func TestServerPlanResourceChange(t *testing.T) {
 			resourceType:            testServeResourceTypeAttributePlanModifiersType,
 			expectedRequiresReplace: []*tftypes.AttributePath{tftypes.NewAttributePath().WithAttributeName("scratch_disk").WithAttributeName("interface")},
 		},
+		// TODO: Attribute plan modifiers should run before plan unknown marking.
+		// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/183
+		// "attr_plan_modifiers_trigger_computed_unknown": {
+		// 	resource:     "test_attribute_plan_modifiers",
+		// 	resourceType: testServeResourceTypeAttributePlanModifiersType,
+		// 	priorState: tftypes.NewValue(testServeResourceTypeAttributePlanModifiersType, map[string]tftypes.Value{
+		// 		"computed_string_no_modifiers": tftypes.NewValue(tftypes.String, "statevalue"),
+		// 		"name":                         tftypes.NewValue(tftypes.String, "TESTATTRONE"),
+		// 		"size":                         tftypes.NewValue(tftypes.Number, 3),
+		// 		"scratch_disk": tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		// 			"id":        tftypes.String,
+		// 			"interface": tftypes.String,
+		// 			"filesystem": tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		// 				"size":   tftypes.Number,
+		// 				"format": tftypes.String,
+		// 			}},
+		// 		}}, map[string]tftypes.Value{
+		// 			"id":        tftypes.NewValue(tftypes.String, "my-scr-disk"),
+		// 			"interface": tftypes.NewValue(tftypes.String, "scsi"),
+		// 			"filesystem": tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		// 				"size":   tftypes.Number,
+		// 				"format": tftypes.String,
+		// 			}}, nil),
+		// 		}),
+		// 		"region": tftypes.NewValue(tftypes.String, "DEFAULTVALUE"),
+		// 	}),
+		// 	config: tftypes.NewValue(testServeResourceTypeAttributePlanModifiersType, map[string]tftypes.Value{
+		// 		"computed_string_no_modifiers": tftypes.NewValue(tftypes.String, nil),
+		// 		"name":                         tftypes.NewValue(tftypes.String, "TESTATTRONE"),
+		// 		"size":                         tftypes.NewValue(tftypes.Number, 3),
+		// 		"scratch_disk": tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		// 			"id":        tftypes.String,
+		// 			"interface": tftypes.String,
+		// 			"filesystem": tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		// 				"size":   tftypes.Number,
+		// 				"format": tftypes.String,
+		// 			}},
+		// 		}}, map[string]tftypes.Value{
+		// 			"id":        tftypes.NewValue(tftypes.String, "my-scr-disk"),
+		// 			"interface": tftypes.NewValue(tftypes.String, "scsi"),
+		// 			"filesystem": tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		// 				"size":   tftypes.Number,
+		// 				"format": tftypes.String,
+		// 			}}, nil),
+		// 		}),
+		// 		"region": tftypes.NewValue(tftypes.String, "DEFAULTVALUE"),
+		// 	}),
+		// 	proposedNewState: tftypes.NewValue(testServeResourceTypeAttributePlanModifiersType, map[string]tftypes.Value{
+		// 		"computed_string_no_modifiers": tftypes.NewValue(tftypes.String, "statevalue"),
+		// 		"name":                         tftypes.NewValue(tftypes.String, "TESTATTRONE"),
+		// 		"size":                         tftypes.NewValue(tftypes.Number, 3),
+		// 		"scratch_disk": tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		// 			"id":        tftypes.String,
+		// 			"interface": tftypes.String,
+		// 			"filesystem": tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		// 				"size":   tftypes.Number,
+		// 				"format": tftypes.String,
+		// 			}},
+		// 		}}, map[string]tftypes.Value{
+		// 			"id":        tftypes.NewValue(tftypes.String, "my-scr-disk"),
+		// 			"interface": tftypes.NewValue(tftypes.String, "scsi"),
+		// 			"filesystem": tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		// 				"size":   tftypes.Number,
+		// 				"format": tftypes.String,
+		// 			}}, nil),
+		// 		}),
+		// 		"region": tftypes.NewValue(tftypes.String, "DEFAULTVALUE"),
+		// 	}),
+		// 	expectedPlannedState: tftypes.NewValue(testServeResourceTypeAttributePlanModifiersType, map[string]tftypes.Value{
+		// 		"computed_string_no_modifiers": tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+		// 		"name":                         tftypes.NewValue(tftypes.String, "MODIFIED_TWO"),
+		// 		"size":                         tftypes.NewValue(tftypes.Number, 3),
+		// 		"scratch_disk": tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		// 			"id":        tftypes.String,
+		// 			"interface": tftypes.String,
+		// 			"filesystem": tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		// 				"size":   tftypes.Number,
+		// 				"format": tftypes.String,
+		// 			}},
+		// 		}}, map[string]tftypes.Value{
+		// 			"id":        tftypes.NewValue(tftypes.String, "my-scr-disk"),
+		// 			"interface": tftypes.NewValue(tftypes.String, "scsi"),
+		// 			"filesystem": tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		// 				"size":   tftypes.Number,
+		// 				"format": tftypes.String,
+		// 			}}, nil),
+		// 		}),
+		// 		"region": tftypes.NewValue(tftypes.String, "DEFAULTVALUE"),
+		// 	}),
+		// 	expectedRequiresReplace: []*tftypes.AttributePath{tftypes.NewAttributePath().WithAttributeName("scratch_disk").WithAttributeName("interface")},
+		// },
 		"attr_plan_modifiers_nested_modifier": {
 			priorState: tftypes.NewValue(testServeResourceTypeAttributePlanModifiersType, map[string]tftypes.Value{
-				"name": tftypes.NewValue(tftypes.String, "name1"),
-				"size": tftypes.NewValue(tftypes.Number, 3),
+				"computed_string_no_modifiers": tftypes.NewValue(tftypes.String, "statevalue"),
+				"name":                         tftypes.NewValue(tftypes.String, "name1"),
+				"size":                         tftypes.NewValue(tftypes.Number, 3),
 				"scratch_disk": tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
 					"id":        tftypes.String,
 					"interface": tftypes.String,
@@ -2837,8 +3183,9 @@ func TestServerPlanResourceChange(t *testing.T) {
 				"region": tftypes.NewValue(tftypes.String, "region1"),
 			}),
 			proposedNewState: tftypes.NewValue(testServeResourceTypeAttributePlanModifiersType, map[string]tftypes.Value{
-				"name": tftypes.NewValue(tftypes.String, "name1"),
-				"size": tftypes.NewValue(tftypes.Number, 3),
+				"computed_string_no_modifiers": tftypes.NewValue(tftypes.String, "statevalue"),
+				"name":                         tftypes.NewValue(tftypes.String, "name1"),
+				"size":                         tftypes.NewValue(tftypes.Number, 3),
 				"scratch_disk": tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
 					"id":        tftypes.String,
 					"interface": tftypes.String,
@@ -2857,8 +3204,9 @@ func TestServerPlanResourceChange(t *testing.T) {
 				"region": tftypes.NewValue(tftypes.String, "region1"),
 			}),
 			config: tftypes.NewValue(testServeResourceTypeAttributePlanModifiersType, map[string]tftypes.Value{
-				"name": tftypes.NewValue(tftypes.String, "name1"),
-				"size": tftypes.NewValue(tftypes.Number, 3),
+				"computed_string_no_modifiers": tftypes.NewValue(tftypes.String, nil),
+				"name":                         tftypes.NewValue(tftypes.String, "name1"),
+				"size":                         tftypes.NewValue(tftypes.Number, 3),
 				"scratch_disk": tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
 					"id":        tftypes.String,
 					"interface": tftypes.String,
@@ -2877,8 +3225,9 @@ func TestServerPlanResourceChange(t *testing.T) {
 				"region": tftypes.NewValue(tftypes.String, "region1"),
 			}),
 			expectedPlannedState: tftypes.NewValue(testServeResourceTypeAttributePlanModifiersType, map[string]tftypes.Value{
-				"name": tftypes.NewValue(tftypes.String, "name1"),
-				"size": tftypes.NewValue(tftypes.Number, 3),
+				"computed_string_no_modifiers": tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+				"name":                         tftypes.NewValue(tftypes.String, "name1"),
+				"size":                         tftypes.NewValue(tftypes.Number, 3),
 				"scratch_disk": tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
 					"id":        tftypes.String,
 					"interface": tftypes.String,


### PR DESCRIPTION
Closes #181
Reference: https://github.com/hashicorp/terraform/blob/main/docs/resource-instance-change-lifecycle.md 

`ProposedNewState` is the merged `PriorState` and `Configuration`. This allows us to verify if any configuration changes have occurred.

Previously, any `Computed` attributes would always trigger plan differences due to the unknown marking.

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # hashicups_order.edu will be updated in-place
  ~ resource "hashicups_order" "edu" {
      ~ id           = "1" -> (known after apply)
      ~ items        = [
          ~ {
            ~ coffee   = {
              + description = (known after apply)
                id          = 3
              ~ image       = "/nomad.png" -> (known after apply)
              ~ name        = "Nomadicano" -> (known after apply)
              ~ price       = 150 -> (known after apply)
              ~ teaser      = "Drink one today and you will want to schedule another" -> (known after apply)
            }
              # (1 unchanged attribute hidden)

            ~ coffee   = {
              + description = (known after apply)
                id          = 1
              ~ image       = "/packer.png" -> (known after apply)
              ~ name        = "Packer Spiced Latte" -> (known after apply)
              ~ price       = 350 -> (known after apply)
              ~ teaser      = "Packed with goodness to spice up your images" -> (known after apply)
            }
              # (2 unchanged attributes hidden)
          },
        ]
      ~ last_updated = "Tuesday, 28-Sep-21 11:53:27 EDT" -> (known after apply)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

This change limits the unknown marking to only be performed when there is actually a change between the `ProposedNewState` and `State`.

Without a configuration change:

```
No changes. Your infrastructure matches the configuration.
```

With a configuration change:

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # hashicups_order.edu will be updated in-place
  ~ resource "hashicups_order" "edu" {
      ~ id           = "1" -> (known after apply)
      ~ items        = [
          ~ {
            ~ coffee   = {
              + description = (known after apply)
                id          = 3
              ~ image       = "/nomad.png" -> (known after apply)
              ~ name        = "Nomadicano" -> (known after apply)
              ~ price       = 150 -> (known after apply)
              ~ teaser      = "Drink one today and you will want to schedule another" -> (known after apply)
            }
              # (1 unchanged attribute hidden)

            ~ coffee   = {
              + description = (known after apply)
              ~ id          = 1 -> 2
              ~ image       = "/packer.png" -> (known after apply)
              ~ name        = "Packer Spiced Latte" -> (known after apply)
              ~ price       = 350 -> (known after apply)
              ~ teaser      = "Packed with goodness to spice up your images" -> (known after apply)
            }
              # (2 unchanged attributes hidden)
          },
        ]
      ~ last_updated = "Tuesday, 28-Sep-21 11:53:27 EDT" -> (known after apply)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

As a followup, it may be necessary to invoke two passes of attribute and resource plan modifiers to ensure any changes captured by those modifiers triggers the unknown marking. As it stands now, a plan with no configuration changes, but changes due to plan modifiers will not correctly trigger the unknown marking. See also: https://github.com/hashicorp/terraform-plugin-framework/issues/183