### PR TITLE
correct NewProtocol6ProviderServerWithError to match the sdkv2 defini…

### DIFF
--- a/.changelog/303.txt
+++ b/.changelog/303.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+tfsdk: Correct `NewProtocol6ProviderServerWithError` function signature to align to sdk v2 `TestCase.ProtoV6ProviderFactories`
+```

--- a/tfsdk/serve.go
+++ b/tfsdk/serve.go
@@ -63,12 +63,12 @@ func NewProtocol6ProviderServer(p Provider) func() tfprotov6.ProviderServer {
 // acceptance testing helper/resource.TestCase.ProtoV6ProviderFactories.
 //
 // The error return is not currently used, but it may be in the future.
-func NewProtocol6ProviderServerWithError(p Provider) (func() tfprotov6.ProviderServer, error) {
-	return func() tfprotov6.ProviderServer {
+func NewProtocol6ProviderServerWithError(p Provider) func() (tfprotov6.ProviderServer, error) {
+	return func() (tfprotov6.ProviderServer, error) {
 		return &server{
 			p: p,
-		}
-	}, nil
+		}, nil
+	}
 }
 
 // Serve serves a provider, blocking until the context is canceled.

--- a/tfsdk/serve_test.go
+++ b/tfsdk/serve_test.go
@@ -33,13 +33,11 @@ func TestNewProtocol6ProviderServer(t *testing.T) {
 func TestNewProtocol6ProviderServerWithError(t *testing.T) {
 	provider := &testServeProvider{}
 
-	providerServerFunc, err := NewProtocol6ProviderServerWithError(provider)
+	providerServer, err := NewProtocol6ProviderServerWithError(provider)()
 
 	if err != nil {
 		t.Fatalf("unexpected error creating ProviderServer: %s", err)
 	}
-
-	providerServer := providerServerFunc()
 
 	// Simple verification
 	_, err = providerServer.GetProviderSchema(context.Background(), &tfprotov6.GetProviderSchemaRequest{})


### PR DESCRIPTION
…tion for ProtoV6ProviderFactories

The SDKv2 `TestCase` `ProtoV6ProviderFactories` expects a slightly different function signature, which results in test provider definitions like:

```
"example": func() (tfprotov6.ProviderServer, error) {
		srv, err := tfsdk.NewProtocol6ProviderServerWithError(New())
		return srv(), err
	},
```

https://github.com/hashicorp/terraform-plugin-sdk/blob/main/helper/resource/testing.go#L343-L348

This change aligns the function signature to work as below:

```
	"example": tfsdk.NewProtocol6ProviderServerWithError(New("test")),
```

I have done some simple integration tests with the corner provider.