### PR TITLE
internal: Migrate ValidateResourceConfig RPC to fromproto6, fwserver, and toproto6

### DIFF
--- a/internal/fromproto6/validateresourceconfig.go
+++ b/internal/fromproto6/validateresourceconfig.go
@@ -1,0 +1,27 @@
+package fromproto6
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+)
+
+// ValidateResourceConfigRequest returns the *fwserver.ValidateResourceConfigRequest
+// equivalent of a *tfprotov6.ValidateResourceConfigRequest.
+func ValidateResourceConfigRequest(ctx context.Context, proto6 *tfprotov6.ValidateResourceConfigRequest, resourceType tfsdk.ResourceType, resourceSchema *tfsdk.Schema) (*fwserver.ValidateResourceConfigRequest, diag.Diagnostics) {
+	if proto6 == nil {
+		return nil, nil
+	}
+
+	fw := &fwserver.ValidateResourceConfigRequest{}
+
+	config, diags := Config(ctx, proto6.Config, resourceSchema)
+
+	fw.Config = config
+	fw.ResourceType = resourceType
+
+	return fw, diags
+}

--- a/internal/fromproto6/validateresourceconfig_test.go
+++ b/internal/fromproto6/validateresourceconfig_test.go
@@ -1,0 +1,106 @@
+package fromproto6_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fromproto6"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func TestValidateResourceConfigRequest(t *testing.T) {
+	t.Parallel()
+
+	testProto6Type := tftypes.Object{
+		AttributeTypes: map[string]tftypes.Type{
+			"test_attribute": tftypes.String,
+		},
+	}
+
+	testProto6Value := tftypes.NewValue(testProto6Type, map[string]tftypes.Value{
+		"test_attribute": tftypes.NewValue(tftypes.String, "test-value"),
+	})
+
+	testProto6DynamicValue, err := tfprotov6.NewDynamicValue(testProto6Type, testProto6Value)
+
+	if err != nil {
+		t.Fatalf("unexpected error calling tfprotov6.NewDynamicValue(): %s", err)
+	}
+
+	testFwSchema := &tfsdk.Schema{
+		Attributes: map[string]tfsdk.Attribute{
+			"test_attribute": {
+				Required: true,
+				Type:     types.StringType,
+			},
+		},
+	}
+
+	testCases := map[string]struct {
+		input               *tfprotov6.ValidateResourceConfigRequest
+		resourceSchema      *tfsdk.Schema
+		resourceType        tfsdk.ResourceType
+		expected            *fwserver.ValidateResourceConfigRequest
+		expectedDiagnostics diag.Diagnostics
+	}{
+		"nil": {
+			input:    nil,
+			expected: nil,
+		},
+		"empty": {
+			input:    &tfprotov6.ValidateResourceConfigRequest{},
+			expected: &fwserver.ValidateResourceConfigRequest{},
+		},
+		"config-missing-schema": {
+			input: &tfprotov6.ValidateResourceConfigRequest{
+				Config: &testProto6DynamicValue,
+			},
+			expected: &fwserver.ValidateResourceConfigRequest{},
+			expectedDiagnostics: diag.Diagnostics{
+				diag.NewErrorDiagnostic(
+					"Unable to Convert Configuration",
+					"An unexpected error was encountered when converting the configuration from the protocol type. "+
+						"This is always an issue in the Terraform Provider SDK used to implement the provider and should be reported to the provider developers.\n\n"+
+						"Please report this to the provider developer:\n\n"+
+						"Missing schema.",
+				),
+			},
+		},
+		"config": {
+			input: &tfprotov6.ValidateResourceConfigRequest{
+				Config: &testProto6DynamicValue,
+			},
+			resourceSchema: testFwSchema,
+			expected: &fwserver.ValidateResourceConfigRequest{
+				Config: &tfsdk.Config{
+					Raw:    testProto6Value,
+					Schema: *testFwSchema,
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, diags := fromproto6.ValidateResourceConfigRequest(context.Background(), testCase.input, testCase.resourceType, testCase.resourceSchema)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+
+			if diff := cmp.Diff(diags, testCase.expectedDiagnostics); diff != "" {
+				t.Errorf("unexpected diagnostics difference: %s", diff)
+			}
+		})
+	}
+}

