### PR TITLE
tfsdk: Added Debug field to ServeOpts for running providers via debugger and testing processes

### DIFF
--- a/.changelog/243.txt
+++ b/.changelog/243.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+tfsdk: Added `Debug` field to `ServeOpts` for running providers via debugger and testing processes
+```


### PR DESCRIPTION
Closes #239
Reference: https://www.terraform.io/plugin/sdkv2/debugging

Similar to Terraform Plugin SDK, providers need to be executable via debugger and testing processes for instrumenting the provider code. In this workflow, the caller manages the provider lifecycle, rather than Terraform CLI. The Terraform CLI reattach configuration is output to stdout.

Verified in a framework-based provider by:

- `go mod edit -replace=github.com/hashicorp/terraform-plugin-framework=/Users/bflad/src/github.com/hashicorp/terraform-plugin-framework` (use this worktree)
- Updated provider `main` function code to 

```go
func main() {
	var debug bool

	flag.BoolVar(&debug, "debug", false, "set to true to run the provider with support for debuggers like delve")
	flag.Parse()

	var err error
	ctx := context.Background()
	serveOpts := tfsdk.ServeOpts{
		Name: "registry.terraform.io/bflad/framework",
	}

	if debug {
		err = tfsdk.Debug(ctx, provider.New, serveOpts)
	} else {
		err = tfsdk.Serve(ctx, provider.New, serveOpts)
	}

	if err != nil {
		fmt.Printf("Error serving provider: %s", err)
		os.Exit(1)
	}
}
```

- Added provider VSCode configuration to `.vscode/launch.json` (refer also to terraform-provider-scaffolding)

```json
        {
            "name": "Debug - Attach External CLI",
            "type": "go",
            "request": "launch",
            "mode": "debug",
            // this assumes your workspace is the root of the repo
            "program": "${workspaceFolder}",
            "env": {},
            "args": [
                // pass the debug flag for reattaching
                "-debug",
            ],
        }
```

- In provider code, set a breakpoint
- Launched debug process
- Copied TF_REATTACH_PROVIDERS string from Outputs > Go Debug
- Exported environment variable and executed Terraform CLI
- Breakpoint hit and halted further execution
