### PR TITLE
tfsdk: Support block plan modification

### DIFF
--- a/tfsdk/attribute_plan_modification.go
+++ b/tfsdk/attribute_plan_modification.go
@@ -2,6 +2,7 @@ package tfsdk
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -127,7 +128,10 @@ func (r RequiresReplaceModifier) Modify(ctx context.Context, req ModifyAttribute
 	}
 
 	attrSchema, err := req.State.Schema.AttributeAtPath(req.AttributePath)
-	if err != nil {
+
+	// Path may lead to block instead of attribute. Blocks cannot be Computed.
+	// If ErrPathIsBlock, attrSchema.Computed will still be false later.
+	if err != nil && !errors.Is(err, ErrPathIsBlock) {
 		resp.Diagnostics.AddAttributeError(req.AttributePath,
 			"Error finding attribute schema",
 			fmt.Sprintf("An unexpected error was encountered retrieving the schema for this attribute. This is always a bug in the provider.\n\nError: %s", err),
@@ -264,7 +268,10 @@ func (r RequiresReplaceIfModifier) Modify(ctx context.Context, req ModifyAttribu
 	}
 
 	attrSchema, err := req.State.Schema.AttributeAtPath(req.AttributePath)
-	if err != nil {
+
+	// Path may lead to block instead of attribute. Blocks cannot be Computed.
+	// If ErrPathIsBlock, attrSchema.Computed will still be false later.
+	if err != nil && !errors.Is(err, ErrPathIsBlock) {
 		resp.Diagnostics.AddAttributeError(req.AttributePath,
 			"Error finding attribute schema",
 			fmt.Sprintf("An unexpected error was encountered retrieving the schema for this attribute. This is always a bug in the provider.\n\nError: %s", err),

--- a/tfsdk/attribute_plan_modification_test.go
+++ b/tfsdk/attribute_plan_modification_test.go
@@ -839,6 +839,25 @@ func TestRequiresReplaceIfModifier(t *testing.T) {
 		},
 	}
 
+	blockSchema := Schema{
+		Blocks: map[string]Block{
+			"block": {
+				Attributes: map[string]Attribute{
+					"optional-computed": {
+						Type:     types.StringType,
+						Optional: true,
+						Computed: true,
+					},
+					"optional": {
+						Type:     types.StringType,
+						Optional: true,
+					},
+				},
+				NestingMode: BlockNestingModeList,
+			},
+		},
+	}
+
 	tests := map[string]testCase{
 		"null-state": {
 			// when we first create the resource, it shouldn't
@@ -1155,6 +1174,325 @@ func TestRequiresReplaceIfModifier(t *testing.T) {
 			ifReturn:     true,
 			expectedPlan: types.String{Null: true},
 			expectedRR:   true,
+		},
+		"block-no-change": {
+			state: State{
+				Schema: blockSchema,
+				Raw: tftypes.NewValue(blockSchema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"block": tftypes.NewValue(
+						tftypes.List{
+							ElementType: tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"optional-computed": tftypes.String,
+									"optional":          tftypes.String,
+								},
+							},
+						}, []tftypes.Value{
+							tftypes.NewValue(tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"optional-computed": tftypes.String,
+									"optional":          tftypes.String,
+								},
+							}, map[string]tftypes.Value{
+								"optional-computed": tftypes.NewValue(tftypes.String, "samevalue"),
+								"optional":          tftypes.NewValue(tftypes.String, "samevalue"),
+							}),
+						}),
+				}),
+			},
+			plan: Plan{
+				Schema: blockSchema,
+				Raw: tftypes.NewValue(blockSchema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"block": tftypes.NewValue(
+						tftypes.List{
+							ElementType: tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"optional-computed": tftypes.String,
+									"optional":          tftypes.String,
+								},
+							},
+						}, []tftypes.Value{
+							tftypes.NewValue(tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"optional-computed": tftypes.String,
+									"optional":          tftypes.String,
+								},
+							}, map[string]tftypes.Value{
+								"optional-computed": tftypes.NewValue(tftypes.String, "samevalue"),
+								"optional":          tftypes.NewValue(tftypes.String, "samevalue"),
+							}),
+						}),
+				}),
+			},
+			config: Config{
+				Schema: blockSchema,
+				Raw: tftypes.NewValue(blockSchema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"block": tftypes.NewValue(
+						tftypes.List{
+							ElementType: tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"optional-computed": tftypes.String,
+									"optional":          tftypes.String,
+								},
+							},
+						}, []tftypes.Value{
+							tftypes.NewValue(tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"optional-computed": tftypes.String,
+									"optional":          tftypes.String,
+								},
+							}, map[string]tftypes.Value{
+								"optional-computed": tftypes.NewValue(tftypes.String, "samevalue"),
+								"optional":          tftypes.NewValue(tftypes.String, "samevalue"),
+							}),
+						}),
+				}),
+			},
+			path: tftypes.NewAttributePath().WithAttributeName("block"),
+			expectedPlan: types.List{
+				ElemType: types.ObjectType{
+					AttrTypes: map[string]attr.Type{
+						"optional-computed": types.StringType,
+						"optional":          types.StringType,
+					},
+				},
+				Elems: []attr.Value{
+					types.Object{
+						AttrTypes: map[string]attr.Type{
+							"optional-computed": types.StringType,
+							"optional":          types.StringType,
+						},
+						Attrs: map[string]attr.Value{
+							"optional-computed": types.String{Value: "samevalue"},
+							"optional":          types.String{Value: "samevalue"},
+						},
+					},
+				},
+			},
+			ifReturn:   false,
+			expectedRR: false,
+		},
+		"block-element-count-change": {
+			state: State{
+				Schema: blockSchema,
+				Raw: tftypes.NewValue(blockSchema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"block": tftypes.NewValue(
+						tftypes.List{
+							ElementType: tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"optional-computed": tftypes.String,
+									"optional":          tftypes.String,
+								},
+							},
+						}, []tftypes.Value{
+							tftypes.NewValue(tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"optional-computed": tftypes.String,
+									"optional":          tftypes.String,
+								},
+							}, map[string]tftypes.Value{
+								"optional-computed": tftypes.NewValue(tftypes.String, "samevalue"),
+								"optional":          tftypes.NewValue(tftypes.String, "samevalue"),
+							}),
+						}),
+				}),
+			},
+			plan: Plan{
+				Schema: blockSchema,
+				Raw: tftypes.NewValue(blockSchema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"block": tftypes.NewValue(
+						tftypes.List{
+							ElementType: tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"optional-computed": tftypes.String,
+									"optional":          tftypes.String,
+								},
+							},
+						}, []tftypes.Value{
+							tftypes.NewValue(tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"optional-computed": tftypes.String,
+									"optional":          tftypes.String,
+								},
+							}, map[string]tftypes.Value{
+								"optional-computed": tftypes.NewValue(tftypes.String, "samevalue"),
+								"optional":          tftypes.NewValue(tftypes.String, "samevalue"),
+							}),
+							tftypes.NewValue(tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"optional-computed": tftypes.String,
+									"optional":          tftypes.String,
+								},
+							}, map[string]tftypes.Value{
+								"optional-computed": tftypes.NewValue(tftypes.String, "newvalue"),
+								"optional":          tftypes.NewValue(tftypes.String, "newvalue"),
+							}),
+						}),
+				}),
+			},
+			config: Config{
+				Schema: blockSchema,
+				Raw: tftypes.NewValue(blockSchema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"block": tftypes.NewValue(
+						tftypes.List{
+							ElementType: tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"optional-computed": tftypes.String,
+									"optional":          tftypes.String,
+								},
+							},
+						}, []tftypes.Value{
+							tftypes.NewValue(tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"optional-computed": tftypes.String,
+									"optional":          tftypes.String,
+								},
+							}, map[string]tftypes.Value{
+								"optional-computed": tftypes.NewValue(tftypes.String, "samevalue"),
+								"optional":          tftypes.NewValue(tftypes.String, "samevalue"),
+							}),
+							tftypes.NewValue(tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"optional-computed": tftypes.String,
+									"optional":          tftypes.String,
+								},
+							}, map[string]tftypes.Value{
+								"optional-computed": tftypes.NewValue(tftypes.String, "newvalue"),
+								"optional":          tftypes.NewValue(tftypes.String, "newvalue"),
+							}),
+						}),
+				}),
+			},
+			path: tftypes.NewAttributePath().WithAttributeName("block"),
+			expectedPlan: types.List{
+				ElemType: types.ObjectType{
+					AttrTypes: map[string]attr.Type{
+						"optional-computed": types.StringType,
+						"optional":          types.StringType,
+					},
+				},
+				Elems: []attr.Value{
+					types.Object{
+						AttrTypes: map[string]attr.Type{
+							"optional-computed": types.StringType,
+							"optional":          types.StringType,
+						},
+						Attrs: map[string]attr.Value{
+							"optional-computed": types.String{Value: "samevalue"},
+							"optional":          types.String{Value: "samevalue"},
+						},
+					},
+					types.Object{
+						AttrTypes: map[string]attr.Type{
+							"optional-computed": types.StringType,
+							"optional":          types.StringType,
+						},
+						Attrs: map[string]attr.Value{
+							"optional-computed": types.String{Value: "newvalue"},
+							"optional":          types.String{Value: "newvalue"},
+						},
+					},
+				},
+			},
+			ifReturn:   true,
+			expectedRR: true,
+		},
+		"block-nested-attribute-change": {
+			state: State{
+				Schema: blockSchema,
+				Raw: tftypes.NewValue(blockSchema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"block": tftypes.NewValue(
+						tftypes.List{
+							ElementType: tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"optional-computed": tftypes.String,
+									"optional":          tftypes.String,
+								},
+							},
+						}, []tftypes.Value{
+							tftypes.NewValue(tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"optional-computed": tftypes.String,
+									"optional":          tftypes.String,
+								},
+							}, map[string]tftypes.Value{
+								"optional-computed": tftypes.NewValue(tftypes.String, "samevalue"),
+								"optional":          tftypes.NewValue(tftypes.String, "oldvalue"),
+							}),
+						}),
+				}),
+			},
+			plan: Plan{
+				Schema: blockSchema,
+				Raw: tftypes.NewValue(blockSchema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"block": tftypes.NewValue(
+						tftypes.List{
+							ElementType: tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"optional-computed": tftypes.String,
+									"optional":          tftypes.String,
+								},
+							},
+						}, []tftypes.Value{
+							tftypes.NewValue(tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"optional-computed": tftypes.String,
+									"optional":          tftypes.String,
+								},
+							}, map[string]tftypes.Value{
+								"optional-computed": tftypes.NewValue(tftypes.String, "samevalue"),
+								"optional":          tftypes.NewValue(tftypes.String, "newvalue"),
+							}),
+						}),
+				}),
+			},
+			config: Config{
+				Schema: blockSchema,
+				Raw: tftypes.NewValue(blockSchema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"block": tftypes.NewValue(
+						tftypes.List{
+							ElementType: tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"optional-computed": tftypes.String,
+									"optional":          tftypes.String,
+								},
+							},
+						}, []tftypes.Value{
+							tftypes.NewValue(tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"optional-computed": tftypes.String,
+									"optional":          tftypes.String,
+								},
+							}, map[string]tftypes.Value{
+								"optional-computed": tftypes.NewValue(tftypes.String, "samevalue"),
+								"optional":          tftypes.NewValue(tftypes.String, "newvalue"),
+							}),
+						}),
+				}),
+			},
+			path: tftypes.NewAttributePath().WithAttributeName("block"),
+			expectedPlan: types.List{
+				ElemType: types.ObjectType{
+					AttrTypes: map[string]attr.Type{
+						"optional-computed": types.StringType,
+						"optional":          types.StringType,
+					},
+				},
+				Elems: []attr.Value{
+					types.Object{
+						AttrTypes: map[string]attr.Type{
+							"optional-computed": types.StringType,
+							"optional":          types.StringType,
+						},
+						Attrs: map[string]attr.Value{
+							"optional-computed": types.String{Value: "samevalue"},
+							"optional":          types.String{Value: "newvalue"},
+						},
+					},
+				},
+			},
+			ifReturn:   true,
+			expectedRR: true,
 		},
 	}
 

--- a/tfsdk/attribute_plan_modification_test.go
+++ b/tfsdk/attribute_plan_modification_test.go
@@ -188,6 +188,25 @@ func TestRequiresReplaceModifier(t *testing.T) {
 		},
 	}
 
