### PR TITLE
internal: ValidateDataSourceConfig RPC tidying

### DIFF
--- a/internal/fwserver/server_validatedatasourceconfig.go
+++ b/internal/fwserver/server_validatedatasourceconfig.go
@@ -18,8 +18,7 @@ type ValidateDataSourceConfigRequest struct {
 // ValidateDataSourceConfigResponse is the framework server response for the
 // ValidateDataSourceConfig RPC.
 type ValidateDataSourceConfigResponse struct {
-	PreparedConfig *tfsdk.Config
-	Diagnostics    diag.Diagnostics
+	Diagnostics diag.Diagnostics
 }
 
 // ValidateDataSourceConfig implements the framework server ValidateDataSourceConfig RPC.
@@ -78,9 +77,9 @@ func (s *Server) ValidateDataSourceConfig(ctx context.Context, req *ValidateData
 			Diagnostics: resp.Diagnostics,
 		}
 
-		logging.FrameworkDebug(ctx, "Calling provider defined Provider ValidateConfig")
+		logging.FrameworkDebug(ctx, "Calling provider defined DataSource ValidateConfig")
 		dataSource.ValidateConfig(ctx, vdscReq, vdscResp)
-		logging.FrameworkDebug(ctx, "Called provider defined Provider ValidateConfig")
+		logging.FrameworkDebug(ctx, "Called provider defined DataSource ValidateConfig")
 
 		resp.Diagnostics = vdscResp.Diagnostics
 	}

--- a/internal/proto6server/serve.go
+++ b/internal/proto6server/serve.go
@@ -1287,17 +1287,6 @@ func (s *Server) applyResourceChange(ctx context.Context, req *tfprotov6.ApplyRe
 	}
 }
 
-// validateDataResourceConfigResponse is a thin abstraction to allow native Diagnostics usage
-type validateDataResourceConfigResponse struct {
-	Diagnostics diag.Diagnostics
-}
-
-func (r validateDataResourceConfigResponse) toTfprotov6() *tfprotov6.ValidateDataResourceConfigResponse {
-	return &tfprotov6.ValidateDataResourceConfigResponse{
-		Diagnostics: toproto6.Diagnostics(r.Diagnostics),
-	}
-}
-
 func (s *Server) ValidateDataResourceConfig(ctx context.Context, proto6Req *tfprotov6.ValidateDataResourceConfigRequest) (*tfprotov6.ValidateDataResourceConfigResponse, error) {
 	ctx = s.registerContext(ctx)
 	ctx = logging.InitContext(ctx)


### PR DESCRIPTION
Some minor items caught after the migration:

- Remove `PreparedConfig` from fwserver `ValidateDataSourceConfigResponse` (this field only applied to `ValidateProviderConfigResponse`)
- Fix logging copy-paste
- Remove now unused proto6server `validateDataResourceConfigResponse`