--- a/internal/fwserver/server_getproviderschema_test.go
+++ b/internal/fwserver/server_getproviderschema_test.go
@@ -33,6 +33,7 @@ func TestServerGetProviderSchema(t *testing.T) {
 			expectedResponse: &fwserver.GetProviderSchemaResponse{
 				DataSourceSchemas: map[string]*tfsdk.Schema{},
 				Provider:          &tfsdk.Schema{},
+				ResourceSchemas:   map[string]*tfsdk.Schema{},
 			},
 		},
 	}

--- a/internal/fwserver/server_validateresourceconfig.go
+++ b/internal/fwserver/server_validateresourceconfig.go
@@ -1,0 +1,97 @@
+package fwserver
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/internal/logging"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+)
+
+// ValidateResourceConfigRequest is the framework server request for the
+// ValidateResourceConfig RPC.
+type ValidateResourceConfigRequest struct {
+	Config       *tfsdk.Config
+	ResourceType tfsdk.ResourceType
+}
+
+// ValidateResourceConfigResponse is the framework server response for the
+// ValidateResourceConfig RPC.
+type ValidateResourceConfigResponse struct {
+	Diagnostics diag.Diagnostics
+}
+
+// ValidateResourceConfig implements the framework server ValidateResourceConfig RPC.
+func (s *Server) ValidateResourceConfig(ctx context.Context, req *ValidateResourceConfigRequest, resp *ValidateResourceConfigResponse) {
+	if req == nil || req.Config == nil {
+		return
+	}
+
+	// Always instantiate new Resource instances.
+	logging.FrameworkDebug(ctx, "Calling provider defined ResourceType NewResource")
+	resource, diags := req.ResourceType.NewResource(ctx, s.Provider)
+	logging.FrameworkDebug(ctx, "Called provider defined ResourceType NewResource")
+
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	vdscReq := tfsdk.ValidateResourceConfigRequest{
+		Config: *req.Config,
+	}
+
+	if resource, ok := resource.(tfsdk.ResourceWithConfigValidators); ok {
+		logging.FrameworkTrace(ctx, "Resource implements ResourceWithConfigValidators")
+
+		for _, configValidator := range resource.ConfigValidators(ctx) {
+			vdscResp := &tfsdk.ValidateResourceConfigResponse{
+				Diagnostics: resp.Diagnostics,
+			}
+
+			logging.FrameworkDebug(
+				ctx,
+				"Calling provider defined ResourceConfigValidator",
+				map[string]interface{}{
+					logging.KeyDescription: configValidator.Description(ctx),
+				},
+			)
+			configValidator.Validate(ctx, vdscReq, vdscResp)
+			logging.FrameworkDebug(
+				ctx,
+				"Called provider defined ResourceConfigValidator",
+				map[string]interface{}{
+					logging.KeyDescription: configValidator.Description(ctx),
+				},
+			)
+
+			resp.Diagnostics = vdscResp.Diagnostics
+		}
+	}
+
+	if resource, ok := resource.(tfsdk.ResourceWithValidateConfig); ok {
+		logging.FrameworkTrace(ctx, "Resource implements ResourceWithValidateConfig")
+
+		vdscResp := &tfsdk.ValidateResourceConfigResponse{
+			Diagnostics: resp.Diagnostics,
+		}
+
+		logging.FrameworkDebug(ctx, "Calling provider defined Resource ValidateConfig")
+		resource.ValidateConfig(ctx, vdscReq, vdscResp)
+		logging.FrameworkDebug(ctx, "Called provider defined Resource ValidateConfig")
+
+		resp.Diagnostics = vdscResp.Diagnostics
+	}
+
+	validateSchemaReq := ValidateSchemaRequest{
+		Config: *req.Config,
+	}
+	validateSchemaResp := ValidateSchemaResponse{
+		Diagnostics: resp.Diagnostics,
+	}
+
+	SchemaValidate(ctx, req.Config.Schema, validateSchemaReq, &validateSchemaResp)
+
+	resp.Diagnostics = validateSchemaResp.Diagnostics
+}

