### PR TITLE
internal/proto6server: Always use data source and resource caches, remove intermediate Provider field

### DIFF
--- a/internal/proto6server/serve_import.go
+++ b/internal/proto6server/serve_import.go
@@ -67,7 +67,7 @@ func (r importResourceStateResponse) toTfprotov6(ctx context.Context) *tfprotov6
 }
 
 func (s *Server) importResourceState(ctx context.Context, req *tfprotov6.ImportResourceStateRequest, resp *importResourceStateResponse) {
-	resourceType, diags := s.getResourceType(ctx, req.TypeName)
+	resourceType, diags := s.FrameworkServer.ResourceType(ctx, req.TypeName)
 	resp.Diagnostics.Append(diags...)
 
 	if resp.Diagnostics.HasError() {
@@ -84,7 +84,7 @@ func (s *Server) importResourceState(ctx context.Context, req *tfprotov6.ImportR
 	}
 
 	logging.FrameworkDebug(ctx, "Calling provider defined ResourceType NewResource")
-	resource, diags := resourceType.NewResource(ctx, s.Provider)
+	resource, diags := resourceType.NewResource(ctx, s.FrameworkServer.Provider)
 	logging.FrameworkDebug(ctx, "Called provider defined ResourceType NewResource")
 	resp.Diagnostics.Append(diags...)
 

--- a/internal/proto6server/serve_import_test.go
+++ b/internal/proto6server/serve_import_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
@@ -164,7 +165,9 @@ func TestServerImportResourceState(t *testing.T) {
 				importStateFunc: tc.impl,
 			}
 			testServer := &Server{
-				Provider: s,
+				FrameworkServer: fwserver.Server{
+					Provider: s,
+				},
 			}
 
 			got, err := testServer.ImportResourceState(context.Background(), tc.req)

--- a/internal/proto6server/serve_test.go
+++ b/internal/proto6server/serve_test.go
@@ -1549,8 +1549,8 @@ func TestServerUpgradeResourceState(t *testing.T) {
 				Diagnostics: []*tfprotov6.Diagnostic{
 					{
 						Severity: tfprotov6.DiagnosticSeverityError,
-						Summary:  "Resource not found",
-						Detail:   "No resource named \"\" is configured on the provider",
+						Summary:  "Resource Type Not Found",
+						Detail:   "No resource type named \"\" was found in the provider.",
 					},
 				},
 			},
@@ -1605,8 +1605,8 @@ func TestServerUpgradeResourceState(t *testing.T) {
 				Diagnostics: []*tfprotov6.Diagnostic{
 					{
 						Severity: tfprotov6.DiagnosticSeverityError,
-						Summary:  "Resource not found",
-						Detail:   "No resource named \"unknown\" is configured on the provider",
+						Summary:  "Resource Type Not Found",
+						Detail:   "No resource type named \"unknown\" was found in the provider.",
 					},
 				},
 			},
@@ -1799,7 +1799,9 @@ func TestServerUpgradeResourceState(t *testing.T) {
 			ctx := context.Background()
 			testProvider := &testServeProvider{}
 			testServer := &Server{
-				Provider: testProvider,
+				FrameworkServer: fwserver.Server{
+					Provider: testProvider,
+				},
 			}
 
 			got, err := testServer.UpgradeResourceState(ctx, testCase.request)
@@ -2220,12 +2222,14 @@ func TestServerReadResource(t *testing.T) {
 				readResourceImpl: tc.impl,
 			}
 			testServer := &Server{
-				Provider: s,
+				FrameworkServer: fwserver.Server{
+					Provider: s,
+				},
 			}
 			var pmSchema tfsdk.Schema
 			if tc.providerMeta.Type() != nil {
 				sWithMeta := &testServeProviderWithMetaSchema{s}
-				testServer.Provider = sWithMeta
+				testServer.FrameworkServer.Provider = sWithMeta
 				schema, diags := sWithMeta.GetMetaSchema(context.Background())
 				if len(diags) > 0 {
 					t.Errorf("Unexpected diags: %+v", diags)
@@ -2234,7 +2238,7 @@ func TestServerReadResource(t *testing.T) {
 				pmSchema = schema
 			}
 
-			rt, diags := testServer.getResourceType(context.Background(), tc.resource)
+			rt, diags := testServer.FrameworkServer.ResourceType(context.Background(), tc.resource)
 			if len(diags) > 0 {
 				t.Errorf("Unexpected diags: %+v", diags)
 				return
@@ -4296,7 +4300,9 @@ func TestServerPlanResourceChange(t *testing.T) {
 				modifyPlanFunc: tc.modifyPlanFunc,
 			}
 			testServer := &Server{
-				Provider: s,
+				FrameworkServer: fwserver.Server{
+					Provider: s,
+				},
 			}
 
 			priorStateDV, err := tfprotov6.NewDynamicValue(tc.resourceType, tc.priorState)
@@ -5856,12 +5862,14 @@ func TestServerApplyResourceChange(t *testing.T) {
 				deleteFunc: tc.destroy,
 			}
 			testServer := &Server{
-				Provider: s,
+				FrameworkServer: fwserver.Server{
+					Provider: s,
+				},
 			}
 			var pmSchema tfsdk.Schema
 			if tc.providerMeta.Type() != nil {
 				sWithMeta := &testServeProviderWithMetaSchema{s}
-				testServer.Provider = sWithMeta
+				testServer.FrameworkServer.Provider = sWithMeta
 				schema, diags := sWithMeta.GetMetaSchema(context.Background())
 				if len(diags) > 0 {
 					t.Errorf("Unexpected diags: %+v", diags)
@@ -5870,7 +5878,7 @@ func TestServerApplyResourceChange(t *testing.T) {
 				pmSchema = schema
 			}
 
-			rt, diags := testServer.getResourceType(context.Background(), tc.resource)
+			rt, diags := testServer.FrameworkServer.ResourceType(context.Background(), tc.resource)
 			if len(diags) > 0 {
 				t.Errorf("Unexpected diags: %+v", diags)
 				return
@@ -6382,12 +6390,14 @@ func TestServerReadDataSource(t *testing.T) {
 				readDataSourceImpl: tc.impl,
 			}
 			testServer := &Server{
-				Provider: s,
+				FrameworkServer: fwserver.Server{
+					Provider: s,
+				},
 			}
 			var pmSchema tfsdk.Schema
 			if tc.providerMeta.Type() != nil {
 				sWithMeta := &testServeProviderWithMetaSchema{s}
-				testServer.Provider = sWithMeta
+				testServer.FrameworkServer.Provider = sWithMeta
 				schema, diags := sWithMeta.GetMetaSchema(context.Background())
 				if len(diags) > 0 {
 					t.Errorf("Unexpected diags: %+v", diags)
@@ -6396,7 +6406,7 @@ func TestServerReadDataSource(t *testing.T) {
 				pmSchema = schema
 			}
 
-			rt, diags := testServer.getDataSourceType(context.Background(), tc.dataSource)
+			rt, diags := testServer.FrameworkServer.DataSourceType(context.Background(), tc.dataSource)
 			if len(diags) > 0 {
 				t.Errorf("Unexpected diags: %+v", diags)
 				return

--- a/providerserver/providerserver.go
+++ b/providerserver/providerserver.go
@@ -21,7 +21,6 @@ func NewProtocol6(p tfsdk.Provider) func() tfprotov6.ProviderServer {
 			FrameworkServer: fwserver.Server{
 				Provider: p,
 			},
-			Provider: p,
 		}
 	}
 }
@@ -37,7 +36,6 @@ func NewProtocol6WithError(p tfsdk.Provider) func() (tfprotov6.ProviderServer, e
 			FrameworkServer: fwserver.Server{
 				Provider: p,
 			},
-			Provider: p,
 		}, nil
 	}
 }
@@ -65,7 +63,6 @@ func Serve(ctx context.Context, providerFunc func() tfsdk.Provider, opts ServeOp
 				FrameworkServer: fwserver.Server{
 					Provider: provider,
 				},
-				Provider: provider,
 			}
 		},
 		tf6serverOpts...,


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/215
Closes #299

This completes the migration to the cached data source and resource schema/type handling in the new `internal/fwserver` package. This also removes the previous `Provider` field so that implementation detail is now wholly within the `internal/fwserver` to remove any confusion.