### PR TITLE
Complicate our RequiresReplace(If) logic.

### DIFF
--- a/.changelog/213.txt
+++ b/.changelog/213.txt
@@ -1,0 +1,7 @@
+```release-note:breaking-change
+Fixed RequiresReplace and RequiresReplaceIf to be more judicious about when they require a resource to be destroyed and recreated. They will no longer require resources to be recreated when _any_ attribute changes, instead limiting it only to the attribute they're declared on. They will also not require resources to be recreated when they're being created or deleted. Finally, they won't require a resource to be recreated if the user has no value in the config for the attribute and the attribute is computed; this is to prevent the resource from being destroyed and recreated when the provider changes the value without any user prompting. Providers that wish to destroy and recreate the resource when an optional and computed attribute is removed from the user's config should do so in their own plan modifier.
+```
+
+```release-note:breaking-change
+RequiresReplaceIf no longer overrides previous plan modifiers' value for RequiresReplace if the function returns false.
+```

--- a/tfsdk/attribute_plan_modification.go
+++ b/tfsdk/attribute_plan_modification.go
@@ -199,9 +199,9 @@ func (r RequiresReplaceIfModifier) Modify(ctx context.Context, req ModifyAttribu
 	res, diags := r.f(ctx, req.AttributeState, req.AttributeConfig, req.AttributePath)
 	resp.Diagnostics.Append(diags...)
 
-	// if the function says to require replacing, we require replacing
-	// if the function says not to, we don't change the value that other
-	// plan modifiers may have set
+	// If the function says to require replacing, we require replacing.
+	// If the function says not to, we don't change the value that prior
+	// plan modifiers may have set.
 	if res {
 		resp.RequiresReplace = true
 	}

--- a/tfsdk/attribute_plan_modification.go
+++ b/tfsdk/attribute_plan_modification.go
@@ -204,6 +204,8 @@ func (r RequiresReplaceIfModifier) Modify(ctx context.Context, req ModifyAttribu
 	// plan modifiers may have set.
 	if res {
 		resp.RequiresReplace = true
+	} else if resp.RequiresReplace {
+		// TODO: log that we didn't override the result
 	}
 }
 

--- a/tfsdk/attribute_plan_modification.go
+++ b/tfsdk/attribute_plan_modification.go
@@ -54,7 +54,29 @@ type AttributePlanModifiers []AttributePlanModifier
 
 // RequiresReplace returns an AttributePlanModifier specifying the attribute as
 // requiring replacement. This behaviour is identical to the ForceNew behaviour
-// in terraform-plugin-sdk.
+// in terraform-plugin-sdk and will result in the resource being destroyed and
+// recreated when the following conditions are met:
+//
+// 1. The resource's state is not null; a null state indicates that we're
+// creating a resource, and we never need to destroy and recreate a resource
+// when we're creating it.
+//
+// 2. The resource's plan is not null; a null plan indicates that we're
+// deleting a resource, and we never need to destroy and recreate a resource
+// when we're deleting it.
+//
+// 3. The attribute's config is not null or the attribute is not computed; a
+// computed attribute with a null config almost always means that the provider
+// is changing the value, and practitioners are usually unpleasantly surprised
+// when a resource is destroyed and recreated when their configuration hasn't
+// changed. This has the unfortunate side effect that removing a computed field
+// from the config will not trigger a destroy and recreate cycle, even when
+// that is warranted. To get around this, provider developer can implement
+// their own AttributePlanModifier that handles that behavior in the way that
+// most makes sense for their use case.
+//
+// 4. The attribute's value in the plan does not match the attribute's value in
+// the state.
 func RequiresReplace() AttributePlanModifier {
 	return RequiresReplaceModifier{}
 }
@@ -63,7 +85,29 @@ func RequiresReplace() AttributePlanModifier {
 // on the attribute.
 type RequiresReplaceModifier struct{}
 
-// Modify sets RequiresReplace on the response to true.
+// Modify fills the AttributePlanModifier interface. It sets RequiresReplace on
+// the response to true if the following criteria are met:
+//
+// 1. The resource's state is not null; a null state indicates that we're
+// creating a resource, and we never need to destroy and recreate a resource
+// when we're creating it.
+//
+// 2. The resource's plan is not null; a null plan indicates that we're
+// deleting a resource, and we never need to destroy and recreate a resource
+// when we're deleting it.
+//
+// 3. The attribute's config is not null or the attribute is not computed; a
+// computed attribute with a null config almost always means that the provider
+// is changing the value, and practitioners are usually unpleasantly surprised
+// when a resource is destroyed and recreated when their configuration hasn't
+// changed. This has the unfortunate side effect that removing a computed field
+// from the config will not trigger a destroy and recreate cycle, even when
+// that is warranted. To get around this, provider developer can implement
+// their own AttributePlanModifier that handles that behavior in the way that
+// most makes sense for their use case.
+//
+// 4. The attribute's value in the plan does not match the attribute's value in
+// the state.
 func (r RequiresReplaceModifier) Modify(ctx context.Context, req ModifyAttributePlanRequest, resp *ModifyAttributePlanResponse) {
 	if req.AttributeConfig == nil || req.AttributePlan == nil || req.AttributeState == nil {
 		// shouldn't happen, but let's not panic if it does
@@ -124,9 +168,37 @@ func (r RequiresReplaceModifier) MarkdownDescription(ctx context.Context) string
 	return "If the value of this attribute changes, Terraform will destroy and recreate the resource."
 }
 
-// RequiresReplaceIf returns an AttributePlanModifier that runs the conditional
-// function f: if it returns true, it specifies the attribute as requiring
-// replacement.
+// RequiresReplaceIf returns an AttributePlanModifier that mimics
+// RequiresReplace, but only when the passed function `f` returns true. The
+// resource will be destroyed and recreated if `f` returns true and the
+// following conditions are met:
+//
+// 1. The resource's state is not null; a null state indicates that we're
+// creating a resource, and we never need to destroy and recreate a resource
+// when we're creating it.
+//
+// 2. The resource's plan is not null; a null plan indicates that we're
+// deleting a resource, and we never need to destroy and recreate a resource
+// when we're deleting it.
+//
+// 3. The attribute's config is not null or the attribute is not computed; a
+// computed attribute with a null config almost always means that the provider
+// is changing the value, and practitioners are usually unpleasantly surprised
+// when a resource is destroyed and recreated when their configuration hasn't
+// changed. This has the unfortunate side effect that removing a computed field
+// from the config will not trigger a destroy and recreate cycle, even when
+// that is warranted. To get around this, provider developer can implement
+// their own AttributePlanModifier that handles that behavior in the way that
+// most makes sense for their use case.
+//
+// 4. The attribute's value in the plan does not match the attribute's value in
+// the state.
+//
+// If `f` does not return true, RequiresReplaceIf will *not* override prior
+// AttributePlanModifiers' determination of whether the resource needs to be
+// recreated or not. This allows for multiple RequiresReplaceIf (or other
+// modifiers that sometimes set RequiresReplace) to be used on a single
+// attribute without the last one in the list always determining the outcome.
 func RequiresReplaceIf(f RequiresReplaceIfFunc, description, markdownDescription string) AttributePlanModifier {
 	return RequiresReplaceIfModifier{
 		f:                   f,
@@ -147,8 +219,32 @@ type RequiresReplaceIfModifier struct {
 	markdownDescription string
 }
 
-// Modify sets RequiresReplace on the response to true if the conditional
-// RequiresReplaceIfFunc returns true.
+// Modify fills the AttributePlanModifier interface. It sets RequiresReplace on
+// the response to true if the following criteria are met:
+//
+// 1. `f` returns true. If `f` returns false, the response will not be modified
+// at all.
+//
+// 2. The resource's state is not null; a null state indicates that we're
+// creating a resource, and we never need to destroy and recreate a resource
+// when we're creating it.
+//
+// 3. The resource's plan is not null; a null plan indicates that we're
+// deleting a resource, and we never need to destroy and recreate a resource
+// when we're deleting it.
+//
+// 4. The attribute's config is not null or the attribute is not computed; a
+// computed attribute with a null config almost always means that the provider
+// is changing the value, and practitioners are usually unpleasantly surprised
+// when a resource is destroyed and recreated when their configuration hasn't
+// changed. This has the unfortunate side effect that removing a computed field
+// from the config will not trigger a destroy and recreate cycle, even when
+// that is warranted. To get around this, provider developer can implement
+// their own AttributePlanModifier that handles that behavior in the way that
+// most makes sense for their use case.
+//
+// 5. The attribute's value in the plan does not match the attribute's value in
+// the state.
 func (r RequiresReplaceIfModifier) Modify(ctx context.Context, req ModifyAttributePlanRequest, resp *ModifyAttributePlanResponse) {
 	if req.AttributeConfig == nil || req.AttributePlan == nil || req.AttributeState == nil {
 		// shouldn't happen, but let's not panic if it does

--- a/tfsdk/attribute_plan_modification_test.go
+++ b/tfsdk/attribute_plan_modification_test.go
@@ -176,12 +176,12 @@ func TestRequiresReplaceModifier(t *testing.T) {
 
 	schema := Schema{
 		Attributes: map[string]Attribute{
-			"a": {
+			"optional-computed": {
 				Type:     types.StringType,
 				Optional: true,
 				Computed: true,
 			},
-			"b": {
+			"optional": {
 				Type:     types.StringType,
 				Optional: true,
 			},
@@ -199,18 +199,18 @@ func TestRequiresReplaceModifier(t *testing.T) {
 			plan: Plan{
 				Schema: schema,
 				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
-					"a": tftypes.NewValue(tftypes.String, "foo"),
-					"b": tftypes.NewValue(tftypes.String, "bar"),
+					"optional-computed": tftypes.NewValue(tftypes.String, "foo"),
+					"optional":          tftypes.NewValue(tftypes.String, "bar"),
 				}),
 			},
 			config: Config{
 				Schema: schema,
 				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
-					"a": tftypes.NewValue(tftypes.String, "foo"),
-					"b": tftypes.NewValue(tftypes.String, "bar"),
+					"optional-computed": tftypes.NewValue(tftypes.String, "foo"),
+					"optional":          tftypes.NewValue(tftypes.String, "bar"),
 				}),
 			},
-			path:         tftypes.NewAttributePath().WithAttributeName("a"),
+			path:         tftypes.NewAttributePath().WithAttributeName("optional-computed"),
 			expectedPlan: types.String{Value: "foo"},
 			expectedRR:   false,
 		},
@@ -228,15 +228,15 @@ func TestRequiresReplaceModifier(t *testing.T) {
 			state: State{
 				Schema: schema,
 				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
-					"a": tftypes.NewValue(tftypes.String, "foo"),
-					"b": tftypes.NewValue(tftypes.String, "bar"),
+					"optional-computed": tftypes.NewValue(tftypes.String, "foo"),
+					"optional":          tftypes.NewValue(tftypes.String, "bar"),
 				}),
 			},
 			config: Config{
 				Schema: schema,
 				Raw:    tftypes.NewValue(schema.TerraformType(context.Background()), nil),
 			},
-			path:         tftypes.NewAttributePath().WithAttributeName("a"),
+			path:         tftypes.NewAttributePath().WithAttributeName("optional-computed"),
 			expectedPlan: nil,
 			expectedRR:   false,
 		},
@@ -247,25 +247,25 @@ func TestRequiresReplaceModifier(t *testing.T) {
 			state: State{
 				Schema: schema,
 				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
-					"a": tftypes.NewValue(tftypes.String, "foo"),
-					"b": tftypes.NewValue(tftypes.String, nil),
+					"optional-computed": tftypes.NewValue(tftypes.String, "foo"),
+					"optional":          tftypes.NewValue(tftypes.String, nil),
 				}),
 			},
 			plan: Plan{
 				Schema: schema,
 				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
-					"a": tftypes.NewValue(tftypes.String, "foo"),
-					"b": tftypes.NewValue(tftypes.String, "bar"),
+					"optional-computed": tftypes.NewValue(tftypes.String, "foo"),
+					"optional":          tftypes.NewValue(tftypes.String, "bar"),
 				}),
 			},
 			config: Config{
 				Schema: schema,
 				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
-					"a": tftypes.NewValue(tftypes.String, "foo"),
-					"b": tftypes.NewValue(tftypes.String, "bar"),
+					"optional-computed": tftypes.NewValue(tftypes.String, "foo"),
+					"optional":          tftypes.NewValue(tftypes.String, "bar"),
 				}),
 			},
-			path:         tftypes.NewAttributePath().WithAttributeName("b"),
+			path:         tftypes.NewAttributePath().WithAttributeName("optional"),
 			expectedPlan: types.String{Value: "bar"},
 			expectedRR:   true,
 		},
