### PR TITLE
tfsdk: Introduce internal/logging package

### DIFF
--- a/internal/logging/context.go
+++ b/internal/logging/context.go
@@ -1,0 +1,20 @@
+package logging
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-log/tfsdklog"
+)
+
+// InitContext creates SDK logger contexts. The incoming context will
+// already have the root SDK logger and root provider logger setup from
+// terraform-plugin-go tf6server RPC handlers.
+func InitContext(ctx context.Context) context.Context {
+	ctx = tfsdklog.NewSubsystem(ctx, SubsystemFramework,
+		// All calls are through the Framework* helper functions
+		tfsdklog.WithAdditionalLocationOffset(1),
+		tfsdklog.WithLevelFromEnv(EnvTfLogSdkFramework),
+	)
+
+	return ctx
+}

--- a/internal/logging/environment_variables.go
+++ b/internal/logging/environment_variables.go
@@ -1,0 +1,9 @@
+package logging
+
+// Environment variables.
+const (
+	// EnvTfLogSdkFramework is an environment variable that sets the logging
+	// level of SDK framework loggers. Infers root SDK logging level, if
+	// unset.
+	EnvTfLogSdkFramework = "TF_LOG_SDK_FRAMEWORK"
+)

--- a/internal/logging/framework.go
+++ b/internal/logging/framework.go
@@ -1,0 +1,32 @@
+package logging
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-log/tfsdklog"
+)
+
+const (
+	// SubsystemFramework is the tfsdklog subsystem name for framework.
+	SubsystemFramework = "framework"
+)
+
+// FrameworkDebug emits a framework subsystem log at DEBUG level.
+func FrameworkDebug(ctx context.Context, msg string, additionalFields ...map[string]interface{}) {
+	tfsdklog.SubsystemDebug(ctx, SubsystemFramework, msg, additionalFields...)
+}
+
+// FrameworkError emits a framework subsystem log at ERROR level.
+func FrameworkError(ctx context.Context, msg string, additionalFields ...map[string]interface{}) {
+	tfsdklog.SubsystemError(ctx, SubsystemFramework, msg, additionalFields...)
+}
+
+// FrameworkTrace emits a framework subsystem log at TRACE level.
+func FrameworkTrace(ctx context.Context, msg string, additionalFields ...map[string]interface{}) {
+	tfsdklog.SubsystemTrace(ctx, SubsystemFramework, msg, additionalFields...)
+}
+
+// FrameworkWarn emits a framework subsystem log at WARN level.
+func FrameworkWarn(ctx context.Context, msg string, additionalFields ...map[string]interface{}) {
+	tfsdklog.SubsystemWarn(ctx, SubsystemFramework, msg, additionalFields...)
+}

--- a/internal/logging/keys.go
+++ b/internal/logging/keys.go
@@ -1,0 +1,23 @@
+package logging
+
+// Structured logging keys.
+//
+// Practitioners or tooling reading logs may be depending on these keys, so be
+// conscious of that when changing them.
+//
+// Refer to the terraform-plugin-go logging keys as well, which should be
+// equivalent to these when possible.
+const (
+	// Attribute path representation, which is typically in flatmap form such
+	// as parent.0.child in this project.
+	KeyAttributePath = "tf_attribute_path"
+
+	// The type of data source being operated on, such as "archive_file"
+	KeyDataSourceType = "tf_data_source_type"
+
+	// Underlying Go error string when logging an error.
+	KeyError = "error"
+
+	// The type of resource being operated on, such as "random_pet"
+	KeyResourceType = "tf_resource_type"
+)

--- a/tfsdk/attribute_plan_modification.go
+++ b/tfsdk/attribute_plan_modification.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/internal/logging"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
-	"github.com/hashicorp/terraform-plugin-log/tfsdklog"
 )
 
 // AttributePlanModifier represents a modifier for an attribute at plan time.
@@ -309,7 +309,7 @@ func (r RequiresReplaceIfModifier) Modify(ctx context.Context, req ModifyAttribu
 	if res {
 		resp.RequiresReplace = true
 	} else if resp.RequiresReplace {
-		tfsdklog.Debug(ctx, "Keeping previous attribute replacement requirement", map[string]interface{}{"attribute_path": req.AttributePath.String()})
+		logging.FrameworkDebug(ctx, "Keeping previous attribute replacement requirement", map[string]interface{}{logging.KeyAttributePath: req.AttributePath.String()})
 	}
 }
 


### PR DESCRIPTION
Similar to other terraform-plugin-* projects. Migrated all existing tfsdklog calls to a new framework subsystem so consumers can filter this project's logs. Additional subsystems may be added in the future.