### PR TITLE
tfsdk: Remove Go documentation deprecation for Schema type Blocks field

### DIFF
--- a/internal/fwserver/schema_validation.go
+++ b/internal/fwserver/schema_validation.go
@@ -48,7 +48,6 @@ func SchemaValidate(ctx context.Context, s tfsdk.Schema, req ValidateSchemaReque
 		resp.Diagnostics = attributeResp.Diagnostics
 	}
 
-	//nolint:staticcheck // Block support is required within the framework.
 	for name, block := range s.Blocks {
 		attributeReq := tfsdk.ValidateAttributeRequest{
 			AttributePath: tftypes.NewAttributePath().WithAttributeName(name),

--- a/internal/proto6server/schema_plan_modification.go
+++ b/internal/proto6server/schema_plan_modification.go
@@ -61,7 +61,6 @@ func SchemaModifyPlan(ctx context.Context, s tfsdk.Schema, req ModifySchemaPlanR
 		AttributeModifyPlan(ctx, attr, attrReq, resp)
 	}
 
-	//nolint:staticcheck // Block support is required within the framework.
 	for name, block := range s.Blocks {
 		blockReq := tfsdk.ModifyAttributePlanRequest{
 			AttributePath: tftypes.NewAttributePath().WithAttributeName(name),

--- a/internal/toproto6/schema.go
+++ b/internal/toproto6/schema.go
@@ -32,7 +32,6 @@ func Schema(ctx context.Context, s *tfsdk.Schema) (*tfprotov6.Schema, error) {
 		attrs = append(attrs, a)
 	}
 
-	//nolint:staticcheck // Block support is required within the framework.
 	for name, block := range s.Blocks {
 		proto6, err := Block(ctx, name, tftypes.NewAttributePath().WithAttributeName(name), block)
 

--- a/tfsdk/schema.go
+++ b/tfsdk/schema.go
@@ -54,9 +54,9 @@ type Schema struct {
 	//   https://www.terraform.io/docs/language/syntax/configuration.html
 	//   https://www.terraform.io/docs/language/expressions/dynamic-blocks.html
 	//
-	// Deprecated: Attributes are preferred over Blocks. Blocks should only be
-	// used for configuration compatibility with previously existing schemas
-	// from an older Terraform Plugin SDK. Efforts should be made to convert
+	// Attributes are preferred over Blocks. Blocks should typically be used
+	// for configuration compatibility with previously existing schemas from
+	// an older Terraform Plugin SDK. Efforts should be made to convert from
 	// Blocks to Attributes as a breaking change for practitioners.
 	Blocks map[string]Block
 


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/329

While attributes will be recommended over blocks going forward, we do not want to alarm or cause confusion with provider developers migrating existing schemas from terraform-plugin-sdk. Terraform also does not provide native functionality to help practitioners switch syntax in configurations, so this deprecation notice is considered premature.