@@ -276,25 +276,25 @@ func TestRequiresReplaceModifier(t *testing.T) {
 			state: State{
 				Schema: schema,
 				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
-					"a": tftypes.NewValue(tftypes.String, "foo"),
-					"b": tftypes.NewValue(tftypes.String, "bar"),
+					"optional-computed": tftypes.NewValue(tftypes.String, "foo"),
+					"optional":          tftypes.NewValue(tftypes.String, "bar"),
 				}),
 			},
 			plan: Plan{
 				Schema: schema,
 				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
-					"a": tftypes.NewValue(tftypes.String, "foo"),
-					"b": tftypes.NewValue(tftypes.String, nil),
+					"optional-computed": tftypes.NewValue(tftypes.String, "foo"),
+					"optional":          tftypes.NewValue(tftypes.String, nil),
 				}),
 			},
 			config: Config{
 				Schema: schema,
 				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
-					"a": tftypes.NewValue(tftypes.String, "foo"),
-					"b": tftypes.NewValue(tftypes.String, nil),
+					"optional-computed": tftypes.NewValue(tftypes.String, "foo"),
+					"optional":          tftypes.NewValue(tftypes.String, nil),
 				}),
 			},
-			path:         tftypes.NewAttributePath().WithAttributeName("b"),
+			path:         tftypes.NewAttributePath().WithAttributeName("optional"),
 			expectedPlan: types.String{Null: true},
 			expectedRR:   true,
 		},
@@ -304,25 +304,25 @@ func TestRequiresReplaceModifier(t *testing.T) {
 			state: State{
 				Schema: schema,
 				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
-					"a": tftypes.NewValue(tftypes.String, "foo"),
-					"b": tftypes.NewValue(tftypes.String, "bar"),
+					"optional-computed": tftypes.NewValue(tftypes.String, "foo"),
+					"optional":          tftypes.NewValue(tftypes.String, "bar"),
 				}),
 			},
 			plan: Plan{
 				Schema: schema,
 				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
-					"a": tftypes.NewValue(tftypes.String, "foo"),
-					"b": tftypes.NewValue(tftypes.String, "quux"),
+					"optional-computed": tftypes.NewValue(tftypes.String, "foo"),
+					"optional":          tftypes.NewValue(tftypes.String, "quux"),
 				}),
 			},
 			config: Config{
 				Schema: schema,
 				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
-					"a": tftypes.NewValue(tftypes.String, "foo"),
-					"b": tftypes.NewValue(tftypes.String, "quux"),
+					"optional-computed": tftypes.NewValue(tftypes.String, "foo"),
+					"optional":          tftypes.NewValue(tftypes.String, "quux"),
 				}),
 			},
-			path:         tftypes.NewAttributePath().WithAttributeName("b"),
+			path:         tftypes.NewAttributePath().WithAttributeName("optional"),
 			expectedPlan: types.String{Value: "quux"},
 			expectedRR:   true,
 		},
