### PR TITLE
Introduce internal/fwserver package and migrate GetProviderSchema

### DIFF
--- a/internal/fromproto6/doc.go
+++ b/internal/fromproto6/doc.go
@@ -1,0 +1,3 @@
+// Package fromproto6 contains functions to convert from protocol version 6
+// (tfprotov6) types to framework types.
+package fromproto6

--- a/internal/fromproto6/getproviderschema.go
+++ b/internal/fromproto6/getproviderschema.go
@@ -1,0 +1,20 @@
+package fromproto6
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+)
+
+// GetProviderSchemaRequest returns the *fwserver.GetProviderSchemaRequest
+// equivalent of a *tfprotov6.GetProviderSchemaRequest.
+func GetProviderSchemaRequest(ctx context.Context, proto6 *tfprotov6.GetProviderSchemaRequest) *fwserver.GetProviderSchemaRequest {
+	if proto6 == nil {
+		return nil
+	}
+
+	fw := &fwserver.GetProviderSchemaRequest{}
+
+	return fw
+}

--- a/internal/fromproto6/getproviderschema_test.go
+++ b/internal/fromproto6/getproviderschema_test.go
@@ -1,0 +1,43 @@
+package fromproto6_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fromproto6"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+)
+
+func TestGetProviderSchemaRequest(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		input    *tfprotov6.GetProviderSchemaRequest
+		expected *fwserver.GetProviderSchemaRequest
+	}{
+		"nil": {
+			input:    nil,
+			expected: nil,
+		},
+		"empty": {
+			input:    &tfprotov6.GetProviderSchemaRequest{},
+			expected: &fwserver.GetProviderSchemaRequest{},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := fromproto6.GetProviderSchemaRequest(context.Background(), testCase.input)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}

--- a/internal/fwserver/doc.go
+++ b/internal/fwserver/doc.go
@@ -1,0 +1,5 @@
+// Package fwserver contains the framework provider server implementation.
+// This package should only ever contain framework-native types, while specific
+// protocol version compatible implementations, such as proto6server, are
+// implemented on top of this abstraction.
+package fwserver

--- a/internal/fwserver/server.go
+++ b/internal/fwserver/server.go
@@ -1,0 +1,12 @@
+package fwserver
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+)
+
+// Server implements the framework provider server. Protocol specific
+// implementations wrap this handling along with calling all request and
+// response type conversions.
+type Server struct {
+	Provider tfsdk.Provider
+}

--- a/internal/fwserver/server_getproviderschema.go
+++ b/internal/fwserver/server_getproviderschema.go
@@ -1,0 +1,120 @@
+package fwserver
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/internal/logging"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+)
+
+// GetProviderSchemaRequest is the framework server request for the
+// GetProviderSchema RPC.
+type GetProviderSchemaRequest struct{}
+
+// GetProviderSchemaResponse is the framework server response for the
+// GetProviderSchema RPC.
+type GetProviderSchemaResponse struct {
+	Provider          *tfsdk.Schema
+	ProviderMeta      *tfsdk.Schema
+	ResourceSchemas   map[string]*tfsdk.Schema
+	DataSourceSchemas map[string]*tfsdk.Schema
+	Diagnostics       diag.Diagnostics
+}
+
+// GetProviderSchema implements the framework server GetProviderSchema RPC.
+func (s *Server) GetProviderSchema(ctx context.Context, req *GetProviderSchemaRequest, resp *GetProviderSchemaResponse) {
+	logging.FrameworkDebug(ctx, "Calling provider defined Provider GetSchema")
+	providerSchema, diags := s.Provider.GetSchema(ctx)
+	logging.FrameworkDebug(ctx, "Called provider defined Provider GetSchema")
+
+	resp.Diagnostics.Append(diags...)
+
+	if diags.HasError() {
+		return
+	}
+
+	resp.Provider = &providerSchema
+
+	if pm, ok := s.Provider.(tfsdk.ProviderWithProviderMeta); ok {
+		logging.FrameworkTrace(ctx, "Provider implements ProviderWithProviderMeta")
+
+		logging.FrameworkDebug(ctx, "Calling provider defined Provider GetMetaSchema")
+		providerMetaSchema, diags := pm.GetMetaSchema(ctx)
+		logging.FrameworkDebug(ctx, "Called provider defined Provider GetMetaSchema")
+
+		resp.Diagnostics.Append(diags...)
+
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		resp.ProviderMeta = &providerMetaSchema
+	}
+
+	// TODO: Cache GetDataSources call
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/299
+	logging.FrameworkDebug(ctx, "Calling provider defined Provider GetResources")
+	resourceSchemas, diags := s.Provider.GetResources(ctx)
+	logging.FrameworkDebug(ctx, "Called provider defined Provider GetResources")
+
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if len(resourceSchemas) > 0 {
+		resp.ResourceSchemas = map[string]*tfsdk.Schema{}
+	}
+
+	for k, v := range resourceSchemas {
+		// KeyResourceType field only necessary here since we are in GetProviderSchema RPC
+		logging.FrameworkTrace(ctx, "Found resource type", map[string]interface{}{logging.KeyResourceType: k})
+
+		logging.FrameworkDebug(ctx, "Calling provider defined ResourceType GetSchema", map[string]interface{}{logging.KeyResourceType: k})
+		schema, diags := v.GetSchema(ctx)
+		logging.FrameworkDebug(ctx, "Called provider defined ResourceType GetSchema", map[string]interface{}{logging.KeyResourceType: k})
+
+		resp.Diagnostics.Append(diags...)
+
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		resp.ResourceSchemas[k] = &schema
+	}
+
+	// TODO: Cache GetDataSources call
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/299
+	logging.FrameworkDebug(ctx, "Calling provider defined Provider GetDataSources")
+	dataSourceSchemas, diags := s.Provider.GetDataSources(ctx)
+	logging.FrameworkDebug(ctx, "Called provider defined Provider GetDataSources")
+
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if len(dataSourceSchemas) > 0 {
+		resp.DataSourceSchemas = map[string]*tfsdk.Schema{}
+	}
+
+	for k, v := range dataSourceSchemas {
+		// KeyDataSourceType field only necessary here since we are in GetProviderSchema RPC
+		logging.FrameworkTrace(ctx, "Found data source type", map[string]interface{}{logging.KeyDataSourceType: k})
+
+		logging.FrameworkDebug(ctx, "Calling provider defined DataSourceType GetSchema", map[string]interface{}{logging.KeyDataSourceType: k})
+		schema, diags := v.GetSchema(ctx)
+		logging.FrameworkDebug(ctx, "Called provider defined DataSourceType GetSchema", map[string]interface{}{logging.KeyDataSourceType: k})
+
+		resp.Diagnostics.Append(diags...)
+
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		resp.DataSourceSchemas[k] = &schema
+	}
+}

