### PR TITLE
Refactor ToTerraformValue to return a tftypes.Value.

### DIFF
--- a/.changelog/231.txt
+++ b/.changelog/231.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+The `ToTerraformValue` method of the `attr.Value` interface now returns a `tftypes.Value`, instead of an `interface{}`. Existing types need to be updated to call `tftypes.ValidateValue` and `tftypes.NewValue`, passing the value they were returning before, instead of returning the value directly.
+```

--- a/attr/value.go
+++ b/attr/value.go
@@ -2,6 +2,8 @@ package attr
 
 import (
 	"context"
+
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
 // Value defines an interface for describing data associated with an attribute.
@@ -12,8 +14,8 @@ type Value interface {
 	Type(context.Context) Type
 
 	// ToTerraformValue returns the data contained in the Value as
-	// a Go type that tftypes.NewValue will accept.
-	ToTerraformValue(context.Context) (interface{}, error)
+	// a tftypes.Value.
+	ToTerraformValue(context.Context) (tftypes.Value, error)
 
 	// Equal must return true if the Value is considered semantically equal
 	// to the Value passed as an argument.

--- a/internal/reflect/interfaces.go
+++ b/internal/reflect/interfaces.go
@@ -311,14 +311,12 @@ func FromAttributeValue(ctx context.Context, typ attr.Type, val attr.Value, path
 	var diags diag.Diagnostics
 
 	if typeWithValidate, ok := typ.(attr.TypeWithValidate); ok {
-		tfType := typ.TerraformType(ctx)
 		tfVal, err := val.ToTerraformValue(ctx)
-
 		if err != nil {
 			return val, append(diags, toTerraformValueErrorDiag(err, path))
 		}
 
-		diags.Append(typeWithValidate.Validate(ctx, tftypes.NewValue(tfType, tfVal), path)...)
+		diags.Append(typeWithValidate.Validate(ctx, tfVal, path)...)
 
 		if diags.HasError() {
 			return val, diags

--- a/internal/reflect/map.go
+++ b/internal/reflect/map.go
@@ -143,24 +143,15 @@ func FromMap(ctx context.Context, typ attr.TypeWithElementType, val reflect.Valu
 			return nil, append(diags, toTerraformValueErrorDiag(err, path))
 		}
 
-		tfElemType := elemType.TerraformType(ctx)
-		err = tftypes.ValidateValue(tfElemType, tfVal)
-
-		if err != nil {
-			return nil, append(diags, validateValueErrorDiag(err, path))
-		}
-
-		tfElemVal := tftypes.NewValue(tfElemType, tfVal)
-
 		if typeWithValidate, ok := typ.(attr.TypeWithValidate); ok {
-			diags.Append(typeWithValidate.Validate(ctx, tfElemVal, path.WithElementKeyString(key.String()))...)
+			diags.Append(typeWithValidate.Validate(ctx, tfVal, path.WithElementKeyString(key.String()))...)
 
 			if diags.HasError() {
 				return nil, diags
 			}
 		}
 
-		tfElems[key.String()] = tfElemVal
+		tfElems[key.String()] = tfVal
 	}
 
 	err := tftypes.ValidateValue(tfType, tfElems)

--- a/internal/reflect/slice.go
+++ b/internal/reflect/slice.go
@@ -151,32 +151,22 @@ func FromSlice(ctx context.Context, typ attr.Type, val reflect.Value, path *tfty
 		}
 
 		tfVal, err := val.ToTerraformValue(ctx)
-
 		if err != nil {
 			return nil, append(diags, toTerraformValueErrorDiag(err, path))
 		}
 
-		err = tftypes.ValidateValue(elemType.TerraformType(ctx), tfVal)
-
-		if err != nil {
-			return nil, append(diags, validateValueErrorDiag(err, path))
-		}
-
-		tfElemVal := tftypes.NewValue(elemType.TerraformType(ctx), tfVal)
-
 		if tfType.Is(tftypes.Set{}) {
-			valPath = path.WithElementKeyValue(tfElemVal)
+			valPath = path.WithElementKeyValue(tfVal)
 		}
 
 		if typeWithValidate, ok := elemType.(attr.TypeWithValidate); ok {
-			diags.Append(typeWithValidate.Validate(ctx, tfElemVal, valPath)...)
-
+			diags.Append(typeWithValidate.Validate(ctx, tfVal, valPath)...)
 			if diags.HasError() {
 				return nil, diags
 			}
 		}
 
-		tfElems = append(tfElems, tfElemVal)
+		tfElems = append(tfElems, tfVal)
 	}
 
 	err := tftypes.ValidateValue(tfType, tfElems)

--- a/internal/reflect/struct.go
+++ b/internal/reflect/struct.go
@@ -186,16 +186,10 @@ func FromStruct(ctx context.Context, typ attr.TypeWithAttributeTypes, val reflec
 
 		objTypes[name] = attrType.TerraformType(ctx)
 
-		tfVal, err := attrVal.ToTerraformValue(ctx)
+		tfObjVal, err := attrVal.ToTerraformValue(ctx)
 		if err != nil {
 			return nil, append(diags, toTerraformValueErrorDiag(err, path))
 		}
-		err = tftypes.ValidateValue(objTypes[name], tfVal)
-		if err != nil {
-			return nil, append(diags, validateValueErrorDiag(err, path))
-		}
-
-		tfObjVal := tftypes.NewValue(objTypes[name], tfVal)
 
 		if typeWithValidate, ok := typ.(attr.TypeWithValidate); ok {
 			diags.Append(typeWithValidate.Validate(ctx, tfObjVal, path)...)

--- a/tfsdk/attribute.go
+++ b/tfsdk/attribute.go
@@ -305,7 +305,6 @@ func (a Attribute) validate(ctx context.Context, req ValidateAttributeRequest, r
 
 	if a.DeprecationMessage != "" && attributeConfig != nil {
 		tfValue, err := attributeConfig.ToTerraformValue(ctx)
-
 		if err != nil {
 			resp.Diagnostics.AddAttributeError(
 				req.AttributePath,
@@ -316,7 +315,7 @@ func (a Attribute) validate(ctx context.Context, req ValidateAttributeRequest, r
 			return
 		}
 
-		if tfValue != nil {
+		if !tfValue.IsNull() {
 			resp.Diagnostics.AddAttributeWarning(
 				req.AttributePath,
 				"Attribute Deprecated",
@@ -378,8 +377,7 @@ func (a Attribute) validateAttributes(ctx context.Context, req ValidateAttribute
 		}
 
 		for _, value := range s.Elems {
-			tfValueRaw, err := value.ToTerraformValue(ctx)
-
+			tfValue, err := value.ToTerraformValue(ctx)
 			if err != nil {
 				err := fmt.Errorf("error running ToTerraformValue on element value: %v", value)
 				resp.Diagnostics.AddAttributeError(
@@ -390,8 +388,6 @@ func (a Attribute) validateAttributes(ctx context.Context, req ValidateAttribute
 
 				return
 			}
-
-			tfValue := tftypes.NewValue(s.ElemType.TerraformType(ctx), tfValueRaw)
 
 			for nestedName, nestedAttr := range a.Attributes.GetAttributes() {
 				nestedAttrReq := ValidateAttributeRequest{
@@ -584,8 +580,7 @@ func (a Attribute) modifyPlan(ctx context.Context, req ModifyAttributePlanReques
 		}
 
 		for _, value := range s.Elems {
-			tfValueRaw, err := value.ToTerraformValue(ctx)
-
+			tfValue, err := value.ToTerraformValue(ctx)
 			if err != nil {
 				err := fmt.Errorf("error running ToTerraformValue on element value: %v", value)
 				resp.Diagnostics.AddAttributeError(
@@ -596,8 +591,6 @@ func (a Attribute) modifyPlan(ctx context.Context, req ModifyAttributePlanReques
 
 				return
 			}
-
-			tfValue := tftypes.NewValue(s.ElemType.TerraformType(ctx), tfValueRaw)
 
 			for name, attr := range a.Attributes.GetAttributes() {
 				attrReq := ModifyAttributePlanRequest{

--- a/tfsdk/attribute_plan_modification.go
+++ b/tfsdk/attribute_plan_modification.go
@@ -147,7 +147,7 @@ func (r RequiresReplaceModifier) Modify(ctx context.Context, req ModifyAttribute
 		)
 		return
 	}
-	if configRaw == nil && attrSchema.Computed {
+	if configRaw.IsNull() && attrSchema.Computed {
 		// if the config is null and the attribute is computed, this
 		// could be an out of band change, don't require replace
 		return
@@ -287,7 +287,7 @@ func (r RequiresReplaceIfModifier) Modify(ctx context.Context, req ModifyAttribu
 		)
 		return
 	}
-	if configRaw == nil && attrSchema.Computed {
+	if configRaw.IsNull() && attrSchema.Computed {
 		// if the config is null and the attribute is computed, this
 		// could be an out of band change, don't require replace
 		return
@@ -354,7 +354,7 @@ func (r UseStateForUnknownModifier) Modify(ctx context.Context, req ModifyAttrib
 	}
 
 	// if we have no state value, there's nothing to preserve
-	if val == nil {
+	if val.IsNull() {
 		return
 	}
 
@@ -369,7 +369,7 @@ func (r UseStateForUnknownModifier) Modify(ctx context.Context, req ModifyAttrib
 
 	// if it's not planned to be the unknown value, stick with
 	// the concrete plan
-	if val != tftypes.UnknownValue {
+	if val.IsKnown() {
 		return
 	}
 
@@ -384,7 +384,7 @@ func (r UseStateForUnknownModifier) Modify(ctx context.Context, req ModifyAttrib
 
 	// if the config is the unknown value, use the unknown value
 	// otherwise, interpolation gets messed up
-	if val == tftypes.UnknownValue {
+	if !val.IsKnown() {
 		return
 	}
 

--- a/tfsdk/attribute_plan_modification_test.go
+++ b/tfsdk/attribute_plan_modification_test.go
@@ -95,31 +95,30 @@ func TestUseStateForUnknownModifier(t *testing.T) {
 				},
 			}
 
-			var configRaw, planRaw, stateRaw interface{}
+			configVal := tftypes.NewValue(tftypes.String, nil)
+			stateVal := tftypes.NewValue(tftypes.String, nil)
+			planVal := tftypes.NewValue(tftypes.String, nil)
 			if tc.config != nil {
 				val, err := tc.config.ToTerraformValue(context.Background())
 				if err != nil {
 					t.Fatal(err)
 				}
-				configRaw = val
+				configVal = val
 			}
 			if tc.state != nil {
 				val, err := tc.state.ToTerraformValue(context.Background())
 				if err != nil {
 					t.Fatal(err)
 				}
-				stateRaw = val
+				stateVal = val
 			}
 			if tc.plan != nil {
 				val, err := tc.plan.ToTerraformValue(context.Background())
 				if err != nil {
 					t.Fatal(err)
 				}
-				planRaw = val
+				planVal = val
 			}
-			configVal := tftypes.NewValue(tftypes.String, configRaw)
-			stateVal := tftypes.NewValue(tftypes.String, stateRaw)
-			planVal := tftypes.NewValue(tftypes.String, planRaw)
 
 			req := ModifyAttributePlanRequest{
 				AttributePath: tftypes.NewAttributePath(),

--- a/tfsdk/block.go
+++ b/tfsdk/block.go
@@ -269,8 +269,7 @@ func (b Block) modifyPlan(ctx context.Context, req ModifyAttributePlanRequest, r
 		}
 
 		for _, value := range s.Elems {
-			tfValueRaw, err := value.ToTerraformValue(ctx)
-
+			tfValue, err := value.ToTerraformValue(ctx)
 			if err != nil {
 				err := fmt.Errorf("error running ToTerraformValue on element value: %v", value)
 				resp.Diagnostics.AddAttributeError(
@@ -281,8 +280,6 @@ func (b Block) modifyPlan(ctx context.Context, req ModifyAttributePlanRequest, r
 
 				return
 			}
-
-			tfValue := tftypes.NewValue(s.ElemType.TerraformType(ctx), tfValueRaw)
 
 			for name, attr := range b.Attributes {
 				attrReq := ModifyAttributePlanRequest{
@@ -482,8 +479,7 @@ func (b Block) validate(ctx context.Context, req ValidateAttributeRequest, resp 
 		}
 
 		for _, value := range s.Elems {
-			tfValueRaw, err := value.ToTerraformValue(ctx)
-
+			tfValue, err := value.ToTerraformValue(ctx)
 			if err != nil {
 				err := fmt.Errorf("error running ToTerraformValue on element value: %v", value)
 				resp.Diagnostics.AddAttributeError(
@@ -494,8 +490,6 @@ func (b Block) validate(ctx context.Context, req ValidateAttributeRequest, resp 
 
 				return
 			}
-
-			tfValue := tftypes.NewValue(s.ElemType.TerraformType(ctx), tfValueRaw)
 
 			for name, attr := range b.Attributes {
 				nestedAttrReq := ValidateAttributeRequest{
@@ -549,7 +543,7 @@ func (b Block) validate(ctx context.Context, req ValidateAttributeRequest, resp 
 			return
 		}
 
-		if tfValue != nil {
+		if !tfValue.IsNull() {
 			resp.Diagnostics.AddAttributeWarning(
 				req.AttributePath,
 				"Block Deprecated",

--- a/tfsdk/convert.go
+++ b/tfsdk/convert.go
@@ -6,27 +6,18 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
 // ConvertValue creates a new attr.Value of the attr.Type `typ`, using the data
 // in `val`, which can be of any attr.Type so long as its TerraformType method
 // returns a tftypes.Type that `typ`'s ValueFromTerraform method can accept.
 func ConvertValue(ctx context.Context, val attr.Value, typ attr.Type) (attr.Value, diag.Diagnostics) {
-	tftype := typ.TerraformType(ctx)
-	tfval, err := val.ToTerraformValue(ctx)
+	newVal, err := val.ToTerraformValue(ctx)
 	if err != nil {
 		return nil, diag.Diagnostics{diag.NewErrorDiagnostic("Error converting value",
 			fmt.Sprintf("An unexpected error was encountered converting a %T to a %s. This is always a problem with the provider. Please tell the provider developers that %T ran into the following error during ToTerraformValue: %s", val, typ, val, err),
 		)}
 	}
-	err = tftypes.ValidateValue(tftype, tfval)
-	if err != nil {
-		return nil, diag.Diagnostics{diag.NewErrorDiagnostic("Error converting value",
-			fmt.Sprintf("An unexpected error was encountered converting a %T to a %s. This is always a problem with the provider. Please tell the provider developers that %T is not compatible with %s.", val, typ, val, typ),
-		)}
-	}
-	newVal := tftypes.NewValue(tftype, tfval)
 	res, err := typ.ValueFromTerraform(ctx, newVal)
 	if err != nil {
 		return nil, diag.Diagnostics{diag.NewErrorDiagnostic("Error converting value",

--- a/tfsdk/convert_test.go
+++ b/tfsdk/convert_test.go
@@ -43,7 +43,7 @@ func TestConvert(t *testing.T) {
 			typ: types.NumberType,
 			expectedDiags: diag.Diagnostics{diag.NewErrorDiagnostic(
 				"Error converting value",
-				"An unexpected error was encountered converting a types.String to a types.NumberType. This is always a problem with the provider. Please tell the provider developers that types.String is not compatible with types.NumberType.",
+				"An unexpected error was encountered converting a types.String to a types.NumberType. This is always a problem with the provider. Please tell the provider developers that types.NumberType returned the following error when calling ValueFromTerraform: can't unmarshal tftypes.String into *big.Float, expected *big.Float",
 			)},
 		},
 	}
@@ -56,6 +56,9 @@ func TestConvert(t *testing.T) {
 			got, diags := ConvertValue(context.Background(), tc.val, tc.typ)
 
 			if diff := cmp.Diff(diags, tc.expectedDiags); diff != "" {
+				for _, diag := range diags {
+					t.Logf("Diag summary: %q, Diag details: %q", diag.Summary(), diag.Detail())
+				}
 				t.Fatalf("Unexpected diff in diags (-wanted, +got): %s", diff)
 			}
 

--- a/tfsdk/plan.go
+++ b/tfsdk/plan.go
@@ -122,7 +122,7 @@ func (p *Plan) Set(ctx context.Context, val interface{}) diag.Diagnostics {
 		return diags
 	}
 
-	newPlanVal, err := newPlanAttrValue.ToTerraformValue(ctx)
+	newPlan, err := newPlanAttrValue.ToTerraformValue(ctx)
 	if err != nil {
 		err = fmt.Errorf("error running ToTerraformValue on plan: %w", err)
 		diags.AddError(
@@ -131,8 +131,6 @@ func (p *Plan) Set(ctx context.Context, val interface{}) diag.Diagnostics {
 		)
 		return diags
 	}
-
-	newPlan := tftypes.NewValue(p.Schema.AttributeType().TerraformType(ctx), newPlanVal)
 
 	p.Raw = newPlan
 	return diags
@@ -167,7 +165,7 @@ func (p *Plan) SetAttribute(ctx context.Context, path *tftypes.AttributePath, va
 		return diags
 	}
 
-	newTfVal, err := newVal.ToTerraformValue(ctx)
+	tfVal, err := newVal.ToTerraformValue(ctx)
 	if err != nil {
 		err = fmt.Errorf("error running ToTerraformValue on new plan value: %w", err)
 		diags.AddAttributeError(
@@ -177,8 +175,6 @@ func (p *Plan) SetAttribute(ctx context.Context, path *tftypes.AttributePath, va
 		)
 		return diags
 	}
-
-	tfVal := tftypes.NewValue(attrType.TerraformType(ctx), newTfVal)
 
 	if attrTypeWithValidate, ok := attrType.(attr.TypeWithValidate); ok {
 		diags.Append(attrTypeWithValidate.Validate(ctx, tfVal, path)...)

--- a/tfsdk/state.go
+++ b/tfsdk/state.go
@@ -131,7 +131,7 @@ func (s *State) Set(ctx context.Context, val interface{}) diag.Diagnostics {
 		return diags
 	}
 
-	newStateVal, err := newStateAttrValue.ToTerraformValue(ctx)
+	newState, err := newStateAttrValue.ToTerraformValue(ctx)
 	if err != nil {
 		err = fmt.Errorf("error running ToTerraformValue on state: %w", err)
 		diags.AddError(
@@ -140,8 +140,6 @@ func (s *State) Set(ctx context.Context, val interface{}) diag.Diagnostics {
 		)
 		return diags
 	}
-
-	newState := tftypes.NewValue(s.Schema.AttributeType().TerraformType(ctx), newStateVal)
 
 	s.Raw = newState
 	return diags
@@ -176,7 +174,7 @@ func (s *State) SetAttribute(ctx context.Context, path *tftypes.AttributePath, v
 		return diags
 	}
 
-	newTfVal, err := newVal.ToTerraformValue(ctx)
+	tfVal, err := newVal.ToTerraformValue(ctx)
 	if err != nil {
 		err = fmt.Errorf("error running ToTerraformValue on new state value: %w", err)
 		diags.AddAttributeError(
@@ -186,8 +184,6 @@ func (s *State) SetAttribute(ctx context.Context, path *tftypes.AttributePath, v
 		)
 		return diags
 	}
-
-	tfVal := tftypes.NewValue(attrType.TerraformType(ctx), newTfVal)
 
 	if attrTypeWithValidate, ok := attrType.(attr.TypeWithValidate); ok {
 		diags.Append(attrTypeWithValidate.Validate(ctx, tfVal, path)...)

--- a/tfsdk/value_as.go
+++ b/tfsdk/value_as.go
@@ -7,7 +7,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/reflect"
-	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
 // ValueAs populates the Go value passed as `target` with
@@ -23,12 +22,5 @@ func ValueAs(ctx context.Context, val attr.Value, target interface{}) diag.Diagn
 		return diag.Diagnostics{diag.NewErrorDiagnostic("Error converting value",
 			fmt.Sprintf("An unexpected error was encountered converting a %T to its equivalent Terraform representation. This is always a bug in the provider.\n\nError: %s", val, err))}
 	}
-	typ := val.Type(ctx).TerraformType(ctx)
-	err = tftypes.ValidateValue(typ, raw)
-	if err != nil {
-		return diag.Diagnostics{diag.NewErrorDiagnostic("Invalid value conversion",
-			fmt.Sprintf("An unexpected error was encountered converting a %T to its equivalent Terraform representation. This is always a bug in the provider.\n\nError: %s", val, err))}
-	}
-	v := tftypes.NewValue(typ, raw)
-	return reflect.Into(ctx, val.Type(ctx), v, target, reflect.Options{})
+	return reflect.Into(ctx, val.Type(ctx), raw, target, reflect.Options{})
 }

--- a/types/bool.go
+++ b/types/bool.go
@@ -47,17 +47,18 @@ func (b Bool) Type(_ context.Context) attr.Type {
 	return BoolType
 }
 
-// ToTerraformValue returns the data contained in the *Bool as a bool. If
-// Unknown is true, it returns a tftypes.UnknownValue. If Null is true, it
-// returns nil.
-func (b Bool) ToTerraformValue(_ context.Context) (interface{}, error) {
+// ToTerraformValue returns the data contained in the *Bool as a tftypes.Value.
+func (b Bool) ToTerraformValue(_ context.Context) (tftypes.Value, error) {
 	if b.Null {
-		return nil, nil
+		return tftypes.NewValue(tftypes.Bool, nil), nil
 	}
 	if b.Unknown {
-		return tftypes.UnknownValue, nil
+		return tftypes.NewValue(tftypes.Bool, tftypes.UnknownValue), nil
 	}
-	return b.Value, nil
+	if err := tftypes.ValidateValue(tftypes.Bool, b.Value); err != nil {
+		return tftypes.NewValue(tftypes.Bool, tftypes.UnknownValue), err
+	}
+	return tftypes.NewValue(tftypes.Bool, b.Value), nil
 }
 
 // Equal returns true if `other` is a *Bool and has the same value as `b`.

--- a/types/bool_test.go
+++ b/types/bool_test.go
@@ -89,19 +89,19 @@ func TestBoolToTerraformValue(t *testing.T) {
 	tests := map[string]testCase{
 		"true": {
 			input:       Bool{Value: true},
-			expectation: true,
+			expectation: tftypes.NewValue(tftypes.Bool, true),
 		},
 		"false": {
 			input:       Bool{Value: false},
-			expectation: false,
+			expectation: tftypes.NewValue(tftypes.Bool, false),
 		},
 		"unknown": {
 			input:       Bool{Unknown: true},
-			expectation: tftypes.UnknownValue,
+			expectation: tftypes.NewValue(tftypes.Bool, tftypes.UnknownValue),
 		},
 		"null": {
 			input:       Bool{Null: true},
-			expectation: nil,
+			expectation: tftypes.NewValue(tftypes.Bool, nil),
 		},
 	}
 	for name, test := range tests {

--- a/types/float64.go
+++ b/types/float64.go
@@ -114,19 +114,22 @@ func (f Float64) Equal(other attr.Value) bool {
 	return f.Value == o.Value
 }
 
-// ToTerraformValue returns the data contained in the Float64 as a float64.
-// If Unknown is true, it returns a tftypes.UnknownValue. If Null is true, it
-// returns nil.
-func (f Float64) ToTerraformValue(ctx context.Context) (interface{}, error) {
+// ToTerraformValue returns the data contained in the Float64 as a
+// tftypes.Value.
+func (f Float64) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
 	if f.Null {
-		return nil, nil
+		return tftypes.NewValue(tftypes.Number, nil), nil
 	}
 
 	if f.Unknown {
-		return tftypes.UnknownValue, nil
+		return tftypes.NewValue(tftypes.Number, tftypes.UnknownValue), nil
 	}
 
-	return big.NewFloat(f.Value), nil
+	bf := big.NewFloat(f.Value)
+	if err := tftypes.ValidateValue(tftypes.Number, bf); err != nil {
+		return tftypes.NewValue(tftypes.Number, tftypes.UnknownValue), err
+	}
+	return tftypes.NewValue(tftypes.Number, bf), nil
 }
 
 // Type returns a NumberType.

--- a/types/float64_test.go
+++ b/types/float64_test.go
@@ -90,19 +90,19 @@ func TestFloat64ToTerraformValue(t *testing.T) {
 	tests := map[string]testCase{
 		"value-int": {
 			input:       Float64{Value: 123},
-			expectation: big.NewFloat(123.0),
+			expectation: tftypes.NewValue(tftypes.Number, big.NewFloat(123.0)),
 		},
 		"value-float": {
 			input:       Float64{Value: 123.456},
-			expectation: big.NewFloat(123.456),
+			expectation: tftypes.NewValue(tftypes.Number, big.NewFloat(123.456)),
 		},
 		"unknown": {
 			input:       Float64{Unknown: true},
-			expectation: tftypes.UnknownValue,
+			expectation: tftypes.NewValue(tftypes.Number, tftypes.UnknownValue),
 		},
 		"null": {
 			input:       Float64{Null: true},
-			expectation: nil,
+			expectation: tftypes.NewValue(tftypes.Number, nil),
 		},
 	}
 	for name, test := range tests {

--- a/types/int64.go
+++ b/types/int64.go
@@ -127,19 +127,21 @@ func (i Int64) Equal(other attr.Value) bool {
 	return i.Value == o.Value
 }
 
-// ToTerraformValue returns the data contained in the Int64 as a int64.
-// If Unknown is true, it returns a tftypes.UnknownValue. If Null is true, it
-// returns nil.
-func (i Int64) ToTerraformValue(ctx context.Context) (interface{}, error) {
+// ToTerraformValue returns the data contained in the Int64 as a tftypes.Value.
+func (i Int64) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
 	if i.Null {
-		return nil, nil
+		return tftypes.NewValue(tftypes.Number, nil), nil
 	}
 
 	if i.Unknown {
-		return tftypes.UnknownValue, nil
+		return tftypes.NewValue(tftypes.Number, tftypes.UnknownValue), nil
 	}
 
-	return new(big.Float).SetInt64(i.Value), nil
+	bf := new(big.Float).SetInt64(i.Value)
+	if err := tftypes.ValidateValue(tftypes.Number, bf); err != nil {
+		return tftypes.NewValue(tftypes.Number, tftypes.UnknownValue), err
+	}
+	return tftypes.NewValue(tftypes.Number, bf), nil
 }
 
 // Type returns a NumberType.

--- a/types/int64_test.go
+++ b/types/int64_test.go
@@ -86,15 +86,15 @@ func TestInt64ToTerraformValue(t *testing.T) {
 	tests := map[string]testCase{
 		"value": {
 			input:       Int64{Value: 123},
-			expectation: big.NewFloat(123),
+			expectation: tftypes.NewValue(tftypes.Number, big.NewFloat(123)),
 		},
 		"unknown": {
 			input:       Int64{Unknown: true},
-			expectation: tftypes.UnknownValue,
+			expectation: tftypes.NewValue(tftypes.Number, tftypes.UnknownValue),
 		},
 		"null": {
 			input:       Int64{Null: true},
-			expectation: nil,
+			expectation: tftypes.NewValue(tftypes.Number, nil),
 		},
 	}
 	for name, test := range tests {

--- a/types/list_test.go
+++ b/types/list_test.go
@@ -316,18 +316,18 @@ func TestListToTerraformValue(t *testing.T) {
 					String{Value: "world"},
 				},
 			},
-			expectation: []tftypes.Value{
+			expectation: tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, []tftypes.Value{
 				tftypes.NewValue(tftypes.String, "hello"),
 				tftypes.NewValue(tftypes.String, "world"),
-			},
+			}),
 		},
 		"unknown": {
-			input:       List{Unknown: true},
-			expectation: tftypes.UnknownValue,
+			input:       List{ElemType: StringType, Unknown: true},
+			expectation: tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, tftypes.UnknownValue),
 		},
 		"null": {
-			input:       List{Null: true},
-			expectation: nil,
+			input:       List{ElemType: StringType, Null: true},
+			expectation: tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, nil),
 		},
 		"partial-unknown": {
 			input: List{
@@ -337,10 +337,10 @@ func TestListToTerraformValue(t *testing.T) {
 					String{Value: "hello, world"},
 				},
 			},
-			expectation: []tftypes.Value{
+			expectation: tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, []tftypes.Value{
 				tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
 				tftypes.NewValue(tftypes.String, "hello, world"),
-			},
+			}),
 		},
 		"partial-null": {
 			input: List{
@@ -350,10 +350,10 @@ func TestListToTerraformValue(t *testing.T) {
 					String{Value: "hello, world"},
 				},
 			},
-			expectation: []tftypes.Value{
+			expectation: tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, []tftypes.Value{
 				tftypes.NewValue(tftypes.String, nil),
 				tftypes.NewValue(tftypes.String, "hello, world"),
-			},
+			}),
 		},
 	}
 	for name, test := range tests {

--- a/types/map_test.go
+++ b/types/map_test.go
@@ -287,7 +287,7 @@ func TestMapToTerraformValue(t *testing.T) {
 
 	type testCase struct {
 		input       Map
-		expectation interface{}
+		expectation tftypes.Value
 	}
 	tests := map[string]testCase{
 		"value": {
@@ -298,18 +298,18 @@ func TestMapToTerraformValue(t *testing.T) {
 					"w": String{Value: "world"},
 				},
 			},
-			expectation: map[string]tftypes.Value{
+			expectation: tftypes.NewValue(tftypes.Map{ElementType: tftypes.String}, map[string]tftypes.Value{
 				"h": tftypes.NewValue(tftypes.String, "hello"),
 				"w": tftypes.NewValue(tftypes.String, "world"),
-			},
+			}),
 		},
 		"unknown": {
-			input:       Map{Unknown: true},
-			expectation: tftypes.UnknownValue,
+			input:       Map{ElemType: StringType, Unknown: true},
+			expectation: tftypes.NewValue(tftypes.Map{ElementType: tftypes.String}, tftypes.UnknownValue),
 		},
 		"null": {
-			input:       Map{Null: true},
-			expectation: nil,
+			input:       Map{ElemType: StringType, Null: true},
+			expectation: tftypes.NewValue(tftypes.Map{ElementType: tftypes.String}, nil),
 		},
 		"partial-unknown": {
 			input: Map{
@@ -319,10 +319,10 @@ func TestMapToTerraformValue(t *testing.T) {
 					"hw":  String{Value: "hello, world"},
 				},
 			},
-			expectation: map[string]tftypes.Value{
+			expectation: tftypes.NewValue(tftypes.Map{ElementType: tftypes.String}, map[string]tftypes.Value{
 				"unk": tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
 				"hw":  tftypes.NewValue(tftypes.String, "hello, world"),
-			},
+			}),
 		},
 		"partial-null": {
 			input: Map{
@@ -332,10 +332,10 @@ func TestMapToTerraformValue(t *testing.T) {
 					"hw": String{Value: "hello, world"},
 				},
 			},
-			expectation: map[string]tftypes.Value{
+			expectation: tftypes.NewValue(tftypes.Map{ElementType: tftypes.String}, map[string]tftypes.Value{
 				"n":  tftypes.NewValue(tftypes.String, nil),
 				"hw": tftypes.NewValue(tftypes.String, "hello, world"),
-			},
+			}),
 		},
 	}
 	for name, test := range tests {

--- a/types/number.go
+++ b/types/number.go
@@ -58,7 +58,7 @@ func (n Number) ToTerraformValue(_ context.Context) (tftypes.Value, error) {
 		return tftypes.NewValue(tftypes.Number, nil), nil
 	}
 	if err := tftypes.ValidateValue(tftypes.Number, n.Value); err != nil {
-		return tftypes.NewValue(tftypes.Number, tftypes.UnknownValue), nil
+		return tftypes.NewValue(tftypes.Number, tftypes.UnknownValue), err
 	}
 	return tftypes.NewValue(tftypes.Number, n.Value), nil
 }

--- a/types/number.go
+++ b/types/number.go
@@ -45,20 +45,22 @@ func (n Number) Type(_ context.Context) attr.Type {
 	return NumberType
 }
 
-// ToTerraformValue returns the data contained in the *Number as a *big.Float.
-// If Unknown is true, it returns a tftypes.UnknownValue. If Null is true, it
-// returns nil.
-func (n Number) ToTerraformValue(_ context.Context) (interface{}, error) {
+// ToTerraformValue returns the data contained in the *Number as a
+// tftypes.Value.
+func (n Number) ToTerraformValue(_ context.Context) (tftypes.Value, error) {
 	if n.Null {
-		return nil, nil
+		return tftypes.NewValue(tftypes.Number, nil), nil
 	}
 	if n.Unknown {
-		return tftypes.UnknownValue, nil
+		return tftypes.NewValue(tftypes.Number, tftypes.UnknownValue), nil
 	}
 	if n.Value == nil {
-		return nil, nil
+		return tftypes.NewValue(tftypes.Number, nil), nil
 	}
-	return n.Value, nil
+	if err := tftypes.ValidateValue(tftypes.Number, n.Value); err != nil {
+		return tftypes.NewValue(tftypes.Number, tftypes.UnknownValue), nil
+	}
+	return tftypes.NewValue(tftypes.Number, n.Value), nil
 }
 
 // Equal returns true if `other` is a *Number and has the same value as `n`.

--- a/types/number_test.go
+++ b/types/number_test.go
@@ -85,24 +85,24 @@ func TestNumberToTerraformValue(t *testing.T) {
 
 	type testCase struct {
 		input       Number
-		expectation interface{}
+		expectation tftypes.Value
 	}
 	tests := map[string]testCase{
 		"value": {
 			input:       Number{Value: big.NewFloat(123)},
-			expectation: big.NewFloat(123),
+			expectation: tftypes.NewValue(tftypes.Number, big.NewFloat(123)),
 		},
 		"value-nil": {
 			input:       Number{Value: nil},
-			expectation: nil,
+			expectation: tftypes.NewValue(tftypes.Number, nil),
 		},
 		"unknown": {
 			input:       Number{Unknown: true},
-			expectation: tftypes.UnknownValue,
+			expectation: tftypes.NewValue(tftypes.Number, tftypes.UnknownValue),
 		},
 		"null": {
 			input:       Number{Null: true},
-			expectation: nil,
+			expectation: tftypes.NewValue(tftypes.Number, nil),
 		},
 	}
 	for name, test := range tests {

--- a/types/object_test.go
+++ b/types/object_test.go
@@ -626,7 +626,7 @@ func TestObjectToTerraformValue(t *testing.T) {
 	t.Parallel()
 	type testCase struct {
 		receiver    Object
-		expected    interface{}
+		expected    tftypes.Value
 		expectedErr string
 	}
 	tests := map[string]testCase{
@@ -672,7 +672,16 @@ func TestObjectToTerraformValue(t *testing.T) {
 					},
 				},
 			},
-			expected: map[string]tftypes.Value{
+			expected: tftypes.NewValue(tftypes.Object{
+				AttributeTypes: map[string]tftypes.Type{
+					"a": tftypes.List{ElementType: tftypes.String},
+					"b": tftypes.String,
+					"c": tftypes.Bool,
+					"d": tftypes.Number,
+					"e": tftypes.Object{AttributeTypes: map[string]tftypes.Type{"name": tftypes.String}},
+					"f": tftypes.Set{ElementType: tftypes.String},
+				},
+			}, map[string]tftypes.Value{
 				"a": tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, []tftypes.Value{
 					tftypes.NewValue(tftypes.String, "hello"),
 					tftypes.NewValue(tftypes.String, "world"),
@@ -691,7 +700,7 @@ func TestObjectToTerraformValue(t *testing.T) {
 					tftypes.NewValue(tftypes.String, "hello"),
 					tftypes.NewValue(tftypes.String, "world"),
 				}),
-			},
+			}),
 		},
 		"unknown": {
 			receiver: Object{
@@ -709,7 +718,20 @@ func TestObjectToTerraformValue(t *testing.T) {
 				},
 				Unknown: true,
 			},
-			expected: tftypes.UnknownValue,
+			expected: tftypes.NewValue(tftypes.Object{
+				AttributeTypes: map[string]tftypes.Type{
+					"a": tftypes.List{ElementType: tftypes.String},
+					"b": tftypes.String,
+					"c": tftypes.Bool,
+					"d": tftypes.Number,
+					"e": tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"name": tftypes.String,
+						},
+					},
+					"f": tftypes.Set{ElementType: tftypes.String},
+				},
+			}, tftypes.UnknownValue),
 		},
 		"null": {
 			receiver: Object{
@@ -727,7 +749,20 @@ func TestObjectToTerraformValue(t *testing.T) {
 				},
 				Null: true,
 			},
-			expected: nil,
+			expected: tftypes.NewValue(tftypes.Object{
+				AttributeTypes: map[string]tftypes.Type{
+					"a": tftypes.List{ElementType: tftypes.String},
+					"b": tftypes.String,
+					"c": tftypes.Bool,
+					"d": tftypes.Number,
+					"e": tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"name": tftypes.String,
+						},
+					},
+					"f": tftypes.Set{ElementType: tftypes.String},
+				},
+			}, nil),
 		},
 		"partial-unknown": {
 			receiver: Object{
@@ -771,7 +806,20 @@ func TestObjectToTerraformValue(t *testing.T) {
 					},
 				},
 			},
-			expected: map[string]tftypes.Value{
+			expected: tftypes.NewValue(tftypes.Object{
+				AttributeTypes: map[string]tftypes.Type{
+					"a": tftypes.List{ElementType: tftypes.String},
+					"b": tftypes.String,
+					"c": tftypes.Bool,
+					"d": tftypes.Number,
+					"e": tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"name": tftypes.String,
+						},
+					},
+					"f": tftypes.Set{ElementType: tftypes.String},
+				},
+			}, map[string]tftypes.Value{
 				"a": tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, []tftypes.Value{
 					tftypes.NewValue(tftypes.String, "hello"),
 					tftypes.NewValue(tftypes.String, "world"),
@@ -790,7 +838,7 @@ func TestObjectToTerraformValue(t *testing.T) {
 					tftypes.NewValue(tftypes.String, "hello"),
 					tftypes.NewValue(tftypes.String, "world"),
 				}),
-			},
+			}),
 		},
 		"partial-null": {
 			receiver: Object{
@@ -834,7 +882,20 @@ func TestObjectToTerraformValue(t *testing.T) {
 					},
 				},
 			},
-			expected: map[string]tftypes.Value{
+			expected: tftypes.NewValue(tftypes.Object{
+				AttributeTypes: map[string]tftypes.Type{
+					"a": tftypes.List{ElementType: tftypes.String},
+					"b": tftypes.String,
+					"c": tftypes.Bool,
+					"d": tftypes.Number,
+					"e": tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"name": tftypes.String,
+						},
+					},
+					"f": tftypes.Set{ElementType: tftypes.String},
+				},
+			}, map[string]tftypes.Value{
 				"a": tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, []tftypes.Value{
 					tftypes.NewValue(tftypes.String, "hello"),
 					tftypes.NewValue(tftypes.String, "world"),
@@ -853,7 +914,7 @@ func TestObjectToTerraformValue(t *testing.T) {
 					tftypes.NewValue(tftypes.String, "hello"),
 					tftypes.NewValue(tftypes.String, "world"),
 				}),
-			},
+			}),
 		},
 		"deep-partial-unknown": {
 			receiver: Object{
@@ -888,7 +949,7 @@ func TestObjectToTerraformValue(t *testing.T) {
 							"name": String{Unknown: true},
 						},
 					},
-					"f": List{
+					"f": Set{
 						ElemType: StringType,
 						Elems: []attr.Value{
 							String{Value: "hello"},
@@ -897,7 +958,20 @@ func TestObjectToTerraformValue(t *testing.T) {
 					},
 				},
 			},
-			expected: map[string]tftypes.Value{
+			expected: tftypes.NewValue(tftypes.Object{
+				AttributeTypes: map[string]tftypes.Type{
+					"a": tftypes.List{ElementType: tftypes.String},
+					"b": tftypes.String,
+					"c": tftypes.Bool,
+					"d": tftypes.Number,
+					"e": tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"name": tftypes.String,
+						},
+					},
+					"f": tftypes.Set{ElementType: tftypes.String},
+				},
+			}, map[string]tftypes.Value{
 				"a": tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, []tftypes.Value{
 					tftypes.NewValue(tftypes.String, "hello"),
 					tftypes.NewValue(tftypes.String, "world"),
@@ -916,7 +990,7 @@ func TestObjectToTerraformValue(t *testing.T) {
 					tftypes.NewValue(tftypes.String, "hello"),
 					tftypes.NewValue(tftypes.String, "world"),
 				}),
-			},
+			}),
 		},
 		"deep-partial-null": {
 			receiver: Object{
@@ -960,7 +1034,20 @@ func TestObjectToTerraformValue(t *testing.T) {
 					},
 				},
 			},
-			expected: map[string]tftypes.Value{
+			expected: tftypes.NewValue(tftypes.Object{
+				AttributeTypes: map[string]tftypes.Type{
+					"a": tftypes.List{ElementType: tftypes.String},
+					"b": tftypes.String,
+					"c": tftypes.Bool,
+					"d": tftypes.Number,
+					"e": tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"name": tftypes.String,
+						},
+					},
+					"f": tftypes.Set{ElementType: tftypes.String},
+				},
+			}, map[string]tftypes.Value{
 				"a": tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, []tftypes.Value{
 					tftypes.NewValue(tftypes.String, "hello"),
 					tftypes.NewValue(tftypes.String, "world"),
@@ -979,7 +1066,7 @@ func TestObjectToTerraformValue(t *testing.T) {
 					tftypes.NewValue(tftypes.String, "hello"),
 					tftypes.NewValue(tftypes.String, "world"),
 				}),
-			},
+			}),
 		},
 	}
 

--- a/types/set_test.go
+++ b/types/set_test.go
@@ -550,7 +550,7 @@ func TestSetToTerraformValue(t *testing.T) {
 
 	type testCase struct {
 		input       Set
-		expectation interface{}
+		expectation tftypes.Value
 	}
 	tests := map[string]testCase{
 		"value": {
@@ -561,10 +561,10 @@ func TestSetToTerraformValue(t *testing.T) {
 					String{Value: "world"},
 				},
 			},
-			expectation: []tftypes.Value{
+			expectation: tftypes.NewValue(tftypes.Set{ElementType: tftypes.String}, []tftypes.Value{
 				tftypes.NewValue(tftypes.String, "hello"),
 				tftypes.NewValue(tftypes.String, "world"),
-			},
+			}),
 		},
 		"value-duplicates": {
 			input: Set{
@@ -576,18 +576,18 @@ func TestSetToTerraformValue(t *testing.T) {
 			},
 			// Duplicate validation does not occur during this method.
 			// This is okay, as tftypes allows duplicates.
-			expectation: []tftypes.Value{
+			expectation: tftypes.NewValue(tftypes.Set{ElementType: tftypes.String}, []tftypes.Value{
 				tftypes.NewValue(tftypes.String, "hello"),
 				tftypes.NewValue(tftypes.String, "hello"),
-			},
+			}),
 		},
 		"unknown": {
-			input:       Set{Unknown: true},
-			expectation: tftypes.UnknownValue,
+			input:       Set{ElemType: StringType, Unknown: true},
+			expectation: tftypes.NewValue(tftypes.Set{ElementType: tftypes.String}, tftypes.UnknownValue),
 		},
 		"null": {
-			input:       Set{Null: true},
-			expectation: nil,
+			input:       Set{ElemType: StringType, Null: true},
+			expectation: tftypes.NewValue(tftypes.Set{ElementType: tftypes.String}, nil),
 		},
 		"partial-unknown": {
 			input: Set{
@@ -597,10 +597,10 @@ func TestSetToTerraformValue(t *testing.T) {
 					String{Value: "hello, world"},
 				},
 			},
-			expectation: []tftypes.Value{
+			expectation: tftypes.NewValue(tftypes.Set{ElementType: tftypes.String}, []tftypes.Value{
 				tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
 				tftypes.NewValue(tftypes.String, "hello, world"),
-			},
+			}),
 		},
 		"partial-null": {
 			input: Set{
@@ -610,10 +610,10 @@ func TestSetToTerraformValue(t *testing.T) {
 					String{Value: "hello, world"},
 				},
 			},
-			expectation: []tftypes.Value{
+			expectation: tftypes.NewValue(tftypes.Set{ElementType: tftypes.String}, []tftypes.Value{
 				tftypes.NewValue(tftypes.String, nil),
 				tftypes.NewValue(tftypes.String, "hello, world"),
-			},
+			}),
 		},
 	}
 	for name, test := range tests {

--- a/types/string.go
+++ b/types/string.go
@@ -43,17 +43,19 @@ func (s String) Type(_ context.Context) attr.Type {
 	return StringType
 }
 
-// ToTerraformValue returns the data contained in the *String as a string. If
-// Unknown is true, it returns a tftypes.UnknownValue. If Null is true, it
-// returns nil.
-func (s String) ToTerraformValue(_ context.Context) (interface{}, error) {
+// ToTerraformValue returns the data contained in the *String as a
+// tftypes.Value.
+func (s String) ToTerraformValue(_ context.Context) (tftypes.Value, error) {
 	if s.Null {
-		return nil, nil
+		return tftypes.NewValue(tftypes.String, nil), nil
 	}
 	if s.Unknown {
-		return tftypes.UnknownValue, nil
+		return tftypes.NewValue(tftypes.String, tftypes.UnknownValue), nil
 	}
-	return s.Value, nil
+	if err := tftypes.ValidateValue(tftypes.String, s.Value); err != nil {
+		return tftypes.NewValue(tftypes.String, tftypes.UnknownValue), err
+	}
+	return tftypes.NewValue(tftypes.String, s.Value), nil
 }
 
 // Equal returns true if `other` is a *String and has the same value as `s`.

--- a/types/string_test.go
+++ b/types/string_test.go
@@ -86,15 +86,15 @@ func TestStringToTerraformValue(t *testing.T) {
 	tests := map[string]testCase{
 		"value": {
 			input:       String{Value: "hello"},
-			expectation: "hello",
+			expectation: tftypes.NewValue(tftypes.String, "hello"),
 		},
 		"unknown": {
 			input:       String{Unknown: true},
-			expectation: tftypes.UnknownValue,
+			expectation: tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
 		},
 		"null": {
 			input:       String{Null: true},
-			expectation: nil,
+			expectation: tftypes.NewValue(tftypes.String, nil),
 		},
 	}
 	for name, test := range tests {


### PR DESCRIPTION
Refactor the `attr.Value.ToTerraformValue` to return a `tftypes.Value`,
which simplifies a bunch of code and makes the interface safer by
allowing it to be type checked by the compiler. It did require quite a
bit of refactoring of internal code, however.

This also simplifies checking whether an arbitrary `attr.Value` is null
or unknown considerably.

Fixes #171.