@@ -332,25 +332,25 @@ func TestRequiresReplaceModifier(t *testing.T) {
 			state: State{
 				Schema: schema,
 				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
-					"a": tftypes.NewValue(tftypes.String, "foo"),
-					"b": tftypes.NewValue(tftypes.String, "bar"),
+					"optional-computed": tftypes.NewValue(tftypes.String, "foo"),
+					"optional":          tftypes.NewValue(tftypes.String, "bar"),
 				}),
 			},
 			plan: Plan{
 				Schema: schema,
 				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
-					"a": tftypes.NewValue(tftypes.String, "foo"),
-					"b": tftypes.NewValue(tftypes.String, "quux"),
+					"optional-computed": tftypes.NewValue(tftypes.String, "foo"),
+					"optional":          tftypes.NewValue(tftypes.String, "quux"),
 				}),
 			},
 			config: Config{
 				Schema: schema,
 				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
-					"a": tftypes.NewValue(tftypes.String, "foo"),
-					"b": tftypes.NewValue(tftypes.String, "quux"),
+					"optional-computed": tftypes.NewValue(tftypes.String, "foo"),
+					"optional":          tftypes.NewValue(tftypes.String, "quux"),
 				}),
 			},
-			path:         tftypes.NewAttributePath().WithAttributeName("a"),
+			path:         tftypes.NewAttributePath().WithAttributeName("optional-computed"),
 			expectedPlan: types.String{Value: "foo"},
 			expectedRR:   false,
 		},
@@ -367,25 +367,25 @@ func TestRequiresReplaceModifier(t *testing.T) {
 			state: State{
 				Schema: schema,
 				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
-					"a": tftypes.NewValue(tftypes.String, "foo"),
-					"b": tftypes.NewValue(tftypes.String, "bar"),
+					"optional-computed": tftypes.NewValue(tftypes.String, "foo"),
+					"optional":          tftypes.NewValue(tftypes.String, "bar"),
 				}),
 			},
 			plan: Plan{
 				Schema: schema,
 				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
-					"a": tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
-					"b": tftypes.NewValue(tftypes.String, "bar"),
+					"optional-computed": tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+					"optional":          tftypes.NewValue(tftypes.String, "bar"),
 				}),
 			},
 			config: Config{
 				Schema: schema,
 				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
-					"a": tftypes.NewValue(tftypes.String, nil),
-					"b": tftypes.NewValue(tftypes.String, "quux"),
+					"optional-computed": tftypes.NewValue(tftypes.String, nil),
+					"optional":          tftypes.NewValue(tftypes.String, "quux"),
 				}),
 			},
-			path:         tftypes.NewAttributePath().WithAttributeName("a"),
+			path:         tftypes.NewAttributePath().WithAttributeName("optional-computed"),
 			expectedPlan: types.String{Unknown: true},
 			expectedRR:   false,
 		},
@@ -403,25 +403,25 @@ func TestRequiresReplaceModifier(t *testing.T) {
 			state: State{
 				Schema: schema,
 				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
-					"a": tftypes.NewValue(tftypes.String, "foo"),
-					"b": tftypes.NewValue(tftypes.String, "bar"),
+					"optional-computed": tftypes.NewValue(tftypes.String, "foo"),
+					"optional":          tftypes.NewValue(tftypes.String, "bar"),
 				}),
 			},
 			plan: Plan{
 				Schema: schema,
 				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
-					"a": tftypes.NewValue(tftypes.String, "foo"),
-					"b": tftypes.NewValue(tftypes.String, nil),
+					"optional-computed": tftypes.NewValue(tftypes.String, "foo"),
+					"optional":          tftypes.NewValue(tftypes.String, nil),
 				}),
 			},
 			config: Config{
 				Schema: schema,
 				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
-					"a": tftypes.NewValue(tftypes.String, "foo"),
-					"b": tftypes.NewValue(tftypes.String, nil),
+					"optional-computed": tftypes.NewValue(tftypes.String, "foo"),
+					"optional":          tftypes.NewValue(tftypes.String, nil),
 				}),
 			},
-			path:         tftypes.NewAttributePath().WithAttributeName("b"),
+			path:         tftypes.NewAttributePath().WithAttributeName("optional"),
 			expectedPlan: types.String{Null: true},
 			expectedRR:   true,
 		},
@@ -491,12 +491,12 @@ func TestRequiresReplaceIfModifier(t *testing.T) {
 
 	schema := Schema{
 		Attributes: map[string]Attribute{
-			"a": {
+			"optional-computed": {
 				Type:     types.StringType,
 				Optional: true,
 				Computed: true,
 			},
-			"b": {
+			"optional": {
 				Type:     types.StringType,
 				Optional: true,
 			},
@@ -514,18 +514,18 @@ func TestRequiresReplaceIfModifier(t *testing.T) {
 			plan: Plan{
 				Schema: schema,
 				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
-					"a": tftypes.NewValue(tftypes.String, "foo"),
-					"b": tftypes.NewValue(tftypes.String, "bar"),
+					"optional-computed": tftypes.NewValue(tftypes.String, "foo"),
+					"optional":          tftypes.NewValue(tftypes.String, "bar"),
 				}),
 			},
 			config: Config{
 				Schema: schema,
 				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
-					"a": tftypes.NewValue(tftypes.String, "foo"),
-					"b": tftypes.NewValue(tftypes.String, "bar"),
+					"optional-computed": tftypes.NewValue(tftypes.String, "foo"),
+					"optional":          tftypes.NewValue(tftypes.String, "bar"),
 				}),
 			},
-			path:         tftypes.NewAttributePath().WithAttributeName("a"),
+			path:         tftypes.NewAttributePath().WithAttributeName("optional-computed"),
 			ifReturn:     true,
 			expectedPlan: types.String{Value: "foo"},
 			expectedRR:   false,
@@ -544,15 +544,15 @@ func TestRequiresReplaceIfModifier(t *testing.T) {
 			state: State{
 				Schema: schema,
 				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
-					"a": tftypes.NewValue(tftypes.String, "foo"),
-					"b": tftypes.NewValue(tftypes.String, "bar"),
+					"optional-computed": tftypes.NewValue(tftypes.String, "foo"),
+					"optional":          tftypes.NewValue(tftypes.String, "bar"),
 				}),
 			},
 			config: Config{
 				Schema: schema,
 				Raw:    tftypes.NewValue(schema.TerraformType(context.Background()), nil),
 			},
-			path:         tftypes.NewAttributePath().WithAttributeName("a"),
+			path:         tftypes.NewAttributePath().WithAttributeName("optional-computed"),
 			ifReturn:     true,
 			expectedPlan: nil,
 			expectedRR:   false,
@@ -564,25 +564,25 @@ func TestRequiresReplaceIfModifier(t *testing.T) {
 			state: State{
 				Schema: schema,
 				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
-					"a": tftypes.NewValue(tftypes.String, "foo"),
-					"b": tftypes.NewValue(tftypes.String, nil),
+					"optional-computed": tftypes.NewValue(tftypes.String, "foo"),
+					"optional":          tftypes.NewValue(tftypes.String, nil),
 				}),
 			},
 			plan: Plan{
 				Schema: schema,
 				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
-					"a": tftypes.NewValue(tftypes.String, "foo"),
-					"b": tftypes.NewValue(tftypes.String, "bar"),
+					"optional-computed": tftypes.NewValue(tftypes.String, "foo"),
+					"optional":          tftypes.NewValue(tftypes.String, "bar"),
 				}),
 			},
 			config: Config{
 				Schema: schema,
 				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
-					"a": tftypes.NewValue(tftypes.String, "foo"),
-					"b": tftypes.NewValue(tftypes.String, "bar"),
+					"optional-computed": tftypes.NewValue(tftypes.String, "foo"),
+					"optional":          tftypes.NewValue(tftypes.String, "bar"),
 				}),
 			},
-			path:         tftypes.NewAttributePath().WithAttributeName("b"),
+			path:         tftypes.NewAttributePath().WithAttributeName("optional"),
 			ifReturn:     true,
 			expectedPlan: types.String{Value: "bar"},
 			expectedRR:   true,
