### PR TITLE
Allow using ValueAs into attr.Value.

### DIFF
--- a/.changelog/232.txt
+++ b/.changelog/232.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+Added the ability to get an attribute as a generic `attr.Value` when using `GetAttribute`.
+```

--- a/internal/reflect/generic_attr_value.go
+++ b/internal/reflect/generic_attr_value.go
@@ -1,0 +1,12 @@
+package reflect
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+)
+
+func IsGenericAttrValue(ctx context.Context, target interface{}) bool {
+	return reflect.TypeOf((*attr.Value)(nil)) == reflect.TypeOf(target)
+}

--- a/tfsdk/value_as.go
+++ b/tfsdk/value_as.go
@@ -14,6 +14,10 @@ import (
 // the contents of `val`, using the reflection rules
 // defined for `Get` and `GetAttribute`.
 func ValueAs(ctx context.Context, val attr.Value, target interface{}) diag.Diagnostics {
+	if reflect.IsGenericAttrValue(ctx, target) {
+		*(target.(*attr.Value)) = val
+		return nil
+	}
 	raw, err := val.ToTerraformValue(ctx)
 	if err != nil {
 		return diag.Diagnostics{diag.NewErrorDiagnostic("Error converting value",

--- a/tfsdk/value_as_test.go
+++ b/tfsdk/value_as_test.go
@@ -96,3 +96,17 @@ func TestValueAs(t *testing.T) {
 		})
 	}
 }
+
+func TestValueAs_generic(t *testing.T) {
+	t.Parallel()
+
+	var target attr.Value
+	val := types.String{Value: "hello"}
+	diags := ValueAs(context.Background(), val, &target)
+	if len(diags) > 0 {
+		t.Fatalf("Unexpected diagnostics: %s", diags)
+	}
+	if !val.Equal(target.(attr.Value)) {
+		t.Errorf("Expected target to be %v, got %v", val, target)
+	}
+}


### PR DESCRIPTION
Allow for generic handling of attr.Values by special-casing ValueAs
(and, consequently, GetAttribute) to bypass reflection when we want to
just obtain the raw attr.Value.

Fixes #230.