+	blockSchema := Schema{
+		Blocks: map[string]Block{
+			"block": {
+				Attributes: map[string]Attribute{
+					"optional-computed": {
+						Type:     types.StringType,
+						Optional: true,
+						Computed: true,
+					},
+					"optional": {
+						Type:     types.StringType,
+						Optional: true,
+					},
+				},
+				NestingMode: BlockNestingModeList,
+			},
+		},
+	}
+
 	tests := map[string]testCase{
 		"null-state": {
 			// when we first create the resource, it shouldn't
@@ -424,6 +443,322 @@ func TestRequiresReplaceModifier(t *testing.T) {
 			path:         tftypes.NewAttributePath().WithAttributeName("optional"),
 			expectedPlan: types.String{Null: true},
 			expectedRR:   true,
+		},
+		"block-no-change": {
+			state: State{
+				Schema: blockSchema,
+				Raw: tftypes.NewValue(blockSchema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"block": tftypes.NewValue(
+						tftypes.List{
+							ElementType: tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"optional-computed": tftypes.String,
+									"optional":          tftypes.String,
+								},
+							},
+						}, []tftypes.Value{
+							tftypes.NewValue(tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"optional-computed": tftypes.String,
+									"optional":          tftypes.String,
+								},
+							}, map[string]tftypes.Value{
+								"optional-computed": tftypes.NewValue(tftypes.String, "samevalue"),
+								"optional":          tftypes.NewValue(tftypes.String, "samevalue"),
+							}),
+						}),
+				}),
+			},
+			plan: Plan{
+				Schema: blockSchema,
+				Raw: tftypes.NewValue(blockSchema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"block": tftypes.NewValue(
+						tftypes.List{
+							ElementType: tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"optional-computed": tftypes.String,
+									"optional":          tftypes.String,
+								},
+							},
+						}, []tftypes.Value{
+							tftypes.NewValue(tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"optional-computed": tftypes.String,
+									"optional":          tftypes.String,
+								},
+							}, map[string]tftypes.Value{
+								"optional-computed": tftypes.NewValue(tftypes.String, "samevalue"),
+								"optional":          tftypes.NewValue(tftypes.String, "samevalue"),
+							}),
+						}),
+				}),
+			},
+			config: Config{
+				Schema: blockSchema,
+				Raw: tftypes.NewValue(blockSchema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"block": tftypes.NewValue(
+						tftypes.List{
+							ElementType: tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"optional-computed": tftypes.String,
+									"optional":          tftypes.String,
+								},
+							},
+						}, []tftypes.Value{
+							tftypes.NewValue(tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"optional-computed": tftypes.String,
+									"optional":          tftypes.String,
+								},
+							}, map[string]tftypes.Value{
+								"optional-computed": tftypes.NewValue(tftypes.String, "samevalue"),
+								"optional":          tftypes.NewValue(tftypes.String, "samevalue"),
+							}),
+						}),
+				}),
+			},
+			path: tftypes.NewAttributePath().WithAttributeName("block"),
+			expectedPlan: types.List{
+				ElemType: types.ObjectType{
+					AttrTypes: map[string]attr.Type{
+						"optional-computed": types.StringType,
+						"optional":          types.StringType,
+					},
+				},
+				Elems: []attr.Value{
+					types.Object{
+						AttrTypes: map[string]attr.Type{
+							"optional-computed": types.StringType,
+							"optional":          types.StringType,
+						},
+						Attrs: map[string]attr.Value{
+							"optional-computed": types.String{Value: "samevalue"},
+							"optional":          types.String{Value: "samevalue"},
+						},
+					},
+				},
+			},
+			expectedRR: false,
+		},
+		"block-element-count-change": {
+			state: State{
+				Schema: blockSchema,
+				Raw: tftypes.NewValue(blockSchema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"block": tftypes.NewValue(
+						tftypes.List{
+							ElementType: tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"optional-computed": tftypes.String,
+									"optional":          tftypes.String,
+								},
+							},
+						}, []tftypes.Value{
+							tftypes.NewValue(tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"optional-computed": tftypes.String,
+									"optional":          tftypes.String,
+								},
+							}, map[string]tftypes.Value{
+								"optional-computed": tftypes.NewValue(tftypes.String, "samevalue"),
+								"optional":          tftypes.NewValue(tftypes.String, "samevalue"),
+							}),
+						}),
+				}),
+			},
+			plan: Plan{
+				Schema: blockSchema,
+				Raw: tftypes.NewValue(blockSchema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"block": tftypes.NewValue(
+						tftypes.List{
+							ElementType: tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"optional-computed": tftypes.String,
+									"optional":          tftypes.String,
+								},
+							},
+						}, []tftypes.Value{
+							tftypes.NewValue(tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"optional-computed": tftypes.String,
+									"optional":          tftypes.String,
+								},
+							}, map[string]tftypes.Value{
+								"optional-computed": tftypes.NewValue(tftypes.String, "samevalue"),
+								"optional":          tftypes.NewValue(tftypes.String, "samevalue"),
+							}),
+							tftypes.NewValue(tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"optional-computed": tftypes.String,
+									"optional":          tftypes.String,
+								},
+							}, map[string]tftypes.Value{
+								"optional-computed": tftypes.NewValue(tftypes.String, "newvalue"),
+								"optional":          tftypes.NewValue(tftypes.String, "newvalue"),
+							}),
+						}),
+				}),
+			},
+			config: Config{
+				Schema: blockSchema,
+				Raw: tftypes.NewValue(blockSchema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"block": tftypes.NewValue(
+						tftypes.List{
+							ElementType: tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"optional-computed": tftypes.String,
+									"optional":          tftypes.String,
+								},
+							},
+						}, []tftypes.Value{
+							tftypes.NewValue(tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"optional-computed": tftypes.String,
+									"optional":          tftypes.String,
+								},
+							}, map[string]tftypes.Value{
+								"optional-computed": tftypes.NewValue(tftypes.String, "samevalue"),
+								"optional":          tftypes.NewValue(tftypes.String, "samevalue"),
+							}),
+							tftypes.NewValue(tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"optional-computed": tftypes.String,
+									"optional":          tftypes.String,
+								},
+							}, map[string]tftypes.Value{
+								"optional-computed": tftypes.NewValue(tftypes.String, "newvalue"),
+								"optional":          tftypes.NewValue(tftypes.String, "newvalue"),
+							}),
+						}),
+				}),
+			},
+			path: tftypes.NewAttributePath().WithAttributeName("block"),
+			expectedPlan: types.List{
+				ElemType: types.ObjectType{
+					AttrTypes: map[string]attr.Type{
+						"optional-computed": types.StringType,
+						"optional":          types.StringType,
+					},
+				},
+				Elems: []attr.Value{
+					types.Object{
+						AttrTypes: map[string]attr.Type{
+							"optional-computed": types.StringType,
+							"optional":          types.StringType,
+						},
+						Attrs: map[string]attr.Value{
+							"optional-computed": types.String{Value: "samevalue"},
+							"optional":          types.String{Value: "samevalue"},
+						},
+					},
+					types.Object{
+						AttrTypes: map[string]attr.Type{
+							"optional-computed": types.StringType,
+							"optional":          types.StringType,
+						},
+						Attrs: map[string]attr.Value{
+							"optional-computed": types.String{Value: "newvalue"},
+							"optional":          types.String{Value: "newvalue"},
+						},
+					},
+				},
+			},
+			expectedRR: true,
+		},
+		"block-nested-attribute-change": {
+			state: State{
+				Schema: blockSchema,
+				Raw: tftypes.NewValue(blockSchema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"block": tftypes.NewValue(
+						tftypes.List{
+							ElementType: tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"optional-computed": tftypes.String,
+									"optional":          tftypes.String,
+								},
+							},
+						}, []tftypes.Value{
+							tftypes.NewValue(tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"optional-computed": tftypes.String,
+									"optional":          tftypes.String,
+								},
+							}, map[string]tftypes.Value{
+								"optional-computed": tftypes.NewValue(tftypes.String, "samevalue"),
+								"optional":          tftypes.NewValue(tftypes.String, "oldvalue"),
+							}),
+						}),
+				}),
+			},
+			plan: Plan{
+				Schema: blockSchema,
+				Raw: tftypes.NewValue(blockSchema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"block": tftypes.NewValue(
+						tftypes.List{
+							ElementType: tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"optional-computed": tftypes.String,
+									"optional":          tftypes.String,
+								},
+							},
+						}, []tftypes.Value{
+							tftypes.NewValue(tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"optional-computed": tftypes.String,
+									"optional":          tftypes.String,
+								},
+							}, map[string]tftypes.Value{
+								"optional-computed": tftypes.NewValue(tftypes.String, "samevalue"),
+								"optional":          tftypes.NewValue(tftypes.String, "newvalue"),
+							}),
+						}),
+				}),
+			},
+			config: Config{
+				Schema: blockSchema,
+				Raw: tftypes.NewValue(blockSchema.TerraformType(context.Background()), map[string]tftypes.Value{
+					"block": tftypes.NewValue(
+						tftypes.List{
+							ElementType: tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"optional-computed": tftypes.String,
+									"optional":          tftypes.String,
+								},
+							},
+						}, []tftypes.Value{
+							tftypes.NewValue(tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"optional-computed": tftypes.String,
+									"optional":          tftypes.String,
+								},
+							}, map[string]tftypes.Value{
+								"optional-computed": tftypes.NewValue(tftypes.String, "samevalue"),
+								"optional":          tftypes.NewValue(tftypes.String, "newvalue"),
+							}),
+						}),
+				}),
+			},
+			path: tftypes.NewAttributePath().WithAttributeName("block"),
+			expectedPlan: types.List{
+				ElemType: types.ObjectType{
+					AttrTypes: map[string]attr.Type{
+						"optional-computed": types.StringType,
+						"optional":          types.StringType,
+					},
+				},
+				Elems: []attr.Value{
+					types.Object{
+						AttrTypes: map[string]attr.Type{
+							"optional-computed": types.StringType,
+							"optional":          types.StringType,
+						},
+						Attrs: map[string]attr.Value{
+							"optional-computed": types.String{Value: "samevalue"},
+							"optional":          types.String{Value: "newvalue"},
+						},
+					},
+				},
+			},
+			expectedRR: true,
 		},
 	}
 

--- a/tfsdk/attribute_test.go
+++ b/tfsdk/attribute_test.go
@@ -698,9 +698,10 @@ func TestAttributeModifyPlan(t *testing.T) {
 	t.Parallel()
 
 	testCases := map[string]struct {
-		req          ModifyAttributePlanRequest
-		resp         ModifyAttributePlanResponse
-		expectedResp ModifyAttributePlanResponse
+		req                ModifyAttributePlanRequest
+		resp               ModifyAttributePlanResponse
+		expectedResp       ModifyAttributePlanResponse
+		expectedSchemaResp ModifySchemaPlanResponse
 	}{
 		"config-error": {
 			req: ModifyAttributePlanRequest{
@@ -769,6 +770,33 @@ func TestAttributeModifyPlan(t *testing.T) {
 						"An unexpected error was encountered trying to read an attribute from the configuration. This is always an error in the provider. Please report the following to the provider developer:\n\n"+
 							"can't use tftypes.String<\"testvalue\"> as value of List with ElementType types.primitive, can only use tftypes.String values",
 					),
+				},
+			},
+			expectedSchemaResp: ModifySchemaPlanResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewAttributeErrorDiagnostic(
+						tftypes.NewAttributePath().WithAttributeName("test"),
+						"Configuration Read Error",
+						"An unexpected error was encountered trying to read an attribute from the configuration. This is always an error in the provider. Please report the following to the provider developer:\n\n"+
+							"can't use tftypes.String<\"testvalue\"> as value of List with ElementType types.primitive, can only use tftypes.String values",
+					),
+				},
+				Plan: Plan{
+					Raw: tftypes.NewValue(tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"test": tftypes.String,
+						},
+					}, map[string]tftypes.Value{
+						"test": tftypes.NewValue(tftypes.String, "testvalue"),
+					}),
+					Schema: Schema{
+						Attributes: map[string]Attribute{
+							"test": {
+								Type:     types.StringType,
+								Required: true,
+							},
+						},
+					},
 				},
 			},
 		},
@@ -851,6 +879,37 @@ func TestAttributeModifyPlan(t *testing.T) {
 					),
 				},
 			},
+			expectedSchemaResp: ModifySchemaPlanResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic(
+						"Previous error diag",
+						"This was a previous error",
+					),
+					diag.NewAttributeErrorDiagnostic(
+						tftypes.NewAttributePath().WithAttributeName("test"),
+						"Configuration Read Error",
+						"An unexpected error was encountered trying to read an attribute from the configuration. This is always an error in the provider. Please report the following to the provider developer:\n\n"+
+							"can't use tftypes.String<\"testvalue\"> as value of List with ElementType types.primitive, can only use tftypes.String values",
+					),
+				},
+				Plan: Plan{
+					Raw: tftypes.NewValue(tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"test": tftypes.String,
+						},
+					}, map[string]tftypes.Value{
+						"test": tftypes.NewValue(tftypes.String, "testvalue"),
+					}),
+					Schema: Schema{
+						Attributes: map[string]Attribute{
+							"test": {
+								Type:     types.StringType,
+								Required: true,
+							},
+						},
+					},
+				},
+			},
 		},
 		"plan-error": {
 			req: ModifyAttributePlanRequest{
@@ -919,6 +978,33 @@ func TestAttributeModifyPlan(t *testing.T) {
 						"An unexpected error was encountered trying to read an attribute from the plan. This is always an error in the provider. Please report the following to the provider developer:\n\n"+
 							"can't use tftypes.String<\"testvalue\"> as value of List with ElementType types.primitive, can only use tftypes.String values",
 					),
+				},
+			},
+			expectedSchemaResp: ModifySchemaPlanResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewAttributeErrorDiagnostic(
+						tftypes.NewAttributePath().WithAttributeName("test"),
+						"Plan Read Error",
+						"An unexpected error was encountered trying to read an attribute from the plan. This is always an error in the provider. Please report the following to the provider developer:\n\n"+
+							"can't use tftypes.String<\"testvalue\"> as value of List with ElementType types.primitive, can only use tftypes.String values",
+					),
+				},
+				Plan: Plan{
+					Raw: tftypes.NewValue(tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"test": tftypes.String,
+						},
+					}, map[string]tftypes.Value{
+						"test": tftypes.NewValue(tftypes.String, "testvalue"),
+					}),
+					Schema: Schema{
+						Attributes: map[string]Attribute{
+							"test": {
+								Type:     types.ListType{ElemType: types.StringType},
+								Required: true,
+							},
+						},
+					},
 				},
 			},
 		},
@@ -1001,6 +1087,37 @@ func TestAttributeModifyPlan(t *testing.T) {
 					),
 				},
 			},
+			expectedSchemaResp: ModifySchemaPlanResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic(
+						"Previous error diag",
+						"This was a previous error",
+					),
+					diag.NewAttributeErrorDiagnostic(
+						tftypes.NewAttributePath().WithAttributeName("test"),
+						"Plan Read Error",
+						"An unexpected error was encountered trying to read an attribute from the plan. This is always an error in the provider. Please report the following to the provider developer:\n\n"+
+							"can't use tftypes.String<\"testvalue\"> as value of List with ElementType types.primitive, can only use tftypes.String values",
+					),
+				},
+				Plan: Plan{
+					Raw: tftypes.NewValue(tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"test": tftypes.String,
+						},
+					}, map[string]tftypes.Value{
+						"test": tftypes.NewValue(tftypes.String, "testvalue"),
+					}),
+					Schema: Schema{
+						Attributes: map[string]Attribute{
+							"test": {
+								Type:     types.ListType{ElemType: types.StringType},
+								Required: true,
+							},
+						},
+					},
+				},
+			},
 		},
 		"state-error": {
 			req: ModifyAttributePlanRequest{
@@ -1069,6 +1186,33 @@ func TestAttributeModifyPlan(t *testing.T) {
 						"An unexpected error was encountered trying to read an attribute from the state. This is always an error in the provider. Please report the following to the provider developer:\n\n"+
 							"can't use tftypes.String<\"testvalue\"> as value of List with ElementType types.primitive, can only use tftypes.String values",
 					),
+				},
+			},
+			expectedSchemaResp: ModifySchemaPlanResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewAttributeErrorDiagnostic(
+						tftypes.NewAttributePath().WithAttributeName("test"),
+						"State Read Error",
+						"An unexpected error was encountered trying to read an attribute from the state. This is always an error in the provider. Please report the following to the provider developer:\n\n"+
+							"can't use tftypes.String<\"testvalue\"> as value of List with ElementType types.primitive, can only use tftypes.String values",
+					),
+				},
+				Plan: Plan{
+					Raw: tftypes.NewValue(tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"test": tftypes.String,
+						},
+					}, map[string]tftypes.Value{
+						"test": tftypes.NewValue(tftypes.String, "testvalue"),
+					}),
+					Schema: Schema{
+						Attributes: map[string]Attribute{
+							"test": {
+								Type:     types.StringType,
+								Required: true,
+							},
+						},
+					},
 				},
 			},
 		},