@@ -594,26 +594,26 @@ func TestRequiresReplaceIfModifier(t *testing.T) {
 			state: State{
 				Schema: schema,
 				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
-					"a": tftypes.NewValue(tftypes.String, "foo"),
-					"b": tftypes.NewValue(tftypes.String, "bar"),
+					"optional-computed": tftypes.NewValue(tftypes.String, "foo"),
+					"optional":          tftypes.NewValue(tftypes.String, "bar"),
 				}),
 			},
 			plan: Plan{
 				Schema: schema,
 				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
-					"a": tftypes.NewValue(tftypes.String, "foo"),
-					"b": tftypes.NewValue(tftypes.String, nil),
+					"optional-computed": tftypes.NewValue(tftypes.String, "foo"),
+					"optional":          tftypes.NewValue(tftypes.String, nil),
 				}),
 			},
 			config: Config{
 				Schema: schema,
 				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
-					"a": tftypes.NewValue(tftypes.String, "foo"),
-					"b": tftypes.NewValue(tftypes.String, nil),
+					"optional-computed": tftypes.NewValue(tftypes.String, "foo"),
+					"optional":          tftypes.NewValue(tftypes.String, nil),
 				}),
 			},
 			ifReturn:     true,
-			path:         tftypes.NewAttributePath().WithAttributeName("b"),
+			path:         tftypes.NewAttributePath().WithAttributeName("optional"),
 			expectedPlan: types.String{Null: true},
 			expectedRR:   true,
 		},
@@ -624,25 +624,25 @@ func TestRequiresReplaceIfModifier(t *testing.T) {
 			state: State{
 				Schema: schema,
 				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
-					"a": tftypes.NewValue(tftypes.String, "foo"),
-					"b": tftypes.NewValue(tftypes.String, "bar"),
+					"optional-computed": tftypes.NewValue(tftypes.String, "foo"),
+					"optional":          tftypes.NewValue(tftypes.String, "bar"),
 				}),
 			},
 			plan: Plan{
 				Schema: schema,
 				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
-					"a": tftypes.NewValue(tftypes.String, "foo"),
-					"b": tftypes.NewValue(tftypes.String, "quux"),
+					"optional-computed": tftypes.NewValue(tftypes.String, "foo"),
+					"optional":          tftypes.NewValue(tftypes.String, "quux"),
 				}),
 			},
 			config: Config{
 				Schema: schema,
 				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
-					"a": tftypes.NewValue(tftypes.String, "foo"),
-					"b": tftypes.NewValue(tftypes.String, "quux"),
+					"optional-computed": tftypes.NewValue(tftypes.String, "foo"),
+					"optional":          tftypes.NewValue(tftypes.String, "quux"),
 				}),
 			},
-			path:         tftypes.NewAttributePath().WithAttributeName("b"),
+			path:         tftypes.NewAttributePath().WithAttributeName("optional"),
 			ifReturn:     true,
 			expectedPlan: types.String{Value: "quux"},
 			expectedRR:   true,
@@ -654,25 +654,25 @@ func TestRequiresReplaceIfModifier(t *testing.T) {
 			state: State{
 				Schema: schema,
 				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
-					"a": tftypes.NewValue(tftypes.String, "foo"),
-					"b": tftypes.NewValue(tftypes.String, "bar"),
+					"optional-computed": tftypes.NewValue(tftypes.String, "foo"),
+					"optional":          tftypes.NewValue(tftypes.String, "bar"),
 				}),
 			},
 			plan: Plan{
 				Schema: schema,
 				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
-					"a": tftypes.NewValue(tftypes.String, "foo"),
-					"b": tftypes.NewValue(tftypes.String, "quux"),
+					"optional-computed": tftypes.NewValue(tftypes.String, "foo"),
+					"optional":          tftypes.NewValue(tftypes.String, "quux"),
 				}),
 			},
 			config: Config{
 				Schema: schema,
 				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
-					"a": tftypes.NewValue(tftypes.String, "foo"),
-					"b": tftypes.NewValue(tftypes.String, "quux"),
+					"optional-computed": tftypes.NewValue(tftypes.String, "foo"),
+					"optional":          tftypes.NewValue(tftypes.String, "quux"),
 				}),
 			},
-			path:         tftypes.NewAttributePath().WithAttributeName("b"),
+			path:         tftypes.NewAttributePath().WithAttributeName("optional"),
 			ifReturn:     false,
 			expectedPlan: types.String{Value: "quux"},
 			expectedRR:   false,
@@ -683,25 +683,25 @@ func TestRequiresReplaceIfModifier(t *testing.T) {
 			state: State{
 				Schema: schema,
 				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
-					"a": tftypes.NewValue(tftypes.String, "foo"),
-					"b": tftypes.NewValue(tftypes.String, "bar"),
+					"optional-computed": tftypes.NewValue(tftypes.String, "foo"),
+					"optional":          tftypes.NewValue(tftypes.String, "bar"),
 				}),
 			},
 			plan: Plan{
 				Schema: schema,
 				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
-					"a": tftypes.NewValue(tftypes.String, "foo"),
-					"b": tftypes.NewValue(tftypes.String, "quux"),
+					"optional-computed": tftypes.NewValue(tftypes.String, "foo"),
+					"optional":          tftypes.NewValue(tftypes.String, "quux"),
 				}),
 			},
 			config: Config{
 				Schema: schema,
 				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
-					"a": tftypes.NewValue(tftypes.String, "foo"),
-					"b": tftypes.NewValue(tftypes.String, "quux"),
+					"optional-computed": tftypes.NewValue(tftypes.String, "foo"),
+					"optional":          tftypes.NewValue(tftypes.String, "quux"),
 				}),
 			},
-			path:         tftypes.NewAttributePath().WithAttributeName("a"),
+			path:         tftypes.NewAttributePath().WithAttributeName("optional-computed"),
 			ifReturn:     true,
 			expectedPlan: types.String{Value: "foo"},
 			expectedRR:   false,
@@ -719,25 +719,25 @@ func TestRequiresReplaceIfModifier(t *testing.T) {
 			state: State{
 				Schema: schema,
 				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
-					"a": tftypes.NewValue(tftypes.String, "foo"),
-					"b": tftypes.NewValue(tftypes.String, "bar"),
+					"optional-computed": tftypes.NewValue(tftypes.String, "foo"),
+					"optional":          tftypes.NewValue(tftypes.String, "bar"),
 				}),
 			},
 			plan: Plan{
 				Schema: schema,
 				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
-					"a": tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
-					"b": tftypes.NewValue(tftypes.String, "bar"),
+					"optional-computed": tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+					"optional":          tftypes.NewValue(tftypes.String, "bar"),
 				}),
 			},
 			config: Config{
 				Schema: schema,
 				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
-					"a": tftypes.NewValue(tftypes.String, nil),
-					"b": tftypes.NewValue(tftypes.String, "quux"),
+					"optional-computed": tftypes.NewValue(tftypes.String, nil),
+					"optional":          tftypes.NewValue(tftypes.String, "quux"),
 				}),
 			},
-			path:         tftypes.NewAttributePath().WithAttributeName("a"),
+			path:         tftypes.NewAttributePath().WithAttributeName("optional-computed"),
 			ifReturn:     true,
 			expectedPlan: types.String{Unknown: true},
 			expectedRR:   false,
@@ -756,25 +756,25 @@ func TestRequiresReplaceIfModifier(t *testing.T) {
 			state: State{
 				Schema: schema,
 				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
-					"a": tftypes.NewValue(tftypes.String, "foo"),
-					"b": tftypes.NewValue(tftypes.String, "bar"),
+					"optional-computed": tftypes.NewValue(tftypes.String, "foo"),
+					"optional":          tftypes.NewValue(tftypes.String, "bar"),
 				}),
 			},
 			plan: Plan{
 				Schema: schema,
 				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
-					"a": tftypes.NewValue(tftypes.String, "foo"),
-					"b": tftypes.NewValue(tftypes.String, nil),
+					"optional-computed": tftypes.NewValue(tftypes.String, "foo"),
+					"optional":          tftypes.NewValue(tftypes.String, nil),
 				}),
 			},
 			config: Config{
 				Schema: schema,
 				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
-					"a": tftypes.NewValue(tftypes.String, "foo"),
-					"b": tftypes.NewValue(tftypes.String, nil),
+					"optional-computed": tftypes.NewValue(tftypes.String, "foo"),
+					"optional":          tftypes.NewValue(tftypes.String, nil),
 				}),
 			},
