### PR TITLE
Only set RequiresReplace if value has changed and config is non-null

### DIFF
--- a/tfsdk/attribute_plan_modification.go
+++ b/tfsdk/attribute_plan_modification.go
@@ -64,7 +64,9 @@ type RequiresReplaceModifier struct{}
 
 // Modify sets RequiresReplace on the response to true.
 func (r RequiresReplaceModifier) Modify(ctx context.Context, req ModifyAttributePlanRequest, resp *ModifyAttributePlanResponse) {
-	resp.RequiresReplace = true
+	if req.AttributePlan != req.AttributeState && req.AttributeConfig != nil {
+		resp.RequiresReplace = true
+	}
 }
 
 // Description returns a human-readable description of the plan modifier.
@@ -103,9 +105,11 @@ type RequiresReplaceIfModifier struct {
 // Modify sets RequiresReplace on the response to true if the conditional
 // RequiresReplaceIfFunc returns true.
 func (r RequiresReplaceIfModifier) Modify(ctx context.Context, req ModifyAttributePlanRequest, resp *ModifyAttributePlanResponse) {
-	res, diags := r.f(ctx, req.AttributeState, req.AttributeConfig, req.AttributePath)
-	resp.Diagnostics.Append(diags...)
-	resp.RequiresReplace = res
+	if req.AttributePlan != req.AttributeState && req.AttributeConfig != nil {
+		res, diags := r.f(ctx, req.AttributeState, req.AttributeConfig, req.AttributePath)
+		resp.Diagnostics.Append(diags...)
+		resp.RequiresReplace = res
+	}
 }
 
 // Description returns a human-readable description of the plan modifier.


### PR DESCRIPTION
The following conditions must now be met in order for the RequiresReplace helpers to set RequiresReplace on the attribute:

- The planned value must not be equal to the current state.
- The config value must not be null.

This more closely mirrors the ForceNew behaviour in SDKv2, and corrects unexpected behaviour in which Computed attributes with null config values would force resource recreation whenever updated by the provider.

Should fix https://github.com/hashicorp/terraform-plugin-framework/issues/187.

Needs careful testing.