--- a/internal/fwserver/server_validateresourceconfig_test.go
+++ b/internal/fwserver/server_validateresourceconfig_test.go
@@ -1,0 +1,50 @@
+package fwserver_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/emptyprovider"
+)
+
+// TODO: Migrate tfsdk.Provider bits of proto6server.testProviderServer to
+// new internal/testing/provider.Provider that allows customization of all
+// method implementations via struct fields. Then, create additional test
+// cases in this unit test.
+//
+// For now this testing is covered by proto6server.ValidateResourceConfig.
+//
+// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/215
+func TestServerValidateResourceConfig(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		server           *fwserver.Server
+		request          *fwserver.ValidateResourceConfigRequest
+		expectedResponse *fwserver.ValidateResourceConfigResponse
+	}{
+		"empty-provider": {
+			server: &fwserver.Server{
+				Provider: &emptyprovider.Provider{},
+			},
+			expectedResponse: &fwserver.ValidateResourceConfigResponse{},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			response := &fwserver.ValidateResourceConfigResponse{}
+			testCase.server.ValidateResourceConfig(context.Background(), testCase.request, response)
+
+			if diff := cmp.Diff(response, testCase.expectedResponse); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}

--- a/internal/proto6server/serve_test.go
+++ b/internal/proto6server/serve_test.go
@@ -350,6 +350,16 @@ func TestServerGetProviderSchema_logging(t *testing.T) {
 			"@module":  "sdk.framework",
 		},
 		{
+			"@level":   "trace",
+			"@message": "Checking ResourceSchemas lock",
+			"@module":  "sdk.framework",
+		},
+		{
+			"@level":   "trace",
+			"@message": "Checking ResourceTypes lock",
+			"@module":  "sdk.framework",
+		},
+		{
 			"@level":   "debug",
 			"@message": "Calling provider defined Provider GetResources",
 			"@module":  "sdk.framework",

--- a/internal/proto6server/serve_test.go
+++ b/internal/proto6server/serve_test.go
@@ -1481,7 +1481,9 @@ func TestServerValidateResourceConfig(t *testing.T) {
 				validateResourceConfigImpl: tc.impl,
 			}
 			testServer := &Server{
-				Provider: s,
+				FrameworkServer: fwserver.Server{
+					Provider: s,
+				},
 			}
 
 			dv, err := tfprotov6.NewDynamicValue(tc.resourceType, tc.config)

--- a/internal/toproto6/validateresourceconfig.go
+++ b/internal/toproto6/validateresourceconfig.go
@@ -1,0 +1,22 @@
+package toproto6
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+)
+
+// ValidateResourceConfigResponse returns the *tfprotov6.ValidateResourceConfigResponse
+// equivalent of a *fwserver.ValidateResourceConfigResponse.
+func ValidateResourceConfigResponse(ctx context.Context, fw *fwserver.ValidateResourceConfigResponse) *tfprotov6.ValidateResourceConfigResponse {
+	if fw == nil {
+		return nil
+	}
+
+	proto6 := &tfprotov6.ValidateResourceConfigResponse{
+		Diagnostics: Diagnostics(fw.Diagnostics),
+	}
+
+	return proto6
+}

--- a/internal/toproto6/validateresourceconfig_test.go
+++ b/internal/toproto6/validateresourceconfig_test.go
@@ -1,0 +1,66 @@
+package toproto6_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
+	"github.com/hashicorp/terraform-plugin-framework/internal/toproto6"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+)
+
+func TestValidateResourceConfigResponse(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		input    *fwserver.ValidateResourceConfigResponse
+		expected *tfprotov6.ValidateResourceConfigResponse
+	}{
+		"nil": {
+			input:    nil,
+			expected: nil,
+		},
+		"empty": {
+			input:    &fwserver.ValidateResourceConfigResponse{},
+			expected: &tfprotov6.ValidateResourceConfigResponse{},
+		},
+		"diagnostics": {
+			input: &fwserver.ValidateResourceConfigResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewWarningDiagnostic("test warning summary", "test warning details"),
+					diag.NewErrorDiagnostic("test error summary", "test error details"),
+				},
+			},
+			expected: &tfprotov6.ValidateResourceConfigResponse{
+				Diagnostics: []*tfprotov6.Diagnostic{
+					{
+						Severity: tfprotov6.DiagnosticSeverityWarning,
+						Summary:  "test warning summary",
+						Detail:   "test warning details",
+					},
+					{
+						Severity: tfprotov6.DiagnosticSeverityError,
+						Summary:  "test error summary",
+						Detail:   "test error details",
+					},
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := toproto6.ValidateResourceConfigResponse(context.Background(), testCase.input)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/215
Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/299

This migration is almost identical to what was done for `ValidateDataSourceConfig`. This introduces framework server caching for resource types and schemas, similar to the data source schema, data source type, and provider schema caches, which is needed with other resource RPCs.