-			path:         tftypes.NewAttributePath().WithAttributeName("b"),
+			path:         tftypes.NewAttributePath().WithAttributeName("optional"),
 			ifReturn:     true,
 			expectedPlan: types.String{Null: true},
 			expectedRR:   true,

--- a/tfsdk/attribute_plan_modification_test.go
+++ b/tfsdk/attribute_plan_modification_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
@@ -156,6 +157,676 @@ func TestUseStateForUnknownModifier(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.expected, resp.AttributePlan); diff != "" {
 				t.Errorf("Unexpected diff (-wanted, +got): %s", diff)
+			}
+		})
+	}
+}
+
+func TestRequiresReplaceModifier(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		state        State
+		plan         Plan
+		config       Config
+		path         *tftypes.AttributePath
+		expectedPlan attr.Value
+		expectedRR   bool
+	}
+
+	schema := Schema{
+		Attributes: map[string]Attribute{
+			"a": {
+				Type:     types.StringType,
+				Optional: true,
+				Computed: true,
+			},
+			"b": {
+				Type:     types.StringType,
+				Optional: true,
+			},
+		},
+	}
+
+	tests := map[string]testCase{
+		"null-state": {
+			// when we first create the resource, it shouldn't
+			// require replacing immediately
+			state: State{
+				Schema: schema,
+				Raw:    tftypes.NewValue(schema.TerraformType(context.Background()), nil),
+			},
+			plan: Plan{
+				Schema: schema,
+				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"a": tftypes.NewValue(tftypes.String, "foo"),
+					"b": tftypes.NewValue(tftypes.String, "bar"),
+				}),
+			},
+			config: Config{
+				Schema: schema,
+				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"a": tftypes.NewValue(tftypes.String, "foo"),
+					"b": tftypes.NewValue(tftypes.String, "bar"),
+				}),
+			},
+			path:         tftypes.NewAttributePath().WithAttributeName("a"),
+			expectedPlan: types.String{Value: "foo"},
+			expectedRR:   false,
+		},
+		"null-plan": {
+			// when we destroy the resource, it shouldn't require
+			// replacing
+			//
+			// Terraform doesn't usually ask for provider input on
+			// the plan when destroying resources, but in case it
+			// does, let's make sure we handle it right
+			plan: Plan{
+				Schema: schema,
+				Raw:    tftypes.NewValue(schema.TerraformType(context.Background()), nil),
+			},
+			state: State{
+				Schema: schema,
+				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"a": tftypes.NewValue(tftypes.String, "foo"),
+					"b": tftypes.NewValue(tftypes.String, "bar"),
+				}),
+			},
+			config: Config{
+				Schema: schema,
+				Raw:    tftypes.NewValue(schema.TerraformType(context.Background()), nil),
+			},
+			path:         tftypes.NewAttributePath().WithAttributeName("a"),
+			expectedPlan: nil,
+			expectedRR:   false,
+		},
+		"null-attribute-state": {
+			// make sure we're not confusing an attribute going
+			// from null to a value with the resource getting
+			// created
+			state: State{
+				Schema: schema,
+				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"a": tftypes.NewValue(tftypes.String, "foo"),
+					"b": tftypes.NewValue(tftypes.String, nil),
+				}),
+			},
+			plan: Plan{
+				Schema: schema,
+				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"a": tftypes.NewValue(tftypes.String, "foo"),
+					"b": tftypes.NewValue(tftypes.String, "bar"),
+				}),
+			},
+			config: Config{
+				Schema: schema,
+				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"a": tftypes.NewValue(tftypes.String, "foo"),
+					"b": tftypes.NewValue(tftypes.String, "bar"),
+				}),
+			},
+			path:         tftypes.NewAttributePath().WithAttributeName("b"),
+			expectedPlan: types.String{Value: "bar"},
+			expectedRR:   true,
+		},
+		"null-attribute-plan": {
+			// make sure we're not confusing an attribute going
+			// from a value to null with the resource getting
+			// destroyed
+			state: State{
+				Schema: schema,
+				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"a": tftypes.NewValue(tftypes.String, "foo"),
+					"b": tftypes.NewValue(tftypes.String, "bar"),
+				}),
+			},
+			plan: Plan{
+				Schema: schema,
+				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"a": tftypes.NewValue(tftypes.String, "foo"),
+					"b": tftypes.NewValue(tftypes.String, nil),
+				}),
+			},
+			config: Config{
+				Schema: schema,
+				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"a": tftypes.NewValue(tftypes.String, "foo"),
+					"b": tftypes.NewValue(tftypes.String, nil),
+				}),
+			},
+			path:         tftypes.NewAttributePath().WithAttributeName("b"),
+			expectedPlan: types.String{Null: true},
+			expectedRR:   true,
+		},
+		"known-state-change": {
+			// when updating the attribute, if it has changed, it
+			// should require replacing
+			state: State{
+				Schema: schema,
+				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"a": tftypes.NewValue(tftypes.String, "foo"),
+					"b": tftypes.NewValue(tftypes.String, "bar"),
+				}),
+			},
+			plan: Plan{
+				Schema: schema,
+				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"a": tftypes.NewValue(tftypes.String, "foo"),
+					"b": tftypes.NewValue(tftypes.String, "quux"),
+				}),
+			},
+			config: Config{
+				Schema: schema,
+				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"a": tftypes.NewValue(tftypes.String, "foo"),
+					"b": tftypes.NewValue(tftypes.String, "quux"),
+				}),
+			},
+			path:         tftypes.NewAttributePath().WithAttributeName("b"),
+			expectedPlan: types.String{Value: "quux"},
+			expectedRR:   true,
+		},
+		"known-state-no-change": {
+			// when the attribute hasn't changed, it shouldn't
+			// require replacing
+			state: State{
+				Schema: schema,
+				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"a": tftypes.NewValue(tftypes.String, "foo"),
+					"b": tftypes.NewValue(tftypes.String, "bar"),
+				}),
+			},
+			plan: Plan{
+				Schema: schema,
+				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"a": tftypes.NewValue(tftypes.String, "foo"),
+					"b": tftypes.NewValue(tftypes.String, "quux"),
+				}),
+			},
+			config: Config{
+				Schema: schema,
+				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"a": tftypes.NewValue(tftypes.String, "foo"),
+					"b": tftypes.NewValue(tftypes.String, "quux"),
+				}),
+			},
+			path:         tftypes.NewAttributePath().WithAttributeName("a"),
+			expectedPlan: types.String{Value: "foo"},
+			expectedRR:   false,
+		},
+		"null-config-computed": {
+			// if the config is null for a computed attribute, we
+			// shouldn't require replacing, even if it's a change.
+			//
+			// this is sometimes unintuitive, if the practitioner
+			// is changing it on purpose. However, it's
+			// indistinguishable from the provider changing it, and
+			// practitioners pretty much never expect the resource
+			// to be recreated if the provider is the one changing
+			// the value.
+			state: State{
+				Schema: schema,
+				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"a": tftypes.NewValue(tftypes.String, "foo"),
+					"b": tftypes.NewValue(tftypes.String, "bar"),
+				}),
+			},
+			plan: Plan{
+				Schema: schema,
+				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"a": tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+					"b": tftypes.NewValue(tftypes.String, "bar"),
+				}),
+			},
+			config: Config{
+				Schema: schema,
+				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"a": tftypes.NewValue(tftypes.String, nil),
+					"b": tftypes.NewValue(tftypes.String, "quux"),
+				}),
+			},
+			path:         tftypes.NewAttributePath().WithAttributeName("a"),
+			expectedPlan: types.String{Unknown: true},
+			expectedRR:   false,
+		},
+		"null-config-not-computed": {
+			// if the config is null for a non-computed attribute,
+			// we should require replacing if it's a change.
+			//
+			// unlike computed attributes, this is always a
+			// practitioner making a change, and therefore the
+			// destroy/recreate cycle is likely expected.
+			//
+			// this test is technically covered by
+			// null-attribute-plan, but let's duplicate it just to
+			// be explicit about what each case is actually testing
+			state: State{
+				Schema: schema,
+				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"a": tftypes.NewValue(tftypes.String, "foo"),
+					"b": tftypes.NewValue(tftypes.String, "bar"),
+				}),
+			},
+			plan: Plan{
+				Schema: schema,
+				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"a": tftypes.NewValue(tftypes.String, "foo"),
+					"b": tftypes.NewValue(tftypes.String, nil),
+				}),
+			},
+			config: Config{
+				Schema: schema,
+				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"a": tftypes.NewValue(tftypes.String, "foo"),
+					"b": tftypes.NewValue(tftypes.String, nil),
+				}),
+			},
+			path:         tftypes.NewAttributePath().WithAttributeName("b"),
+			expectedPlan: types.String{Null: true},
+			expectedRR:   true,
+		},
+	}
+
+	for name, tc := range tests {
+		name, tc := name, tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			attrConfig, diags := tc.config.GetAttribute(context.Background(), tc.path)
+			if diags.HasError() {
+				t.Fatalf("Got unexpected diagnostics: %s", diags)
+			}
+
+			attrState, diags := tc.state.GetAttribute(context.Background(), tc.path)
+			if diags.HasError() {
+				t.Fatalf("Got unexpected diagnostics: %s", diags)
+			}
+
+			attrPlan, diags := tc.plan.GetAttribute(context.Background(), tc.path)
+			if diags.HasError() {
+				t.Fatalf("Got unexpected diagnostics: %s", diags)
+			}
+
+			req := ModifyAttributePlanRequest{
+				AttributePath:   tc.path,
+				Config:          tc.config,
+				State:           tc.state,
+				Plan:            tc.plan,
+				AttributeConfig: attrConfig,
+				AttributeState:  attrState,
+				AttributePlan:   attrPlan,
+				ProviderMeta:    Config{},
+			}
+			resp := &ModifyAttributePlanResponse{
+				AttributePlan: req.AttributePlan,
+			}
+			modifier := RequiresReplace()
+
+			modifier.Modify(context.Background(), req, resp)
+			if resp.Diagnostics.HasError() {
+				t.Fatalf("Unexpected diagnostics: %s", resp.Diagnostics)
+			}
+			if diff := cmp.Diff(tc.expectedPlan, resp.AttributePlan); diff != "" {
+				t.Fatalf("Unexpected diff in plan (-wanted, +got): %s", diff)
+			}
+			if diff := cmp.Diff(tc.expectedRR, resp.RequiresReplace); diff != "" {
+				t.Fatalf("Unexpected diff in RequiresReplace (-wanted, +got): %s", diff)
+			}
+		})
+	}
+}
+
+func TestRequiresReplaceIfModifier(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		state        State
+		plan         Plan
+		config       Config
+		path         *tftypes.AttributePath
+		ifReturn     bool
+		expectedPlan attr.Value
+		expectedRR   bool
+	}
+
+	schema := Schema{
+		Attributes: map[string]Attribute{
+			"a": {
+				Type:     types.StringType,
+				Optional: true,
+				Computed: true,
+			},
+			"b": {
+				Type:     types.StringType,
+				Optional: true,
+			},
+		},
+	}
+
+	tests := map[string]testCase{
+		"null-state": {
+			// when we first create the resource, it shouldn't
+			// require replacing immediately
+			state: State{
+				Schema: schema,
+				Raw:    tftypes.NewValue(schema.TerraformType(context.Background()), nil),
+			},
+			plan: Plan{
+				Schema: schema,
+				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"a": tftypes.NewValue(tftypes.String, "foo"),
+					"b": tftypes.NewValue(tftypes.String, "bar"),
+				}),
+			},
+			config: Config{
+				Schema: schema,
+				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"a": tftypes.NewValue(tftypes.String, "foo"),
+					"b": tftypes.NewValue(tftypes.String, "bar"),
+				}),
+			},
+			path:         tftypes.NewAttributePath().WithAttributeName("a"),
+			ifReturn:     true,
+			expectedPlan: types.String{Value: "foo"},
+			expectedRR:   false,
+		},
+		"null-plan": {
+			// when we destroy the resource, it shouldn't require
+			// replacing
+			//
+			// Terraform doesn't usually ask for provider input on
+			// the plan when destroying resources, but in case it
+			// does, let's make sure we handle it right
+			plan: Plan{
+				Schema: schema,
+				Raw:    tftypes.NewValue(schema.TerraformType(context.Background()), nil),
+			},
+			state: State{
+				Schema: schema,
+				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"a": tftypes.NewValue(tftypes.String, "foo"),
+					"b": tftypes.NewValue(tftypes.String, "bar"),
+				}),
+			},
+			config: Config{
+				Schema: schema,
+				Raw:    tftypes.NewValue(schema.TerraformType(context.Background()), nil),
+			},
+			path:         tftypes.NewAttributePath().WithAttributeName("a"),
+			ifReturn:     true,
+			expectedPlan: nil,
+			expectedRR:   false,
+		},
+		"null-attribute-state": {
+			// make sure we're not confusing an attribute going
+			// from null to a value with the resource getting
+			// created
+			state: State{
+				Schema: schema,
+				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"a": tftypes.NewValue(tftypes.String, "foo"),
+					"b": tftypes.NewValue(tftypes.String, nil),
+				}),
+			},
+			plan: Plan{
+				Schema: schema,
+				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"a": tftypes.NewValue(tftypes.String, "foo"),
+					"b": tftypes.NewValue(tftypes.String, "bar"),
+				}),
+			},
+			config: Config{
+				Schema: schema,
+				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"a": tftypes.NewValue(tftypes.String, "foo"),
+					"b": tftypes.NewValue(tftypes.String, "bar"),
+				}),
+			},
+			path:         tftypes.NewAttributePath().WithAttributeName("b"),
+			ifReturn:     true,
+			expectedPlan: types.String{Value: "bar"},
+			expectedRR:   true,
+		},
+		"null-attribute-plan": {
+			// make sure we're not confusing an attribute going
+			// from a value to null with the resource getting
+			// destroyed
+			state: State{
+				Schema: schema,
+				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"a": tftypes.NewValue(tftypes.String, "foo"),
+					"b": tftypes.NewValue(tftypes.String, "bar"),
+				}),
+			},
+			plan: Plan{
+				Schema: schema,
+				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"a": tftypes.NewValue(tftypes.String, "foo"),
+					"b": tftypes.NewValue(tftypes.String, nil),
+				}),
+			},
+			config: Config{
+				Schema: schema,
+				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"a": tftypes.NewValue(tftypes.String, "foo"),
+					"b": tftypes.NewValue(tftypes.String, nil),
+				}),
+			},
+			ifReturn:     true,
+			path:         tftypes.NewAttributePath().WithAttributeName("b"),
+			expectedPlan: types.String{Null: true},
+			expectedRR:   true,
+		},
+		"known-state-change-true": {
+			// when updating the attribute, if it has changed and
+			// the function returns true, it should require
+			// replacing
+			state: State{
+				Schema: schema,
+				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"a": tftypes.NewValue(tftypes.String, "foo"),
+					"b": tftypes.NewValue(tftypes.String, "bar"),
+				}),
+			},
+			plan: Plan{
+				Schema: schema,
+				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"a": tftypes.NewValue(tftypes.String, "foo"),
+					"b": tftypes.NewValue(tftypes.String, "quux"),
+				}),
+			},
+			config: Config{
+				Schema: schema,
+				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"a": tftypes.NewValue(tftypes.String, "foo"),
+					"b": tftypes.NewValue(tftypes.String, "quux"),
+				}),
+			},
+			path:         tftypes.NewAttributePath().WithAttributeName("b"),
+			ifReturn:     true,
+			expectedPlan: types.String{Value: "quux"},
+			expectedRR:   true,
+		},
+		"known-state-change-false": {
+			// when updating the attribute, if it has changed and
+			// the function returns false, it should not require
+			// replacing
+			state: State{
+				Schema: schema,
+				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"a": tftypes.NewValue(tftypes.String, "foo"),
+					"b": tftypes.NewValue(tftypes.String, "bar"),
+				}),
+			},
+			plan: Plan{
+				Schema: schema,
+				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"a": tftypes.NewValue(tftypes.String, "foo"),
+					"b": tftypes.NewValue(tftypes.String, "quux"),
+				}),
+			},
+			config: Config{
+				Schema: schema,
+				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"a": tftypes.NewValue(tftypes.String, "foo"),
+					"b": tftypes.NewValue(tftypes.String, "quux"),
+				}),
+			},
+			path:         tftypes.NewAttributePath().WithAttributeName("b"),
+			ifReturn:     false,
+			expectedPlan: types.String{Value: "quux"},
+			expectedRR:   false,
+		},
+		"known-state-no-change": {
+			// when the attribute hasn't changed, it shouldn't
+			// require replacing
+			state: State{
+				Schema: schema,
+				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"a": tftypes.NewValue(tftypes.String, "foo"),
+					"b": tftypes.NewValue(tftypes.String, "bar"),
+				}),
+			},
+			plan: Plan{
+				Schema: schema,
+				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"a": tftypes.NewValue(tftypes.String, "foo"),
+					"b": tftypes.NewValue(tftypes.String, "quux"),
+				}),
+			},
+			config: Config{
+				Schema: schema,
+				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"a": tftypes.NewValue(tftypes.String, "foo"),
+					"b": tftypes.NewValue(tftypes.String, "quux"),
+				}),
+			},
+			path:         tftypes.NewAttributePath().WithAttributeName("a"),
+			ifReturn:     true,
+			expectedPlan: types.String{Value: "foo"},
+			expectedRR:   false,
+		},
+		"null-config-computed": {
+			// if the config is null for a computed attribute, we
+			// shouldn't require replacing, even if it's a change.
+			//
+			// this is sometimes unintuitive, if the practitioner
+			// is changing it on purpose. However, it's
+			// indistinguishable from the provider changing it, and
+			// practitioners pretty much never expect the resource
+			// to be recreated if the provider is the one changing
+			// the value.
+			state: State{
+				Schema: schema,
+				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"a": tftypes.NewValue(tftypes.String, "foo"),
+					"b": tftypes.NewValue(tftypes.String, "bar"),
+				}),
+			},
+			plan: Plan{
+				Schema: schema,
+				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"a": tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+					"b": tftypes.NewValue(tftypes.String, "bar"),
+				}),
+			},
+			config: Config{
+				Schema: schema,
+				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"a": tftypes.NewValue(tftypes.String, nil),
+					"b": tftypes.NewValue(tftypes.String, "quux"),
+				}),
+			},
+			path:         tftypes.NewAttributePath().WithAttributeName("a"),
+			ifReturn:     true,
+			expectedPlan: types.String{Unknown: true},
+			expectedRR:   false,
+		},
+		"null-config-not-computed": {
+			// if the config is null for a non-computed attribute,
+			// we should require replacing if it's a change.
+			//
+			// unlike computed attributes, this is always a
+			// practitioner making a change, and therefore the
+			// destroy/recreate cycle is likely expected.
+			//
+			// this test is technically covered by
+			// null-attribute-plan, but let's duplicate it just to
+			// be explicit about what each case is actually testing
+			state: State{
+				Schema: schema,
+				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"a": tftypes.NewValue(tftypes.String, "foo"),
+					"b": tftypes.NewValue(tftypes.String, "bar"),
+				}),
+			},
+			plan: Plan{
+				Schema: schema,
+				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"a": tftypes.NewValue(tftypes.String, "foo"),
+					"b": tftypes.NewValue(tftypes.String, nil),
+				}),
+			},
+			config: Config{
+				Schema: schema,
+				Raw: tftypes.NewValue(schema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"a": tftypes.NewValue(tftypes.String, "foo"),
+					"b": tftypes.NewValue(tftypes.String, nil),
+				}),
+			},
+			path:         tftypes.NewAttributePath().WithAttributeName("b"),
+			ifReturn:     true,
+			expectedPlan: types.String{Null: true},
+			expectedRR:   true,
+		},
+	}
+
+	for name, tc := range tests {
+		name, tc := name, tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			attrConfig, diags := tc.config.GetAttribute(context.Background(), tc.path)
+			if diags.HasError() {
+				t.Fatalf("Got unexpected diagnostics: %s", diags)
+			}
+
+			attrState, diags := tc.state.GetAttribute(context.Background(), tc.path)
+			if diags.HasError() {
+				t.Fatalf("Got unexpected diagnostics: %s", diags)
+			}
+
+			attrPlan, diags := tc.plan.GetAttribute(context.Background(), tc.path)
+			if diags.HasError() {
+				t.Fatalf("Got unexpected diagnostics: %s", diags)
+			}
+
+			req := ModifyAttributePlanRequest{
+				AttributePath:   tc.path,
+				Config:          tc.config,
+				State:           tc.state,
+				Plan:            tc.plan,
+				AttributeConfig: attrConfig,
+				AttributeState:  attrState,
+				AttributePlan:   attrPlan,
+				ProviderMeta:    Config{},
+			}
+			resp := &ModifyAttributePlanResponse{
+				AttributePlan: req.AttributePlan,
+			}
+			modifier := RequiresReplaceIf(func(ctx context.Context, state, config attr.Value, path *tftypes.AttributePath) (bool, diag.Diagnostics) {
+				return tc.ifReturn, nil
+			}, "", "")
+
+			modifier.Modify(context.Background(), req, resp)
+			if resp.Diagnostics.HasError() {
+				t.Fatalf("Unexpected diagnostics: %s", resp.Diagnostics)
+			}
+			if diff := cmp.Diff(tc.expectedPlan, resp.AttributePlan); diff != "" {
+				t.Fatalf("Unexpected diff in plan (-wanted, +got): %s", diff)
+			}
+			if diff := cmp.Diff(tc.expectedRR, resp.RequiresReplace); diff != "" {
+				t.Fatalf("Unexpected diff in RequiresReplace (-wanted, +got): %s", diff)
 			}
 		})
 	}

