### PR TITLE
Skip validation of a values missing in config

### DIFF
--- a/tfsdk/config.go
+++ b/tfsdk/config.go
@@ -91,11 +91,13 @@ func (c Config) getAttributeValue(ctx context.Context, path *tftypes.AttributePa
 	//       If found, convert this value to an unknown value.
 	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/186
 
-	if attrTypeWithValidate, ok := attrType.(attr.TypeWithValidate); ok {
-		diags.Append(attrTypeWithValidate.Validate(ctx, tfValue, path)...)
+	if err == nil {
+		if attrTypeWithValidate, ok := attrType.(attr.TypeWithValidate); ok {
+			diags.Append(attrTypeWithValidate.Validate(ctx, tfValue, path)...)
 
-		if diags.HasError() {
-			return nil, diags
+			if diags.HasError() {
+				return nil, diags
+			}
 		}
 	}
 

--- a/tfsdk/config.go
+++ b/tfsdk/config.go
@@ -90,14 +90,11 @@ func (c Config) getAttributeValue(ctx context.Context, path *tftypes.AttributePa
 	// TODO: If ErrInvalidStep, check parent paths for unknown value.
 	//       If found, convert this value to an unknown value.
 	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/186
+	if attrTypeWithValidate, ok := attrType.(attr.TypeWithValidate); ok {
+		diags.Append(attrTypeWithValidate.Validate(ctx, tfValue, path)...)
 
-	if err == nil {
-		if attrTypeWithValidate, ok := attrType.(attr.TypeWithValidate); ok {
-			diags.Append(attrTypeWithValidate.Validate(ctx, tfValue, path)...)
-
-			if diags.HasError() {
-				return nil, diags
-			}
+		if diags.HasError() {
+			return nil, diags
 		}
 	}
 

--- a/tfsdk/config_test.go
+++ b/tfsdk/config_test.go
@@ -335,6 +335,28 @@ func TestConfigGetAttribute(t *testing.T) {
 			expected:      &testtypes.String{String: types.String{Value: "namevalue"}, CreatedBy: testtypes.StringTypeWithValidateWarning{}},
 			expectedDiags: diag.Diagnostics{testtypes.TestWarningDiagnostic(tftypes.NewAttributePath().WithAttributeName("name"))},
 		},
+		"Computed-Computed-object": {
+			config: Config{
+				Raw: tftypes.NewValue(tftypes.Object{
+					AttributeTypes: map[string]tftypes.Type{
+						"name": tftypes.String,
+					},
+				}, map[string]tftypes.Value{
+					"name": tftypes.NewValue(tftypes.String, "namevalue"),
+				}),
+				Schema: Schema{
+					Attributes: map[string]Attribute{
+						"name": {
+							Type:     testtypes.StringTypeWithValidateWarning{},
+							Required: true,
+						},
+					},
+				},
+			},
+			target:        new(testtypes.String),
+			expected:      &testtypes.String{String: types.String{Value: "namevalue"}, CreatedBy: testtypes.StringTypeWithValidateWarning{}},
+			expectedDiags: diag.Diagnostics{testtypes.TestWarningDiagnostic(tftypes.NewAttributePath().WithAttributeName("name"))},
+		},
 	}
 
 	for name, tc := range testCases {
@@ -1584,6 +1606,35 @@ func TestConfigGetAttributeValue(t *testing.T) {
 			path:          tftypes.NewAttributePath().WithAttributeName("test"),
 			expected:      testtypes.String{String: types.String{Value: "value"}, CreatedBy: testtypes.StringTypeWithValidateWarning{}},
 			expectedDiags: diag.Diagnostics{testtypes.TestWarningDiagnostic(tftypes.NewAttributePath().WithAttributeName("test"))},
+		},
+		"AttrTypeInt64WithValidateError-nested-missing-in-config": {
+			config: Config{
+				Raw: tftypes.NewValue(tftypes.Object{
+					AttributeTypes: map[string]tftypes.Type{
+						"parent": tftypes.Object{},
+					},
+				}, map[string]tftypes.Value{
+					"parent": tftypes.NewValue(tftypes.Object{}, nil),
+				}),
+				Schema: Schema{
+					Attributes: map[string]Attribute{
+						"parent": {
+							Attributes: SingleNestedAttributes(map[string]Attribute{
+								"test": {
+									Type:     types.Int64Type,
+									Optional: true,
+									Computed: true,
+								},
+							}),
+							Computed: true,
+							Optional: true,
+						},
+					},
+				},
+			},
+			path:          tftypes.NewAttributePath().WithAttributeName("parent").WithAttributeName("test"),
+			expected:      types.Int64{Null: true},
+			expectedDiags: nil,
 		},
 	}
 

--- a/tfsdk/state.go
+++ b/tfsdk/state.go
@@ -91,11 +91,13 @@ func (s State) getAttributeValue(ctx context.Context, path *tftypes.AttributePat
 	//       If found, convert this value to an unknown value.
 	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/186
 
-	if attrTypeWithValidate, ok := attrType.(attr.TypeWithValidate); ok {
-		diags.Append(attrTypeWithValidate.Validate(ctx, tfValue, path)...)
+	if err == nil {
+		if attrTypeWithValidate, ok := attrType.(attr.TypeWithValidate); ok {
+			diags.Append(attrTypeWithValidate.Validate(ctx, tfValue, path)...)
 
-		if diags.HasError() {
-			return nil, diags
+			if diags.HasError() {
+				return nil, diags
+			}
 		}
 	}
 

--- a/tfsdk/state_test.go
+++ b/tfsdk/state_test.go
@@ -2282,6 +2282,35 @@ func TestStateGetAttributeValue(t *testing.T) {
 			expected:      testtypes.String{String: types.String{Value: "value"}, CreatedBy: testtypes.StringTypeWithValidateWarning{}},
 			expectedDiags: diag.Diagnostics{testtypes.TestWarningDiagnostic(tftypes.NewAttributePath().WithAttributeName("test"))},
 		},
+		"AttrTypeInt64WithValidateError-nested-missing-in-config": {
+			state: State{
+				Raw: tftypes.NewValue(tftypes.Object{
+					AttributeTypes: map[string]tftypes.Type{
+						"parent": tftypes.Object{},
+					},
+				}, map[string]tftypes.Value{
+					"parent": tftypes.NewValue(tftypes.Object{}, nil),
+				}),
+				Schema: Schema{
+					Attributes: map[string]Attribute{
+						"parent": {
+							Attributes: SingleNestedAttributes(map[string]Attribute{
+								"test": {
+									Type:     types.Int64Type,
+									Optional: true,
+									Computed: true,
+								},
+							}),
+							Computed: true,
+							Optional: true,
+						},
+					},
+				},
+			},
+			path:          tftypes.NewAttributePath().WithAttributeName("parent").WithAttributeName("test"),
+			expected:      types.Int64{Null: true},
+			expectedDiags: nil,
+		},
 	}
 
 	for name, tc := range testCases {

--- a/types/float64.go
+++ b/types/float64.go
@@ -13,6 +13,10 @@ import (
 func float64Validate(_ context.Context, in tftypes.Value, path *tftypes.AttributePath) diag.Diagnostics {
 	var diags diag.Diagnostics
 
+	if !in.IsKnown() || in.IsNull() {
+		return diags
+	}
+
 	if !in.Type().Equal(tftypes.Number) {
 		diags.AddAttributeError(
 			path,
@@ -20,10 +24,6 @@ func float64Validate(_ context.Context, in tftypes.Value, path *tftypes.Attribut
 			"An unexpected error was encountered trying to validate an attribute value. This is always an error in the provider. Please report the following to the provider developer:\n\n"+
 				fmt.Sprintf("Expected Number value, received %T with value: %v", in, in),
 		)
-		return diags
-	}
-
-	if !in.IsKnown() || in.IsNull() {
 		return diags
 	}
 

--- a/types/int64.go
+++ b/types/int64.go
@@ -13,6 +13,10 @@ import (
 func int64Validate(_ context.Context, in tftypes.Value, path *tftypes.AttributePath) diag.Diagnostics {
 	var diags diag.Diagnostics
 
+	if !in.IsKnown() || in.IsNull() {
+		return diags
+	}
+
 	if !in.Type().Equal(tftypes.Number) {
 		diags.AddAttributeError(
 			path,
@@ -20,10 +24,6 @@ func int64Validate(_ context.Context, in tftypes.Value, path *tftypes.AttributeP
 			"An unexpected error was encountered trying to validate an attribute value. This is always an error in the provider. Please report the following to the provider developer:\n\n"+
 				fmt.Sprintf("Expected Number value, received %T with value: %v", in, in),
 		)
-		return diags
-	}
-
-	if !in.IsKnown() || in.IsNull() {
 		return diags
 	}
 


### PR DESCRIPTION
**Problem**

I have the following schema:

```
"spec": {
	Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
		"options": {
			Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
				"lock": {
					Description: "Lock specifies the locking mode (strict|best_effort) to be applied with  the role.",
					Optional:    true,
					Type:        types.StringType,
				},
				"max_sessions": {
					Description: "MaxSessions defines the maximum number of  concurrent sessions per connection.",
					Optional:    true,
					Computed:    true,
					Type:        types.Int64Type,
				},
			}),
			Computed:    true,
			Description: "Options is for OpenSSH options like agent forwarding.",
			Optional:    true,
			PlanModifiers: []tfsdk.AttributePlanModifier{tfsdk.UseStateForUnknown()},
		},
```

And the following config:

```
spec {}
```

`"spec"` is the base object, `"options"` is the child computed object, and `"max_sessions"` is the bottommost Int64 value, which, in turn, is also computed.

`options` might either be missing in my configuration at all, set partially or set completely, including `max_sessions` attribute.

When `options` section is missing in the configuration completely, Terraform crashes:

```
github.com/hashicorp/terraform-plugin-framework/types.int64Validate({0x103337498, 0x1400030b600}, {{0x0, 0x0}, {0x0, 0x0}}, 0x14000683ce0)
	/Users/gzigzigzeo/go/src/github.com/gravitational/teleport-plugins/vendor/github.com/hashicorp/terraform-plugin-framework/types/int64.go:16 +0x44
github.com/hashicorp/terraform-plugin-framework/types.primitive.Validate(0x3, {0x103337498, 0x1400030b600}, {{0x0, 0x0}, {0x0, 0x0}}, 0x14000683ce0)
	/Users/gzigzigzeo/go/src/github.com/gravitational/teleport-plugins/vendor/github.com/hashicorp/terraform-plugin-framework/types/primitive.go:121 +0xd8
github.com/hashicorp/terraform-plugin-framework/tfsdk.Config.getAttributeValue({{{0x103341820, 0x140004f8690}, {0x1031eb6a0, 0x140004f41e0}}, {0x14000558bd0, 0x0, 0x0, {0x0, 0x0}, {0x0, ...}, ...}}, ...)
```

**Solution**

That happens because Terraform Framework tries to validate the type of `spec.options.max_sessions` config value, which is missing in the config, hence, can't have a type to validate. It must be skipped.