### PR TITLE
tfsdk: Remove empty schema restriction

### DIFF
--- a/.changelog/252.txt
+++ b/.changelog/252.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+tfsdk: Removed `Schema` restriction that it must contain at least one attribute or block
+```

--- a/tfsdk/schema.go
+++ b/tfsdk/schema.go
@@ -189,13 +189,8 @@ func (s Schema) blockAtPath(path *tftypes.AttributePath) (Block, error) {
 	}
 }
 
-// tfprotov6Schema returns the *tfprotov6.Schema equivalent of a Schema. At least
-// one attribute must be set in the schema, or an error will be returned.
+// tfprotov6Schema returns the *tfprotov6.Schema equivalent of a Schema.
 func (s Schema) tfprotov6Schema(ctx context.Context) (*tfprotov6.Schema, error) {
-	if len(s.Attributes) < 1 && len(s.Blocks) < 1 {
-		return nil, errors.New("must have at least one attribute or block in the schema")
-	}
-
 	result := &tfprotov6.Schema{
 		Version: s.Version,
 	}

--- a/tfsdk/schema_test.go
+++ b/tfsdk/schema_test.go
@@ -1305,8 +1305,11 @@ func TestSchemaTfprotov6Schema(t *testing.T) {
 
 	tests := map[string]testCase{
 		"empty-val": {
-			input:       Schema{},
-			expectedErr: "must have at least one attribute or block in the schema",
+			input: Schema{},
+			expected: &tfprotov6.Schema{
+				Block:   &tfprotov6.SchemaBlock{},
+				Version: 0,
+			},
 		},
 		"basic-attrs": {
 			input: Schema{


### PR DESCRIPTION
Closes #250

This restriction does not seem necessary. Updated unit test and also real world verified against Terraform CLI with a test provider.