### PR TITLE
tfsdk: Return null value when missing from Config, Plan, and State GetAttribute() method

### DIFF
--- a/.changelog/185.txt
+++ b/.changelog/185.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+tfsdk: Fetch null values from valid missing `Config`, `Plan`, and `State` paths in `GetAttribute()` method
+```

--- a/tfsdk/attribute_test.go
+++ b/tfsdk/attribute_test.go
@@ -708,15 +708,15 @@ func TestAttributeModifyPlan(t *testing.T) {
 				Config: Config{
 					Raw: tftypes.NewValue(tftypes.Object{
 						AttributeTypes: map[string]tftypes.Type{
-							"nottest": tftypes.String,
+							"test": tftypes.String,
 						},
 					}, map[string]tftypes.Value{
-						"nottest": tftypes.NewValue(tftypes.String, "testvalue"),
+						"test": tftypes.NewValue(tftypes.String, "testvalue"),
 					}),
 					Schema: Schema{
 						Attributes: map[string]Attribute{
 							"test": {
-								Type:     types.StringType,
+								Type:     types.ListType{ElemType: types.StringType},
 								Required: true,
 							},
 						},
@@ -766,7 +766,8 @@ func TestAttributeModifyPlan(t *testing.T) {
 					diag.NewAttributeErrorDiagnostic(
 						tftypes.NewAttributePath().WithAttributeName("test"),
 						"Configuration Read Error",
-						"An unexpected error was encountered trying to read an attribute from the configuration. This is always an error in the provider. Please report the following to the provider developer:\n\nAttributeName(\"test\") still remains in the path: step cannot be applied to this value",
+						"An unexpected error was encountered trying to read an attribute from the configuration. This is always an error in the provider. Please report the following to the provider developer:\n\n"+
+							"can't use tftypes.String<\"testvalue\"> as value of List with ElementType types.primitive, can only use tftypes.String values",
 					),
 				},
 			},
@@ -777,15 +778,15 @@ func TestAttributeModifyPlan(t *testing.T) {
 				Config: Config{
 					Raw: tftypes.NewValue(tftypes.Object{
 						AttributeTypes: map[string]tftypes.Type{
-							"nottest": tftypes.String,
+							"test": tftypes.String,
 						},
 					}, map[string]tftypes.Value{
-						"nottest": tftypes.NewValue(tftypes.String, "testvalue"),
+						"test": tftypes.NewValue(tftypes.String, "testvalue"),
 					}),
 					Schema: Schema{
 						Attributes: map[string]Attribute{
 							"test": {
-								Type:     types.StringType,
+								Type:     types.ListType{ElemType: types.StringType},
 								Required: true,
 							},
 						},
@@ -845,7 +846,8 @@ func TestAttributeModifyPlan(t *testing.T) {
 					diag.NewAttributeErrorDiagnostic(
 						tftypes.NewAttributePath().WithAttributeName("test"),
 						"Configuration Read Error",
-						"An unexpected error was encountered trying to read an attribute from the configuration. This is always an error in the provider. Please report the following to the provider developer:\n\nAttributeName(\"test\") still remains in the path: step cannot be applied to this value",
+						"An unexpected error was encountered trying to read an attribute from the configuration. This is always an error in the provider. Please report the following to the provider developer:\n\n"+
+							"can't use tftypes.String<\"testvalue\"> as value of List with ElementType types.primitive, can only use tftypes.String values",
 					),
 				},
 			},
@@ -2151,15 +2153,15 @@ func TestAttributeValidate(t *testing.T) {
 				Config: Config{
 					Raw: tftypes.NewValue(tftypes.Object{
 						AttributeTypes: map[string]tftypes.Type{
-							"nottest": tftypes.String,
+							"test": tftypes.String,
 						},
 					}, map[string]tftypes.Value{
-						"nottest": tftypes.NewValue(tftypes.String, "testvalue"),
+						"test": tftypes.NewValue(tftypes.String, "testvalue"),
 					}),
 					Schema: Schema{
 						Attributes: map[string]Attribute{
 							"test": {
-								Type:     types.StringType,
+								Type:     types.ListType{ElemType: types.StringType},
 								Required: true,
 							},
 						},
@@ -2171,7 +2173,8 @@ func TestAttributeValidate(t *testing.T) {
 					diag.NewAttributeErrorDiagnostic(
 						tftypes.NewAttributePath().WithAttributeName("test"),
 						"Configuration Read Error",
-						"An unexpected error was encountered trying to read an attribute from the configuration. This is always an error in the provider. Please report the following to the provider developer:\n\nAttributeName(\"test\") still remains in the path: step cannot be applied to this value",
+						"An unexpected error was encountered trying to read an attribute from the configuration. This is always an error in the provider. Please report the following to the provider developer:\n\n"+
+							"can't use tftypes.String<\"testvalue\"> as value of List with ElementType types.primitive, can only use tftypes.String values",
 					),
 				},
 			},

--- a/tfsdk/attribute_test.go
+++ b/tfsdk/attribute_test.go
@@ -875,15 +875,15 @@ func TestAttributeModifyPlan(t *testing.T) {
 				Plan: Plan{
 					Raw: tftypes.NewValue(tftypes.Object{
 						AttributeTypes: map[string]tftypes.Type{
-							"nottest": tftypes.String,
+							"test": tftypes.String,
 						},
 					}, map[string]tftypes.Value{
-						"nottest": tftypes.NewValue(tftypes.String, "testvalue"),
+						"test": tftypes.NewValue(tftypes.String, "testvalue"),
 					}),
 					Schema: Schema{
 						Attributes: map[string]Attribute{
 							"test": {
-								Type:     types.StringType,
+								Type:     types.ListType{ElemType: types.StringType},
 								Required: true,
 							},
 						},
@@ -916,7 +916,8 @@ func TestAttributeModifyPlan(t *testing.T) {
 					diag.NewAttributeErrorDiagnostic(
 						tftypes.NewAttributePath().WithAttributeName("test"),
 						"Plan Read Error",
-						"An unexpected error was encountered trying to read an attribute from the plan. This is always an error in the provider. Please report the following to the provider developer:\n\nAttributeName(\"test\") still remains in the path: step cannot be applied to this value",
+						"An unexpected error was encountered trying to read an attribute from the plan. This is always an error in the provider. Please report the following to the provider developer:\n\n"+
+							"can't use tftypes.String<\"testvalue\"> as value of List with ElementType types.primitive, can only use tftypes.String values",
 					),
 				},
 			},
@@ -944,15 +945,15 @@ func TestAttributeModifyPlan(t *testing.T) {
 				Plan: Plan{
 					Raw: tftypes.NewValue(tftypes.Object{
 						AttributeTypes: map[string]tftypes.Type{
-							"nottest": tftypes.String,
+							"test": tftypes.String,
 						},
 					}, map[string]tftypes.Value{
-						"nottest": tftypes.NewValue(tftypes.String, "testvalue"),
+						"test": tftypes.NewValue(tftypes.String, "testvalue"),
 					}),
 					Schema: Schema{
 						Attributes: map[string]Attribute{
 							"test": {
-								Type:     types.StringType,
+								Type:     types.ListType{ElemType: types.StringType},
 								Required: true,
 							},
 						},
@@ -995,7 +996,8 @@ func TestAttributeModifyPlan(t *testing.T) {
 					diag.NewAttributeErrorDiagnostic(
 						tftypes.NewAttributePath().WithAttributeName("test"),
 						"Plan Read Error",
-						"An unexpected error was encountered trying to read an attribute from the plan. This is always an error in the provider. Please report the following to the provider developer:\n\nAttributeName(\"test\") still remains in the path: step cannot be applied to this value",
+						"An unexpected error was encountered trying to read an attribute from the plan. This is always an error in the provider. Please report the following to the provider developer:\n\n"+
+							"can't use tftypes.String<\"testvalue\"> as value of List with ElementType types.primitive, can only use tftypes.String values",
 					),
 				},
 			},
@@ -1040,15 +1042,15 @@ func TestAttributeModifyPlan(t *testing.T) {
 				State: State{
 					Raw: tftypes.NewValue(tftypes.Object{
 						AttributeTypes: map[string]tftypes.Type{
-							"nottest": tftypes.String,
+							"test": tftypes.String,
 						},
 					}, map[string]tftypes.Value{
-						"nottest": tftypes.NewValue(tftypes.String, "testvalue"),
+						"test": tftypes.NewValue(tftypes.String, "testvalue"),
 					}),
 					Schema: Schema{
 						Attributes: map[string]Attribute{
 							"test": {
-								Type:     types.StringType,
+								Type:     types.ListType{ElemType: types.StringType},
 								Required: true,
 							},
 						},
@@ -1064,7 +1066,8 @@ func TestAttributeModifyPlan(t *testing.T) {
 					diag.NewAttributeErrorDiagnostic(
 						tftypes.NewAttributePath().WithAttributeName("test"),
 						"State Read Error",
-						"An unexpected error was encountered trying to read an attribute from the state. This is always an error in the provider. Please report the following to the provider developer:\n\nAttributeName(\"test\") still remains in the path: step cannot be applied to this value",
+						"An unexpected error was encountered trying to read an attribute from the state. This is always an error in the provider. Please report the following to the provider developer:\n\n"+
+							"can't use tftypes.String<\"testvalue\"> as value of List with ElementType types.primitive, can only use tftypes.String values",
 					),
 				},
 			},
@@ -1109,15 +1112,15 @@ func TestAttributeModifyPlan(t *testing.T) {
 				State: State{
 					Raw: tftypes.NewValue(tftypes.Object{
 						AttributeTypes: map[string]tftypes.Type{
-							"nottest": tftypes.String,
+							"test": tftypes.String,
 						},
 					}, map[string]tftypes.Value{
-						"nottest": tftypes.NewValue(tftypes.String, "testvalue"),
+						"test": tftypes.NewValue(tftypes.String, "testvalue"),
 					}),
 					Schema: Schema{
 						Attributes: map[string]Attribute{
 							"test": {
-								Type:     types.StringType,
+								Type:     types.ListType{ElemType: types.StringType},
 								Required: true,
 							},
 						},
@@ -1143,7 +1146,8 @@ func TestAttributeModifyPlan(t *testing.T) {
 					diag.NewAttributeErrorDiagnostic(
 						tftypes.NewAttributePath().WithAttributeName("test"),
 						"State Read Error",
-						"An unexpected error was encountered trying to read an attribute from the state. This is always an error in the provider. Please report the following to the provider developer:\n\nAttributeName(\"test\") still remains in the path: step cannot be applied to this value",
+						"An unexpected error was encountered trying to read an attribute from the state. This is always an error in the provider. Please report the following to the provider developer:\n\n"+
+							"can't use tftypes.String<\"testvalue\"> as value of List with ElementType types.primitive, can only use tftypes.String values",
 					),
 				},
 			},

--- a/tfsdk/config.go
+++ b/tfsdk/config.go
@@ -56,6 +56,10 @@ func (c Config) GetAttribute(ctx context.Context, path *tftypes.AttributePath) (
 		return nil, diags
 	}
 
+	// TODO: If ErrInvalidStep, check parent paths for unknown value.
+	//       If found, convert this value to an unknown value.
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/186
+
 	if attrTypeWithValidate, ok := attrType.(attr.TypeWithValidate); ok {
 		diags.Append(attrTypeWithValidate.Validate(ctx, tfValue, path)...)
 

--- a/tfsdk/config.go
+++ b/tfsdk/config.go
@@ -2,6 +2,7 @@ package tfsdk
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -44,7 +45,9 @@ func (c Config) GetAttribute(ctx context.Context, path *tftypes.AttributePath) (
 	}
 
 	tfValue, err := c.terraformValueAtPath(path)
-	if err != nil {
+
+	// Ignoring ErrInvalidStep will allow this method to return a null value of the type.
+	if err != nil && !errors.Is(err, tftypes.ErrInvalidStep) {
 		diags.AddAttributeError(
 			path,
 			"Configuration Read Error",

--- a/tfsdk/config_test.go
+++ b/tfsdk/config_test.go
@@ -157,72 +157,944 @@ func TestConfigGetAttribute(t *testing.T) {
 
 	type testCase struct {
 		config        Config
+		path          *tftypes.AttributePath
 		expected      attr.Value
 		expectedDiags diag.Diagnostics
 	}
 
 	testCases := map[string]testCase{
-		"basic": {
+		"empty": {
 			config: Config{
 				Raw: tftypes.NewValue(tftypes.Object{
 					AttributeTypes: map[string]tftypes.Type{
-						"name": tftypes.String,
+						"test":  tftypes.String,
+						"other": tftypes.Bool,
+					},
+				}, nil),
+				Schema: Schema{
+					Attributes: map[string]Attribute{
+						"test": {
+							Type:     types.StringType,
+							Required: true,
+						},
+						"other": {
+							Type:     types.BoolType,
+							Optional: true,
+						},
+					},
+				},
+			},
+			path:     tftypes.NewAttributePath().WithAttributeName("test"),
+			expected: nil,
+		},
+		"WithAttributeName-nonexistent": {
+			config: Config{
+				Raw: tftypes.NewValue(tftypes.Object{
+					AttributeTypes: map[string]tftypes.Type{
+						"test": tftypes.String,
 					},
 				}, map[string]tftypes.Value{
-					"name": tftypes.NewValue(tftypes.String, "namevalue"),
+					"test": tftypes.NewValue(tftypes.String, "value"),
 				}),
 				Schema: Schema{
 					Attributes: map[string]Attribute{
-						"name": {
+						"test": {
 							Type:     types.StringType,
 							Required: true,
 						},
 					},
 				},
 			},
-			expected: types.String{Value: "namevalue"},
+			path:     tftypes.NewAttributePath().WithAttributeName("other"),
+			expected: nil,
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					tftypes.NewAttributePath().WithAttributeName("other"),
+					"Configuration Read Error",
+					"An unexpected error was encountered trying to read an attribute from the configuration. This is always an error in the provider. Please report the following to the provider developer:\n\n"+
+						"AttributeName(\"other\") still remains in the path: could not find attribute \"other\" in schema",
+				),
+			},
+		},
+		"WithAttributeName-List-null-WithElementKeyInt": {
+			config: Config{
+				Raw: tftypes.NewValue(tftypes.Object{
+					AttributeTypes: map[string]tftypes.Type{
+						"test": tftypes.List{
+							ElementType: tftypes.String,
+						},
+						"other": tftypes.Bool,
+					},
+				}, map[string]tftypes.Value{
+					"test": tftypes.NewValue(tftypes.List{
+						ElementType: tftypes.String,
+					}, nil),
+					"other": tftypes.NewValue(tftypes.Bool, nil),
+				}),
+				Schema: Schema{
+					Attributes: map[string]Attribute{
+						"test": {
+							Type: types.ListType{
+								ElemType: types.StringType,
+							},
+							Required: true,
+						},
+						"other": {
+							Type:     types.BoolType,
+							Optional: true,
+						},
+					},
+				},
+			},
+			path:     tftypes.NewAttributePath().WithAttributeName("test").WithElementKeyInt(0),
+			expected: nil,
+			// TODO: https://github.com/hashicorp/terraform-plugin-framework/issues/150
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					tftypes.NewAttributePath().WithAttributeName("test").WithElementKeyInt(0),
+					"Configuration Read Error",
+					"An unexpected error was encountered trying to read an attribute from the configuration. This is always an error in the provider. Please report the following to the provider developer:\n\n"+
+						"ElementKeyInt(0) still remains in the path: step cannot be applied to this value",
+				),
+			},
+		},
+		"WithAttributeName-List-WithElementKeyInt": {
+			config: Config{
+				Raw: tftypes.NewValue(tftypes.Object{
+					AttributeTypes: map[string]tftypes.Type{
+						"test": tftypes.List{
+							ElementType: tftypes.String,
+						},
+						"other": tftypes.Bool,
+					},
+				}, map[string]tftypes.Value{
+					"test": tftypes.NewValue(tftypes.List{
+						ElementType: tftypes.String,
+					}, []tftypes.Value{
+						tftypes.NewValue(tftypes.String, "value"),
+						tftypes.NewValue(tftypes.String, "othervalue"),
+					}),
+					"other": tftypes.NewValue(tftypes.Bool, nil),
+				}),
+				Schema: Schema{
+					Attributes: map[string]Attribute{
+						"test": {
+							Type: types.ListType{
+								ElemType: types.StringType,
+							},
+							Required: true,
+						},
+						"other": {
+							Type:     types.BoolType,
+							Optional: true,
+						},
+					},
+				},
+			},
+			path:     tftypes.NewAttributePath().WithAttributeName("test").WithElementKeyInt(0),
+			expected: types.String{Value: "value"},
+		},
+		"WithAttributeName-ListNestedAttributes-null-WithElementKeyInt-WithAttributeName": {
+			config: Config{
+				Raw: tftypes.NewValue(tftypes.Object{
+					AttributeTypes: map[string]tftypes.Type{
+						"test": tftypes.List{
+							ElementType: tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"sub_test": tftypes.String,
+								},
+							},
+						},
+						"other": tftypes.Bool,
+					},
+				}, map[string]tftypes.Value{
+					"test": tftypes.NewValue(tftypes.List{
+						ElementType: tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"sub_test": tftypes.String,
+							},
+						},
+					}, nil),
+					"other": tftypes.NewValue(tftypes.Bool, nil),
+				}),
+				Schema: Schema{
+					Attributes: map[string]Attribute{
+						"test": {
+							Attributes: ListNestedAttributes(map[string]Attribute{
+								"sub_test": {
+									Type:     types.StringType,
+									Required: true,
+								},
+							}, ListNestedAttributesOptions{}),
+							Required: true,
+						},
+						"other": {
+							Type:     types.BoolType,
+							Optional: true,
+						},
+					},
+				},
+			},
+			path:     tftypes.NewAttributePath().WithAttributeName("test").WithElementKeyInt(0).WithAttributeName("sub_test"),
+			expected: nil,
+			// TODO: https://github.com/hashicorp/terraform-plugin-framework/issues/150
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					tftypes.NewAttributePath().WithAttributeName("test").WithElementKeyInt(0).WithAttributeName("sub_test"),
+					"Configuration Read Error",
+					"An unexpected error was encountered trying to read an attribute from the configuration. This is always an error in the provider. Please report the following to the provider developer:\n\n"+
+						"ElementKeyInt(0).AttributeName(\"sub_test\") still remains in the path: step cannot be applied to this value",
+				),
+			},
+		},
+		"WithAttributeName-ListNestedAttributes-WithElementKeyInt-WithAttributeName": {
+			config: Config{
+				Raw: tftypes.NewValue(tftypes.Object{
+					AttributeTypes: map[string]tftypes.Type{
+						"test": tftypes.List{
+							ElementType: tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"sub_test": tftypes.String,
+								},
+							},
+						},
+						"other": tftypes.Bool,
+					},
+				}, map[string]tftypes.Value{
+					"test": tftypes.NewValue(tftypes.List{
+						ElementType: tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"sub_test": tftypes.String,
+							},
+						},
+					}, []tftypes.Value{
+						tftypes.NewValue(tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"sub_test": tftypes.String,
+							},
+						}, map[string]tftypes.Value{
+							"sub_test": tftypes.NewValue(tftypes.String, "value"),
+						}),
+					}),
+					"other": tftypes.NewValue(tftypes.Bool, nil),
+				}),
+				Schema: Schema{
+					Attributes: map[string]Attribute{
+						"test": {
+							Attributes: ListNestedAttributes(map[string]Attribute{
+								"sub_test": {
+									Type:     types.StringType,
+									Required: true,
+								},
+							}, ListNestedAttributesOptions{}),
+							Required: true,
+						},
+						"other": {
+							Type:     types.BoolType,
+							Optional: true,
+						},
+					},
+				},
+			},
+			path:     tftypes.NewAttributePath().WithAttributeName("test").WithElementKeyInt(0).WithAttributeName("sub_test"),
+			expected: types.String{Value: "value"},
+		},
+		"WithAttributeName-Map-null-WithElementKeyString": {
+			config: Config{
+				Raw: tftypes.NewValue(tftypes.Object{
+					AttributeTypes: map[string]tftypes.Type{
+						"test": tftypes.Map{
+							ElementType: tftypes.String,
+						},
+						"other": tftypes.Bool,
+					},
+				}, map[string]tftypes.Value{
+					"test": tftypes.NewValue(tftypes.Map{
+						ElementType: tftypes.String,
+					}, nil),
+					"other": tftypes.NewValue(tftypes.Bool, nil),
+				}),
+				Schema: Schema{
+					Attributes: map[string]Attribute{
+						"test": {
+							Type: types.MapType{
+								ElemType: types.StringType,
+							},
+							Required: true,
+						},
+						"other": {
+							Type:     types.BoolType,
+							Optional: true,
+						},
+					},
+				},
+			},
+			path:     tftypes.NewAttributePath().WithAttributeName("test").WithElementKeyString("sub_test"),
+			expected: nil,
+			// TODO: https://github.com/hashicorp/terraform-plugin-framework/issues/150
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					tftypes.NewAttributePath().WithAttributeName("test").WithElementKeyString("sub_test"),
+					"Configuration Read Error",
+					"An unexpected error was encountered trying to read an attribute from the configuration. This is always an error in the provider. Please report the following to the provider developer:\n\n"+
+						"ElementKeyString(\"sub_test\") still remains in the path: step cannot be applied to this value",
+				),
+			},
+		},
+		"WithAttributeName-Map-WithElementKeyString": {
+			config: Config{
+				Raw: tftypes.NewValue(tftypes.Object{
+					AttributeTypes: map[string]tftypes.Type{
+						"test": tftypes.Map{
+							ElementType: tftypes.String,
+						},
+						"other": tftypes.Bool,
+					},
+				}, map[string]tftypes.Value{
+					"test": tftypes.NewValue(tftypes.Map{
+						ElementType: tftypes.String,
+					}, map[string]tftypes.Value{
+						"sub_test": tftypes.NewValue(tftypes.String, "value"),
+						"other":    tftypes.NewValue(tftypes.String, "othervalue"),
+					}),
+					"other": tftypes.NewValue(tftypes.Bool, nil),
+				}),
+				Schema: Schema{
+					Attributes: map[string]Attribute{
+						"test": {
+							Type: types.MapType{
+								ElemType: types.StringType,
+							},
+							Required: true,
+						},
+						"other": {
+							Type:     types.BoolType,
+							Optional: true,
+						},
+					},
+				},
+			},
+			path:     tftypes.NewAttributePath().WithAttributeName("test").WithElementKeyString("sub_test"),
+			expected: types.String{Value: "value"},
+		},
+		"WithAttributeName-Map-WithElementKeyString-nonexistent": {
+			config: Config{
+				Raw: tftypes.NewValue(tftypes.Object{
+					AttributeTypes: map[string]tftypes.Type{
+						"test": tftypes.Map{
+							ElementType: tftypes.String,
+						},
+						"other": tftypes.Bool,
+					},
+				}, map[string]tftypes.Value{
+					"test": tftypes.NewValue(tftypes.Map{
+						ElementType: tftypes.String,
+					}, map[string]tftypes.Value{
+						"sub_test": tftypes.NewValue(tftypes.String, "value"),
+					}),
+					"other": tftypes.NewValue(tftypes.Bool, nil),
+				}),
+				Schema: Schema{
+					Attributes: map[string]Attribute{
+						"test": {
+							Type: types.MapType{
+								ElemType: types.StringType,
+							},
+							Required: true,
+						},
+						"other": {
+							Type:     types.BoolType,
+							Optional: true,
+						},
+					},
+				},
+			},
+			path:     tftypes.NewAttributePath().WithAttributeName("test").WithElementKeyString("other"),
+			expected: nil,
+			// TODO: https://github.com/hashicorp/terraform-plugin-framework/issues/150
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					tftypes.NewAttributePath().WithAttributeName("test").WithElementKeyString("other"),
+					"Configuration Read Error",
+					"An unexpected error was encountered trying to read an attribute from the configuration. This is always an error in the provider. Please report the following to the provider developer:\n\n"+
+						"ElementKeyString(\"other\") still remains in the path: step cannot be applied to this value",
+				),
+			},
+		},
+		"WithAttributeName-MapNestedAttributes-null-WithElementKeyInt-WithAttributeName": {
+			config: Config{
+				Raw: tftypes.NewValue(tftypes.Object{
+					AttributeTypes: map[string]tftypes.Type{
+						"test": tftypes.Map{
+							ElementType: tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"sub_test": tftypes.String,
+								},
+							},
+						},
+						"other": tftypes.Bool,
+					},
+				}, map[string]tftypes.Value{
+					"test": tftypes.NewValue(tftypes.Map{
+						ElementType: tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"sub_test": tftypes.String,
+							},
+						},
+					}, nil),
+					"other": tftypes.NewValue(tftypes.Bool, nil),
+				}),
+				Schema: Schema{
+					Attributes: map[string]Attribute{
+						"test": {
+							Attributes: MapNestedAttributes(map[string]Attribute{
+								"sub_test": {
+									Type:     types.StringType,
+									Required: true,
+								},
+							}, MapNestedAttributesOptions{}),
+							Required: true,
+						},
+						"other": {
+							Type:     types.BoolType,
+							Optional: true,
+						},
+					},
+				},
+			},
+			path:     tftypes.NewAttributePath().WithAttributeName("test").WithElementKeyString("element").WithAttributeName("sub_test"),
+			expected: nil,
+			// TODO: https://github.com/hashicorp/terraform-plugin-framework/issues/150
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					tftypes.NewAttributePath().WithAttributeName("test").WithElementKeyString("element").WithAttributeName("sub_test"),
+					"Configuration Read Error",
+					"An unexpected error was encountered trying to read an attribute from the configuration. This is always an error in the provider. Please report the following to the provider developer:\n\n"+
+						"ElementKeyString(\"element\").AttributeName(\"sub_test\") still remains in the path: step cannot be applied to this value",
+				),
+			},
+		},
+		"WithAttributeName-MapNestedAttributes-WithElementKeyString-WithAttributeName": {
+			config: Config{
+				Raw: tftypes.NewValue(tftypes.Object{
+					AttributeTypes: map[string]tftypes.Type{
+						"test": tftypes.Map{
+							ElementType: tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"sub_test": tftypes.String,
+								},
+							},
+						},
+						"other": tftypes.Bool,
+					},
+				}, map[string]tftypes.Value{
+					"test": tftypes.NewValue(tftypes.Map{
+						ElementType: tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"sub_test": tftypes.String,
+							},
+						},
+					}, map[string]tftypes.Value{
+						"element": tftypes.NewValue(tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"sub_test": tftypes.String,
+							},
+						}, map[string]tftypes.Value{
+							"sub_test": tftypes.NewValue(tftypes.String, "value"),
+						}),
+					}),
+					"other": tftypes.NewValue(tftypes.Bool, nil),
+				}),
+				Schema: Schema{
+					Attributes: map[string]Attribute{
+						"test": {
+							Attributes: MapNestedAttributes(map[string]Attribute{
+								"sub_test": {
+									Type:     types.StringType,
+									Required: true,
+								},
+							}, MapNestedAttributesOptions{}),
+							Required: true,
+						},
+						"other": {
+							Type:     types.BoolType,
+							Optional: true,
+						},
+					},
+				},
+			},
+			path:     tftypes.NewAttributePath().WithAttributeName("test").WithElementKeyString("element").WithAttributeName("sub_test"),
+			expected: types.String{Value: "value"},
+		},
+		"WithAttributeName-Object-WithAttributeName": {
+			config: Config{
+				Raw: tftypes.NewValue(tftypes.Object{
+					AttributeTypes: map[string]tftypes.Type{
+						"test": tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"sub_test": tftypes.String,
+							},
+						},
+						"other": tftypes.Bool,
+					},
+				}, map[string]tftypes.Value{
+					"test": tftypes.NewValue(tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"sub_test": tftypes.String,
+						},
+					}, map[string]tftypes.Value{
+						"sub_test": tftypes.NewValue(tftypes.String, "value"),
+					}),
+					"other": tftypes.NewValue(tftypes.Bool, nil),
+				}),
+				Schema: Schema{
+					Attributes: map[string]Attribute{
+						"test": {
+							Type: types.ObjectType{
+								AttrTypes: map[string]attr.Type{
+									"sub_test": types.StringType,
+								},
+							},
+							Required: true,
+						},
+						"other": {
+							Type:     types.BoolType,
+							Optional: true,
+						},
+					},
+				},
+			},
+			path:     tftypes.NewAttributePath().WithAttributeName("test").WithAttributeName("sub_test"),
+			expected: types.String{Value: "value"},
+		},
+		"WithAttributeName-Set-null-WithElementKeyValue": {
+			config: Config{
+				Raw: tftypes.NewValue(tftypes.Object{
+					AttributeTypes: map[string]tftypes.Type{
+						"test": tftypes.Set{
+							ElementType: tftypes.String,
+						},
+						"other": tftypes.Bool,
+					},
+				}, map[string]tftypes.Value{
+					"test": tftypes.NewValue(tftypes.Set{
+						ElementType: tftypes.String,
+					}, nil),
+					"other": tftypes.NewValue(tftypes.Bool, nil),
+				}),
+				Schema: Schema{
+					Attributes: map[string]Attribute{
+						"test": {
+							Type: types.SetType{
+								ElemType: types.StringType,
+							},
+							Required: true,
+						},
+						"other": {
+							Type:     types.BoolType,
+							Optional: true,
+						},
+					},
+				},
+			},
+			path:     tftypes.NewAttributePath().WithAttributeName("test").WithElementKeyValue(tftypes.NewValue(tftypes.String, "value")),
+			expected: nil,
+			// TODO: https://github.com/hashicorp/terraform-plugin-framework/issues/150
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					tftypes.NewAttributePath().WithAttributeName("test").WithElementKeyValue(tftypes.NewValue(tftypes.String, "value")),
+					"Configuration Read Error",
+					"An unexpected error was encountered trying to read an attribute from the configuration. This is always an error in the provider. Please report the following to the provider developer:\n\n"+
+						"ElementKeyValue(tftypes.String<\"value\">) still remains in the path: step cannot be applied to this value",
+				),
+			},
+		},
+		"WithAttributeName-Set-WithElementKeyValue": {
+			config: Config{
+				Raw: tftypes.NewValue(tftypes.Object{
+					AttributeTypes: map[string]tftypes.Type{
+						"test": tftypes.Set{
+							ElementType: tftypes.String,
+						},
+						"other": tftypes.Bool,
+					},
+				}, map[string]tftypes.Value{
+					"test": tftypes.NewValue(tftypes.Set{
+						ElementType: tftypes.String,
+					}, []tftypes.Value{
+						tftypes.NewValue(tftypes.String, "value"),
+						tftypes.NewValue(tftypes.String, "othervalue"),
+					}),
+					"other": tftypes.NewValue(tftypes.Bool, nil),
+				}),
+				Schema: Schema{
+					Attributes: map[string]Attribute{
+						"test": {
+							Type: types.SetType{
+								ElemType: types.StringType,
+							},
+							Required: true,
+						},
+						"other": {
+							Type:     types.BoolType,
+							Optional: true,
+						},
+					},
+				},
+			},
+			path:     tftypes.NewAttributePath().WithAttributeName("test").WithElementKeyValue(tftypes.NewValue(tftypes.String, "value")),
+			expected: types.String{Value: "value"},
+		},
+		"WithAttributeName-SetNestedAttributes-null-WithElementKeyValue-WithAttributeName": {
+			config: Config{
+				Raw: tftypes.NewValue(tftypes.Object{
+					AttributeTypes: map[string]tftypes.Type{
+						"test": tftypes.Set{
+							ElementType: tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"sub_test": tftypes.String,
+								},
+							},
+						},
+						"other": tftypes.Bool,
+					},
+				}, map[string]tftypes.Value{
+					"test": tftypes.NewValue(tftypes.Set{
+						ElementType: tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"sub_test": tftypes.String,
+							},
+						},
+					}, nil),
+					"other": tftypes.NewValue(tftypes.Bool, nil),
+				}),
+				Schema: Schema{
+					Attributes: map[string]Attribute{
+						"test": {
+							Attributes: SetNestedAttributes(map[string]Attribute{
+								"sub_test": {
+									Type:     types.StringType,
+									Required: true,
+								},
+							}, SetNestedAttributesOptions{}),
+							Required: true,
+						},
+						"other": {
+							Type:     types.BoolType,
+							Optional: true,
+						},
+					},
+				},
+			},
+			path: tftypes.NewAttributePath().WithAttributeName("test").WithElementKeyValue(tftypes.NewValue(tftypes.Object{
+				AttributeTypes: map[string]tftypes.Type{
+					"sub_test": tftypes.String,
+				},
+			}, map[string]tftypes.Value{
+				"sub_test": tftypes.NewValue(tftypes.String, "value"),
+			})).WithAttributeName("sub_test"),
+			expected: nil,
+			// TODO: https://github.com/hashicorp/terraform-plugin-framework/issues/150
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					tftypes.NewAttributePath().WithAttributeName("test").WithElementKeyValue(tftypes.NewValue(tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"sub_test": tftypes.String,
+						},
+					}, map[string]tftypes.Value{
+						"sub_test": tftypes.NewValue(tftypes.String, "value"),
+					})).WithAttributeName("sub_test"),
+					"Configuration Read Error",
+					"An unexpected error was encountered trying to read an attribute from the configuration. This is always an error in the provider. Please report the following to the provider developer:\n\n"+
+						"ElementKeyValue(tftypes.Object[\"sub_test\":tftypes.String]<\"sub_test\":tftypes.String<\"value\">>).AttributeName(\"sub_test\") still remains in the path: step cannot be applied to this value",
+				),
+			},
+		},
+		"WithAttributeName-SetNestedAttributes-WithElementKeyValue-WithAttributeName": {
+			config: Config{
+				Raw: tftypes.NewValue(tftypes.Object{
+					AttributeTypes: map[string]tftypes.Type{
+						"test": tftypes.Set{
+							ElementType: tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"sub_test": tftypes.String,
+								},
+							},
+						},
+						"other": tftypes.Bool,
+					},
+				}, map[string]tftypes.Value{
+					"test": tftypes.NewValue(tftypes.Set{
+						ElementType: tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"sub_test": tftypes.String,
+							},
+						},
+					}, []tftypes.Value{
+						tftypes.NewValue(tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"sub_test": tftypes.String,
+							},
+						}, map[string]tftypes.Value{
+							"sub_test": tftypes.NewValue(tftypes.String, "value"),
+						}),
+					}),
+					"other": tftypes.NewValue(tftypes.Bool, nil),
+				}),
+				Schema: Schema{
+					Attributes: map[string]Attribute{
+						"test": {
+							Attributes: SetNestedAttributes(map[string]Attribute{
+								"sub_test": {
+									Type:     types.StringType,
+									Required: true,
+								},
+							}, SetNestedAttributesOptions{}),
+							Required: true,
+						},
+						"other": {
+							Type:     types.BoolType,
+							Optional: true,
+						},
+					},
+				},
+			},
+			path: tftypes.NewAttributePath().WithAttributeName("test").WithElementKeyValue(tftypes.NewValue(tftypes.Object{
+				AttributeTypes: map[string]tftypes.Type{
+					"sub_test": tftypes.String,
+				},
+			}, map[string]tftypes.Value{
+				"sub_test": tftypes.NewValue(tftypes.String, "value"),
+			})).WithAttributeName("sub_test"),
+			expected: types.String{Value: "value"},
+		},
+		"WithAttributeName-SingleNestedAttributes-null-WithAttributeName": {
+			config: Config{
+				Raw: tftypes.NewValue(tftypes.Object{
+					AttributeTypes: map[string]tftypes.Type{
+						"test": tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"sub_test": tftypes.String,
+							},
+						},
+						"other": tftypes.Bool,
+					},
+				}, map[string]tftypes.Value{
+					"test": tftypes.NewValue(tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"sub_test": tftypes.String,
+						},
+					}, nil),
+					"other": tftypes.NewValue(tftypes.Bool, nil),
+				}),
+				Schema: Schema{
+					Attributes: map[string]Attribute{
+						"test": {
+							Attributes: SingleNestedAttributes(map[string]Attribute{
+								"sub_test": {
+									Type:     types.StringType,
+									Required: true,
+								},
+							}),
+							Required: true,
+						},
+						"other": {
+							Type:     types.BoolType,
+							Optional: true,
+						},
+					},
+				},
+			},
+			path:     tftypes.NewAttributePath().WithAttributeName("test").WithAttributeName("sub_test"),
+			expected: nil,
+			// TODO: https://github.com/hashicorp/terraform-plugin-framework/issues/150
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					tftypes.NewAttributePath().WithAttributeName("test").WithAttributeName("sub_test"),
+					"Configuration Read Error",
+					"An unexpected error was encountered trying to read an attribute from the configuration. This is always an error in the provider. Please report the following to the provider developer:\n\n"+
+						"AttributeName(\"sub_test\") still remains in the path: step cannot be applied to this value",
+				),
+			},
+		},
+		"WithAttributeName-SingleNestedAttributes-WithAttributeName": {
+			config: Config{
+				Raw: tftypes.NewValue(tftypes.Object{
+					AttributeTypes: map[string]tftypes.Type{
+						"test": tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"sub_test": tftypes.String,
+							},
+						},
+						"other": tftypes.Bool,
+					},
+				}, map[string]tftypes.Value{
+					"test": tftypes.NewValue(tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"sub_test": tftypes.String,
+						},
+					}, map[string]tftypes.Value{
+						"sub_test": tftypes.NewValue(tftypes.String, "value"),
+					}),
+					"other": tftypes.NewValue(tftypes.Bool, nil),
+				}),
+				Schema: Schema{
+					Attributes: map[string]Attribute{
+						"test": {
+							Attributes: SingleNestedAttributes(map[string]Attribute{
+								"sub_test": {
+									Type:     types.StringType,
+									Required: true,
+								},
+							}),
+							Required: true,
+						},
+						"other": {
+							Type:     types.BoolType,
+							Optional: true,
+						},
+					},
+				},
+			},
+			path:     tftypes.NewAttributePath().WithAttributeName("test").WithAttributeName("sub_test"),
+			expected: types.String{Value: "value"},
+		},
+		"WithAttributeName-String-null": {
+			config: Config{
+				Raw: tftypes.NewValue(tftypes.Object{
+					AttributeTypes: map[string]tftypes.Type{
+						"test":  tftypes.String,
+						"other": tftypes.Bool,
+					},
+				}, map[string]tftypes.Value{
+					"test":  tftypes.NewValue(tftypes.String, nil),
+					"other": tftypes.NewValue(tftypes.Bool, nil),
+				}),
+				Schema: Schema{
+					Attributes: map[string]Attribute{
+						"test": {
+							Type:     types.StringType,
+							Required: true,
+						},
+						"other": {
+							Type:     types.StringType,
+							Required: true,
+						},
+					},
+				},
+			},
+			path:     tftypes.NewAttributePath().WithAttributeName("test"),
+			expected: types.String{Null: true},
+		},
+		"WithAttributeName-String-unknown": {
+			config: Config{
+				Raw: tftypes.NewValue(tftypes.Object{
+					AttributeTypes: map[string]tftypes.Type{
+						"test":  tftypes.String,
+						"other": tftypes.Bool,
+					},
+				}, map[string]tftypes.Value{
+					"test":  tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+					"other": tftypes.NewValue(tftypes.Bool, nil),
+				}),
+				Schema: Schema{
+					Attributes: map[string]Attribute{
+						"test": {
+							Type:     types.StringType,
+							Required: true,
+						},
+						"other": {
+							Type:     types.BoolType,
+							Optional: true,
+						},
+					},
+				},
+			},
+			path:     tftypes.NewAttributePath().WithAttributeName("test"),
+			expected: types.String{Unknown: true},
+		},
+		"WithAttributeName-String-value": {
+			config: Config{
+				Raw: tftypes.NewValue(tftypes.Object{
+					AttributeTypes: map[string]tftypes.Type{
+						"test":  tftypes.String,
+						"other": tftypes.Bool,
+					},
+				}, map[string]tftypes.Value{
+					"test":  tftypes.NewValue(tftypes.String, "value"),
+					"other": tftypes.NewValue(tftypes.Bool, nil),
+				}),
+				Schema: Schema{
+					Attributes: map[string]Attribute{
+						"test": {
+							Type:     types.StringType,
+							Required: true,
+						},
+						"other": {
+							Type:     types.BoolType,
+							Optional: true,
+						},
+					},
+				},
+			},
+			path:     tftypes.NewAttributePath().WithAttributeName("test"),
+			expected: types.String{Value: "value"},
 		},
 		"AttrTypeWithValidateError": {
 			config: Config{
 				Raw: tftypes.NewValue(tftypes.Object{
 					AttributeTypes: map[string]tftypes.Type{
-						"name": tftypes.String,
+						"test":  tftypes.String,
+						"other": tftypes.Bool,
 					},
 				}, map[string]tftypes.Value{
-					"name": tftypes.NewValue(tftypes.String, "namevalue"),
+					"test":  tftypes.NewValue(tftypes.String, "value"),
+					"other": tftypes.NewValue(tftypes.Bool, nil),
 				}),
 				Schema: Schema{
 					Attributes: map[string]Attribute{
-						"name": {
+						"test": {
 							Type:     testtypes.StringTypeWithValidateError{},
 							Required: true,
+						},
+						"other": {
+							Type:     types.BoolType,
+							Optional: true,
 						},
 					},
 				},
 			},
+			path:          tftypes.NewAttributePath().WithAttributeName("test"),
 			expected:      nil,
-			expectedDiags: diag.Diagnostics{testtypes.TestErrorDiagnostic(tftypes.NewAttributePath().WithAttributeName("name"))},
+			expectedDiags: diag.Diagnostics{testtypes.TestErrorDiagnostic(tftypes.NewAttributePath().WithAttributeName("test"))},
 		},
 		"AttrTypeWithValidateWarning": {
 			config: Config{
 				Raw: tftypes.NewValue(tftypes.Object{
 					AttributeTypes: map[string]tftypes.Type{
-						"name": tftypes.String,
+						"test":  tftypes.String,
+						"other": tftypes.Bool,
 					},
 				}, map[string]tftypes.Value{
-					"name": tftypes.NewValue(tftypes.String, "namevalue"),
+					"test":  tftypes.NewValue(tftypes.String, "value"),
+					"other": tftypes.NewValue(tftypes.Bool, nil),
 				}),
 				Schema: Schema{
 					Attributes: map[string]Attribute{
-						"name": {
+						"test": {
 							Type:     testtypes.StringTypeWithValidateWarning{},
 							Required: true,
+						},
+						"other": {
+							Type:     types.BoolType,
+							Optional: true,
 						},
 					},
 				},
 			},
-			expected:      testtypes.String{String: types.String{Value: "namevalue"}, CreatedBy: testtypes.StringTypeWithValidateWarning{}},
-			expectedDiags: diag.Diagnostics{testtypes.TestWarningDiagnostic(tftypes.NewAttributePath().WithAttributeName("name"))},
+			path:          tftypes.NewAttributePath().WithAttributeName("test"),
+			expected:      testtypes.String{String: types.String{Value: "value"}, CreatedBy: testtypes.StringTypeWithValidateWarning{}},
+			expectedDiags: diag.Diagnostics{testtypes.TestWarningDiagnostic(tftypes.NewAttributePath().WithAttributeName("test"))},
 		},
 	}
 
@@ -231,9 +1103,12 @@ func TestConfigGetAttribute(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			val, diags := tc.config.GetAttribute(context.Background(), tftypes.NewAttributePath().WithAttributeName("name"))
-
+			val, diags := tc.config.GetAttribute(context.Background(), tc.path)
 			if diff := cmp.Diff(diags, tc.expectedDiags); diff != "" {
+				for _, d := range diags {
+					t.Log(d.Summary())
+					t.Log(d.Detail())
+				}
 				t.Errorf("unexpected diagnostics (+wanted, -got): %s", diff)
 			}
 

--- a/tfsdk/config_test.go
+++ b/tfsdk/config_test.go
@@ -1027,10 +1027,6 @@ func TestConfigGetAttribute(t *testing.T) {
 
 			val, diags := tc.config.GetAttribute(context.Background(), tc.path)
 			if diff := cmp.Diff(diags, tc.expectedDiags); diff != "" {
-				for _, d := range diags {
-					t.Log(d.Summary())
-					t.Log(d.Detail())
-				}
 				t.Errorf("unexpected diagnostics (+wanted, -got): %s", diff)
 			}
 

--- a/tfsdk/config_test.go
+++ b/tfsdk/config_test.go
@@ -247,16 +247,7 @@ func TestConfigGetAttribute(t *testing.T) {
 				},
 			},
 			path:     tftypes.NewAttributePath().WithAttributeName("test").WithElementKeyInt(0),
-			expected: nil,
-			// TODO: https://github.com/hashicorp/terraform-plugin-framework/issues/150
-			expectedDiags: diag.Diagnostics{
-				diag.NewAttributeErrorDiagnostic(
-					tftypes.NewAttributePath().WithAttributeName("test").WithElementKeyInt(0),
-					"Configuration Read Error",
-					"An unexpected error was encountered trying to read an attribute from the configuration. This is always an error in the provider. Please report the following to the provider developer:\n\n"+
-						"ElementKeyInt(0) still remains in the path: step cannot be applied to this value",
-				),
-			},
+			expected: types.String{Null: true},
 		},
 		"WithAttributeName-List-WithElementKeyInt": {
 			config: Config{
@@ -336,16 +327,7 @@ func TestConfigGetAttribute(t *testing.T) {
 				},
 			},
 			path:     tftypes.NewAttributePath().WithAttributeName("test").WithElementKeyInt(0).WithAttributeName("sub_test"),
-			expected: nil,
-			// TODO: https://github.com/hashicorp/terraform-plugin-framework/issues/150
-			expectedDiags: diag.Diagnostics{
-				diag.NewAttributeErrorDiagnostic(
-					tftypes.NewAttributePath().WithAttributeName("test").WithElementKeyInt(0).WithAttributeName("sub_test"),
-					"Configuration Read Error",
-					"An unexpected error was encountered trying to read an attribute from the configuration. This is always an error in the provider. Please report the following to the provider developer:\n\n"+
-						"ElementKeyInt(0).AttributeName(\"sub_test\") still remains in the path: step cannot be applied to this value",
-				),
-			},
+			expected: types.String{Null: true},
 		},
 		"WithAttributeName-ListNestedAttributes-WithElementKeyInt-WithAttributeName": {
 			config: Config{
@@ -430,16 +412,7 @@ func TestConfigGetAttribute(t *testing.T) {
 				},
 			},
 			path:     tftypes.NewAttributePath().WithAttributeName("test").WithElementKeyString("sub_test"),
-			expected: nil,
-			// TODO: https://github.com/hashicorp/terraform-plugin-framework/issues/150
-			expectedDiags: diag.Diagnostics{
-				diag.NewAttributeErrorDiagnostic(
-					tftypes.NewAttributePath().WithAttributeName("test").WithElementKeyString("sub_test"),
-					"Configuration Read Error",
-					"An unexpected error was encountered trying to read an attribute from the configuration. This is always an error in the provider. Please report the following to the provider developer:\n\n"+
-						"ElementKeyString(\"sub_test\") still remains in the path: step cannot be applied to this value",
-				),
-			},
+			expected: types.String{Null: true},
 		},
 		"WithAttributeName-Map-WithElementKeyString": {
 			config: Config{
@@ -510,16 +483,7 @@ func TestConfigGetAttribute(t *testing.T) {
 				},
 			},
 			path:     tftypes.NewAttributePath().WithAttributeName("test").WithElementKeyString("other"),
-			expected: nil,
-			// TODO: https://github.com/hashicorp/terraform-plugin-framework/issues/150
-			expectedDiags: diag.Diagnostics{
-				diag.NewAttributeErrorDiagnostic(
-					tftypes.NewAttributePath().WithAttributeName("test").WithElementKeyString("other"),
-					"Configuration Read Error",
-					"An unexpected error was encountered trying to read an attribute from the configuration. This is always an error in the provider. Please report the following to the provider developer:\n\n"+
-						"ElementKeyString(\"other\") still remains in the path: step cannot be applied to this value",
-				),
-			},
+			expected: types.String{Null: true},
 		},
 		"WithAttributeName-MapNestedAttributes-null-WithElementKeyInt-WithAttributeName": {
 			config: Config{
@@ -563,16 +527,7 @@ func TestConfigGetAttribute(t *testing.T) {
 				},
 			},
 			path:     tftypes.NewAttributePath().WithAttributeName("test").WithElementKeyString("element").WithAttributeName("sub_test"),
-			expected: nil,
-			// TODO: https://github.com/hashicorp/terraform-plugin-framework/issues/150
-			expectedDiags: diag.Diagnostics{
-				diag.NewAttributeErrorDiagnostic(
-					tftypes.NewAttributePath().WithAttributeName("test").WithElementKeyString("element").WithAttributeName("sub_test"),
-					"Configuration Read Error",
-					"An unexpected error was encountered trying to read an attribute from the configuration. This is always an error in the provider. Please report the following to the provider developer:\n\n"+
-						"ElementKeyString(\"element\").AttributeName(\"sub_test\") still remains in the path: step cannot be applied to this value",
-				),
-			},
+			expected: types.String{Null: true},
 		},
 		"WithAttributeName-MapNestedAttributes-WithElementKeyString-WithAttributeName": {
 			config: Config{
@@ -698,16 +653,7 @@ func TestConfigGetAttribute(t *testing.T) {
 				},
 			},
 			path:     tftypes.NewAttributePath().WithAttributeName("test").WithElementKeyValue(tftypes.NewValue(tftypes.String, "value")),
-			expected: nil,
-			// TODO: https://github.com/hashicorp/terraform-plugin-framework/issues/150
-			expectedDiags: diag.Diagnostics{
-				diag.NewAttributeErrorDiagnostic(
-					tftypes.NewAttributePath().WithAttributeName("test").WithElementKeyValue(tftypes.NewValue(tftypes.String, "value")),
-					"Configuration Read Error",
-					"An unexpected error was encountered trying to read an attribute from the configuration. This is always an error in the provider. Please report the following to the provider developer:\n\n"+
-						"ElementKeyValue(tftypes.String<\"value\">) still remains in the path: step cannot be applied to this value",
-				),
-			},
+			expected: types.String{Null: true},
 		},
 		"WithAttributeName-Set-WithElementKeyValue": {
 			config: Config{
@@ -793,22 +739,7 @@ func TestConfigGetAttribute(t *testing.T) {
 			}, map[string]tftypes.Value{
 				"sub_test": tftypes.NewValue(tftypes.String, "value"),
 			})).WithAttributeName("sub_test"),
-			expected: nil,
-			// TODO: https://github.com/hashicorp/terraform-plugin-framework/issues/150
-			expectedDiags: diag.Diagnostics{
-				diag.NewAttributeErrorDiagnostic(
-					tftypes.NewAttributePath().WithAttributeName("test").WithElementKeyValue(tftypes.NewValue(tftypes.Object{
-						AttributeTypes: map[string]tftypes.Type{
-							"sub_test": tftypes.String,
-						},
-					}, map[string]tftypes.Value{
-						"sub_test": tftypes.NewValue(tftypes.String, "value"),
-					})).WithAttributeName("sub_test"),
-					"Configuration Read Error",
-					"An unexpected error was encountered trying to read an attribute from the configuration. This is always an error in the provider. Please report the following to the provider developer:\n\n"+
-						"ElementKeyValue(tftypes.Object[\"sub_test\":tftypes.String]<\"sub_test\":tftypes.String<\"value\">>).AttributeName(\"sub_test\") still remains in the path: step cannot be applied to this value",
-				),
-			},
+			expected: types.String{Null: true},
 		},
 		"WithAttributeName-SetNestedAttributes-WithElementKeyValue-WithAttributeName": {
 			config: Config{
@@ -906,16 +837,7 @@ func TestConfigGetAttribute(t *testing.T) {
 				},
 			},
 			path:     tftypes.NewAttributePath().WithAttributeName("test").WithAttributeName("sub_test"),
-			expected: nil,
-			// TODO: https://github.com/hashicorp/terraform-plugin-framework/issues/150
-			expectedDiags: diag.Diagnostics{
-				diag.NewAttributeErrorDiagnostic(
-					tftypes.NewAttributePath().WithAttributeName("test").WithAttributeName("sub_test"),
-					"Configuration Read Error",
-					"An unexpected error was encountered trying to read an attribute from the configuration. This is always an error in the provider. Please report the following to the provider developer:\n\n"+
-						"AttributeName(\"sub_test\") still remains in the path: step cannot be applied to this value",
-				),
-			},
+			expected: types.String{Null: true},
 		},
 		"WithAttributeName-SingleNestedAttributes-WithAttributeName": {
 			config: Config{

--- a/tfsdk/plan.go
+++ b/tfsdk/plan.go
@@ -45,7 +45,9 @@ func (p Plan) GetAttribute(ctx context.Context, path *tftypes.AttributePath) (at
 	}
 
 	tfValue, err := p.terraformValueAtPath(path)
-	if err != nil {
+
+	// Ignoring ErrInvalidStep will allow this method to return a null value of the type.
+	if err != nil && !errors.Is(err, tftypes.ErrInvalidStep) {
 		diags.AddAttributeError(
 			path,
 			"Plan Read Error",
@@ -53,6 +55,10 @@ func (p Plan) GetAttribute(ctx context.Context, path *tftypes.AttributePath) (at
 		)
 		return nil, diags
 	}
+
+	// TODO: If ErrInvalidStep, check parent paths for unknown value.
+	//       If found, convert this value to an unknown value.
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/186
 
 	if attrTypeWithValidate, ok := attrType.(attr.TypeWithValidate); ok {
 		diags.Append(attrTypeWithValidate.Validate(ctx, tfValue, path)...)


### PR DESCRIPTION
Closes #150

Includes more exhaustive unit testing `Config`, `Plan`, and `State` `GetAttribute()` method, which is copied between all of them. Also left TODOs for #186 to follow this up with unknown parent checking.