### PR TITLE
.github/workflows: Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: release
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
+
+permissions:
+  # Allow creating GitHub release
+  contents: write
+  # Allow closing associated milestone
+  issues: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # Required for release notes
+          fetch-depth: 0
+      - id: go-version
+        # Reference: https://github.com/actions/setup-go/issues/23
+        run: echo "::set-output name=version::$(cat ./.go-version)"
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ steps.go-version.outputs.version }}
+      - name: Generate Release Notes
+        # Fetch CHANGELOG.md contents up to Git tag prior to this release, skipping top two lines
+        run: sed -n -e "1{/# /d;}" -e "2{/^$/d;}" -e "/# $(git describe --abbrev=0 --exclude="$(git describe --abbrev=0 --match='v*.*.*' --tags)" --match='v*.*.*' --tags | tr -d v)/q;p" CHANGELOG.md > /tmp/release-notes.txt
+      - uses: goreleaser/goreleaser-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: release --release-notes /tmp/release-notes.txt --rm-dist


### PR DESCRIPTION
Copied from terraform-plugin-sdk. `.goreleaser.yml` is already in place and up to date.