@@ -1151,6 +1295,37 @@ func TestAttributeModifyPlan(t *testing.T) {
 					),
 				},
 			},
+			expectedSchemaResp: ModifySchemaPlanResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic(
+						"Previous error diag",
+						"This was a previous error",
+					),
+					diag.NewAttributeErrorDiagnostic(
+						tftypes.NewAttributePath().WithAttributeName("test"),
+						"State Read Error",
+						"An unexpected error was encountered trying to read an attribute from the state. This is always an error in the provider. Please report the following to the provider developer:\n\n"+
+							"can't use tftypes.String<\"testvalue\"> as value of List with ElementType types.primitive, can only use tftypes.String values",
+					),
+				},
+				Plan: Plan{
+					Raw: tftypes.NewValue(tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"test": tftypes.String,
+						},
+					}, map[string]tftypes.Value{
+						"test": tftypes.NewValue(tftypes.String, "testvalue"),
+					}),
+					Schema: Schema{
+						Attributes: map[string]Attribute{
+							"test": {
+								Type:     types.StringType,
+								Required: true,
+							},
+						},
+					},
+				},
+			},
 		},
 		"no-plan-modifiers": {
 			req: ModifyAttributePlanRequest{
@@ -1212,6 +1387,25 @@ func TestAttributeModifyPlan(t *testing.T) {
 			},
 			expectedResp: ModifyAttributePlanResponse{
 				AttributePlan: types.String{Value: "testvalue"},
+			},
+			expectedSchemaResp: ModifySchemaPlanResponse{
+				Plan: Plan{
+					Raw: tftypes.NewValue(tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"test": tftypes.String,
+						},
+					}, map[string]tftypes.Value{
+						"test": tftypes.NewValue(tftypes.String, "testvalue"),
+					}),
+					Schema: Schema{
+						Attributes: map[string]Attribute{
+							"test": {
+								Type:     types.StringType,
+								Required: true,
+							},
+						},
+					},
+				},
 			},
 		},
 		"attribute-plan": {
@@ -1286,6 +1480,29 @@ func TestAttributeModifyPlan(t *testing.T) {
 			},
 			expectedResp: ModifyAttributePlanResponse{
 				AttributePlan: types.String{Value: "MODIFIED_TWO"},
+			},
+			expectedSchemaResp: ModifySchemaPlanResponse{
+				Plan: Plan{
+					Raw: tftypes.NewValue(tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"test": tftypes.String,
+						},
+					}, map[string]tftypes.Value{
+						"test": tftypes.NewValue(tftypes.String, "MODIFIED_TWO"),
+					}),
+					Schema: Schema{
+						Attributes: map[string]Attribute{
+							"test": {
+								Type:     types.StringType,
+								Required: true,
+								PlanModifiers: []AttributePlanModifier{
+									testAttrPlanValueModifierOne{},
+									testAttrPlanValueModifierTwo{},
+								},
+							},
+						},
+					},
+				},
 			},
 		},
 		"attribute-plan-previous-error": {
@@ -1373,6 +1590,35 @@ func TestAttributeModifyPlan(t *testing.T) {
 					),
 				},
 			},
+			expectedSchemaResp: ModifySchemaPlanResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic(
+						"Previous error diag",
+						"This was a previous error",
+					),
+				},
+				Plan: Plan{
+					Raw: tftypes.NewValue(tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"test": tftypes.String,
+						},
+					}, map[string]tftypes.Value{
+						"test": tftypes.NewValue(tftypes.String, "MODIFIED_TWO"),
+					}),
+					Schema: Schema{
+						Attributes: map[string]Attribute{
+							"test": {
+								Type:     types.StringType,
+								Required: true,
+								PlanModifiers: []AttributePlanModifier{
+									testAttrPlanValueModifierOne{},
+									testAttrPlanValueModifierTwo{},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 		"requires-replacement": {
 			req: ModifyAttributePlanRequest{
@@ -1439,11 +1685,33 @@ func TestAttributeModifyPlan(t *testing.T) {
 				},
 			},
 			resp: ModifyAttributePlanResponse{
-				AttributePlan: types.String{Value: "testvalue"},
+				AttributePlan: types.String{Value: "newtestvalue"},
 			},
 			expectedResp: ModifyAttributePlanResponse{
-				AttributePlan:   types.String{Value: "testvalue"},
+				AttributePlan:   types.String{Value: "newtestvalue"},
 				RequiresReplace: true,
+			},
+			expectedSchemaResp: ModifySchemaPlanResponse{
+				Plan: Plan{
+					Raw: tftypes.NewValue(tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"test": tftypes.String,
+						},
+					}, map[string]tftypes.Value{
+						"test": tftypes.NewValue(tftypes.String, "newtestvalue"),
+					}),
+					Schema: Schema{
+						Attributes: map[string]Attribute{
+							"test": {
+								Type:     types.StringType,
+								Required: true,
+							},
+						},
+					},
+				},
+				RequiresReplace: []*tftypes.AttributePath{
+					tftypes.NewAttributePath().WithAttributeName("test"),
+				},
 			},
 		},
 		"requires-replacement-previous-error": {
@@ -1511,7 +1779,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 				},
 			},
 			resp: ModifyAttributePlanResponse{
-				AttributePlan: types.String{Value: "testvalue"},
+				AttributePlan: types.String{Value: "newtestvalue"},
 				Diagnostics: diag.Diagnostics{
 					diag.NewErrorDiagnostic(
 						"Previous error diag",
@@ -1520,7 +1788,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 				},
 			},
 			expectedResp: ModifyAttributePlanResponse{
-				AttributePlan: types.String{Value: "testvalue"},
+				AttributePlan: types.String{Value: "newtestvalue"},
 				Diagnostics: diag.Diagnostics{
 					diag.NewErrorDiagnostic(
 						"Previous error diag",
@@ -1528,6 +1796,34 @@ func TestAttributeModifyPlan(t *testing.T) {
 					),
 				},
 				RequiresReplace: true,
+			},
+			expectedSchemaResp: ModifySchemaPlanResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic(
+						"Previous error diag",
+						"This was a previous error",
+					),
+				},
+				Plan: Plan{
+					Raw: tftypes.NewValue(tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"test": tftypes.String,
+						},
+					}, map[string]tftypes.Value{
+						"test": tftypes.NewValue(tftypes.String, "newtestvalue"),
+					}),
+					Schema: Schema{
+						Attributes: map[string]Attribute{
+							"test": {
+								Type:     types.StringType,
+								Required: true,
+							},
+						},
+					},
+				},
+				RequiresReplace: []*tftypes.AttributePath{
+					tftypes.NewAttributePath().WithAttributeName("test"),
+				},
 			},
 		},
 		"requires-replacement-passthrough": {
@@ -1604,6 +1900,28 @@ func TestAttributeModifyPlan(t *testing.T) {
 				AttributePlan:   types.String{Value: "TESTATTRTWO"},
 				RequiresReplace: true,
 			},
+			expectedSchemaResp: ModifySchemaPlanResponse{
+				Plan: Plan{
+					Raw: tftypes.NewValue(tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"test": tftypes.String,
+						},
+					}, map[string]tftypes.Value{
+						"test": tftypes.NewValue(tftypes.String, "TESTATTRTWO"),
+					}),
+					Schema: Schema{
+						Attributes: map[string]Attribute{
+							"test": {
+								Type:     types.StringType,
+								Required: true,
+							},
+						},
+					},
+				},
+				RequiresReplace: []*tftypes.AttributePath{
+					tftypes.NewAttributePath().WithAttributeName("test"),
+				},
+			},
 		},
 		"requires-replacement-unset": {
 			req: ModifyAttributePlanRequest{
@@ -1677,6 +1995,25 @@ func TestAttributeModifyPlan(t *testing.T) {
 			},
 			expectedResp: ModifyAttributePlanResponse{
 				AttributePlan: types.String{Value: "testvalue"},
+			},
+			expectedSchemaResp: ModifySchemaPlanResponse{
+				Plan: Plan{
+					Raw: tftypes.NewValue(tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"test": tftypes.String,
+						},
+					}, map[string]tftypes.Value{
+						"test": tftypes.NewValue(tftypes.String, "testvalue"),
+					}),
+					Schema: Schema{
+						Attributes: map[string]Attribute{
+							"test": {
+								Type:     types.StringType,
+								Required: true,
+							},
+						},
+					},
+				},
 			},
 		},
 		"warnings": {
@@ -1759,6 +2096,38 @@ func TestAttributeModifyPlan(t *testing.T) {
 						"Warning diag",
 						"This is a warning",
 					),
+				},
+			},
+			expectedSchemaResp: ModifySchemaPlanResponse{
+				Diagnostics: diag.Diagnostics{
+					// Diagnostics.Append() deduplicates, so the warning will only
+					// be here once unless the test implementation is changed to
+					// different modifiers or the modifier itself is changed.
+					diag.NewWarningDiagnostic(
+						"Warning diag",
+						"This is a warning",
+					),
+				},
+				Plan: Plan{
+					Raw: tftypes.NewValue(tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"test": tftypes.String,
+						},
+					}, map[string]tftypes.Value{
+						"test": tftypes.NewValue(tftypes.String, "TESTDIAG"),
+					}),
+					Schema: Schema{
+						Attributes: map[string]Attribute{
+							"test": {
+								Type:     types.StringType,
+								Required: true,
+								PlanModifiers: []AttributePlanModifier{
+									testWarningDiagModifier{},
+									testWarningDiagModifier{},
+								},
+							},
+						},
+					},
 				},
 			},
 		},
@@ -1854,6 +2223,42 @@ func TestAttributeModifyPlan(t *testing.T) {
 					),
 				},
 			},
+			expectedSchemaResp: ModifySchemaPlanResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic(
+						"Previous error diag",
+						"This was a previous error",
+					),
+					// Diagnostics.Append() deduplicates, so the warning will only
+					// be here once unless the test implementation is changed to
+					// different modifiers or the modifier itself is changed.
+					diag.NewWarningDiagnostic(
+						"Warning diag",
+						"This is a warning",
+					),
+				},
+				Plan: Plan{
+					Raw: tftypes.NewValue(tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"test": tftypes.String,
+						},
+					}, map[string]tftypes.Value{
+						"test": tftypes.NewValue(tftypes.String, "TESTDIAG"),
+					}),
+					Schema: Schema{
+						Attributes: map[string]Attribute{
+							"test": {
+								Type:     types.StringType,
+								Required: true,
+								PlanModifiers: []AttributePlanModifier{
+									testWarningDiagModifier{},
+									testWarningDiagModifier{},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 		"error": {
 			req: ModifyAttributePlanRequest{
@@ -1932,6 +2337,35 @@ func TestAttributeModifyPlan(t *testing.T) {
 						"Error diag",
 						"This is an error",
 					),
+				},
+			},
+			expectedSchemaResp: ModifySchemaPlanResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic(
+						"Error diag",
+						"This is an error",
+					),
+				},
+				Plan: Plan{
+					Raw: tftypes.NewValue(tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"test": tftypes.String,
+						},
+					}, map[string]tftypes.Value{
+						"test": tftypes.NewValue(tftypes.String, "TESTDIAG"),
+					}),
+					Schema: Schema{
+						Attributes: map[string]Attribute{
+							"test": {
+								Type:     types.StringType,
+								Required: true,
+								PlanModifiers: []AttributePlanModifier{
+									testErrorDiagModifier{},
+									testErrorDiagModifier{},
+								},
+							},
+						},
+					},
 				},
 			},
 		},
@@ -2024,6 +2458,39 @@ func TestAttributeModifyPlan(t *testing.T) {
 					),
 				},
 			},