--- a/tfsdk/attribute_plan_modification_test.go
+++ b/tfsdk/attribute_plan_modification_test.go
@@ -432,17 +432,17 @@ func TestRequiresReplaceModifier(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			attrConfig, diags := tc.config.GetAttribute(context.Background(), tc.path)
+			attrConfig, diags := tc.config.getAttributeValue(context.Background(), tc.path)
 			if diags.HasError() {
 				t.Fatalf("Got unexpected diagnostics: %s", diags)
 			}
 
-			attrState, diags := tc.state.GetAttribute(context.Background(), tc.path)
+			attrState, diags := tc.state.getAttributeValue(context.Background(), tc.path)
 			if diags.HasError() {
 				t.Fatalf("Got unexpected diagnostics: %s", diags)
 			}
 
-			attrPlan, diags := tc.plan.GetAttribute(context.Background(), tc.path)
+			attrPlan, diags := tc.plan.getAttributeValue(context.Background(), tc.path)
 			if diags.HasError() {
 				t.Fatalf("Got unexpected diagnostics: %s", diags)
 			}
@@ -786,17 +786,17 @@ func TestRequiresReplaceIfModifier(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			attrConfig, diags := tc.config.GetAttribute(context.Background(), tc.path)
+			attrConfig, diags := tc.config.getAttributeValue(context.Background(), tc.path)
 			if diags.HasError() {
 				t.Fatalf("Got unexpected diagnostics: %s", diags)
 			}
 
-			attrState, diags := tc.state.GetAttribute(context.Background(), tc.path)
+			attrState, diags := tc.state.getAttributeValue(context.Background(), tc.path)
 			if diags.HasError() {
 				t.Fatalf("Got unexpected diagnostics: %s", diags)
 			}
 
-			attrPlan, diags := tc.plan.GetAttribute(context.Background(), tc.path)
+			attrPlan, diags := tc.plan.getAttributeValue(context.Background(), tc.path)
 			if diags.HasError() {
 				t.Fatalf("Got unexpected diagnostics: %s", diags)
 			}

--- a/tfsdk/attribute_test.go
+++ b/tfsdk/attribute_test.go
@@ -1383,7 +1383,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 							"test": tftypes.String,
 						},
 					}, map[string]tftypes.Value{
-						"test": tftypes.NewValue(tftypes.String, "testvalue"),
+						"test": tftypes.NewValue(tftypes.String, "newtestvalue"),
 					}),
 					Schema: Schema{
 						Attributes: map[string]Attribute{
@@ -1403,7 +1403,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 							"test": tftypes.String,
 						},
 					}, map[string]tftypes.Value{
-						"test": tftypes.NewValue(tftypes.String, "testvalue"),
+						"test": tftypes.NewValue(tftypes.String, "newtestvalue"),
 					}),
 					Schema: Schema{
 						Attributes: map[string]Attribute{
@@ -1455,7 +1455,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 							"test": tftypes.String,
 						},
 					}, map[string]tftypes.Value{
-						"test": tftypes.NewValue(tftypes.String, "testvalue"),
+						"test": tftypes.NewValue(tftypes.String, "newtestvalue"),
 					}),
 					Schema: Schema{
 						Attributes: map[string]Attribute{
@@ -1475,7 +1475,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 							"test": tftypes.String,
 						},
 					}, map[string]tftypes.Value{
-						"test": tftypes.NewValue(tftypes.String, "testvalue"),
+						"test": tftypes.NewValue(tftypes.String, "newtestvalue"),
 					}),
 					Schema: Schema{
 						Attributes: map[string]Attribute{
@@ -1547,8 +1547,8 @@ func TestAttributeModifyPlan(t *testing.T) {
 								Type:     types.StringType,
 								Required: true,
 								PlanModifiers: []AttributePlanModifier{
-									RequiresReplace(),
 									testAttrPlanValueModifierOne{},
+									RequiresReplace(),
 								},
 							},
 						},
@@ -2041,7 +2041,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 			attribute.modifyPlan(context.Background(), tc.req, &tc.resp)
 
 			if diff := cmp.Diff(tc.expectedResp, tc.resp); diff != "" {
-				t.Errorf("Unexpected response (+wanted, -got): %s", diff)
+				t.Errorf("Unexpected response (-wanted, +got): %s", diff)
 			}
 		})
 	}