--- a/internal/fwserver/server_getproviderschema_test.go
+++ b/internal/fwserver/server_getproviderschema_test.go
@@ -1,0 +1,53 @@
+package fwserver_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/emptyprovider"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+)
+
+// TODO: Migrate tfsdk.Provider bits of proto6server.testProviderServer to
+// new internal/testing/provider.Provider that allows customization of all
+// method implementations via struct fields. Then, create additional test
+// cases in this unit test.
+//
+// For now this testing is covered by proto6server.GetProviderSchema.
+//
+// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/215
+func TestServerGetProviderSchema(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		server           fwserver.Server
+		request          *fwserver.GetProviderSchemaRequest
+		expectedResponse *fwserver.GetProviderSchemaResponse
+	}{
+		"empty-provider": {
+			server: fwserver.Server{
+				Provider: &emptyprovider.Provider{},
+			},
+			expectedResponse: &fwserver.GetProviderSchemaResponse{
+				Provider: &tfsdk.Schema{},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			response := &fwserver.GetProviderSchemaResponse{}
+			testCase.server.GetProviderSchema(context.Background(), testCase.request, response)
+
+			if diff := cmp.Diff(response, testCase.expectedResponse); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}

--- a/internal/proto6server/serve_test.go
+++ b/internal/proto6server/serve_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
 	"github.com/hashicorp/terraform-plugin-framework/internal/logging"
 	"github.com/hashicorp/terraform-plugin-framework/internal/testing/emptyprovider"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
@@ -270,7 +271,9 @@ func TestServerGetProviderSchema(t *testing.T) {
 
 	s := new(testServeProvider)
 	testServer := &Server{
-		Provider: s,
+		FrameworkServer: fwserver.Server{
+			Provider: s,
+		},
 	}
 	got, err := testServer.GetProviderSchema(context.Background(), new(tfprotov6.GetProviderSchemaRequest))
 	if err != nil {
@@ -313,7 +316,9 @@ func TestServerGetProviderSchema_logging(t *testing.T) {
 	ctx = logging.InitContext(ctx)
 
 	testServer := &Server{
-		Provider: &emptyprovider.Provider{},
+		FrameworkServer: fwserver.Server{
+			Provider: &emptyprovider.Provider{},
+		},
 	}
 
 	_, err := testServer.GetProviderSchema(ctx, new(tfprotov6.GetProviderSchemaRequest))
@@ -371,7 +376,9 @@ func TestServerGetProviderSchemaWithProviderMeta(t *testing.T) {
 
 	s := new(testServeProviderWithMetaSchema)
 	testServer := &Server{
-		Provider: s,
+		FrameworkServer: fwserver.Server{
+			Provider: s,
+		},
 	}
 	got, err := testServer.GetProviderSchema(context.Background(), new(tfprotov6.GetProviderSchemaRequest))
 	if err != nil {

--- a/internal/toproto6/getproviderschema.go
+++ b/internal/toproto6/getproviderschema.go
@@ -1,0 +1,78 @@
+package toproto6
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+)
+
+// GetProviderSchemaResponse returns the *tfprotov6.GetProviderSchemaResponse
+// equivalent of a *fwserver.GetProviderSchemaResponse.
+func GetProviderSchemaResponse(ctx context.Context, fw *fwserver.GetProviderSchemaResponse) *tfprotov6.GetProviderSchemaResponse {
+	if fw == nil {
+		return nil
+	}
+
+	protov6 := &tfprotov6.GetProviderSchemaResponse{
+		DataSourceSchemas: map[string]*tfprotov6.Schema{},
+		Diagnostics:       Diagnostics(fw.Diagnostics),
+		ResourceSchemas:   map[string]*tfprotov6.Schema{},
+	}
+
+	var err error
+
+	protov6.Provider, err = Schema(ctx, fw.Provider)
+
+	if err != nil {
+		protov6.Diagnostics = append(protov6.Diagnostics, &tfprotov6.Diagnostic{
+			Severity: tfprotov6.DiagnosticSeverityError,
+			Summary:  "Error converting provider schema",
+			Detail:   "The provider schema couldn't be converted into a usable type. This is always a problem with the provider. Please report the following to the provider developer:\n\n" + err.Error(),
+		})
+
+		return protov6
+	}
+
+	protov6.ProviderMeta, err = Schema(ctx, fw.ProviderMeta)
+
+	if err != nil {
+		protov6.Diagnostics = append(protov6.Diagnostics, &tfprotov6.Diagnostic{
+			Severity: tfprotov6.DiagnosticSeverityError,
+			Summary:  "Error converting provider_meta schema",
+			Detail:   "The provider_meta schema couldn't be converted into a usable type. This is always a problem with the provider. Please report the following to the provider developer:\n\n" + err.Error(),
+		})
+
+		return protov6
+	}
+
+	for dataSourceType, dataSourceSchema := range fw.DataSourceSchemas {
+		protov6.DataSourceSchemas[dataSourceType], err = Schema(ctx, dataSourceSchema)
+
+		if err != nil {
+			protov6.Diagnostics = append(protov6.Diagnostics, &tfprotov6.Diagnostic{
+				Severity: tfprotov6.DiagnosticSeverityError,
+				Summary:  "Error converting data source schema",
+				Detail:   "The schema for the data source \"" + dataSourceType + "\" couldn't be converted into a usable type. This is always a problem with the provider. Please report the following to the provider developer:\n\n" + err.Error(),
+			})
+
+			return protov6
+		}
+	}
+
+	for resourceType, resourceSchema := range fw.ResourceSchemas {
+		protov6.ResourceSchemas[resourceType], err = Schema(ctx, resourceSchema)
+
+		if err != nil {
+			protov6.Diagnostics = append(protov6.Diagnostics, &tfprotov6.Diagnostic{
+				Severity: tfprotov6.DiagnosticSeverityError,
+				Summary:  "Error converting resource schema",
+				Detail:   "The schema for the resource \"" + resourceType + "\" couldn't be converted into a usable type. This is always a problem with the provider. Please report the following to the provider developer:\n\n" + err.Error(),
+			})
+
+			return protov6
+		}
+	}
+
+	return protov6
+}

--- a/internal/toproto6/getproviderschema_test.go
+++ b/internal/toproto6/getproviderschema_test.go
@@ -1,0 +1,3653 @@
+package toproto6_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
+	"github.com/hashicorp/terraform-plugin-framework/internal/toproto6"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// TODO: DynamicPseudoType support
+// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/147
+// TODO: Tuple type support
+// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/54
+func TestGetProviderSchemaResponse(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		input    *fwserver.GetProviderSchemaResponse
+		expected *tfprotov6.GetProviderSchemaResponse
+	}{
+		"nil": {
+			input:    nil,
+			expected: nil,
+		},
+		"data-source-multiple-data-sources": {
+			input: &fwserver.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfsdk.Schema{
+					"test_data_source_1": {
+						Attributes: map[string]tfsdk.Attribute{
+							"test_attribute": {
+								Computed: true,
+								Type:     types.BoolType,
+							},
+						},
+					},
+					"test_data_source_2": {
+						Attributes: map[string]tfsdk.Attribute{
+							"test_attribute": {
+								Computed: true,
+								Type:     types.BoolType,
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{
+					"test_data_source_1": {
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Computed: true,
+									Name:     "test_attribute",
+									Type:     tftypes.Bool,
+								},
+							},
+						},
+					},
+					"test_data_source_2": {
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Computed: true,
+									Name:     "test_attribute",
+									Type:     tftypes.Bool,
+								},
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"data-source-attribute-computed": {
+			input: &fwserver.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfsdk.Schema{
+					"test_data_source": {
+						Attributes: map[string]tfsdk.Attribute{
+							"test_attribute": {
+								Computed: true,
+								Type:     types.BoolType,
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{
+					"test_data_source": {
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Computed: true,
+									Name:     "test_attribute",
+									Type:     tftypes.Bool,
+								},
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"data-source-attribute-deprecated": {
+			input: &fwserver.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfsdk.Schema{
+					"test_data_source": {
+						Attributes: map[string]tfsdk.Attribute{
+							"test_attribute": {
+								DeprecationMessage: "deprecated",
+								Optional:           true,
+								Type:               types.BoolType,
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{
+					"test_data_source": {
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Deprecated: true,
+									Name:       "test_attribute",
+									Optional:   true,
+									Type:       tftypes.Bool,
+								},
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"data-source-attribute-optional": {
+			input: &fwserver.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfsdk.Schema{
+					"test_data_source": {
+						Attributes: map[string]tfsdk.Attribute{
+							"test_attribute": {
+								Optional: true,
+								Type:     types.BoolType,
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{
+					"test_data_source": {
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Name:     "test_attribute",
+									Optional: true,
+									Type:     tftypes.Bool,
+								},
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"data-source-attribute-optional-computed": {
+			input: &fwserver.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfsdk.Schema{
+					"test_data_source": {
+						Attributes: map[string]tfsdk.Attribute{
+							"test_attribute": {
+								Computed: true,
+								Optional: true,
+								Type:     types.BoolType,
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{
+					"test_data_source": {
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Computed: true,
+									Name:     "test_attribute",
+									Optional: true,
+									Type:     tftypes.Bool,
+								},
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"data-source-attribute-required": {
+			input: &fwserver.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfsdk.Schema{
+					"test_data_source": {
+						Attributes: map[string]tfsdk.Attribute{
+							"test_attribute": {
+								Required: true,
+								Type:     types.BoolType,
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{
+					"test_data_source": {
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Name:     "test_attribute",
+									Type:     tftypes.Bool,
+									Required: true,
+								},
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"data-source-attribute-sensitive": {
+			input: &fwserver.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfsdk.Schema{
+					"test_data_source": {
+						Attributes: map[string]tfsdk.Attribute{
+							"test_attribute": {
+								Computed:  true,
+								Sensitive: true,
+								Type:      types.BoolType,
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{
+					"test_data_source": {
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Computed:  true,
+									Name:      "test_attribute",
+									Sensitive: true,
+									Type:      tftypes.Bool,
+								},
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"data-source-attribute-type-bool": {
+			input: &fwserver.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfsdk.Schema{
+					"test_data_source": {
+						Attributes: map[string]tfsdk.Attribute{
+							"test_attribute": {
+								Required: true,
+								Type:     types.BoolType,
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{
+					"test_data_source": {
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Name:     "test_attribute",
+									Required: true,
+									Type:     tftypes.Bool,
+								},
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"data-source-attribute-type-float64": {
+			input: &fwserver.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfsdk.Schema{
+					"test_data_source": {
+						Attributes: map[string]tfsdk.Attribute{
+							"test_attribute": {
+								Required: true,
+								Type:     types.Float64Type,
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{
+					"test_data_source": {
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Name:     "test_attribute",
+									Required: true,
+									Type:     tftypes.Number,
+								},
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"data-source-attribute-type-int64": {
+			input: &fwserver.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfsdk.Schema{
+					"test_data_source": {
+						Attributes: map[string]tfsdk.Attribute{
+							"test_attribute": {
+								Required: true,
+								Type:     types.Int64Type,
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{
+					"test_data_source": {
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Name:     "test_attribute",
+									Required: true,
+									Type:     tftypes.Number,
+								},
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"data-source-attribute-type-list-list-string": {
+			input: &fwserver.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfsdk.Schema{
+					"test_data_source": {
+						Attributes: map[string]tfsdk.Attribute{
+							"test_attribute": {
+								Required: true,
+								Type: types.ListType{
+									ElemType: types.ListType{
+										ElemType: types.StringType,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{
+					"test_data_source": {
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Name:     "test_attribute",
+									Required: true,
+									Type: tftypes.List{
+										ElementType: tftypes.List{
+											ElementType: tftypes.String,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"data-source-attribute-type-list-nested-attributes": {
+			input: &fwserver.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfsdk.Schema{
+					"test_data_source": {
+						Attributes: map[string]tfsdk.Attribute{
+							"test_attribute": {
+								Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
+									"test_nested_attribute": {
+										Type:     types.StringType,
+										Required: true,
+									},
+								}, tfsdk.ListNestedAttributesOptions{}),
+								Required: true,
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{
+					"test_data_source": {
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Name: "test_attribute",
+									NestedType: &tfprotov6.SchemaObject{
+										Nesting: tfprotov6.SchemaObjectNestingModeList,
+										Attributes: []*tfprotov6.SchemaAttribute{
+											{
+												Name:     "test_nested_attribute",
+												Type:     tftypes.String,
+												Required: true,
+											},
+										},
+									},
+									Required: true,
+								},
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"data-source-attribute-type-list-object": {
+			input: &fwserver.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfsdk.Schema{
+					"test_data_source": {
+						Attributes: map[string]tfsdk.Attribute{
+							"test_attribute": {
+								Required: true,
+								Type: types.ListType{
+									ElemType: types.ObjectType{
+										AttrTypes: map[string]attr.Type{
+											"test_object_attribute": types.StringType,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{
+					"test_data_source": {
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Name:     "test_attribute",
+									Required: true,
+									Type: tftypes.List{
+										ElementType: tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"test_object_attribute": tftypes.String,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"data-source-attribute-type-list-string": {
+			input: &fwserver.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfsdk.Schema{
+					"test_data_source": {
+						Attributes: map[string]tfsdk.Attribute{
+							"test_attribute": {
+								Required: true,
+								Type: types.ListType{
+									ElemType: types.StringType,
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{
+					"test_data_source": {
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Name:     "test_attribute",
+									Required: true,
+									Type: tftypes.List{
+										ElementType: tftypes.String,
+									},
+								},
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"data-source-attribute-type-map-nested-attributes": {
+			input: &fwserver.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfsdk.Schema{
+					"test_data_source": {
+						Attributes: map[string]tfsdk.Attribute{
+							"test_attribute": {
+								Attributes: tfsdk.MapNestedAttributes(map[string]tfsdk.Attribute{
+									"test_nested_attribute": {
+										Type:     types.StringType,
+										Required: true,
+									},
+								}, tfsdk.MapNestedAttributesOptions{}),
+								Required: true,
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{
+					"test_data_source": {
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Name: "test_attribute",
+									NestedType: &tfprotov6.SchemaObject{
+										Nesting: tfprotov6.SchemaObjectNestingModeMap,
+										Attributes: []*tfprotov6.SchemaAttribute{
+											{
+												Name:     "test_nested_attribute",
+												Type:     tftypes.String,
+												Required: true,
+											},
+										},
+									},
+									Required: true,
+								},
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"data-source-attribute-type-map-string": {
+			input: &fwserver.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfsdk.Schema{
+					"test_data_source": {
+						Attributes: map[string]tfsdk.Attribute{
+							"test_attribute": {
+								Required: true,
+								Type: types.MapType{
+									ElemType: types.StringType,
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{
+					"test_data_source": {
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Name:     "test_attribute",
+									Required: true,
+									Type: tftypes.Map{
+										ElementType: tftypes.String,
+									},
+								},
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"data-source-attribute-type-number": {
+			input: &fwserver.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfsdk.Schema{
+					"test_data_source": {
+						Attributes: map[string]tfsdk.Attribute{
+							"test_attribute": {
+								Required: true,
+								Type:     types.NumberType,
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{
+					"test_data_source": {
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Name:     "test_attribute",
+									Required: true,
+									Type:     tftypes.Number,
+								},
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"data-source-attribute-type-object": {
+			input: &fwserver.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfsdk.Schema{
+					"test_data_source": {
+						Attributes: map[string]tfsdk.Attribute{
+							"test_attribute": {
+								Required: true,
+								Type: types.ObjectType{
+									AttrTypes: map[string]attr.Type{
+										"test_object_attribute": types.StringType,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{
+					"test_data_source": {
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Name:     "test_attribute",
+									Required: true,
+									Type: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"test_object_attribute": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"data-source-attribute-type-set-nested-attributes": {
+			input: &fwserver.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfsdk.Schema{
+					"test_data_source": {
+						Attributes: map[string]tfsdk.Attribute{
+							"test_attribute": {
+								Attributes: tfsdk.SetNestedAttributes(map[string]tfsdk.Attribute{
+									"test_nested_attribute": {
+										Type:     types.StringType,
+										Required: true,
+									},
+								}, tfsdk.SetNestedAttributesOptions{}),
+								Required: true,
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{
+					"test_data_source": {
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Name: "test_attribute",
+									NestedType: &tfprotov6.SchemaObject{
+										Nesting: tfprotov6.SchemaObjectNestingModeSet,
+										Attributes: []*tfprotov6.SchemaAttribute{
+											{
+												Name:     "test_nested_attribute",
+												Type:     tftypes.String,
+												Required: true,
+											},
+										},
+									},
+									Required: true,
+								},
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"data-source-attribute-type-set-object": {
+			input: &fwserver.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfsdk.Schema{
+					"test_data_source": {
+						Attributes: map[string]tfsdk.Attribute{
+							"test_attribute": {
+								Required: true,
+								Type: types.SetType{
+									ElemType: types.ObjectType{
+										AttrTypes: map[string]attr.Type{
+											"test_object_attribute": types.StringType,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{
+					"test_data_source": {
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Name:     "test_attribute",
+									Required: true,
+									Type: tftypes.Set{
+										ElementType: tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"test_object_attribute": tftypes.String,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"data-source-attribute-type-set-set-string": {
+			input: &fwserver.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfsdk.Schema{
+					"test_data_source": {
+						Attributes: map[string]tfsdk.Attribute{
+							"test_attribute": {
+								Required: true,
+								Type: types.SetType{
+									ElemType: types.SetType{
+										ElemType: types.StringType,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{
+					"test_data_source": {
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Name:     "test_attribute",
+									Required: true,
+									Type: tftypes.Set{
+										ElementType: tftypes.Set{
+											ElementType: tftypes.String,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"data-source-attribute-type-set-string": {
+			input: &fwserver.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfsdk.Schema{
+					"test_data_source": {
+						Attributes: map[string]tfsdk.Attribute{
+							"test_attribute": {
+								Required: true,
+								Type: types.SetType{
+									ElemType: types.StringType,
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{
+					"test_data_source": {
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Name:     "test_attribute",
+									Required: true,
+									Type: tftypes.Set{
+										ElementType: tftypes.String,
+									},
+								},
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"data-source-attribute-type-single-nested-attributes": {
+			input: &fwserver.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfsdk.Schema{
+					"test_data_source": {
+						Attributes: map[string]tfsdk.Attribute{
+							"test_attribute": {
+								Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
+									"test_nested_attribute": {
+										Type:     types.StringType,
+										Required: true,
+									},
+								}),
+								Required: true,
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{
+					"test_data_source": {
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Name: "test_attribute",
+									NestedType: &tfprotov6.SchemaObject{
+										Nesting: tfprotov6.SchemaObjectNestingModeSingle,
+										Attributes: []*tfprotov6.SchemaAttribute{
+											{
+												Name:     "test_nested_attribute",
+												Type:     tftypes.String,
+												Required: true,
+											},
+										},
+									},
+									Required: true,
+								},
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"data-source-attribute-type-string": {
+			input: &fwserver.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfsdk.Schema{
+					"test_data_source": {
+						Attributes: map[string]tfsdk.Attribute{
+							"test_attribute": {
+								Required: true,
+								Type:     types.StringType,
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{
+					"test_data_source": {
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Name:     "test_attribute",
+									Required: true,
+									Type:     tftypes.String,
+								},
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"data-source-block-list": {
+			input: &fwserver.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfsdk.Schema{
+					"test_data_source": {
+						Blocks: map[string]tfsdk.Block{
+							"test_block": {
+								Attributes: map[string]tfsdk.Attribute{
+									"test_attribute": {
+										Type:     types.StringType,
+										Required: true,
+									},
+								},
+								NestingMode: tfsdk.BlockNestingModeList,
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{
+					"test_data_source": {
+						Block: &tfprotov6.SchemaBlock{
+							BlockTypes: []*tfprotov6.SchemaNestedBlock{
+								{
+									Block: &tfprotov6.SchemaBlock{
+										Attributes: []*tfprotov6.SchemaAttribute{
+											{
+												Name:     "test_attribute",
+												Type:     tftypes.String,
+												Required: true,
+											},
+										},
+									},
+									Nesting:  tfprotov6.SchemaNestedBlockNestingModeList,
+									TypeName: "test_block",
+								},
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"data-source-block-set": {
+			input: &fwserver.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfsdk.Schema{
+					"test_data_source": {
+						Blocks: map[string]tfsdk.Block{
+							"test_block": {
+								Attributes: map[string]tfsdk.Attribute{
+									"test_attribute": {
+										Type:     types.StringType,
+										Required: true,
+									},
+								},
+								NestingMode: tfsdk.BlockNestingModeSet,
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{
+					"test_data_source": {
+						Block: &tfprotov6.SchemaBlock{
+							BlockTypes: []*tfprotov6.SchemaNestedBlock{
+								{
+									Block: &tfprotov6.SchemaBlock{
+										Attributes: []*tfprotov6.SchemaAttribute{
+											{
+												Name:     "test_attribute",
+												Type:     tftypes.String,
+												Required: true,
+											},
+										},
+									},
+									Nesting:  tfprotov6.SchemaNestedBlockNestingModeSet,
+									TypeName: "test_block",
+								},
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"data-source-version": {
+			input: &fwserver.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfsdk.Schema{
+					"test_data_source": {
+						Version: 123,
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{
+					"test_data_source": {
+						Block:   &tfprotov6.SchemaBlock{},
+						Version: 123,
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"provider-attribute-computed": {
+			input: &fwserver.GetProviderSchemaResponse{
+				Provider: &tfsdk.Schema{
+					Attributes: map[string]tfsdk.Attribute{
+						"test_attribute": {
+							Computed: true,
+							Type:     types.BoolType,
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				Provider: &tfprotov6.Schema{
+					Block: &tfprotov6.SchemaBlock{
+						Attributes: []*tfprotov6.SchemaAttribute{
+							{
+								Computed: true,
+								Name:     "test_attribute",
+								Type:     tftypes.Bool,
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"provider-attribute-deprecated": {
+			input: &fwserver.GetProviderSchemaResponse{
+				Provider: &tfsdk.Schema{
+					Attributes: map[string]tfsdk.Attribute{
+						"test_attribute": {
+							DeprecationMessage: "deprecated",
+							Optional:           true,
+							Type:               types.BoolType,
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				Provider: &tfprotov6.Schema{
+					Block: &tfprotov6.SchemaBlock{
+						Attributes: []*tfprotov6.SchemaAttribute{
+							{
+								Deprecated: true,
+								Name:       "test_attribute",
+								Optional:   true,
+								Type:       tftypes.Bool,
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"provider-attribute-optional": {
+			input: &fwserver.GetProviderSchemaResponse{
+				Provider: &tfsdk.Schema{
+					Attributes: map[string]tfsdk.Attribute{
+						"test_attribute": {
+							Optional: true,
+							Type:     types.BoolType,
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				Provider: &tfprotov6.Schema{
+					Block: &tfprotov6.SchemaBlock{
+						Attributes: []*tfprotov6.SchemaAttribute{
+							{
+								Name:     "test_attribute",
+								Optional: true,
+								Type:     tftypes.Bool,
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"provider-attribute-optional-computed": {
+			input: &fwserver.GetProviderSchemaResponse{
+				Provider: &tfsdk.Schema{
+					Attributes: map[string]tfsdk.Attribute{
+						"test_attribute": {
+							Computed: true,
+							Optional: true,
+							Type:     types.BoolType,
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				Provider: &tfprotov6.Schema{
+					Block: &tfprotov6.SchemaBlock{
+						Attributes: []*tfprotov6.SchemaAttribute{
+							{
+								Computed: true,
+								Name:     "test_attribute",
+								Optional: true,
+								Type:     tftypes.Bool,
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"provider-attribute-required": {
+			input: &fwserver.GetProviderSchemaResponse{
+				Provider: &tfsdk.Schema{
+					Attributes: map[string]tfsdk.Attribute{
+						"test_attribute": {
+							Required: true,
+							Type:     types.BoolType,
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				Provider: &tfprotov6.Schema{
+					Block: &tfprotov6.SchemaBlock{
+						Attributes: []*tfprotov6.SchemaAttribute{
+							{
+								Name:     "test_attribute",
+								Type:     tftypes.Bool,
+								Required: true,
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"provider-attribute-sensitive": {
+			input: &fwserver.GetProviderSchemaResponse{
+				Provider: &tfsdk.Schema{
+					Attributes: map[string]tfsdk.Attribute{
+						"test_attribute": {
+							Computed:  true,
+							Sensitive: true,
+							Type:      types.BoolType,
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				Provider: &tfprotov6.Schema{
+					Block: &tfprotov6.SchemaBlock{
+						Attributes: []*tfprotov6.SchemaAttribute{
+							{
+								Computed:  true,
+								Name:      "test_attribute",
+								Sensitive: true,
+								Type:      tftypes.Bool,
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"provider-attribute-type-bool": {
+			input: &fwserver.GetProviderSchemaResponse{
+				Provider: &tfsdk.Schema{
+					Attributes: map[string]tfsdk.Attribute{
+						"test_attribute": {
+							Required: true,
+							Type:     types.BoolType,
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				Provider: &tfprotov6.Schema{
+					Block: &tfprotov6.SchemaBlock{
+						Attributes: []*tfprotov6.SchemaAttribute{
+							{
+								Name:     "test_attribute",
+								Required: true,
+								Type:     tftypes.Bool,
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"provider-attribute-type-float64": {
+			input: &fwserver.GetProviderSchemaResponse{
+				Provider: &tfsdk.Schema{
+					Attributes: map[string]tfsdk.Attribute{
+						"test_attribute": {
+							Required: true,
+							Type:     types.Float64Type,
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				Provider: &tfprotov6.Schema{
+					Block: &tfprotov6.SchemaBlock{
+						Attributes: []*tfprotov6.SchemaAttribute{
+							{
+								Name:     "test_attribute",
+								Required: true,
+								Type:     tftypes.Number,
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"provider-attribute-type-int64": {
+			input: &fwserver.GetProviderSchemaResponse{
+				Provider: &tfsdk.Schema{
+					Attributes: map[string]tfsdk.Attribute{
+						"test_attribute": {
+							Required: true,
+							Type:     types.Int64Type,
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				Provider: &tfprotov6.Schema{
+					Block: &tfprotov6.SchemaBlock{
+						Attributes: []*tfprotov6.SchemaAttribute{
+							{
+								Name:     "test_attribute",
+								Required: true,
+								Type:     tftypes.Number,
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"provider-attribute-type-list-list-string": {
+			input: &fwserver.GetProviderSchemaResponse{
+				Provider: &tfsdk.Schema{
+					Attributes: map[string]tfsdk.Attribute{
+						"test_attribute": {
+							Required: true,
+							Type: types.ListType{
+								ElemType: types.ListType{
+									ElemType: types.StringType,
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				Provider: &tfprotov6.Schema{
+					Block: &tfprotov6.SchemaBlock{
+						Attributes: []*tfprotov6.SchemaAttribute{
+							{
+								Name:     "test_attribute",
+								Required: true,
+								Type: tftypes.List{
+									ElementType: tftypes.List{
+										ElementType: tftypes.String,
+									},
+								},
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"provider-attribute-type-list-nested-attributes": {
+			input: &fwserver.GetProviderSchemaResponse{
+				Provider: &tfsdk.Schema{
+					Attributes: map[string]tfsdk.Attribute{
+						"test_attribute": {
+							Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
+								"test_nested_attribute": {
+									Type:     types.StringType,
+									Required: true,
+								},
+							}, tfsdk.ListNestedAttributesOptions{}),
+							Required: true,
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				Provider: &tfprotov6.Schema{
+					Block: &tfprotov6.SchemaBlock{
+						Attributes: []*tfprotov6.SchemaAttribute{
+							{
+								Name: "test_attribute",
+								NestedType: &tfprotov6.SchemaObject{
+									Nesting: tfprotov6.SchemaObjectNestingModeList,
+									Attributes: []*tfprotov6.SchemaAttribute{
+										{
+											Name:     "test_nested_attribute",
+											Type:     tftypes.String,
+											Required: true,
+										},
+									},
+								},
+								Required: true,
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"provider-attribute-type-list-object": {
+			input: &fwserver.GetProviderSchemaResponse{
+				Provider: &tfsdk.Schema{
+					Attributes: map[string]tfsdk.Attribute{
+						"test_attribute": {
+							Required: true,
+							Type: types.ListType{
+								ElemType: types.ObjectType{
+									AttrTypes: map[string]attr.Type{
+										"test_object_attribute": types.StringType,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				Provider: &tfprotov6.Schema{
+					Block: &tfprotov6.SchemaBlock{
+						Attributes: []*tfprotov6.SchemaAttribute{
+							{
+								Name:     "test_attribute",
+								Required: true,
+								Type: tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"test_object_attribute": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"provider-attribute-type-list-string": {
+			input: &fwserver.GetProviderSchemaResponse{
+				Provider: &tfsdk.Schema{
+					Attributes: map[string]tfsdk.Attribute{
+						"test_attribute": {
+							Required: true,
+							Type: types.ListType{
+								ElemType: types.StringType,
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				Provider: &tfprotov6.Schema{
+					Block: &tfprotov6.SchemaBlock{
+						Attributes: []*tfprotov6.SchemaAttribute{
+							{
+								Name:     "test_attribute",
+								Required: true,
+								Type: tftypes.List{
+									ElementType: tftypes.String,
+								},
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"provider-attribute-type-map-nested-attributes": {
+			input: &fwserver.GetProviderSchemaResponse{
+				Provider: &tfsdk.Schema{
+					Attributes: map[string]tfsdk.Attribute{
+						"test_attribute": {
+							Attributes: tfsdk.MapNestedAttributes(map[string]tfsdk.Attribute{
+								"test_nested_attribute": {
+									Type:     types.StringType,
+									Required: true,
+								},
+							}, tfsdk.MapNestedAttributesOptions{}),
+							Required: true,
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				Provider: &tfprotov6.Schema{
+					Block: &tfprotov6.SchemaBlock{
+						Attributes: []*tfprotov6.SchemaAttribute{
+							{
+								Name: "test_attribute",
+								NestedType: &tfprotov6.SchemaObject{
+									Nesting: tfprotov6.SchemaObjectNestingModeMap,
+									Attributes: []*tfprotov6.SchemaAttribute{
+										{
+											Name:     "test_nested_attribute",
+											Type:     tftypes.String,
+											Required: true,
+										},
+									},
+								},
+								Required: true,
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"provider-attribute-type-map-string": {
+			input: &fwserver.GetProviderSchemaResponse{
+				Provider: &tfsdk.Schema{
+					Attributes: map[string]tfsdk.Attribute{
+						"test_attribute": {
+							Required: true,
+							Type: types.MapType{
+								ElemType: types.StringType,
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				Provider: &tfprotov6.Schema{
+					Block: &tfprotov6.SchemaBlock{
+						Attributes: []*tfprotov6.SchemaAttribute{
+							{
+								Name:     "test_attribute",
+								Required: true,
+								Type: tftypes.Map{
+									ElementType: tftypes.String,
+								},
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"provider-attribute-type-number": {
+			input: &fwserver.GetProviderSchemaResponse{
+				Provider: &tfsdk.Schema{
+					Attributes: map[string]tfsdk.Attribute{
+						"test_attribute": {
+							Required: true,
+							Type:     types.NumberType,
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				Provider: &tfprotov6.Schema{
+					Block: &tfprotov6.SchemaBlock{
+						Attributes: []*tfprotov6.SchemaAttribute{
+							{
+								Name:     "test_attribute",
+								Required: true,
+								Type:     tftypes.Number,
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"provider-attribute-type-object": {
+			input: &fwserver.GetProviderSchemaResponse{
+				Provider: &tfsdk.Schema{
+					Attributes: map[string]tfsdk.Attribute{
+						"test_attribute": {
+							Required: true,
+							Type: types.ObjectType{
+								AttrTypes: map[string]attr.Type{
+									"test_object_attribute": types.StringType,
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				Provider: &tfprotov6.Schema{
+					Block: &tfprotov6.SchemaBlock{
+						Attributes: []*tfprotov6.SchemaAttribute{
+							{
+								Name:     "test_attribute",
+								Required: true,
+								Type: tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"test_object_attribute": tftypes.String,
+									},
+								},
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"provider-attribute-type-set-nested-attributes": {
+			input: &fwserver.GetProviderSchemaResponse{
+				Provider: &tfsdk.Schema{
+					Attributes: map[string]tfsdk.Attribute{
+						"test_attribute": {
+							Attributes: tfsdk.SetNestedAttributes(map[string]tfsdk.Attribute{
+								"test_nested_attribute": {
+									Type:     types.StringType,
+									Required: true,
+								},
+							}, tfsdk.SetNestedAttributesOptions{}),
+							Required: true,
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				Provider: &tfprotov6.Schema{
+					Block: &tfprotov6.SchemaBlock{
+						Attributes: []*tfprotov6.SchemaAttribute{
+							{
+								Name: "test_attribute",
+								NestedType: &tfprotov6.SchemaObject{
+									Nesting: tfprotov6.SchemaObjectNestingModeSet,
+									Attributes: []*tfprotov6.SchemaAttribute{
+										{
+											Name:     "test_nested_attribute",
+											Type:     tftypes.String,
+											Required: true,
+										},
+									},
+								},
+								Required: true,
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"provider-attribute-type-set-object": {
+			input: &fwserver.GetProviderSchemaResponse{
+				Provider: &tfsdk.Schema{
+					Attributes: map[string]tfsdk.Attribute{
+						"test_attribute": {
+							Required: true,
+							Type: types.SetType{
+								ElemType: types.ObjectType{
+									AttrTypes: map[string]attr.Type{
+										"test_object_attribute": types.StringType,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				Provider: &tfprotov6.Schema{
+					Block: &tfprotov6.SchemaBlock{
+						Attributes: []*tfprotov6.SchemaAttribute{
+							{
+								Name:     "test_attribute",
+								Required: true,
+								Type: tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"test_object_attribute": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"provider-attribute-type-set-set-string": {
+			input: &fwserver.GetProviderSchemaResponse{
+				Provider: &tfsdk.Schema{
+					Attributes: map[string]tfsdk.Attribute{
+						"test_attribute": {
+							Required: true,
+							Type: types.SetType{
+								ElemType: types.SetType{
+									ElemType: types.StringType,
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				Provider: &tfprotov6.Schema{
+					Block: &tfprotov6.SchemaBlock{
+						Attributes: []*tfprotov6.SchemaAttribute{
+							{
+								Name:     "test_attribute",
+								Required: true,
+								Type: tftypes.Set{
+									ElementType: tftypes.Set{
+										ElementType: tftypes.String,
+									},
+								},
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"provider-attribute-type-set-string": {
+			input: &fwserver.GetProviderSchemaResponse{
+				Provider: &tfsdk.Schema{
+					Attributes: map[string]tfsdk.Attribute{
+						"test_attribute": {
+							Required: true,
+							Type: types.SetType{
+								ElemType: types.StringType,
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				Provider: &tfprotov6.Schema{
+					Block: &tfprotov6.SchemaBlock{
+						Attributes: []*tfprotov6.SchemaAttribute{
+							{
+								Name:     "test_attribute",
+								Required: true,
+								Type: tftypes.Set{
+									ElementType: tftypes.String,
+								},
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"provider-attribute-type-single-nested-attributes": {
+			input: &fwserver.GetProviderSchemaResponse{
+				Provider: &tfsdk.Schema{
+					Attributes: map[string]tfsdk.Attribute{
+						"test_attribute": {
+							Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
+								"test_nested_attribute": {
+									Type:     types.StringType,
+									Required: true,
+								},
+							}),
+							Required: true,
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				Provider: &tfprotov6.Schema{
+					Block: &tfprotov6.SchemaBlock{
+						Attributes: []*tfprotov6.SchemaAttribute{
+							{
+								Name: "test_attribute",
+								NestedType: &tfprotov6.SchemaObject{
+									Nesting: tfprotov6.SchemaObjectNestingModeSingle,
+									Attributes: []*tfprotov6.SchemaAttribute{
+										{
+											Name:     "test_nested_attribute",
+											Type:     tftypes.String,
+											Required: true,
+										},
+									},
+								},
+								Required: true,
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"provider-attribute-type-string": {
+			input: &fwserver.GetProviderSchemaResponse{
+				Provider: &tfsdk.Schema{
+					Attributes: map[string]tfsdk.Attribute{
+						"test_attribute": {
+							Required: true,
+							Type:     types.StringType,
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				Provider: &tfprotov6.Schema{
+					Block: &tfprotov6.SchemaBlock{
+						Attributes: []*tfprotov6.SchemaAttribute{
+							{
+								Name:     "test_attribute",
+								Required: true,
+								Type:     tftypes.String,
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"provider-block-list": {
+			input: &fwserver.GetProviderSchemaResponse{
+				Provider: &tfsdk.Schema{
+					Blocks: map[string]tfsdk.Block{
+						"test_block": {
+							Attributes: map[string]tfsdk.Attribute{
+								"test_attribute": {
+									Type:     types.StringType,
+									Required: true,
+								},
+							},
+							NestingMode: tfsdk.BlockNestingModeList,
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				Provider: &tfprotov6.Schema{
+					Block: &tfprotov6.SchemaBlock{
+						BlockTypes: []*tfprotov6.SchemaNestedBlock{
+							{
+								Block: &tfprotov6.SchemaBlock{
+									Attributes: []*tfprotov6.SchemaAttribute{
+										{
+											Name:     "test_attribute",
+											Type:     tftypes.String,
+											Required: true,
+										},
+									},
+								},
+								Nesting:  tfprotov6.SchemaNestedBlockNestingModeList,
+								TypeName: "test_block",
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"provider-block-set": {
+			input: &fwserver.GetProviderSchemaResponse{
+				Provider: &tfsdk.Schema{
+					Blocks: map[string]tfsdk.Block{
+						"test_block": {
+							Attributes: map[string]tfsdk.Attribute{
+								"test_attribute": {
+									Type:     types.StringType,
+									Required: true,
+								},
+							},
+							NestingMode: tfsdk.BlockNestingModeSet,
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				Provider: &tfprotov6.Schema{
+					Block: &tfprotov6.SchemaBlock{
+						BlockTypes: []*tfprotov6.SchemaNestedBlock{
+							{
+								Block: &tfprotov6.SchemaBlock{
+									Attributes: []*tfprotov6.SchemaAttribute{
+										{
+											Name:     "test_attribute",
+											Type:     tftypes.String,
+											Required: true,
+										},
+									},
+								},
+								Nesting:  tfprotov6.SchemaNestedBlockNestingModeSet,
+								TypeName: "test_block",
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"provider-version": {
+			input: &fwserver.GetProviderSchemaResponse{
+				Provider: &tfsdk.Schema{
+					Version: 123,
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				Provider: &tfprotov6.Schema{
+					Block:   &tfprotov6.SchemaBlock{},
+					Version: 123,
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"provider-meta-attribute-computed": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ProviderMeta: &tfsdk.Schema{
+					Attributes: map[string]tfsdk.Attribute{
+						"test_attribute": {
+							Computed: true,
+							Type:     types.BoolType,
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				ProviderMeta: &tfprotov6.Schema{
+					Block: &tfprotov6.SchemaBlock{
+						Attributes: []*tfprotov6.SchemaAttribute{
+							{
+								Computed: true,
+								Name:     "test_attribute",
+								Type:     tftypes.Bool,
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"provider-meta-attribute-deprecated": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ProviderMeta: &tfsdk.Schema{
+					Attributes: map[string]tfsdk.Attribute{
+						"test_attribute": {
+							DeprecationMessage: "deprecated",
+							Optional:           true,
+							Type:               types.BoolType,
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				ProviderMeta: &tfprotov6.Schema{
+					Block: &tfprotov6.SchemaBlock{
+						Attributes: []*tfprotov6.SchemaAttribute{
+							{
+								Deprecated: true,
+								Name:       "test_attribute",
+								Optional:   true,
+								Type:       tftypes.Bool,
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"provider-meta-attribute-optional": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ProviderMeta: &tfsdk.Schema{
+					Attributes: map[string]tfsdk.Attribute{
+						"test_attribute": {
+							Optional: true,
+							Type:     types.BoolType,
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				ProviderMeta: &tfprotov6.Schema{
+					Block: &tfprotov6.SchemaBlock{
+						Attributes: []*tfprotov6.SchemaAttribute{
+							{
+								Name:     "test_attribute",
+								Optional: true,
+								Type:     tftypes.Bool,
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"provider-meta-attribute-optional-computed": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ProviderMeta: &tfsdk.Schema{
+					Attributes: map[string]tfsdk.Attribute{
+						"test_attribute": {
+							Computed: true,
+							Optional: true,
+							Type:     types.BoolType,
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				ProviderMeta: &tfprotov6.Schema{
+					Block: &tfprotov6.SchemaBlock{
+						Attributes: []*tfprotov6.SchemaAttribute{
+							{
+								Computed: true,
+								Name:     "test_attribute",
+								Optional: true,
+								Type:     tftypes.Bool,
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"provider-meta-attribute-required": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ProviderMeta: &tfsdk.Schema{
+					Attributes: map[string]tfsdk.Attribute{
+						"test_attribute": {
+							Required: true,
+							Type:     types.BoolType,
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				ProviderMeta: &tfprotov6.Schema{
+					Block: &tfprotov6.SchemaBlock{
+						Attributes: []*tfprotov6.SchemaAttribute{
+							{
+								Name:     "test_attribute",
+								Type:     tftypes.Bool,
+								Required: true,
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"provider-meta-attribute-sensitive": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ProviderMeta: &tfsdk.Schema{
+					Attributes: map[string]tfsdk.Attribute{
+						"test_attribute": {
+							Computed:  true,
+							Sensitive: true,
+							Type:      types.BoolType,
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				ProviderMeta: &tfprotov6.Schema{
+					Block: &tfprotov6.SchemaBlock{
+						Attributes: []*tfprotov6.SchemaAttribute{
+							{
+								Computed:  true,
+								Name:      "test_attribute",
+								Sensitive: true,
+								Type:      tftypes.Bool,
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"provider-meta-attribute-type-bool": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ProviderMeta: &tfsdk.Schema{
+					Attributes: map[string]tfsdk.Attribute{
+						"test_attribute": {
+							Required: true,
+							Type:     types.BoolType,
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				ProviderMeta: &tfprotov6.Schema{
+					Block: &tfprotov6.SchemaBlock{
+						Attributes: []*tfprotov6.SchemaAttribute{
+							{
+								Name:     "test_attribute",
+								Required: true,
+								Type:     tftypes.Bool,
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"provider-meta-attribute-type-float64": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ProviderMeta: &tfsdk.Schema{
+					Attributes: map[string]tfsdk.Attribute{
+						"test_attribute": {
+							Required: true,
+							Type:     types.Float64Type,
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				ProviderMeta: &tfprotov6.Schema{
+					Block: &tfprotov6.SchemaBlock{
+						Attributes: []*tfprotov6.SchemaAttribute{
+							{
+								Name:     "test_attribute",
+								Required: true,
+								Type:     tftypes.Number,
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"provider-meta-attribute-type-int64": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ProviderMeta: &tfsdk.Schema{
+					Attributes: map[string]tfsdk.Attribute{
+						"test_attribute": {
+							Required: true,
+							Type:     types.Int64Type,
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				ProviderMeta: &tfprotov6.Schema{
+					Block: &tfprotov6.SchemaBlock{
+						Attributes: []*tfprotov6.SchemaAttribute{
+							{
+								Name:     "test_attribute",
+								Required: true,
+								Type:     tftypes.Number,
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"provider-meta-attribute-type-list-list-string": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ProviderMeta: &tfsdk.Schema{
+					Attributes: map[string]tfsdk.Attribute{
+						"test_attribute": {
+							Required: true,
+							Type: types.ListType{
+								ElemType: types.ListType{
+									ElemType: types.StringType,
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				ProviderMeta: &tfprotov6.Schema{
+					Block: &tfprotov6.SchemaBlock{
+						Attributes: []*tfprotov6.SchemaAttribute{
+							{
+								Name:     "test_attribute",
+								Required: true,
+								Type: tftypes.List{
+									ElementType: tftypes.List{
+										ElementType: tftypes.String,
+									},
+								},
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"provider-meta-attribute-type-list-nested-attributes": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ProviderMeta: &tfsdk.Schema{
+					Attributes: map[string]tfsdk.Attribute{
+						"test_attribute": {
+							Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
+								"test_nested_attribute": {
+									Type:     types.StringType,
+									Required: true,
+								},
+							}, tfsdk.ListNestedAttributesOptions{}),
+							Required: true,
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				ProviderMeta: &tfprotov6.Schema{
+					Block: &tfprotov6.SchemaBlock{
+						Attributes: []*tfprotov6.SchemaAttribute{
+							{
+								Name: "test_attribute",
+								NestedType: &tfprotov6.SchemaObject{
+									Nesting: tfprotov6.SchemaObjectNestingModeList,
+									Attributes: []*tfprotov6.SchemaAttribute{
+										{
+											Name:     "test_nested_attribute",
+											Type:     tftypes.String,
+											Required: true,
+										},
+									},
+								},
+								Required: true,
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"provider-meta-attribute-type-list-object": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ProviderMeta: &tfsdk.Schema{
+					Attributes: map[string]tfsdk.Attribute{
+						"test_attribute": {
+							Required: true,
+							Type: types.ListType{
+								ElemType: types.ObjectType{
+									AttrTypes: map[string]attr.Type{
+										"test_nested_attribute": types.StringType,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				ProviderMeta: &tfprotov6.Schema{
+					Block: &tfprotov6.SchemaBlock{
+						Attributes: []*tfprotov6.SchemaAttribute{
+							{
+								Name:     "test_attribute",
+								Required: true,
+								Type: tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"test_nested_attribute": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"provider-meta-attribute-type-list-string": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ProviderMeta: &tfsdk.Schema{
+					Attributes: map[string]tfsdk.Attribute{
+						"test_attribute": {
+							Required: true,
+							Type: types.ListType{
+								ElemType: types.StringType,
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				ProviderMeta: &tfprotov6.Schema{
+					Block: &tfprotov6.SchemaBlock{
+						Attributes: []*tfprotov6.SchemaAttribute{
+							{
+								Name:     "test_attribute",
+								Required: true,
+								Type: tftypes.List{
+									ElementType: tftypes.String,
+								},
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"provider-meta-attribute-type-map-nested-attributes": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ProviderMeta: &tfsdk.Schema{
+					Attributes: map[string]tfsdk.Attribute{
+						"test_attribute": {
+							Attributes: tfsdk.MapNestedAttributes(map[string]tfsdk.Attribute{
+								"test_nested_attribute": {
+									Type:     types.StringType,
+									Required: true,
+								},
+							}, tfsdk.MapNestedAttributesOptions{}),
+							Required: true,
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				ProviderMeta: &tfprotov6.Schema{
+					Block: &tfprotov6.SchemaBlock{
+						Attributes: []*tfprotov6.SchemaAttribute{
+							{
+								Name: "test_attribute",
+								NestedType: &tfprotov6.SchemaObject{
+									Nesting: tfprotov6.SchemaObjectNestingModeMap,
+									Attributes: []*tfprotov6.SchemaAttribute{
+										{
+											Name:     "test_nested_attribute",
+											Type:     tftypes.String,
+											Required: true,
+										},
+									},
+								},
+								Required: true,
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"provider-meta-attribute-type-map-string": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ProviderMeta: &tfsdk.Schema{
+					Attributes: map[string]tfsdk.Attribute{
+						"test_attribute": {
+							Required: true,
+							Type: types.MapType{
+								ElemType: types.StringType,
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				ProviderMeta: &tfprotov6.Schema{
+					Block: &tfprotov6.SchemaBlock{
+						Attributes: []*tfprotov6.SchemaAttribute{
+							{
+								Name:     "test_attribute",
+								Required: true,
+								Type: tftypes.Map{
+									ElementType: tftypes.String,
+								},
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"provider-meta-attribute-type-number": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ProviderMeta: &tfsdk.Schema{
+					Attributes: map[string]tfsdk.Attribute{
+						"test_attribute": {
+							Required: true,
+							Type:     types.NumberType,
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				ProviderMeta: &tfprotov6.Schema{
+					Block: &tfprotov6.SchemaBlock{
+						Attributes: []*tfprotov6.SchemaAttribute{
+							{
+								Name:     "test_attribute",
+								Required: true,
+								Type:     tftypes.Number,
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"provider-meta-attribute-type-object": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ProviderMeta: &tfsdk.Schema{
+					Attributes: map[string]tfsdk.Attribute{
+						"test_attribute": {
+							Required: true,
+							Type: types.ObjectType{
+								AttrTypes: map[string]attr.Type{
+									"test_object_attribute": types.StringType,
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				ProviderMeta: &tfprotov6.Schema{
+					Block: &tfprotov6.SchemaBlock{
+						Attributes: []*tfprotov6.SchemaAttribute{
+							{
+								Name:     "test_attribute",
+								Required: true,
+								Type: tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"test_object_attribute": tftypes.String,
+									},
+								},
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"provider-meta-attribute-type-set-nested-attributes": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ProviderMeta: &tfsdk.Schema{
+					Attributes: map[string]tfsdk.Attribute{
+						"test_attribute": {
+							Attributes: tfsdk.SetNestedAttributes(map[string]tfsdk.Attribute{
+								"test_nested_attribute": {
+									Type:     types.StringType,
+									Required: true,
+								},
+							}, tfsdk.SetNestedAttributesOptions{}),
+							Required: true,
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				ProviderMeta: &tfprotov6.Schema{
+					Block: &tfprotov6.SchemaBlock{
+						Attributes: []*tfprotov6.SchemaAttribute{
+							{
+								Name: "test_attribute",
+								NestedType: &tfprotov6.SchemaObject{
+									Nesting: tfprotov6.SchemaObjectNestingModeSet,
+									Attributes: []*tfprotov6.SchemaAttribute{
+										{
+											Name:     "test_nested_attribute",
+											Type:     tftypes.String,
+											Required: true,
+										},
+									},
+								},
+								Required: true,
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"provider-meta-attribute-type-set-object": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ProviderMeta: &tfsdk.Schema{
+					Attributes: map[string]tfsdk.Attribute{
+						"test_attribute": {
+							Required: true,
+							Type: types.SetType{
+								ElemType: types.ObjectType{
+									AttrTypes: map[string]attr.Type{
+										"test_object_attribute": types.StringType,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				ProviderMeta: &tfprotov6.Schema{
+					Block: &tfprotov6.SchemaBlock{
+						Attributes: []*tfprotov6.SchemaAttribute{
+							{
+								Name:     "test_attribute",
+								Required: true,
+								Type: tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"test_object_attribute": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"provider-meta-attribute-type-set-set-string": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ProviderMeta: &tfsdk.Schema{
+					Attributes: map[string]tfsdk.Attribute{
+						"test_attribute": {
+							Required: true,
+							Type: types.SetType{
+								ElemType: types.SetType{
+									ElemType: types.StringType,
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				ProviderMeta: &tfprotov6.Schema{
+					Block: &tfprotov6.SchemaBlock{
+						Attributes: []*tfprotov6.SchemaAttribute{
+							{
+								Name:     "test_attribute",
+								Required: true,
+								Type: tftypes.Set{
+									ElementType: tftypes.Set{
+										ElementType: tftypes.String,
+									},
+								},
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"provider-meta-attribute-type-set-string": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ProviderMeta: &tfsdk.Schema{
+					Attributes: map[string]tfsdk.Attribute{
+						"test_attribute": {
+							Required: true,
+							Type: types.SetType{
+								ElemType: types.StringType,
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				ProviderMeta: &tfprotov6.Schema{
+					Block: &tfprotov6.SchemaBlock{
+						Attributes: []*tfprotov6.SchemaAttribute{
+							{
+								Name:     "test_attribute",
+								Required: true,
+								Type: tftypes.Set{
+									ElementType: tftypes.String,
+								},
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"provider-meta-attribute-type-single-nested-attributes": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ProviderMeta: &tfsdk.Schema{
+					Attributes: map[string]tfsdk.Attribute{
+						"test_attribute": {
+							Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
+								"test_nested_attribute": {
+									Type:     types.StringType,
+									Required: true,
+								},
+							}),
+							Required: true,
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				ProviderMeta: &tfprotov6.Schema{
+					Block: &tfprotov6.SchemaBlock{
+						Attributes: []*tfprotov6.SchemaAttribute{
+							{
+								Name: "test_attribute",
+								NestedType: &tfprotov6.SchemaObject{
+									Nesting: tfprotov6.SchemaObjectNestingModeSingle,
+									Attributes: []*tfprotov6.SchemaAttribute{
+										{
+											Name:     "test_nested_attribute",
+											Type:     tftypes.String,
+											Required: true,
+										},
+									},
+								},
+								Required: true,
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"provider-meta-attribute-type-string": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ProviderMeta: &tfsdk.Schema{
+					Attributes: map[string]tfsdk.Attribute{
+						"test_attribute": {
+							Required: true,
+							Type:     types.StringType,
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				ProviderMeta: &tfprotov6.Schema{
+					Block: &tfprotov6.SchemaBlock{
+						Attributes: []*tfprotov6.SchemaAttribute{
+							{
+								Name:     "test_attribute",
+								Required: true,
+								Type:     tftypes.String,
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"provider-meta-block-list": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ProviderMeta: &tfsdk.Schema{
+					Blocks: map[string]tfsdk.Block{
+						"test_block": {
+							Attributes: map[string]tfsdk.Attribute{
+								"test_attribute": {
+									Type:     types.StringType,
+									Required: true,
+								},
+							},
+							NestingMode: tfsdk.BlockNestingModeList,
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				ProviderMeta: &tfprotov6.Schema{
+					Block: &tfprotov6.SchemaBlock{
+						BlockTypes: []*tfprotov6.SchemaNestedBlock{
+							{
+								Block: &tfprotov6.SchemaBlock{
+									Attributes: []*tfprotov6.SchemaAttribute{
+										{
+											Name:     "test_attribute",
+											Type:     tftypes.String,
+											Required: true,
+										},
+									},
+								},
+								Nesting:  tfprotov6.SchemaNestedBlockNestingModeList,
+								TypeName: "test_block",
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"provider-meta-block-set": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ProviderMeta: &tfsdk.Schema{
+					Blocks: map[string]tfsdk.Block{
+						"test_block": {
+							Attributes: map[string]tfsdk.Attribute{
+								"test_attribute": {
+									Type:     types.StringType,
+									Required: true,
+								},
+							},
+							NestingMode: tfsdk.BlockNestingModeSet,
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				ProviderMeta: &tfprotov6.Schema{
+					Block: &tfprotov6.SchemaBlock{
+						BlockTypes: []*tfprotov6.SchemaNestedBlock{
+							{
+								Block: &tfprotov6.SchemaBlock{
+									Attributes: []*tfprotov6.SchemaAttribute{
+										{
+											Name:     "test_attribute",
+											Type:     tftypes.String,
+											Required: true,
+										},
+									},
+								},
+								Nesting:  tfprotov6.SchemaNestedBlockNestingModeSet,
+								TypeName: "test_block",
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"provider-meta-version": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ProviderMeta: &tfsdk.Schema{
+					Version: 123,
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				ProviderMeta: &tfprotov6.Schema{
+					Block:   &tfprotov6.SchemaBlock{},
+					Version: 123,
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"resource-multiple-resources": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ResourceSchemas: map[string]*tfsdk.Schema{
+					"test_resource_1": {
+						Attributes: map[string]tfsdk.Attribute{
+							"test_attribute": {
+								Computed: true,
+								Type:     types.BoolType,
+							},
+						},
+					},
+					"test_resource_2": {
+						Attributes: map[string]tfsdk.Attribute{
+							"test_attribute": {
+								Computed: true,
+								Type:     types.BoolType,
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas: map[string]*tfprotov6.Schema{
+					"test_resource_1": {
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Computed: true,
+									Name:     "test_attribute",
+									Type:     tftypes.Bool,
+								},
+							},
+						},
+					},
+					"test_resource_2": {
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Computed: true,
+									Name:     "test_attribute",
+									Type:     tftypes.Bool,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"resource-attribute-computed": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ResourceSchemas: map[string]*tfsdk.Schema{
+					"test_resource": {
+						Attributes: map[string]tfsdk.Attribute{
+							"test_attribute": {
+								Computed: true,
+								Type:     types.BoolType,
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas: map[string]*tfprotov6.Schema{
+					"test_resource": {
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Computed: true,
+									Name:     "test_attribute",
+									Type:     tftypes.Bool,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"resource-attribute-deprecated": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ResourceSchemas: map[string]*tfsdk.Schema{
+					"test_resource": {
+						Attributes: map[string]tfsdk.Attribute{
+							"test_attribute": {
+								DeprecationMessage: "deprecated",
+								Optional:           true,
+								Type:               types.BoolType,
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas: map[string]*tfprotov6.Schema{
+					"test_resource": {
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Deprecated: true,
+									Name:       "test_attribute",
+									Optional:   true,
+									Type:       tftypes.Bool,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"resource-attribute-optional": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ResourceSchemas: map[string]*tfsdk.Schema{
+					"test_resource": {
+						Attributes: map[string]tfsdk.Attribute{
+							"test_attribute": {
+								Optional: true,
+								Type:     types.BoolType,
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas: map[string]*tfprotov6.Schema{
+					"test_resource": {
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Name:     "test_attribute",
+									Optional: true,
+									Type:     tftypes.Bool,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"resource-attribute-optional-computed": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ResourceSchemas: map[string]*tfsdk.Schema{
+					"test_resource": {
+						Attributes: map[string]tfsdk.Attribute{
+							"test_attribute": {
+								Computed: true,
+								Optional: true,
+								Type:     types.BoolType,
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas: map[string]*tfprotov6.Schema{
+					"test_resource": {
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Computed: true,
+									Name:     "test_attribute",
+									Optional: true,
+									Type:     tftypes.Bool,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"resource-attribute-required": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ResourceSchemas: map[string]*tfsdk.Schema{
+					"test_resource": {
+						Attributes: map[string]tfsdk.Attribute{
+							"test_attribute": {
+								Required: true,
+								Type:     types.BoolType,
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas: map[string]*tfprotov6.Schema{
+					"test_resource": {
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Name:     "test_attribute",
+									Type:     tftypes.Bool,
+									Required: true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"resource-attribute-sensitive": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ResourceSchemas: map[string]*tfsdk.Schema{
+					"test_resource": {
+						Attributes: map[string]tfsdk.Attribute{
+							"test_attribute": {
+								Computed:  true,
+								Sensitive: true,
+								Type:      types.BoolType,
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas: map[string]*tfprotov6.Schema{
+					"test_resource": {
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Computed:  true,
+									Name:      "test_attribute",
+									Sensitive: true,
+									Type:      tftypes.Bool,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"resource-attribute-type-bool": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ResourceSchemas: map[string]*tfsdk.Schema{
+					"test_resource": {
+						Attributes: map[string]tfsdk.Attribute{
+							"test_attribute": {
+								Required: true,
+								Type:     types.BoolType,
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas: map[string]*tfprotov6.Schema{
+					"test_resource": {
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Name:     "test_attribute",
+									Required: true,
+									Type:     tftypes.Bool,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"resource-attribute-type-float64": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ResourceSchemas: map[string]*tfsdk.Schema{
+					"test_resource": {
+						Attributes: map[string]tfsdk.Attribute{
+							"test_attribute": {
+								Required: true,
+								Type:     types.Float64Type,
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas: map[string]*tfprotov6.Schema{
+					"test_resource": {
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Name:     "test_attribute",
+									Required: true,
+									Type:     tftypes.Number,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"resource-attribute-type-int64": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ResourceSchemas: map[string]*tfsdk.Schema{
+					"test_resource": {
+						Attributes: map[string]tfsdk.Attribute{
+							"test_attribute": {
+								Required: true,
+								Type:     types.Int64Type,
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas: map[string]*tfprotov6.Schema{
+					"test_resource": {
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Name:     "test_attribute",
+									Required: true,
+									Type:     tftypes.Number,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"resource-attribute-type-list-list-string": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ResourceSchemas: map[string]*tfsdk.Schema{
+					"test_resource": {
+						Attributes: map[string]tfsdk.Attribute{
+							"test_attribute": {
+								Required: true,
+								Type: types.ListType{
+									ElemType: types.ListType{
+										ElemType: types.StringType,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas: map[string]*tfprotov6.Schema{
+					"test_resource": {
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Name:     "test_attribute",
+									Required: true,
+									Type: tftypes.List{
+										ElementType: tftypes.List{
+											ElementType: tftypes.String,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"resource-attribute-type-list-nested-attributes": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ResourceSchemas: map[string]*tfsdk.Schema{
+					"test_resource": {
+						Attributes: map[string]tfsdk.Attribute{
+							"test_attribute": {
+								Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
+									"test_nested_attribute": {
+										Type:     types.StringType,
+										Required: true,
+									},
+								}, tfsdk.ListNestedAttributesOptions{}),
+								Required: true,
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas: map[string]*tfprotov6.Schema{
+					"test_resource": {
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Name: "test_attribute",
+									NestedType: &tfprotov6.SchemaObject{
+										Nesting: tfprotov6.SchemaObjectNestingModeList,
+										Attributes: []*tfprotov6.SchemaAttribute{
+											{
+												Name:     "test_nested_attribute",
+												Type:     tftypes.String,
+												Required: true,
+											},
+										},
+									},
+									Required: true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"resource-attribute-type-list-object": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ResourceSchemas: map[string]*tfsdk.Schema{
+					"test_resource": {
+						Attributes: map[string]tfsdk.Attribute{
+							"test_attribute": {
+								Required: true,
+								Type: types.ListType{
+									ElemType: types.ObjectType{
+										AttrTypes: map[string]attr.Type{
+											"test_object_attribute": types.StringType,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas: map[string]*tfprotov6.Schema{
+					"test_resource": {
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Name:     "test_attribute",
+									Required: true,
+									Type: tftypes.List{
+										ElementType: tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"test_object_attribute": tftypes.String,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"resource-attribute-type-list-string": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ResourceSchemas: map[string]*tfsdk.Schema{
+					"test_resource": {
+						Attributes: map[string]tfsdk.Attribute{
+							"test_attribute": {
+								Required: true,
+								Type: types.ListType{
+									ElemType: types.StringType,
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas: map[string]*tfprotov6.Schema{
+					"test_resource": {
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Name:     "test_attribute",
+									Required: true,
+									Type: tftypes.List{
+										ElementType: tftypes.String,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"resource-attribute-type-map-nested-attributes": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ResourceSchemas: map[string]*tfsdk.Schema{
+					"test_resource": {
+						Attributes: map[string]tfsdk.Attribute{
+							"test_attribute": {
+								Attributes: tfsdk.MapNestedAttributes(map[string]tfsdk.Attribute{
+									"test_nested_attribute": {
+										Type:     types.StringType,
+										Required: true,
+									},
+								}, tfsdk.MapNestedAttributesOptions{}),
+								Required: true,
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas: map[string]*tfprotov6.Schema{
+					"test_resource": {
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Name: "test_attribute",
+									NestedType: &tfprotov6.SchemaObject{
+										Nesting: tfprotov6.SchemaObjectNestingModeMap,
+										Attributes: []*tfprotov6.SchemaAttribute{
+											{
+												Name:     "test_nested_attribute",
+												Type:     tftypes.String,
+												Required: true,
+											},
+										},
+									},
+									Required: true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"resource-attribute-type-map-string": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ResourceSchemas: map[string]*tfsdk.Schema{
+					"test_resource": {
+						Attributes: map[string]tfsdk.Attribute{
+							"test_attribute": {
+								Required: true,
+								Type: types.MapType{
+									ElemType: types.StringType,
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas: map[string]*tfprotov6.Schema{
+					"test_resource": {
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Name:     "test_attribute",
+									Required: true,
+									Type: tftypes.Map{
+										ElementType: tftypes.String,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"resource-attribute-type-number": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ResourceSchemas: map[string]*tfsdk.Schema{
+					"test_resource": {
+						Attributes: map[string]tfsdk.Attribute{
+							"test_attribute": {
+								Required: true,
+								Type:     types.NumberType,
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas: map[string]*tfprotov6.Schema{
+					"test_resource": {
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Name:     "test_attribute",
+									Required: true,
+									Type:     tftypes.Number,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"resource-attribute-type-object": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ResourceSchemas: map[string]*tfsdk.Schema{
+					"test_resource": {
+						Attributes: map[string]tfsdk.Attribute{
+							"test_attribute": {
+								Required: true,
+								Type: types.ObjectType{
+									AttrTypes: map[string]attr.Type{
+										"test_object_attribute": types.StringType,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas: map[string]*tfprotov6.Schema{
+					"test_resource": {
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Name:     "test_attribute",
+									Required: true,
+									Type: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"test_object_attribute": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"resource-attribute-type-set-nested-attributes": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ResourceSchemas: map[string]*tfsdk.Schema{
+					"test_resource": {
+						Attributes: map[string]tfsdk.Attribute{
+							"test_attribute": {
+								Attributes: tfsdk.SetNestedAttributes(map[string]tfsdk.Attribute{
+									"test_nested_attribute": {
+										Type:     types.StringType,
+										Required: true,
+									},
+								}, tfsdk.SetNestedAttributesOptions{}),
+								Required: true,
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas: map[string]*tfprotov6.Schema{
+					"test_resource": {
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Name: "test_attribute",
+									NestedType: &tfprotov6.SchemaObject{
+										Nesting: tfprotov6.SchemaObjectNestingModeSet,
+										Attributes: []*tfprotov6.SchemaAttribute{
+											{
+												Name:     "test_nested_attribute",
+												Type:     tftypes.String,
+												Required: true,
+											},
+										},
+									},
+									Required: true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"resource-attribute-type-set-object": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ResourceSchemas: map[string]*tfsdk.Schema{
+					"test_resource": {
+						Attributes: map[string]tfsdk.Attribute{
+							"test_attribute": {
+								Required: true,
+								Type: types.SetType{
+									ElemType: types.ObjectType{
+										AttrTypes: map[string]attr.Type{
+											"test_object_attribute": types.StringType,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas: map[string]*tfprotov6.Schema{
+					"test_resource": {
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Name:     "test_attribute",
+									Required: true,
+									Type: tftypes.Set{
+										ElementType: tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"test_object_attribute": tftypes.String,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"resource-attribute-type-set-set-string": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ResourceSchemas: map[string]*tfsdk.Schema{
+					"test_resource": {
+						Attributes: map[string]tfsdk.Attribute{
+							"test_attribute": {
+								Required: true,
+								Type: types.SetType{
+									ElemType: types.SetType{
+										ElemType: types.StringType,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas: map[string]*tfprotov6.Schema{
+					"test_resource": {
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Name:     "test_attribute",
+									Required: true,
+									Type: tftypes.Set{
+										ElementType: tftypes.Set{
+											ElementType: tftypes.String,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"resource-attribute-type-set-string": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ResourceSchemas: map[string]*tfsdk.Schema{
+					"test_resource": {
+						Attributes: map[string]tfsdk.Attribute{
+							"test_attribute": {
+								Required: true,
+								Type: types.SetType{
+									ElemType: types.StringType,
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas: map[string]*tfprotov6.Schema{
+					"test_resource": {
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Name:     "test_attribute",
+									Required: true,
+									Type: tftypes.Set{
+										ElementType: tftypes.String,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"resource-attribute-type-single-nested-attributes": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ResourceSchemas: map[string]*tfsdk.Schema{
+					"test_resource": {
+						Attributes: map[string]tfsdk.Attribute{
+							"test_attribute": {
+								Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
+									"test_nested_attribute": {
+										Type:     types.StringType,
+										Required: true,
+									},
+								}),
+								Required: true,
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas: map[string]*tfprotov6.Schema{
+					"test_resource": {
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Name: "test_attribute",
+									NestedType: &tfprotov6.SchemaObject{
+										Nesting: tfprotov6.SchemaObjectNestingModeSingle,
+										Attributes: []*tfprotov6.SchemaAttribute{
+											{
+												Name:     "test_nested_attribute",
+												Type:     tftypes.String,
+												Required: true,
+											},
+										},
+									},
+									Required: true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"resource-attribute-type-string": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ResourceSchemas: map[string]*tfsdk.Schema{
+					"test_resource": {
+						Attributes: map[string]tfsdk.Attribute{
+							"test_attribute": {
+								Required: true,
+								Type:     types.StringType,
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas: map[string]*tfprotov6.Schema{
+					"test_resource": {
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Name:     "test_attribute",
+									Required: true,
+									Type:     tftypes.String,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"resource-block-list": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ResourceSchemas: map[string]*tfsdk.Schema{
+					"test_resource": {
+						Blocks: map[string]tfsdk.Block{
+							"test_block": {
+								Attributes: map[string]tfsdk.Attribute{
+									"test_attribute": {
+										Type:     types.StringType,
+										Required: true,
+									},
+								},
+								NestingMode: tfsdk.BlockNestingModeList,
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas: map[string]*tfprotov6.Schema{
+					"test_resource": {
+						Block: &tfprotov6.SchemaBlock{
+							BlockTypes: []*tfprotov6.SchemaNestedBlock{
+								{
+									Block: &tfprotov6.SchemaBlock{
+										Attributes: []*tfprotov6.SchemaAttribute{
+											{
+												Name:     "test_attribute",
+												Type:     tftypes.String,
+												Required: true,
+											},
+										},
+									},
+									Nesting:  tfprotov6.SchemaNestedBlockNestingModeList,
+									TypeName: "test_block",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"resource-block-set": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ResourceSchemas: map[string]*tfsdk.Schema{
+					"test_resource": {
+						Blocks: map[string]tfsdk.Block{
+							"test_block": {
+								Attributes: map[string]tfsdk.Attribute{
+									"test_attribute": {
+										Type:     types.StringType,
+										Required: true,
+									},
+								},
+								NestingMode: tfsdk.BlockNestingModeSet,
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas: map[string]*tfprotov6.Schema{
+					"test_resource": {
+						Block: &tfprotov6.SchemaBlock{
+							BlockTypes: []*tfprotov6.SchemaNestedBlock{
+								{
+									Block: &tfprotov6.SchemaBlock{
+										Attributes: []*tfprotov6.SchemaAttribute{
+											{
+												Name:     "test_attribute",
+												Type:     tftypes.String,
+												Required: true,
+											},
+										},
+									},
+									Nesting:  tfprotov6.SchemaNestedBlockNestingModeSet,
+									TypeName: "test_block",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"resource-version": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ResourceSchemas: map[string]*tfsdk.Schema{
+					"test_resource": {
+						Version: 123,
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas: map[string]*tfprotov6.Schema{
+					"test_resource": {
+						Block:   &tfprotov6.SchemaBlock{},
+						Version: 123,
+					},
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := toproto6.GetProviderSchemaResponse(context.Background(), testCase.input)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}

--- a/internal/toproto6/schema.go
+++ b/internal/toproto6/schema.go
@@ -10,7 +10,11 @@ import (
 )
 
 // Schema returns the *tfprotov6.Schema equivalent of a Schema.
-func Schema(ctx context.Context, s tfsdk.Schema) (*tfprotov6.Schema, error) {
+func Schema(ctx context.Context, s *tfsdk.Schema) (*tfprotov6.Schema, error) {
+	if s == nil {
+		return nil, nil
+	}
+
 	result := &tfprotov6.Schema{
 		Version: s.Version,
 	}

--- a/internal/toproto6/schema_test.go
+++ b/internal/toproto6/schema_test.go
@@ -17,21 +17,25 @@ func TestSchema(t *testing.T) {
 	t.Parallel()
 
 	type testCase struct {
-		input       tfsdk.Schema
+		input       *tfsdk.Schema
 		expected    *tfprotov6.Schema
 		expectedErr string
 	}
 
 	tests := map[string]testCase{
+		"nil": {
+			input:    nil,
+			expected: nil,
+		},
 		"empty-val": {
-			input: tfsdk.Schema{},
+			input: &tfsdk.Schema{},
 			expected: &tfprotov6.Schema{
 				Block:   &tfprotov6.SchemaBlock{},
 				Version: 0,
 			},
 		},
 		"basic-attrs": {
-			input: tfsdk.Schema{
+			input: &tfsdk.Schema{
 				Version: 1,
 				Attributes: map[string]tfsdk.Attribute{
 					"string": {
@@ -72,7 +76,7 @@ func TestSchema(t *testing.T) {
 			},
 		},
 		"complex-attrs": {
-			input: tfsdk.Schema{
+			input: &tfsdk.Schema{
 				Version: 2,
 				Attributes: map[string]tfsdk.Attribute{
 					"list": {
@@ -131,7 +135,7 @@ func TestSchema(t *testing.T) {
 			},
 		},
 		"nested-attrs": {
-			input: tfsdk.Schema{
+			input: &tfsdk.Schema{
 				Version: 3,
 				Attributes: map[string]tfsdk.Attribute{
 					"single": {
@@ -355,7 +359,7 @@ func TestSchema(t *testing.T) {
 			},
 		},
 		"nested-blocks": {
-			input: tfsdk.Schema{
+			input: &tfsdk.Schema{
 				Version: 3,
 				Blocks: map[string]tfsdk.Block{
 					"list": {
@@ -471,7 +475,7 @@ func TestSchema(t *testing.T) {
 			},
 		},
 		"markdown-description": {
-			input: tfsdk.Schema{
+			input: &tfsdk.Schema{
 				Version: 1,
 				Attributes: map[string]tfsdk.Attribute{
 					"string": {
@@ -497,7 +501,7 @@ func TestSchema(t *testing.T) {
 			},
 		},
 		"plaintext-description": {
-			input: tfsdk.Schema{
+			input: &tfsdk.Schema{
 				Version: 1,
 				Attributes: map[string]tfsdk.Attribute{
 					"string": {
@@ -523,7 +527,7 @@ func TestSchema(t *testing.T) {
 			},
 		},
 		"deprecated": {
-			input: tfsdk.Schema{
+			input: &tfsdk.Schema{
 				Version: 1,
 				Attributes: map[string]tfsdk.Attribute{
 					"string": {

--- a/providerserver/providerserver.go
+++ b/providerserver/providerserver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
 	"github.com/hashicorp/terraform-plugin-framework/internal/proto6server"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
@@ -17,6 +18,9 @@ import (
 func NewProtocol6(p tfsdk.Provider) func() tfprotov6.ProviderServer {
 	return func() tfprotov6.ProviderServer {
 		return &proto6server.Server{
+			FrameworkServer: fwserver.Server{
+				Provider: p,
+			},
 			Provider: p,
 		}
 	}
@@ -30,6 +34,9 @@ func NewProtocol6(p tfsdk.Provider) func() tfprotov6.ProviderServer {
 func NewProtocol6WithError(p tfsdk.Provider) func() (tfprotov6.ProviderServer, error) {
 	return func() (tfprotov6.ProviderServer, error) {
 		return &proto6server.Server{
+			FrameworkServer: fwserver.Server{
+				Provider: p,
+			},
 			Provider: p,
 		}, nil
 	}
@@ -52,8 +59,13 @@ func Serve(ctx context.Context, providerFunc func() tfsdk.Provider, opts ServeOp
 	return tf6server.Serve(
 		opts.Address,
 		func() tfprotov6.ProviderServer {
+			provider := providerFunc()
+
 			return &proto6server.Server{
-				Provider: providerFunc(),
+				FrameworkServer: fwserver.Server{
+					Provider: provider,
+				},
+				Provider: provider,
 			}
 		},
 		tf6serverOpts...,


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/215

This step of the provider server refactoring introduces a new `internal/fwserver` package that will contain the provider server implementation for any protocol version, there only being a version 6 implementation at the moment. This package will contain only framework-native types that aren't already defined by the `tfsdk` package that are used by provider developers today, which is necessary to prevent import cycles. The protocol specific implementations will then wrap this framework server implementation and handle any necessary conversion of protocol specific types to framework specific types and back. Eventually, the existing `internal/proto6server` implementation will make no reference to any framework native types except the framework server and protocol type conversions.

For now, only the `GetProviderSchema` RPC is migrated to show what this refactoring will look like for the rest of the RPCs.

This has a few benefits which can be seen here including clear abstractions for protocol specific handling versus generic framework handling and unit testing at those abstraction boundaries.

_Please note that much of the "end-to-end" unit testing is already in the `internal/proto6server` package, which shows no changes in behavior, and therefore can help gain confidence in this change not introducing potential regressions._