+			expectedSchemaResp: ModifySchemaPlanResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic(
+						"Previous error diag",
+						"This was a previous error",
+					),
+					diag.NewErrorDiagnostic(
+						"Error diag",
+						"This is an error",
+					),
+				},
+				Plan: Plan{
+					Raw: tftypes.NewValue(tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"test": tftypes.String,
+						},
+					}, map[string]tftypes.Value{
+						"test": tftypes.NewValue(tftypes.String, "TESTDIAG"),
+					}),
+					Schema: Schema{
+						Attributes: map[string]Attribute{
+							"test": {
+								Type:     types.StringType,
+								Required: true,
+								PlanModifiers: []AttributePlanModifier{
+									testErrorDiagModifier{},
+									testErrorDiagModifier{},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 
@@ -2038,10 +2505,16 @@ func TestAttributeModifyPlan(t *testing.T) {
 				t.Fatalf("Unexpected error getting %s", err)
 			}
 
-			attribute.modifyPlan(context.Background(), tc.req, &tc.resp)
+			schemaResp := ModifySchemaPlanResponse{Plan: tc.req.Plan}
+
+			attribute.modifyPlan(context.Background(), tc.req, &tc.resp, &schemaResp)
 
 			if diff := cmp.Diff(tc.expectedResp, tc.resp); diff != "" {
 				t.Errorf("Unexpected response (-wanted, +got): %s", diff)
+			}
+
+			if diff := cmp.Diff(tc.expectedSchemaResp, schemaResp); diff != "" {
+				t.Errorf("Unexpected response (+wanted, -got): %s", diff)
 			}
 		})
 	}

--- a/tfsdk/attribute_test.go
+++ b/tfsdk/attribute_test.go
@@ -698,10 +698,9 @@ func TestAttributeModifyPlan(t *testing.T) {
 	t.Parallel()
 
 	testCases := map[string]struct {
-		req                ModifyAttributePlanRequest
-		resp               ModifyAttributePlanResponse
-		expectedResp       ModifyAttributePlanResponse
-		expectedSchemaResp ModifySchemaPlanResponse
+		req          ModifyAttributePlanRequest
+		resp         ModifySchemaPlanResponse // Plan automatically copied from req
+		expectedResp ModifySchemaPlanResponse
 	}{
 		"config-error": {
 			req: ModifyAttributePlanRequest{
@@ -758,21 +757,8 @@ func TestAttributeModifyPlan(t *testing.T) {
 					},
 				},
 			},
-			resp: ModifyAttributePlanResponse{
-				AttributePlan: types.String{Value: "testvalue"},
-			},
-			expectedResp: ModifyAttributePlanResponse{
-				AttributePlan: types.String{Value: "testvalue"},
-				Diagnostics: diag.Diagnostics{
-					diag.NewAttributeErrorDiagnostic(
-						tftypes.NewAttributePath().WithAttributeName("test"),
-						"Configuration Read Error",
-						"An unexpected error was encountered trying to read an attribute from the configuration. This is always an error in the provider. Please report the following to the provider developer:\n\n"+
-							"can't use tftypes.String<\"testvalue\"> as value of List with ElementType types.primitive, can only use tftypes.String values",
-					),
-				},
-			},
-			expectedSchemaResp: ModifySchemaPlanResponse{
+			resp: ModifySchemaPlanResponse{},
+			expectedResp: ModifySchemaPlanResponse{
 				Diagnostics: diag.Diagnostics{
 					diag.NewAttributeErrorDiagnostic(
 						tftypes.NewAttributePath().WithAttributeName("test"),
@@ -855,8 +841,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 					},
 				},
 			},
-			resp: ModifyAttributePlanResponse{
-				AttributePlan: types.String{Value: "testvalue"},
+			resp: ModifySchemaPlanResponse{
 				Diagnostics: diag.Diagnostics{
 					diag.NewErrorDiagnostic(
 						"Previous error diag",
@@ -864,22 +849,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 					),
 				},
 			},
-			expectedResp: ModifyAttributePlanResponse{
-				AttributePlan: types.String{Value: "testvalue"},
-				Diagnostics: diag.Diagnostics{
-					diag.NewErrorDiagnostic(
-						"Previous error diag",
-						"This was a previous error",
-					),
-					diag.NewAttributeErrorDiagnostic(
-						tftypes.NewAttributePath().WithAttributeName("test"),
-						"Configuration Read Error",
-						"An unexpected error was encountered trying to read an attribute from the configuration. This is always an error in the provider. Please report the following to the provider developer:\n\n"+
-							"can't use tftypes.String<\"testvalue\"> as value of List with ElementType types.primitive, can only use tftypes.String values",
-					),
-				},
-			},
-			expectedSchemaResp: ModifySchemaPlanResponse{
+			expectedResp: ModifySchemaPlanResponse{
 				Diagnostics: diag.Diagnostics{
 					diag.NewErrorDiagnostic(
 						"Previous error diag",
@@ -966,21 +936,8 @@ func TestAttributeModifyPlan(t *testing.T) {
 					},
 				},
 			},
-			resp: ModifyAttributePlanResponse{
-				AttributePlan: types.String{Value: "testvalue"},
-			},
-			expectedResp: ModifyAttributePlanResponse{
-				AttributePlan: types.String{Value: "testvalue"},
-				Diagnostics: diag.Diagnostics{
-					diag.NewAttributeErrorDiagnostic(
-						tftypes.NewAttributePath().WithAttributeName("test"),
-						"Plan Read Error",
-						"An unexpected error was encountered trying to read an attribute from the plan. This is always an error in the provider. Please report the following to the provider developer:\n\n"+
-							"can't use tftypes.String<\"testvalue\"> as value of List with ElementType types.primitive, can only use tftypes.String values",
-					),
-				},
-			},
-			expectedSchemaResp: ModifySchemaPlanResponse{
+			resp: ModifySchemaPlanResponse{},
+			expectedResp: ModifySchemaPlanResponse{
 				Diagnostics: diag.Diagnostics{
 					diag.NewAttributeErrorDiagnostic(
 						tftypes.NewAttributePath().WithAttributeName("test"),
@@ -1063,8 +1020,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 					},
 				},
 			},
-			resp: ModifyAttributePlanResponse{
-				AttributePlan: types.String{Value: "testvalue"},
+			resp: ModifySchemaPlanResponse{
 				Diagnostics: diag.Diagnostics{
 					diag.NewErrorDiagnostic(
 						"Previous error diag",
@@ -1072,22 +1028,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 					),
 				},
 			},
-			expectedResp: ModifyAttributePlanResponse{
-				AttributePlan: types.String{Value: "testvalue"},
-				Diagnostics: diag.Diagnostics{
-					diag.NewErrorDiagnostic(
-						"Previous error diag",
-						"This was a previous error",
-					),
-					diag.NewAttributeErrorDiagnostic(
-						tftypes.NewAttributePath().WithAttributeName("test"),
-						"Plan Read Error",
-						"An unexpected error was encountered trying to read an attribute from the plan. This is always an error in the provider. Please report the following to the provider developer:\n\n"+
-							"can't use tftypes.String<\"testvalue\"> as value of List with ElementType types.primitive, can only use tftypes.String values",
-					),
-				},
-			},
-			expectedSchemaResp: ModifySchemaPlanResponse{
+			expectedResp: ModifySchemaPlanResponse{
 				Diagnostics: diag.Diagnostics{
 					diag.NewErrorDiagnostic(
 						"Previous error diag",
@@ -1174,21 +1115,8 @@ func TestAttributeModifyPlan(t *testing.T) {
 					},
 				},
 			},
-			resp: ModifyAttributePlanResponse{
-				AttributePlan: types.String{Value: "testvalue"},
-			},
-			expectedResp: ModifyAttributePlanResponse{
-				AttributePlan: types.String{Value: "testvalue"},
-				Diagnostics: diag.Diagnostics{
-					diag.NewAttributeErrorDiagnostic(
-						tftypes.NewAttributePath().WithAttributeName("test"),
-						"State Read Error",
-						"An unexpected error was encountered trying to read an attribute from the state. This is always an error in the provider. Please report the following to the provider developer:\n\n"+
-							"can't use tftypes.String<\"testvalue\"> as value of List with ElementType types.primitive, can only use tftypes.String values",
-					),
-				},
-			},
-			expectedSchemaResp: ModifySchemaPlanResponse{
+			resp: ModifySchemaPlanResponse{},
+			expectedResp: ModifySchemaPlanResponse{
 				Diagnostics: diag.Diagnostics{
 					diag.NewAttributeErrorDiagnostic(
 						tftypes.NewAttributePath().WithAttributeName("test"),
@@ -1271,8 +1199,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 					},
 				},
 			},
-			resp: ModifyAttributePlanResponse{
-				AttributePlan: types.String{Value: "testvalue"},
+			resp: ModifySchemaPlanResponse{
 				Diagnostics: diag.Diagnostics{
 					diag.NewErrorDiagnostic(
 						"Previous error diag",
@@ -1280,22 +1207,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 					),
 				},
 			},
-			expectedResp: ModifyAttributePlanResponse{
-				AttributePlan: types.String{Value: "testvalue"},
-				Diagnostics: diag.Diagnostics{
-					diag.NewErrorDiagnostic(
-						"Previous error diag",
-						"This was a previous error",
-					),
-					diag.NewAttributeErrorDiagnostic(
-						tftypes.NewAttributePath().WithAttributeName("test"),
-						"State Read Error",
-						"An unexpected error was encountered trying to read an attribute from the state. This is always an error in the provider. Please report the following to the provider developer:\n\n"+
-							"can't use tftypes.String<\"testvalue\"> as value of List with ElementType types.primitive, can only use tftypes.String values",
-					),
-				},
-			},
-			expectedSchemaResp: ModifySchemaPlanResponse{
+			expectedResp: ModifySchemaPlanResponse{
 				Diagnostics: diag.Diagnostics{
 					diag.NewErrorDiagnostic(
 						"Previous error diag",
@@ -1382,13 +1294,8 @@ func TestAttributeModifyPlan(t *testing.T) {
 					},
 				},
 			},
-			resp: ModifyAttributePlanResponse{
-				AttributePlan: types.String{Value: "testvalue"},
-			},
-			expectedResp: ModifyAttributePlanResponse{
-				AttributePlan: types.String{Value: "testvalue"},
-			},
-			expectedSchemaResp: ModifySchemaPlanResponse{
+			resp: ModifySchemaPlanResponse{},
+			expectedResp: ModifySchemaPlanResponse{
 				Plan: Plan{
 					Raw: tftypes.NewValue(tftypes.Object{
 						AttributeTypes: map[string]tftypes.Type{
@@ -1475,13 +1382,8 @@ func TestAttributeModifyPlan(t *testing.T) {
 					},
 				},
 			},
-			resp: ModifyAttributePlanResponse{
-				AttributePlan: types.String{Value: "TESTATTRONE"},
-			},
-			expectedResp: ModifyAttributePlanResponse{
-				AttributePlan: types.String{Value: "MODIFIED_TWO"},
-			},
-			expectedSchemaResp: ModifySchemaPlanResponse{
+			resp: ModifySchemaPlanResponse{},
+			expectedResp: ModifySchemaPlanResponse{
 				Plan: Plan{
 					Raw: tftypes.NewValue(tftypes.Object{
 						AttributeTypes: map[string]tftypes.Type{
@@ -1572,8 +1474,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 					},
 				},
 			},
-			resp: ModifyAttributePlanResponse{
-				AttributePlan: types.String{Value: "TESTATTRONE"},
+			resp: ModifySchemaPlanResponse{
 				Diagnostics: diag.Diagnostics{
 					diag.NewErrorDiagnostic(
 						"Previous error diag",
@@ -1581,16 +1482,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 					),
 				},
 			},
-			expectedResp: ModifyAttributePlanResponse{
-				AttributePlan: types.String{Value: "MODIFIED_TWO"},
-				Diagnostics: diag.Diagnostics{
-					diag.NewErrorDiagnostic(
-						"Previous error diag",
-						"This was a previous error",
-					),
-				},
-			},
-			expectedSchemaResp: ModifySchemaPlanResponse{
+			expectedResp: ModifySchemaPlanResponse{
 				Diagnostics: diag.Diagnostics{
 					diag.NewErrorDiagnostic(
 						"Previous error diag",
@@ -1684,14 +1576,8 @@ func TestAttributeModifyPlan(t *testing.T) {
 					},
 				},
 			},
-			resp: ModifyAttributePlanResponse{
-				AttributePlan: types.String{Value: "newtestvalue"},
-			},
-			expectedResp: ModifyAttributePlanResponse{
-				AttributePlan:   types.String{Value: "newtestvalue"},
-				RequiresReplace: true,
-			},
-			expectedSchemaResp: ModifySchemaPlanResponse{
+			resp: ModifySchemaPlanResponse{},
+			expectedResp: ModifySchemaPlanResponse{
 				Plan: Plan{
 					Raw: tftypes.NewValue(tftypes.Object{
 						AttributeTypes: map[string]tftypes.Type{
@@ -1778,8 +1664,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 					},
 				},
 			},
-			resp: ModifyAttributePlanResponse{
-				AttributePlan: types.String{Value: "newtestvalue"},
+			resp: ModifySchemaPlanResponse{
 				Diagnostics: diag.Diagnostics{
 					diag.NewErrorDiagnostic(
 						"Previous error diag",
@@ -1787,17 +1672,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 					),
 				},
 			},
-			expectedResp: ModifyAttributePlanResponse{
-				AttributePlan: types.String{Value: "newtestvalue"},
-				Diagnostics: diag.Diagnostics{
-					diag.NewErrorDiagnostic(
-						"Previous error diag",
-						"This was a previous error",
-					),
-				},
-				RequiresReplace: true,
-			},
-			expectedSchemaResp: ModifySchemaPlanResponse{
+			expectedResp: ModifySchemaPlanResponse{
 				Diagnostics: diag.Diagnostics{
 					diag.NewErrorDiagnostic(
 						"Previous error diag",
@@ -1893,14 +1768,8 @@ func TestAttributeModifyPlan(t *testing.T) {
 					},
 				},
 			},
-			resp: ModifyAttributePlanResponse{
-				AttributePlan: types.String{Value: "TESTATTRONE"},
-			},
-			expectedResp: ModifyAttributePlanResponse{
-				AttributePlan:   types.String{Value: "TESTATTRTWO"},
-				RequiresReplace: true,
-			},
-			expectedSchemaResp: ModifySchemaPlanResponse{
+			resp: ModifySchemaPlanResponse{},
+			expectedResp: ModifySchemaPlanResponse{
 				Plan: Plan{
 					Raw: tftypes.NewValue(tftypes.Object{
 						AttributeTypes: map[string]tftypes.Type{
@@ -1990,13 +1859,8 @@ func TestAttributeModifyPlan(t *testing.T) {
 					},
 				},
 			},
-			resp: ModifyAttributePlanResponse{
-				AttributePlan: types.String{Value: "testvalue"},
-			},
-			expectedResp: ModifyAttributePlanResponse{
-				AttributePlan: types.String{Value: "testvalue"},
-			},
-			expectedSchemaResp: ModifySchemaPlanResponse{
+			resp: ModifySchemaPlanResponse{},
+			expectedResp: ModifySchemaPlanResponse{
 				Plan: Plan{
 					Raw: tftypes.NewValue(tftypes.Object{
 						AttributeTypes: map[string]tftypes.Type{
@@ -2083,22 +1947,8 @@ func TestAttributeModifyPlan(t *testing.T) {
 					},
 				},
 			},
-			resp: ModifyAttributePlanResponse{
-				AttributePlan: types.String{Value: "TESTDIAG"},
-			},
-			expectedResp: ModifyAttributePlanResponse{
-				AttributePlan: types.String{Value: "TESTDIAG"},
-				Diagnostics: diag.Diagnostics{
-					// Diagnostics.Append() deduplicates, so the warning will only
-					// be here once unless the test implementation is changed to
-					// different modifiers or the modifier itself is changed.
-					diag.NewWarningDiagnostic(
-						"Warning diag",
-						"This is a warning",
-					),
-				},
-			},
-			expectedSchemaResp: ModifySchemaPlanResponse{
+			resp: ModifySchemaPlanResponse{},
+			expectedResp: ModifySchemaPlanResponse{
 				Diagnostics: diag.Diagnostics{
 					// Diagnostics.Append() deduplicates, so the warning will only
 					// be here once unless the test implementation is changed to
@@ -2198,8 +2048,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 					},
 				},
 			},
-			resp: ModifyAttributePlanResponse{
-				AttributePlan: types.String{Value: "TESTDIAG"},
+			resp: ModifySchemaPlanResponse{
 				Diagnostics: diag.Diagnostics{
 					diag.NewErrorDiagnostic(
 						"Previous error diag",
@@ -2207,23 +2056,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 					),
 				},
 			},
-			expectedResp: ModifyAttributePlanResponse{
-				AttributePlan: types.String{Value: "TESTDIAG"},
-				Diagnostics: diag.Diagnostics{
-					diag.NewErrorDiagnostic(
-						"Previous error diag",
-						"This was a previous error",
-					),
-					// Diagnostics.Append() deduplicates, so the warning will only
-					// be here once unless the test implementation is changed to
-					// different modifiers or the modifier itself is changed.
-					diag.NewWarningDiagnostic(
-						"Warning diag",
-						"This is a warning",
-					),
-				},
-			},
-			expectedSchemaResp: ModifySchemaPlanResponse{
+			expectedResp: ModifySchemaPlanResponse{
 				Diagnostics: diag.Diagnostics{
 					diag.NewErrorDiagnostic(
 						"Previous error diag",
@@ -2327,19 +2160,8 @@ func TestAttributeModifyPlan(t *testing.T) {
 					},
 				},
 			},
-			resp: ModifyAttributePlanResponse{
-				AttributePlan: types.String{Value: "TESTDIAG"},
-			},
-			expectedResp: ModifyAttributePlanResponse{
-				AttributePlan: types.String{Value: "TESTDIAG"},
-				Diagnostics: diag.Diagnostics{
-					diag.NewErrorDiagnostic(
-						"Error diag",
-						"This is an error",
-					),
-				},
-			},
-			expectedSchemaResp: ModifySchemaPlanResponse{
+			resp: ModifySchemaPlanResponse{},
+			expectedResp: ModifySchemaPlanResponse{
 				Diagnostics: diag.Diagnostics{
 					diag.NewErrorDiagnostic(
 						"Error diag",
@@ -2436,8 +2258,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 					},
 				},
 			},
-			resp: ModifyAttributePlanResponse{
-				AttributePlan: types.String{Value: "TESTDIAG"},
+			resp: ModifySchemaPlanResponse{
 				Diagnostics: diag.Diagnostics{
 					diag.NewErrorDiagnostic(
 						"Previous error diag",
@@ -2445,20 +2266,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 					),
 				},
 			},
-			expectedResp: ModifyAttributePlanResponse{
-				AttributePlan: types.String{Value: "TESTDIAG"},
-				Diagnostics: diag.Diagnostics{
-					diag.NewErrorDiagnostic(
-						"Previous error diag",
-						"This was a previous error",
-					),
-					diag.NewErrorDiagnostic(
-						"Error diag",
-						"This is an error",
-					),
-				},
-			},
-			expectedSchemaResp: ModifySchemaPlanResponse{
+			expectedResp: ModifySchemaPlanResponse{
 				Diagnostics: diag.Diagnostics{
 					diag.NewErrorDiagnostic(
 						"Previous error diag",
@@ -2505,16 +2313,12 @@ func TestAttributeModifyPlan(t *testing.T) {
 				t.Fatalf("Unexpected error getting %s", err)
 			}
 
-			schemaResp := ModifySchemaPlanResponse{Plan: tc.req.Plan}
+			tc.resp.Plan = tc.req.Plan
 
-			attribute.modifyPlan(context.Background(), tc.req, &tc.resp, &schemaResp)
+			attribute.modifyPlan(context.Background(), tc.req, &tc.resp)
 
 			if diff := cmp.Diff(tc.expectedResp, tc.resp); diff != "" {
 				t.Errorf("Unexpected response (-wanted, +got): %s", diff)
-			}
-
-			if diff := cmp.Diff(tc.expectedSchemaResp, schemaResp); diff != "" {
-				t.Errorf("Unexpected response (+wanted, -got): %s", diff)
 			}
 		})
 	}

--- a/tfsdk/block_test.go
+++ b/tfsdk/block_test.go
@@ -99,19 +99,25 @@ func TestBlockModifyPlan(t *testing.T) {
 		},
 	)
 
-	modifyAttributePlanRequest := func(attrPath *tftypes.AttributePath, schema Schema, configValue, planValue, stateValue string) ModifyAttributePlanRequest {
+	type modifyAttributePlanValues struct {
+		config string
+		plan   string
+		state  string
+	}
+
+	modifyAttributePlanRequest := func(attrPath *tftypes.AttributePath, schema Schema, values modifyAttributePlanValues) ModifyAttributePlanRequest {
 		return ModifyAttributePlanRequest{
 			AttributePath: attrPath,
 			Config: Config{
-				Raw:    schemaTfValue(configValue),
+				Raw:    schemaTfValue(values.config),
 				Schema: schema,
 			},
 			Plan: Plan{
-				Raw:    schemaTfValue(planValue),
+				Raw:    schemaTfValue(values.plan),
 				Schema: schema,
 			},
 			State: State{
-				Raw:    schemaTfValue(stateValue),
+				Raw:    schemaTfValue(values.state),
 				Schema: schema,
 			},
 		}
@@ -126,9 +132,11 @@ func TestBlockModifyPlan(t *testing.T) {
 			req: modifyAttributePlanRequest(
 				tftypes.NewAttributePath().WithAttributeName("test"),
 				schema(nil, nil),
-				"testvalue",
-				"testvalue",
-				"testvalue",
+				modifyAttributePlanValues{
+					config: "testvalue",
+					plan:   "testvalue",
+					state:  "testvalue",
+				},
 			),
 			resp: ModifySchemaPlanResponse{},
 			expectedResp: ModifySchemaPlanResponse{
@@ -144,9 +152,11 @@ func TestBlockModifyPlan(t *testing.T) {
 				schema([]AttributePlanModifier{
 					testBlockPlanModifierNullList{},
 				}, nil),
-				"TESTATTRONE",
-				"TESTATTRONE",
-				"TESTATTRONE",
+				modifyAttributePlanValues{
+					config: "TESTATTRONE",
+					plan:   "TESTATTRONE",
+					state:  "TESTATTRONE",
+				},
 			),
 			resp: ModifySchemaPlanResponse{},
 			expectedResp: ModifySchemaPlanResponse{
@@ -164,9 +174,11 @@ func TestBlockModifyPlan(t *testing.T) {
 				schema([]AttributePlanModifier{
 					testBlockPlanModifierNullList{},
 				}, nil),
-				"TESTATTRONE",
-				"TESTATTRONE",
-				"TESTATTRONE",
+				modifyAttributePlanValues{
+					config: "TESTATTRONE",
+					plan:   "TESTATTRONE",
+					state:  "TESTATTRONE",
+				},
 			),
 			resp: ModifySchemaPlanResponse{
 				Diagnostics: diag.Diagnostics{
@@ -197,9 +209,11 @@ func TestBlockModifyPlan(t *testing.T) {
 				schema([]AttributePlanModifier{
 					RequiresReplace(),
 				}, nil),
-				"newtestvalue",
-				"newtestvalue",
-				"testvalue",
+				modifyAttributePlanValues{
+					config: "newtestvalue",
+					plan:   "newtestvalue",
+					state:  "testvalue",
+				},
 			),
 			resp: ModifySchemaPlanResponse{},
 			expectedResp: ModifySchemaPlanResponse{
@@ -220,9 +234,11 @@ func TestBlockModifyPlan(t *testing.T) {
 				schema([]AttributePlanModifier{
 					RequiresReplace(),
 				}, nil),
-				"newtestvalue",
-				"newtestvalue",
-				"testvalue",
+				modifyAttributePlanValues{
+					config: "newtestvalue",
+					plan:   "newtestvalue",
+					state:  "testvalue",
+				},
 			),
 			resp: ModifySchemaPlanResponse{
 				Diagnostics: diag.Diagnostics{
@@ -257,9 +273,11 @@ func TestBlockModifyPlan(t *testing.T) {
 					RequiresReplace(),
 					testBlockPlanModifierNullList{},
 				}, nil),
-				"newtestvalue",
-				"newtestvalue",
-				"testvalue",
+				modifyAttributePlanValues{
+					config: "newtestvalue",
+					plan:   "newtestvalue",
+					state:  "testvalue",
+				},
 			),
 			resp: ModifySchemaPlanResponse{},
 			expectedResp: ModifySchemaPlanResponse{
@@ -282,9 +300,11 @@ func TestBlockModifyPlan(t *testing.T) {
 					RequiresReplace(),
 					testRequiresReplaceFalseModifier{},
 				}, nil),
-				"newtestvalue",
-				"newtestvalue",
-				"testvalue",
+				modifyAttributePlanValues{
+					config: "newtestvalue",
+					plan:   "newtestvalue",
+					state:  "testvalue",
+				},
 			),
 			resp: ModifySchemaPlanResponse{},
 			expectedResp: ModifySchemaPlanResponse{
@@ -304,9 +324,11 @@ func TestBlockModifyPlan(t *testing.T) {
 					testWarningDiagModifier{},
 					testWarningDiagModifier{},
 				}, nil),
-				"TESTDIAG",
-				"TESTDIAG",
-				"TESTDIAG",
+				modifyAttributePlanValues{
+					config: "TESTDIAG",
+					plan:   "TESTDIAG",
+					state:  "TESTDIAG",
+				},
 			),
 			resp: ModifySchemaPlanResponse{},
 			expectedResp: ModifySchemaPlanResponse{
@@ -335,9 +357,11 @@ func TestBlockModifyPlan(t *testing.T) {
 					testWarningDiagModifier{},
 					testWarningDiagModifier{},
 				}, nil),
-				"TESTDIAG",
-				"TESTDIAG",
-				"TESTDIAG",
+				modifyAttributePlanValues{
+					config: "TESTDIAG",
+					plan:   "TESTDIAG",
+					state:  "TESTDIAG",
+				},
 			),
 			resp: ModifySchemaPlanResponse{
 				Diagnostics: diag.Diagnostics{
@@ -377,9 +401,11 @@ func TestBlockModifyPlan(t *testing.T) {
 					testErrorDiagModifier{},
 					testErrorDiagModifier{},
 				}, nil),
-				"TESTDIAG",
-				"TESTDIAG",
-				"TESTDIAG",
+				modifyAttributePlanValues{
+					config: "TESTDIAG",
+					plan:   "TESTDIAG",
+					state:  "TESTDIAG",
+				},
 			),
 			resp: ModifySchemaPlanResponse{},
 			expectedResp: ModifySchemaPlanResponse{
@@ -405,9 +431,11 @@ func TestBlockModifyPlan(t *testing.T) {
 					testErrorDiagModifier{},
 					testErrorDiagModifier{},
 				}, nil),
-				"TESTDIAG",
-				"TESTDIAG",
-				"TESTDIAG",
+				modifyAttributePlanValues{
+					config: "TESTDIAG",
+					plan:   "TESTDIAG",
+					state:  "TESTDIAG",
+				},
 			),
 			resp: ModifySchemaPlanResponse{
 				Diagnostics: diag.Diagnostics{
@@ -444,9 +472,11 @@ func TestBlockModifyPlan(t *testing.T) {
 					testAttrPlanValueModifierOne{},
 					testAttrPlanValueModifierTwo{},
 				}),
-				"TESTATTRONE",
-				"TESTATTRONE",
-				"TESTATTRONE",
+				modifyAttributePlanValues{
+					config: "TESTATTRONE",
+					plan:   "TESTATTRONE",
+					state:  "TESTATTRONE",
+				},
 			),
 			resp: ModifySchemaPlanResponse{},
 			expectedResp: ModifySchemaPlanResponse{
@@ -466,9 +496,11 @@ func TestBlockModifyPlan(t *testing.T) {
 					testAttrPlanValueModifierOne{},
 					testAttrPlanValueModifierTwo{},
 				}),
-				"TESTATTRONE",
-				"TESTATTRONE",
-				"TESTATTRONE",
+				modifyAttributePlanValues{
+					config: "TESTATTRONE",
+					plan:   "TESTATTRONE",
+					state:  "TESTATTRONE",
+				},
 			),
 			resp: ModifySchemaPlanResponse{
 				Diagnostics: diag.Diagnostics{
@@ -500,9 +532,11 @@ func TestBlockModifyPlan(t *testing.T) {
 				schema(nil, []AttributePlanModifier{
 					RequiresReplace(),
 				}),
-				"newtestvalue",
-				"newtestvalue",
-				"testvalue",
+				modifyAttributePlanValues{
+					config: "newtestvalue",
+					plan:   "newtestvalue",
+					state:  "testvalue",
+				},
 			),
 			resp: ModifySchemaPlanResponse{},
 			expectedResp: ModifySchemaPlanResponse{
@@ -523,9 +557,11 @@ func TestBlockModifyPlan(t *testing.T) {
 				schema(nil, []AttributePlanModifier{
 					RequiresReplace(),
 				}),
-				"newtestvalue",
-				"newtestvalue",
-				"testvalue",
+				modifyAttributePlanValues{
+					config: "newtestvalue",
+					plan:   "newtestvalue",
+					state:  "testvalue",
+				},
 			),
 			resp: ModifySchemaPlanResponse{
 				Diagnostics: diag.Diagnostics{
@@ -560,9 +596,11 @@ func TestBlockModifyPlan(t *testing.T) {
 					RequiresReplace(),
 					testAttrPlanValueModifierOne{},
 				}),
-				"TESTATTRONE",
-				"TESTATTRONE",
-				"previousvalue",
+				modifyAttributePlanValues{
+					config: "TESTATTRONE",
+					plan:   "TESTATTRONE",
+					state:  "previousvalue",
+				},
 			),
 			resp: ModifySchemaPlanResponse{},
 			expectedResp: ModifySchemaPlanResponse{
@@ -585,9 +623,11 @@ func TestBlockModifyPlan(t *testing.T) {
 					RequiresReplace(),
 					testRequiresReplaceFalseModifier{},
 				}),
-				"newtestvalue",
-				"newtestvalue",
-				"testvalue",
+				modifyAttributePlanValues{
+					config: "newtestvalue",
+					plan:   "newtestvalue",
+					state:  "testvalue",
+				},
 			),
 			resp: ModifySchemaPlanResponse{},
 			expectedResp: ModifySchemaPlanResponse{
@@ -607,9 +647,11 @@ func TestBlockModifyPlan(t *testing.T) {
 					testWarningDiagModifier{},
 					testWarningDiagModifier{},
 				}),
-				"TESTDIAG",
-				"TESTDIAG",
-				"TESTDIAG",
+				modifyAttributePlanValues{
+					config: "TESTDIAG",
+					plan:   "TESTDIAG",
+					state:  "TESTDIAG",
+				},
 			),
 			resp: ModifySchemaPlanResponse{},
 			expectedResp: ModifySchemaPlanResponse{
@@ -638,9 +680,11 @@ func TestBlockModifyPlan(t *testing.T) {
 					testWarningDiagModifier{},
 					testWarningDiagModifier{},
 				}),
-				"TESTDIAG",
-				"TESTDIAG",
-				"TESTDIAG",
+				modifyAttributePlanValues{
+					config: "TESTDIAG",
+					plan:   "TESTDIAG",
+					state:  "TESTDIAG",
+				},
 			),
 			resp: ModifySchemaPlanResponse{
 				Diagnostics: diag.Diagnostics{
@@ -680,9 +724,11 @@ func TestBlockModifyPlan(t *testing.T) {
 					testErrorDiagModifier{},
 					testErrorDiagModifier{},
 				}),
-				"TESTDIAG",
-				"TESTDIAG",
-				"TESTDIAG",
+				modifyAttributePlanValues{
+					config: "TESTDIAG",
+					plan:   "TESTDIAG",
+					state:  "TESTDIAG",
+				},
 			),
 			resp: ModifySchemaPlanResponse{},
 			expectedResp: ModifySchemaPlanResponse{
@@ -708,9 +754,11 @@ func TestBlockModifyPlan(t *testing.T) {
 					testErrorDiagModifier{},
 					testErrorDiagModifier{},
 				}),
-				"TESTDIAG",
-				"TESTDIAG",
-				"TESTDIAG",
+				modifyAttributePlanValues{
+					config: "TESTDIAG",
+					plan:   "TESTDIAG",
+					state:  "TESTDIAG",
+				},
 			),
 			resp: ModifySchemaPlanResponse{
 				Diagnostics: diag.Diagnostics{

--- a/tfsdk/block_test.go
+++ b/tfsdk/block_test.go
@@ -16,35 +16,6 @@ import (
 func TestBlockModifyPlan(t *testing.T) {
 	t.Parallel()
 
-	blockValue := func(elementValue string) attr.Value {
-		return types.List{
-			ElemType: types.ObjectType{
-				AttrTypes: map[string]attr.Type{
-					"nested_attr": types.StringType,
-				},
-			},
-			Elems: []attr.Value{
-				types.Object{
-					AttrTypes: map[string]attr.Type{
-						"nested_attr": types.StringType,
-					},
-					Attrs: map[string]attr.Value{
-						"nested_attr": types.String{Value: elementValue},
-					},
-				},
-			},
-		}
-	}
-
-	var blockNullValue attr.Value = types.List{
-		ElemType: types.ObjectType{
-			AttrTypes: map[string]attr.Type{
-				"nested_attr": types.StringType,
-			},
-		},
-		Null: true,
-	}
-
 	schema := func(blockPlanModifiers AttributePlanModifiers, nestedAttrPlanModifiers AttributePlanModifiers) Schema {
 		return Schema{
 			Blocks: map[string]Block{
@@ -147,10 +118,9 @@ func TestBlockModifyPlan(t *testing.T) {
 	}
 
 	testCases := map[string]struct {
-		req                ModifyAttributePlanRequest
-		resp               ModifyAttributePlanResponse
-		expectedResp       ModifyAttributePlanResponse
-		expectedSchemaResp ModifySchemaPlanResponse
+		req          ModifyAttributePlanRequest
+		resp         ModifySchemaPlanResponse // Plan automatically copied from req
+		expectedResp ModifySchemaPlanResponse
 	}{
 		"no-plan-modifiers": {
 			req: modifyAttributePlanRequest(
@@ -160,13 +130,8 @@ func TestBlockModifyPlan(t *testing.T) {
 				"testvalue",
 				"testvalue",
 			),
-			resp: ModifyAttributePlanResponse{
-				AttributePlan: blockValue("testvalue"),
-			},
-			expectedResp: ModifyAttributePlanResponse{
-				AttributePlan: blockValue("testvalue"),
-			},
-			expectedSchemaResp: ModifySchemaPlanResponse{
+			resp: ModifySchemaPlanResponse{},
+			expectedResp: ModifySchemaPlanResponse{
 				Plan: Plan{
 					Raw:    schemaTfValue("testvalue"),
 					Schema: schema(nil, nil),
@@ -183,13 +148,8 @@ func TestBlockModifyPlan(t *testing.T) {
 				"TESTATTRONE",
 				"TESTATTRONE",
 			),
-			resp: ModifyAttributePlanResponse{
-				AttributePlan: blockValue("TESTATTRONE"),
-			},
-			expectedResp: ModifyAttributePlanResponse{
-				AttributePlan: blockNullValue,
-			},
-			expectedSchemaResp: ModifySchemaPlanResponse{
+			resp: ModifySchemaPlanResponse{},
+			expectedResp: ModifySchemaPlanResponse{
 				Plan: Plan{
 					Raw: schemaNullTfValue,
 					Schema: schema([]AttributePlanModifier{
@@ -208,8 +168,7 @@ func TestBlockModifyPlan(t *testing.T) {
 				"TESTATTRONE",
 				"TESTATTRONE",
 			),
-			resp: ModifyAttributePlanResponse{
-				AttributePlan: blockValue("TESTATTRONE"),
+			resp: ModifySchemaPlanResponse{
 				Diagnostics: diag.Diagnostics{
 					diag.NewErrorDiagnostic(
 						"Previous error diag",
@@ -217,16 +176,7 @@ func TestBlockModifyPlan(t *testing.T) {
 					),
 				},
 			},
-			expectedResp: ModifyAttributePlanResponse{
-				AttributePlan: blockNullValue,
-				Diagnostics: diag.Diagnostics{
-					diag.NewErrorDiagnostic(
-						"Previous error diag",
-						"This was a previous error",
-					),
-				},
-			},
-			expectedSchemaResp: ModifySchemaPlanResponse{
+			expectedResp: ModifySchemaPlanResponse{
 				Diagnostics: diag.Diagnostics{
 					diag.NewErrorDiagnostic(
 						"Previous error diag",
@@ -251,14 +201,8 @@ func TestBlockModifyPlan(t *testing.T) {
 				"newtestvalue",
 				"testvalue",
 			),
-			resp: ModifyAttributePlanResponse{
-				AttributePlan: blockValue("newtestvalue"),
-			},
-			expectedResp: ModifyAttributePlanResponse{
-				AttributePlan:   blockValue("newtestvalue"),
-				RequiresReplace: true,
-			},
-			expectedSchemaResp: ModifySchemaPlanResponse{
+			resp: ModifySchemaPlanResponse{},
+			expectedResp: ModifySchemaPlanResponse{
 				Plan: Plan{
 					Raw: schemaTfValue("newtestvalue"),
 					Schema: schema([]AttributePlanModifier{
@@ -280,8 +224,7 @@ func TestBlockModifyPlan(t *testing.T) {
 				"newtestvalue",
 				"testvalue",
 			),
-			resp: ModifyAttributePlanResponse{
-				AttributePlan: blockValue("newtestvalue"),
+			resp: ModifySchemaPlanResponse{
 				Diagnostics: diag.Diagnostics{
 					diag.NewErrorDiagnostic(
 						"Previous error diag",
@@ -289,17 +232,7 @@ func TestBlockModifyPlan(t *testing.T) {
 					),
 				},
 			},
-			expectedResp: ModifyAttributePlanResponse{
-				AttributePlan: blockValue("newtestvalue"),
-				Diagnostics: diag.Diagnostics{
-					diag.NewErrorDiagnostic(
-						"Previous error diag",
-						"This was a previous error",
-					),
-				},
-				RequiresReplace: true,
-			},
-			expectedSchemaResp: ModifySchemaPlanResponse{
+			expectedResp: ModifySchemaPlanResponse{
 				Diagnostics: diag.Diagnostics{
 					diag.NewErrorDiagnostic(
 						"Previous error diag",
@@ -328,14 +261,8 @@ func TestBlockModifyPlan(t *testing.T) {
 				"newtestvalue",
 				"testvalue",
 			),
-			resp: ModifyAttributePlanResponse{
-				AttributePlan: blockValue("newtestvalue"),
-			},
-			expectedResp: ModifyAttributePlanResponse{
-				AttributePlan:   blockNullValue,
-				RequiresReplace: true,
-			},
-			expectedSchemaResp: ModifySchemaPlanResponse{
+			resp: ModifySchemaPlanResponse{},
+			expectedResp: ModifySchemaPlanResponse{
 				Plan: Plan{
 					Raw: schemaNullTfValue,
 					Schema: schema([]AttributePlanModifier{
@@ -359,13 +286,8 @@ func TestBlockModifyPlan(t *testing.T) {
 				"newtestvalue",
 				"testvalue",
 			),
-			resp: ModifyAttributePlanResponse{
-				AttributePlan: blockValue("newtestvalue"),
-			},
-			expectedResp: ModifyAttributePlanResponse{
-				AttributePlan: blockValue("newtestvalue"),
-			},
-			expectedSchemaResp: ModifySchemaPlanResponse{
+			resp: ModifySchemaPlanResponse{},
+			expectedResp: ModifySchemaPlanResponse{
 				Plan: Plan{
 					Raw: schemaTfValue("newtestvalue"),
 					Schema: schema([]AttributePlanModifier{
@@ -386,22 +308,8 @@ func TestBlockModifyPlan(t *testing.T) {
 				"TESTDIAG",
 				"TESTDIAG",
 			),
-			resp: ModifyAttributePlanResponse{
-				AttributePlan: blockValue("TESTDIAG"),
-			},
-			expectedResp: ModifyAttributePlanResponse{
-				AttributePlan: blockValue("TESTDIAG"),
-				Diagnostics: diag.Diagnostics{
-					// Diagnostics.Append() deduplicates, so the warning will only
-					// be here once unless the test implementation is changed to
-					// different modifiers or the modifier itself is changed.
-					diag.NewWarningDiagnostic(
-						"Warning diag",
-						"This is a warning",
-					),
-				},
-			},
-			expectedSchemaResp: ModifySchemaPlanResponse{
+			resp: ModifySchemaPlanResponse{},
+			expectedResp: ModifySchemaPlanResponse{
 				Diagnostics: diag.Diagnostics{
 					// Diagnostics.Append() deduplicates, so the warning will only
 					// be here once unless the test implementation is changed to
@@ -431,8 +339,7 @@ func TestBlockModifyPlan(t *testing.T) {
 				"TESTDIAG",
 				"TESTDIAG",
 			),
-			resp: ModifyAttributePlanResponse{
-				AttributePlan: blockValue("TESTDIAG"),
+			resp: ModifySchemaPlanResponse{
 				Diagnostics: diag.Diagnostics{
 					diag.NewErrorDiagnostic(
 						"Previous error diag",
@@ -440,23 +347,7 @@ func TestBlockModifyPlan(t *testing.T) {
 					),
 				},
 			},
-			expectedResp: ModifyAttributePlanResponse{
-				AttributePlan: blockValue("TESTDIAG"),
-				Diagnostics: diag.Diagnostics{
-					diag.NewErrorDiagnostic(
-						"Previous error diag",
-						"This was a previous error",
-					),
-					// Diagnostics.Append() deduplicates, so the warning will only
-					// be here once unless the test implementation is changed to
-					// different modifiers or the modifier itself is changed.
-					diag.NewWarningDiagnostic(
-						"Warning diag",
-						"This is a warning",
-					),
-				},
-			},
-			expectedSchemaResp: ModifySchemaPlanResponse{
+			expectedResp: ModifySchemaPlanResponse{
 				Diagnostics: diag.Diagnostics{
 					diag.NewErrorDiagnostic(
 						"Previous error diag",
@@ -490,19 +381,8 @@ func TestBlockModifyPlan(t *testing.T) {
 				"TESTDIAG",
 				"TESTDIAG",
 			),
-			resp: ModifyAttributePlanResponse{
-				AttributePlan: blockValue("TESTDIAG"),
-			},
-			expectedResp: ModifyAttributePlanResponse{
-				AttributePlan: blockValue("TESTDIAG"),
-				Diagnostics: diag.Diagnostics{
-					diag.NewErrorDiagnostic(
-						"Error diag",
-						"This is an error",
-					),
-				},
-			},
-			expectedSchemaResp: ModifySchemaPlanResponse{
+			resp: ModifySchemaPlanResponse{},
+			expectedResp: ModifySchemaPlanResponse{
 				Diagnostics: diag.Diagnostics{
 					diag.NewErrorDiagnostic(
 						"Error diag",
@@ -529,8 +409,7 @@ func TestBlockModifyPlan(t *testing.T) {
 				"TESTDIAG",
 				"TESTDIAG",
 			),
-			resp: ModifyAttributePlanResponse{
-				AttributePlan: blockValue("TESTDIAG"),
+			resp: ModifySchemaPlanResponse{
 				Diagnostics: diag.Diagnostics{
 					diag.NewErrorDiagnostic(
 						"Previous error diag",
@@ -538,20 +417,7 @@ func TestBlockModifyPlan(t *testing.T) {
 					),
 				},
 			},
-			expectedResp: ModifyAttributePlanResponse{
-				AttributePlan: blockValue("TESTDIAG"),
-				Diagnostics: diag.Diagnostics{
-					diag.NewErrorDiagnostic(
-						"Previous error diag",
-						"This was a previous error",
-					),
-					diag.NewErrorDiagnostic(
-						"Error diag",
-						"This is an error",
-					),
-				},
-			},
-			expectedSchemaResp: ModifySchemaPlanResponse{
+			expectedResp: ModifySchemaPlanResponse{
 				Diagnostics: diag.Diagnostics{
 					diag.NewErrorDiagnostic(
 						"Previous error diag",
@@ -582,16 +448,8 @@ func TestBlockModifyPlan(t *testing.T) {
 				"TESTATTRONE",
 				"TESTATTRONE",
 			),
-			resp: ModifyAttributePlanResponse{
-				AttributePlan: blockValue("TESTATTRONE"),
-			},
-			expectedResp: ModifyAttributePlanResponse{
-				// This value is not expected to be updated here since plan
-				// modification occurred outside the block itself.
-				// See the schema response instead.
-				AttributePlan: blockValue("TESTATTRONE"),
-			},
-			expectedSchemaResp: ModifySchemaPlanResponse{
+			resp: ModifySchemaPlanResponse{},
+			expectedResp: ModifySchemaPlanResponse{
 				Plan: Plan{
 					Raw: schemaTfValue("MODIFIED_TWO"),
 					Schema: schema(nil, []AttributePlanModifier{
@@ -612,8 +470,7 @@ func TestBlockModifyPlan(t *testing.T) {
 				"TESTATTRONE",
 				"TESTATTRONE",
 			),
-			resp: ModifyAttributePlanResponse{
-				AttributePlan: blockValue("TESTATTRONE"),
+			resp: ModifySchemaPlanResponse{
 				Diagnostics: diag.Diagnostics{
 					diag.NewErrorDiagnostic(
 						"Previous error diag",
@@ -621,19 +478,7 @@ func TestBlockModifyPlan(t *testing.T) {
 					),
 				},
 			},
-			expectedResp: ModifyAttributePlanResponse{
-				// This value is not expected to be updated here since plan
-				// modification occurred outside the block itself.
-				// See the schema response instead.
-				AttributePlan: blockValue("TESTATTRONE"),
-				Diagnostics: diag.Diagnostics{
-					diag.NewErrorDiagnostic(
-						"Previous error diag",
-						"This was a previous error",
-					),
-				},
-			},
-			expectedSchemaResp: ModifySchemaPlanResponse{
+			expectedResp: ModifySchemaPlanResponse{
 				Diagnostics: diag.Diagnostics{
 					diag.NewErrorDiagnostic(
 						"Previous error diag",
@@ -659,13 +504,8 @@ func TestBlockModifyPlan(t *testing.T) {
 				"newtestvalue",
 				"testvalue",
 			),
-			resp: ModifyAttributePlanResponse{
-				AttributePlan: blockValue("newtestvalue"),
-			},
-			expectedResp: ModifyAttributePlanResponse{
-				AttributePlan: blockValue("newtestvalue"),
-			},
-			expectedSchemaResp: ModifySchemaPlanResponse{
+			resp: ModifySchemaPlanResponse{},
+			expectedResp: ModifySchemaPlanResponse{
 				Plan: Plan{
 					Raw: schemaTfValue("newtestvalue"),
 					Schema: schema(nil, []AttributePlanModifier{
@@ -687,8 +527,7 @@ func TestBlockModifyPlan(t *testing.T) {
 				"newtestvalue",
 				"testvalue",
 			),
-			resp: ModifyAttributePlanResponse{
-				AttributePlan: blockValue("newtestvalue"),
+			resp: ModifySchemaPlanResponse{
 				Diagnostics: diag.Diagnostics{
 					diag.NewErrorDiagnostic(
 						"Previous error diag",
@@ -696,16 +535,7 @@ func TestBlockModifyPlan(t *testing.T) {
 					),
 				},
 			},
-			expectedResp: ModifyAttributePlanResponse{
-				AttributePlan: blockValue("newtestvalue"),
-				Diagnostics: diag.Diagnostics{
-					diag.NewErrorDiagnostic(
-						"Previous error diag",
-						"This was a previous error",
-					),
-				},
-			},
-			expectedSchemaResp: ModifySchemaPlanResponse{
+			expectedResp: ModifySchemaPlanResponse{
 				Diagnostics: diag.Diagnostics{
 					diag.NewErrorDiagnostic(
 						"Previous error diag",
@@ -734,16 +564,8 @@ func TestBlockModifyPlan(t *testing.T) {
 				"TESTATTRONE",
 				"previousvalue",
 			),
-			resp: ModifyAttributePlanResponse{
-				AttributePlan: blockValue("TESTATTRONE"),
-			},
-			expectedResp: ModifyAttributePlanResponse{
-				// This value is not expected to be updated here since plan
-				// modification occurred outside the block itself.
-				// See the schema response instead.
-				AttributePlan: blockValue("TESTATTRONE"),
-			},
-			expectedSchemaResp: ModifySchemaPlanResponse{
+			resp: ModifySchemaPlanResponse{},
+			expectedResp: ModifySchemaPlanResponse{
 				Plan: Plan{
 					Raw: schemaTfValue("TESTATTRTWO"),
 					Schema: schema(nil, []AttributePlanModifier{
@@ -767,13 +589,8 @@ func TestBlockModifyPlan(t *testing.T) {
 				"newtestvalue",
 				"testvalue",
 			),
-			resp: ModifyAttributePlanResponse{
-				AttributePlan: blockValue("newtestvalue"),
-			},
-			expectedResp: ModifyAttributePlanResponse{
-				AttributePlan: blockValue("newtestvalue"),
-			},
-			expectedSchemaResp: ModifySchemaPlanResponse{
+			resp: ModifySchemaPlanResponse{},
+			expectedResp: ModifySchemaPlanResponse{
 				Plan: Plan{
 					Raw: schemaTfValue("newtestvalue"),
 					Schema: schema(nil, []AttributePlanModifier{
@@ -794,16 +611,8 @@ func TestBlockModifyPlan(t *testing.T) {
 				"TESTDIAG",
 				"TESTDIAG",
 			),
-			resp: ModifyAttributePlanResponse{
-				AttributePlan: blockValue("TESTDIAG"),
-			},
-			expectedResp: ModifyAttributePlanResponse{
-				AttributePlan: blockValue("TESTDIAG"),
-				// This additional diagnostic is not expected here since plan
-				// modification error occurred outside the block itself.
-				// See the schema response instead.
-			},
-			expectedSchemaResp: ModifySchemaPlanResponse{
+			resp: ModifySchemaPlanResponse{},
+			expectedResp: ModifySchemaPlanResponse{
 				Diagnostics: diag.Diagnostics{
 					// Diagnostics.Append() deduplicates, so the warning will only
 					// be here once unless the test implementation is changed to
@@ -833,8 +642,7 @@ func TestBlockModifyPlan(t *testing.T) {
 				"TESTDIAG",
 				"TESTDIAG",
 			),
-			resp: ModifyAttributePlanResponse{
-				AttributePlan: blockValue("TESTDIAG"),
+			resp: ModifySchemaPlanResponse{
 				Diagnostics: diag.Diagnostics{
 					diag.NewErrorDiagnostic(
 						"Previous error diag",
@@ -842,19 +650,7 @@ func TestBlockModifyPlan(t *testing.T) {
 					),
 				},
 			},
-			expectedResp: ModifyAttributePlanResponse{
-				AttributePlan: blockValue("TESTDIAG"),
-				Diagnostics: diag.Diagnostics{
-					diag.NewErrorDiagnostic(
-						"Previous error diag",
-						"This was a previous error",
-					),
-					// This additional diagnostic is not expected here since plan
-					// modification error occurred outside the block itself.
-					// See the schema response instead.
-				},
-			},
-			expectedSchemaResp: ModifySchemaPlanResponse{
+			expectedResp: ModifySchemaPlanResponse{
 				Diagnostics: diag.Diagnostics{
 					diag.NewErrorDiagnostic(
 						"Previous error diag",
@@ -888,16 +684,8 @@ func TestBlockModifyPlan(t *testing.T) {
 				"TESTDIAG",
 				"TESTDIAG",
 			),
-			resp: ModifyAttributePlanResponse{
-				AttributePlan: blockValue("TESTDIAG"),
-			},
-			expectedResp: ModifyAttributePlanResponse{
-				AttributePlan: blockValue("TESTDIAG"),
-				// This additional diagnostic is not expected here since plan
-				// modification error occurred outside the block itself.
-				// See the schema response instead.
-			},
-			expectedSchemaResp: ModifySchemaPlanResponse{
+			resp: ModifySchemaPlanResponse{},
+			expectedResp: ModifySchemaPlanResponse{
 				Diagnostics: diag.Diagnostics{
 					diag.NewErrorDiagnostic(
 						"Error diag",
@@ -924,8 +712,7 @@ func TestBlockModifyPlan(t *testing.T) {
 				"TESTDIAG",
 				"TESTDIAG",
 			),
-			resp: ModifyAttributePlanResponse{
-				AttributePlan: blockValue("TESTDIAG"),
+			resp: ModifySchemaPlanResponse{
 				Diagnostics: diag.Diagnostics{
 					diag.NewErrorDiagnostic(
 						"Previous error diag",
@@ -933,19 +720,7 @@ func TestBlockModifyPlan(t *testing.T) {
 					),
 				},
 			},
-			expectedResp: ModifyAttributePlanResponse{
-				AttributePlan: blockValue("TESTDIAG"),
-				Diagnostics: diag.Diagnostics{
-					diag.NewErrorDiagnostic(
-						"Previous error diag",
-						"This was a previous error",
-					),
-					// This additional diagnostic is not expected here since plan
-					// modification error occurred outside the block itself.
-					// See the schema response instead.
-				},
-			},
-			expectedSchemaResp: ModifySchemaPlanResponse{
+			expectedResp: ModifySchemaPlanResponse{
 				Diagnostics: diag.Diagnostics{
 					diag.NewErrorDiagnostic(
 						"Previous error diag",
@@ -978,15 +753,11 @@ func TestBlockModifyPlan(t *testing.T) {
 				t.Fatalf("Unexpected error getting %s", err)
 			}
 
-			schemaResp := ModifySchemaPlanResponse{Plan: tc.req.Plan}
+			tc.resp.Plan = tc.req.Plan
 
-			block.modifyPlan(context.Background(), tc.req, &tc.resp, &schemaResp)
+			block.modifyPlan(context.Background(), tc.req, &tc.resp)
 
 			if diff := cmp.Diff(tc.expectedResp, tc.resp); diff != "" {
-				t.Errorf("Unexpected response (+wanted, -got): %s", diff)
-			}
-
-			if diff := cmp.Diff(tc.expectedSchemaResp, schemaResp); diff != "" {
 				t.Errorf("Unexpected response (+wanted, -got): %s", diff)
 			}
 		})

--- a/tfsdk/schema.go
+++ b/tfsdk/schema.go
@@ -317,11 +317,8 @@ func (s Schema) modifyPlan(ctx context.Context, req ModifySchemaPlanRequest, res
 			Plan:          req.Plan,
 			ProviderMeta:  req.ProviderMeta,
 		}
-		attrResp := &ModifyAttributePlanResponse{
-			Diagnostics: resp.Diagnostics,
-		}
 
-		attr.modifyPlan(ctx, attrReq, attrResp, resp)
+		attr.modifyPlan(ctx, attrReq, resp)
 	}
 
 	for name, block := range s.Blocks {
@@ -332,10 +329,7 @@ func (s Schema) modifyPlan(ctx context.Context, req ModifySchemaPlanRequest, res
 			Plan:          req.Plan,
 			ProviderMeta:  req.ProviderMeta,
 		}
-		blockResp := &ModifyAttributePlanResponse{
-			Diagnostics: resp.Diagnostics,
-		}
 
-		block.modifyPlan(ctx, blockReq, blockResp, resp)
+		block.modifyPlan(ctx, blockReq, resp)
 	}
 }

--- a/tfsdk/schema.go
+++ b/tfsdk/schema.go
@@ -18,6 +18,10 @@ var (
 	// it's an element, attribute, or block of a complex type, not a nested
 	// attribute.
 	ErrPathInsideAtomicAttribute = errors.New("path leads to element, attribute, or block of a schema.Attribute that has no schema associated with it")
+
+	// ErrPathIsBlock is used with AttributeAtPath is called on a path is a
+	// block, not an attribute. Use blockAtPath on the path instead.
+	ErrPathIsBlock = errors.New("path leads to block, not an attribute")
 )
 
 // Schema is used to define the shape of practitioner-provider information,
@@ -160,7 +164,7 @@ func (s Schema) AttributeAtPath(path *tftypes.AttributePath) (Attribute, error) 
 	case Attribute:
 		return r, nil
 	case Block:
-		return Attribute{}, ErrPathInsideAtomicAttribute
+		return Attribute{}, ErrPathIsBlock
 	default:
 		return Attribute{}, fmt.Errorf("got unexpected type %T", res)
 	}
@@ -303,138 +307,35 @@ func (s Schema) validate(ctx context.Context, req ValidateSchemaRequest, resp *V
 	}
 }
 
-// modifyAttributePlans runs all AttributePlanModifiers in all schema attributes
-func (s Schema) modifyAttributePlans(ctx context.Context, req ModifySchemaPlanRequest, resp *ModifySchemaPlanResponse) {
-	modifyAttributesPlans(ctx, s.Attributes, tftypes.NewAttributePath(), req, resp)
-}
-
-func modifyAttributesPlans(ctx context.Context, attrs map[string]Attribute, path *tftypes.AttributePath, req ModifySchemaPlanRequest, resp *ModifySchemaPlanResponse) {
-	for name, nestedAttr := range attrs {
-		attrPath := path.WithAttributeName(name)
-		attrPlan, diags := req.Plan.getAttributeValue(ctx, attrPath)
-		resp.Diagnostics.Append(diags...)
-		if diags.HasError() {
-			continue
-		}
-		nestedAttrReq := ModifyAttributePlanRequest{
-			AttributePath: attrPath,
+// modifyPlan runs all AttributePlanModifiers in all schema attributes and blocks
+func (s Schema) modifyPlan(ctx context.Context, req ModifySchemaPlanRequest, resp *ModifySchemaPlanResponse) {
+	for name, attr := range s.Attributes {
+		attrReq := ModifyAttributePlanRequest{
+			AttributePath: tftypes.NewAttributePath().WithAttributeName(name),
 			Config:        req.Config,
 			State:         req.State,
 			Plan:          req.Plan,
 			ProviderMeta:  req.ProviderMeta,
 		}
-		nestedAttrResp := &ModifyAttributePlanResponse{
-			AttributePlan: attrPlan,
-			Diagnostics:   resp.Diagnostics,
+		attrResp := &ModifyAttributePlanResponse{
+			Diagnostics: resp.Diagnostics,
 		}
 
-		nestedAttr.modifyPlan(ctx, nestedAttrReq, nestedAttrResp)
-		if nestedAttrResp.RequiresReplace {
-			resp.RequiresReplace = append(resp.RequiresReplace, attrPath)
+		attr.modifyPlan(ctx, attrReq, attrResp, resp)
+	}
+
+	for name, block := range s.Blocks {
+		blockReq := ModifyAttributePlanRequest{
+			AttributePath: tftypes.NewAttributePath().WithAttributeName(name),
+			Config:        req.Config,
+			State:         req.State,
+			Plan:          req.Plan,
+			ProviderMeta:  req.ProviderMeta,
+		}
+		blockResp := &ModifyAttributePlanResponse{
+			Diagnostics: resp.Diagnostics,
 		}
 
-		setAttrDiags := resp.Plan.SetAttribute(ctx, attrPath, nestedAttrResp.AttributePlan)
-		resp.Diagnostics.Append(setAttrDiags...)
-		if setAttrDiags.HasError() {
-			continue
-		}
-		resp.Diagnostics = nestedAttrResp.Diagnostics
-
-		if nestedAttr.definesAttributes() {
-			nm := nestedAttr.Attributes.GetNestingMode()
-			switch nm {
-			case NestingModeList:
-				l, ok := attrPlan.(types.List)
-
-				if !ok {
-					err := fmt.Errorf("unknown attribute value type (%T) for nesting mode (%T) at path: %s", attrPlan, nm, attrPath)
-					resp.Diagnostics.AddAttributeError(
-						attrPath,
-						"Attribute Plan Modification Error",
-						"Attribute plan modifier cannot walk schema. Report this to the provider developer:\n\n"+err.Error(),
-					)
-
-					continue
-				}
-
-				for idx := range l.Elems {
-					modifyAttributesPlans(ctx, nestedAttr.Attributes.GetAttributes(), attrPath.WithElementKeyInt(idx), req, resp)
-				}
-			case NestingModeSet:
-				s, ok := attrPlan.(types.Set)
-
-				if !ok {
-					err := fmt.Errorf("unknown attribute value type (%T) for nesting mode (%T) at path: %s", attrPlan, nm, attrPath)
-					resp.Diagnostics.AddAttributeError(
-						attrPath,
-						"Attribute Plan Modification Error",
-						"Attribute plan modifier cannot walk schema. Report this to the provider developer:\n\n"+err.Error(),
-					)
-
-					return
-				}
-
-				for _, value := range s.Elems {
-					tfValueRaw, err := value.ToTerraformValue(ctx)
-
-					if err != nil {
-						err := fmt.Errorf("error running ToTerraformValue on element value: %v", value)
-						resp.Diagnostics.AddAttributeError(
-							attrPath,
-							"Attribute Plan Modification Error",
-							"Attribute plan modification cannot convert element into a Terraform value. Report this to the provider developer:\n\n"+err.Error(),
-						)
-
-						return
-					}
-
-					tfValue := tftypes.NewValue(s.ElemType.TerraformType(ctx), tfValueRaw)
-
-					modifyAttributesPlans(ctx, nestedAttr.Attributes.GetAttributes(), attrPath.WithElementKeyValue(tfValue), req, resp)
-				}
-			case NestingModeMap:
-				m, ok := attrPlan.(types.Map)
-
-				if !ok {
-					err := fmt.Errorf("unknown attribute value type (%T) for nesting mode (%T) at path: %s", attrPlan, nm, attrPath)
-					resp.Diagnostics.AddAttributeError(
-						attrPath,
-						"Attribute Plan Modification Error",
-						"Attribute plan modifier cannot walk schema. Report this to the provider developer:\n\n"+err.Error(),
-					)
-
-					continue
-				}
-
-				for key := range m.Elems {
-					modifyAttributesPlans(ctx, nestedAttr.Attributes.GetAttributes(), attrPath.WithElementKeyString(key), req, resp)
-				}
-			case NestingModeSingle:
-				o, ok := attrPlan.(types.Object)
-
-				if !ok {
-					err := fmt.Errorf("unknown attribute value type (%T) for nesting mode (%T) at path: %s", attrPlan, nm, attrPath)
-					resp.Diagnostics.AddAttributeError(
-						attrPath,
-						"Attribute Plan Modification Error",
-						"Attribute plan modifier cannot walk schema. Report this to the provider developer:\n\n"+err.Error(),
-					)
-
-					continue
-				}
-				if len(o.Attrs) > 0 {
-					modifyAttributesPlans(ctx, nestedAttr.Attributes.GetAttributes(), attrPath, req, resp)
-				}
-			default:
-				err := fmt.Errorf("unknown attribute nesting mode (%T: %v) at path: %s", nm, nm, attrPath)
-				resp.Diagnostics.AddAttributeError(
-					attrPath,
-					"Attribute Plan Modification Error",
-					"Attribute plan modifier cannot walk schema. Report this to the provider developer:\n\n"+err.Error(),
-				)
-
-				continue
-			}
-		}
+		block.modifyPlan(ctx, blockReq, blockResp, resp)
 	}
 }

--- a/tfsdk/serve.go
+++ b/tfsdk/serve.go
@@ -807,7 +807,7 @@ func (s *server) planResourceChange(ctx context.Context, req *tfprotov6.PlanReso
 			Diagnostics: resp.Diagnostics,
 		}
 
-		resourceSchema.modifyAttributePlans(ctx, modifySchemaPlanReq, &modifySchemaPlanResp)
+		resourceSchema.modifyPlan(ctx, modifySchemaPlanReq, &modifySchemaPlanResp)
 		resp.RequiresReplace = append(resp.RequiresReplace, modifySchemaPlanResp.RequiresReplace...)
 		plan = modifySchemaPlanResp.Plan.Raw
 		resp.Diagnostics = modifySchemaPlanResp.Diagnostics

--- a/tfsdk/serve_resource_attribute_plan_modifiers_test.go
+++ b/tfsdk/serve_resource_attribute_plan_modifiers_test.go
@@ -18,12 +18,11 @@ func (rt testServeResourceTypeAttributePlanModifiers) GetSchema(_ context.Contex
 			"name": {
 				Required: true,
 				Type:     types.StringType,
-				// For the purposes of testing, these plan modifiers behave
-				// differently for certain values of the attribute.
-				// By default, they do nothing.
 				PlanModifiers: []AttributePlanModifier{
 					testWarningDiagModifier{},
-					testErrorDiagModifier{},
+					// For the purposes of testing, these plan modifiers behave
+					// differently for certain values of the attribute.
+					// By default, they do nothing.
 					testAttrPlanValueModifierOne{},
 					testAttrPlanValueModifierTwo{},
 				},
@@ -210,17 +209,10 @@ type testServeResourceTypeAttributePlanModifiers struct{}
 type testWarningDiagModifier struct{}
 
 func (t testWarningDiagModifier) Modify(ctx context.Context, req ModifyAttributePlanRequest, resp *ModifyAttributePlanResponse) {
-	attrVal, ok := req.AttributePlan.(types.String)
-	if !ok {
-		return
-	}
-
-	if attrVal.Value == "TESTDIAG" {
-		resp.Diagnostics.AddWarning(
-			"Warning diag",
-			"This is a warning",
-		)
-	}
+	resp.Diagnostics.AddWarning(
+		"Warning diag",
+		"This is a warning",
+	)
 }
 
 func (t testWarningDiagModifier) Description(ctx context.Context) string {
@@ -234,17 +226,10 @@ func (t testWarningDiagModifier) MarkdownDescription(ctx context.Context) string
 type testErrorDiagModifier struct{}
 
 func (t testErrorDiagModifier) Modify(ctx context.Context, req ModifyAttributePlanRequest, resp *ModifyAttributePlanResponse) {
-	attrVal, ok := req.AttributePlan.(types.String)
-	if !ok {
-		return
-	}
-
-	if attrVal.Value == "TESTDIAG" {
-		resp.Diagnostics.AddError(
-			"Error diag",
-			"This is an error",
-		)
-	}
+	resp.Diagnostics.AddError(
+		"Error diag",
+		"This is an error",
+	)
 }
 
 func (t testErrorDiagModifier) Description(ctx context.Context) string {

--- a/tfsdk/serve_test.go
+++ b/tfsdk/serve_test.go
@@ -3120,6 +3120,13 @@ func TestServerPlanResourceChange(t *testing.T) {
 			}),
 			resource:     "test_attribute_plan_modifiers",
 			resourceType: testServeResourceTypeAttributePlanModifiersType,
+			expectedDiags: []*tfprotov6.Diagnostic{
+				{
+					Severity: tfprotov6.DiagnosticSeverityWarning,
+					Summary:  "Warning diag",
+					Detail:   "This is a warning",
+				},
+			},
 			expectedPlannedState: tftypes.NewValue(testServeResourceTypeAttributePlanModifiersType, map[string]tftypes.Value{
 				"computed_string_no_modifiers": tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
 				"name":                         tftypes.NewValue(tftypes.String, "name1"),
@@ -3216,6 +3223,13 @@ func TestServerPlanResourceChange(t *testing.T) {
 			}),
 			resource:     "test_attribute_plan_modifiers",
 			resourceType: testServeResourceTypeAttributePlanModifiersType,
+			expectedDiags: []*tfprotov6.Diagnostic{
+				{
+					Severity: tfprotov6.DiagnosticSeverityWarning,
+					Summary:  "Warning diag",
+					Detail:   "This is a warning",
+				},
+			},
 			expectedPlannedState: tftypes.NewValue(testServeResourceTypeAttributePlanModifiersType, map[string]tftypes.Value{
 				"computed_string_no_modifiers": tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
 				"name":                         tftypes.NewValue(tftypes.String, "name1"),
@@ -3305,6 +3319,13 @@ func TestServerPlanResourceChange(t *testing.T) {
 			}),
 			resource:     "test_attribute_plan_modifiers",
 			resourceType: testServeResourceTypeAttributePlanModifiersType,
+			expectedDiags: []*tfprotov6.Diagnostic{
+				{
+					Severity: tfprotov6.DiagnosticSeverityWarning,
+					Summary:  "Warning diag",
+					Detail:   "This is a warning",
+				},
+			},
 			expectedPlannedState: tftypes.NewValue(testServeResourceTypeAttributePlanModifiersType, map[string]tftypes.Value{
 				"computed_string_no_modifiers": tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
 				"name":                         tftypes.NewValue(tftypes.String, "name1"),
@@ -3393,7 +3414,7 @@ func TestServerPlanResourceChange(t *testing.T) {
 				"region": tftypes.NewValue(tftypes.String, "region1"),
 			}),
 			expectedPlannedState: tftypes.NewValue(testServeResourceTypeAttributePlanModifiersType, map[string]tftypes.Value{
-				"computed_string_no_modifiers": tftypes.NewValue(tftypes.String, "statevalue"),
+				"computed_string_no_modifiers": tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
 				"name":                         tftypes.NewValue(tftypes.String, "TESTDIAG"),
 				"size":                         tftypes.NewValue(tftypes.Number, 3),
 				"scratch_disk": tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
@@ -3420,11 +3441,6 @@ func TestServerPlanResourceChange(t *testing.T) {
 					Severity: tfprotov6.DiagnosticSeverityWarning,
 					Summary:  "Warning diag",
 					Detail:   "This is a warning",
-				},
-				{
-					Severity: tfprotov6.DiagnosticSeverityError,
-					Summary:  "Error diag",
-					Detail:   "This is an error",
 				},
 			},
 			expectedRequiresReplace: []*tftypes.AttributePath{tftypes.NewAttributePath().WithAttributeName("scratch_disk").WithAttributeName("interface")},
@@ -3514,8 +3530,15 @@ func TestServerPlanResourceChange(t *testing.T) {
 				}),
 				"region": tftypes.NewValue(tftypes.String, "region1"),
 			}),
-			resource:                "test_attribute_plan_modifiers",
-			resourceType:            testServeResourceTypeAttributePlanModifiersType,
+			resource:     "test_attribute_plan_modifiers",
+			resourceType: testServeResourceTypeAttributePlanModifiersType,
+			expectedDiags: []*tfprotov6.Diagnostic{
+				{
+					Severity: tfprotov6.DiagnosticSeverityWarning,
+					Summary:  "Warning diag",
+					Detail:   "This is a warning",
+				},
+			},
 			expectedRequiresReplace: []*tftypes.AttributePath{tftypes.NewAttributePath().WithAttributeName("scratch_disk").WithAttributeName("interface")},
 		},
 		"attr_plan_modifiers_default_value_modifier": {
@@ -3603,8 +3626,15 @@ func TestServerPlanResourceChange(t *testing.T) {
 				}),
 				"region": tftypes.NewValue(tftypes.String, "DEFAULTVALUE"),
 			}),
-			resource:                "test_attribute_plan_modifiers",
-			resourceType:            testServeResourceTypeAttributePlanModifiersType,
+			resource:     "test_attribute_plan_modifiers",
+			resourceType: testServeResourceTypeAttributePlanModifiersType,
+			expectedDiags: []*tfprotov6.Diagnostic{
+				{
+					Severity: tfprotov6.DiagnosticSeverityWarning,
+					Summary:  "Warning diag",
+					Detail:   "This is a warning",
+				},
+			},
 			expectedRequiresReplace: []*tftypes.AttributePath{tftypes.NewAttributePath().WithAttributeName("scratch_disk").WithAttributeName("interface")},
 		},
 		// TODO: Attribute plan modifiers should run before plan unknown marking.
@@ -3675,6 +3705,13 @@ func TestServerPlanResourceChange(t *testing.T) {
 		// 		}),
 		// 		"region": tftypes.NewValue(tftypes.String, "DEFAULTVALUE"),
 		// 	}),
+		// 	expectedDiags: []*tfprotov6.Diagnostic{
+		// 		{
+		// 			Severity: tfprotov6.DiagnosticSeverityWarning,
+		// 			Summary:  "Warning diag",
+		// 			Detail:   "This is a warning",
+		// 		},
+		// 	},
 		// 	expectedPlannedState: tftypes.NewValue(testServeResourceTypeAttributePlanModifiersType, map[string]tftypes.Value{
 		// 		"computed_string_no_modifiers": tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
 		// 		"name":                         tftypes.NewValue(tftypes.String, "MODIFIED_TWO"),
@@ -3783,8 +3820,15 @@ func TestServerPlanResourceChange(t *testing.T) {
 				}),
 				"region": tftypes.NewValue(tftypes.String, "region1"),
 			}),
-			resource:                "test_attribute_plan_modifiers",
-			resourceType:            testServeResourceTypeAttributePlanModifiersType,
+			resource:     "test_attribute_plan_modifiers",
+			resourceType: testServeResourceTypeAttributePlanModifiersType,
+			expectedDiags: []*tfprotov6.Diagnostic{
+				{
+					Severity: tfprotov6.DiagnosticSeverityWarning,
+					Summary:  "Warning diag",
+					Detail:   "This is a warning",
+				},
+			},
 			expectedRequiresReplace: []*tftypes.AttributePath{tftypes.NewAttributePath().WithAttributeName("scratch_disk").WithAttributeName("interface")},
 		},
 	}


### PR DESCRIPTION
Closes #222

Adds `PlanModifiers` within `Block`s and ensures any children attribute and block plan modifiers of a `Block` are executed.

No changelog entry is necessary unless there is a framework release prior to this support.