--- a/tfsdk/serve_test.go
+++ b/tfsdk/serve_test.go
@@ -2527,7 +2527,7 @@ func TestServerPlanResourceChange(t *testing.T) {
 						"format": tftypes.String,
 					}}, map[string]tftypes.Value{
 						"size":   tftypes.NewValue(tftypes.Number, 1),
-						"format": tftypes.NewValue(tftypes.String, "ext4"),
+						"format": tftypes.NewValue(tftypes.String, "ext3"),
 					}),
 				}),
 				"region": tftypes.NewValue(tftypes.String, "region1"),
@@ -2626,7 +2626,7 @@ func TestServerPlanResourceChange(t *testing.T) {
 					}},
 				}}, map[string]tftypes.Value{
 					"id":        tftypes.NewValue(tftypes.String, "my-scr-disk"),
-					"interface": tftypes.NewValue(tftypes.String, "scsi"),
+					"interface": tftypes.NewValue(tftypes.String, "something-else"),
 					"filesystem": tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
 						"size":   tftypes.Number,
 						"format": tftypes.String,
@@ -2715,7 +2715,7 @@ func TestServerPlanResourceChange(t *testing.T) {
 					}},
 				}}, map[string]tftypes.Value{
 					"id":        tftypes.NewValue(tftypes.String, "my-scr-disk"),
-					"interface": tftypes.NewValue(tftypes.String, "scsi"),
+					"interface": tftypes.NewValue(tftypes.String, "something-else"),
 					"filesystem": tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
 						"size":   tftypes.Number,
 						"format": tftypes.String,
@@ -2804,7 +2804,7 @@ func TestServerPlanResourceChange(t *testing.T) {
 					}},
 				}}, map[string]tftypes.Value{
 					"id":        tftypes.NewValue(tftypes.String, "my-scr-disk"),
-					"interface": tftypes.NewValue(tftypes.String, "scsi"),
+					"interface": tftypes.NewValue(tftypes.String, "something-else"),
 					"filesystem": tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
 						"size":   tftypes.Number,
 						"format": tftypes.String,
@@ -2905,7 +2905,7 @@ func TestServerPlanResourceChange(t *testing.T) {
 					}},
 				}}, map[string]tftypes.Value{
 					"id":        tftypes.NewValue(tftypes.String, "my-scr-disk"),
-					"interface": tftypes.NewValue(tftypes.String, "scsi"),
+					"interface": tftypes.NewValue(tftypes.String, "something-else"),
 					"filesystem": tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
 						"size":   tftypes.Number,
 						"format": tftypes.String,
@@ -2994,7 +2994,7 @@ func TestServerPlanResourceChange(t *testing.T) {
 					}},
 				}}, map[string]tftypes.Value{
 					"id":        tftypes.NewValue(tftypes.String, "my-scr-disk"),
-					"interface": tftypes.NewValue(tftypes.String, "scsi"),
+					"interface": tftypes.NewValue(tftypes.String, "something-else"),
 					"filesystem": tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
 						"size":   tftypes.Number,
 						"format": tftypes.String,
@@ -3174,7 +3174,7 @@ func TestServerPlanResourceChange(t *testing.T) {
 					}},
 				}}, map[string]tftypes.Value{
 					"id":        tftypes.NewValue(tftypes.String, "my-scr-disk"),
-					"interface": tftypes.NewValue(tftypes.String, "scsi"),
+					"interface": tftypes.NewValue(tftypes.String, "something-else"),
 					"filesystem": tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
 						"size":   tftypes.Number,
 						"format": tftypes.String,


### PR DESCRIPTION
Fixes #187, supercedes #203.

This changes the logic on our RequiresReplace function in the following
ways:

* if the attribute being modified has not changed, RequiresReplace isn't
  changed. This prevents the resource from being destroyed and recreated
  when _any_ attribute changes, limiting it only to the attribute with
  RequiresReplace set on it.
* if the attribute being modified is computed and is null in the config,
  RequiresReplace isn't changed. This prevents the resource from being
  destroyed and recreated when the provider returns an unknown value in
  the plan, or even a new, provider-controlled value, because it's
  unlikely the practitioners expect their resource to be destroyed and
  recreated when an attribute out of their control changes. This has the
  unfortunate side-effect that practitioners removing an
  Optional+Computed field from their config will not prompt the default
  RequiresReplace behavior, but providers can specify their own, special
  plan modifier that has a better understanding of practitioner intent
  in that case.
* if the resource is being created or destroyed, RequiresReplace isn't
  changed. This prevents the resource from being marked for destruction
  and recreation when it's just now being created or destroyed, which
  would be nonsensical.

RequiresReplaceIf gets all these changes and an additional change that
it will only set RequiresReplace to true, never to false, as its Modify
method's GoDoc indicated. This means that RequiresReplaceIf functions
can be chained, and that RequiresReplaceIf won't overwrite previous plan
modifiers' determinations on whether or not the resource should be
destroyed and recreated.

Tests were added for RequiresReplace and RequiresReplaceIf to test these
invariants.