### PR TITLE
internal: Add ProviderMeta handling to fwserver

### DIFF
--- a/internal/fwserver/server_getproviderschema.go
+++ b/internal/fwserver/server_getproviderschema.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/internal/logging"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 )
 
@@ -34,21 +33,15 @@ func (s *Server) GetProviderSchema(ctx context.Context, req *GetProviderSchemaRe
 
 	resp.Provider = providerSchema
 
-	if pm, ok := s.Provider.(tfsdk.ProviderWithProviderMeta); ok {
-		logging.FrameworkTrace(ctx, "Provider implements ProviderWithProviderMeta")
+	providerMetaSchema, diags := s.ProviderMetaSchema(ctx)
 
-		logging.FrameworkDebug(ctx, "Calling provider defined Provider GetMetaSchema")
-		providerMetaSchema, diags := pm.GetMetaSchema(ctx)
-		logging.FrameworkDebug(ctx, "Called provider defined Provider GetMetaSchema")
+	resp.Diagnostics.Append(diags...)
 
-		resp.Diagnostics.Append(diags...)
-
-		if resp.Diagnostics.HasError() {
-			return
-		}
-
-		resp.ProviderMeta = &providerMetaSchema
+	if diags.HasError() {
+		return
 	}
+
+	resp.ProviderMeta = providerMetaSchema
 
 	resourceSchemas, diags := s.ResourceSchemas(ctx)
 

--- a/internal/proto6server/serve.go
+++ b/internal/proto6server/serve.go
@@ -441,22 +441,23 @@ func (s *Server) readResource(ctx context.Context, req *tfprotov6.ReadResourceRe
 			Schema: resourceSchema,
 		},
 	}
-	if pm, ok := s.FrameworkServer.Provider.(tfsdk.ProviderWithProviderMeta); ok {
-		logging.FrameworkTrace(ctx, "Provider implements ProviderWithProviderMeta")
-		logging.FrameworkDebug(ctx, "Calling provider defined Provider GetMetaSchema")
-		pmSchema, diags := pm.GetMetaSchema(ctx)
-		logging.FrameworkDebug(ctx, "Called provider defined Provider GetMetaSchema")
-		resp.Diagnostics.Append(diags...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
+
+	providerMetaSchema, diags := s.FrameworkServer.ProviderMetaSchema(ctx)
+
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if providerMetaSchema != nil {
 		readReq.ProviderMeta = tfsdk.Config{
-			Schema: pmSchema,
-			Raw:    tftypes.NewValue(pmSchema.TerraformType(ctx), nil),
+			Schema: *providerMetaSchema,
+			Raw:    tftypes.NewValue(providerMetaSchema.TerraformType(ctx), nil),
 		}
 
 		if req.ProviderMeta != nil {
-			pmValue, err := req.ProviderMeta.Unmarshal(pmSchema.TerraformType(ctx))
+			pmValue, err := req.ProviderMeta.Unmarshal(providerMetaSchema.TerraformType(ctx))
 			if err != nil {
 				resp.Diagnostics.AddError(
 					"Error parsing provider_meta",
@@ -698,24 +699,23 @@ func (s *Server) planResourceChange(ctx context.Context, req *tfprotov6.PlanReso
 				Raw:    plan,
 			},
 		}
-		if pm, ok := s.FrameworkServer.Provider.(tfsdk.ProviderWithProviderMeta); ok {
-			logging.FrameworkTrace(ctx, "Provider implements ProviderWithProviderMeta")
-			logging.FrameworkDebug(ctx, "Calling provider defined Provider GetMetaSchema")
-			pmSchema, diags := pm.GetMetaSchema(ctx)
-			logging.FrameworkDebug(ctx, "Called provider defined Provider GetMetaSchema")
-			if diags != nil {
-				resp.Diagnostics.Append(diags...)
-				if resp.Diagnostics.HasError() {
-					return
-				}
-			}
+
+		providerMetaSchema, diags := s.FrameworkServer.ProviderMetaSchema(ctx)
+
+		resp.Diagnostics.Append(diags...)
+
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		if providerMetaSchema != nil {
 			modifySchemaPlanReq.ProviderMeta = tfsdk.Config{
-				Schema: pmSchema,
-				Raw:    tftypes.NewValue(pmSchema.TerraformType(ctx), nil),
+				Schema: *providerMetaSchema,
+				Raw:    tftypes.NewValue(providerMetaSchema.TerraformType(ctx), nil),
 			}
 
 			if req.ProviderMeta != nil {
-				pmValue, err := req.ProviderMeta.Unmarshal(pmSchema.TerraformType(ctx))
+				pmValue, err := req.ProviderMeta.Unmarshal(providerMetaSchema.TerraformType(ctx))
 				if err != nil {
 					resp.Diagnostics.AddError(
 						"Error parsing provider_meta",
@@ -769,22 +769,23 @@ func (s *Server) planResourceChange(ctx context.Context, req *tfprotov6.PlanReso
 				Raw:    plan,
 			},
 		}
-		if pm, ok := s.FrameworkServer.Provider.(tfsdk.ProviderWithProviderMeta); ok {
-			logging.FrameworkTrace(ctx, "Provider implements ProviderWithProviderMeta")
-			logging.FrameworkDebug(ctx, "Calling provider defined Provider GetMetaSchema")
-			pmSchema, diags := pm.GetMetaSchema(ctx)
-			logging.FrameworkDebug(ctx, "Called provider defined Provider GetMetaSchema")
-			resp.Diagnostics.Append(diags...)
-			if resp.Diagnostics.HasError() {
-				return
-			}
+
+		providerMetaSchema, diags := s.FrameworkServer.ProviderMetaSchema(ctx)
+
+		resp.Diagnostics.Append(diags...)
+
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		if providerMetaSchema != nil {
 			modifyPlanReq.ProviderMeta = tfsdk.Config{
-				Schema: pmSchema,
-				Raw:    tftypes.NewValue(pmSchema.TerraformType(ctx), nil),
+				Schema: *providerMetaSchema,
+				Raw:    tftypes.NewValue(providerMetaSchema.TerraformType(ctx), nil),
 			}
 
 			if req.ProviderMeta != nil {
-				pmValue, err := req.ProviderMeta.Unmarshal(pmSchema.TerraformType(ctx))
+				pmValue, err := req.ProviderMeta.Unmarshal(providerMetaSchema.TerraformType(ctx))
 				if err != nil {
 					resp.Diagnostics.AddError(
 						"Error parsing provider_meta",
@@ -978,22 +979,23 @@ func (s *Server) applyResourceChange(ctx context.Context, req *tfprotov6.ApplyRe
 				Raw:    plan,
 			},
 		}
-		if pm, ok := s.FrameworkServer.Provider.(tfsdk.ProviderWithProviderMeta); ok {
-			logging.FrameworkTrace(ctx, "Provider implements ProviderWithProviderMeta")
-			logging.FrameworkDebug(ctx, "Calling provider defined Provider GetMetaSchema")
-			pmSchema, diags := pm.GetMetaSchema(ctx)
-			logging.FrameworkDebug(ctx, "Called provider defined Provider GetMetaSchema")
-			resp.Diagnostics.Append(diags...)
-			if resp.Diagnostics.HasError() {
-				return
-			}
+
+		providerMetaSchema, diags := s.FrameworkServer.ProviderMetaSchema(ctx)
+
+		resp.Diagnostics.Append(diags...)
+
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		if providerMetaSchema != nil {
 			createReq.ProviderMeta = tfsdk.Config{
-				Schema: pmSchema,
-				Raw:    tftypes.NewValue(pmSchema.TerraformType(ctx), nil),
+				Schema: *providerMetaSchema,
+				Raw:    tftypes.NewValue(providerMetaSchema.TerraformType(ctx), nil),
 			}
 
 			if req.ProviderMeta != nil {
-				pmValue, err := req.ProviderMeta.Unmarshal(pmSchema.TerraformType(ctx))
+				pmValue, err := req.ProviderMeta.Unmarshal(providerMetaSchema.TerraformType(ctx))
 				if err != nil {
 					resp.Diagnostics.AddError(
 						"Error parsing provider_meta",
@@ -1004,6 +1006,7 @@ func (s *Server) applyResourceChange(ctx context.Context, req *tfprotov6.ApplyRe
 				createReq.ProviderMeta.Raw = pmValue
 			}
 		}
+
 		createResp := tfsdk.CreateResourceResponse{
 			State: tfsdk.State{
 				Schema: resourceSchema,
@@ -1040,22 +1043,23 @@ func (s *Server) applyResourceChange(ctx context.Context, req *tfprotov6.ApplyRe
 				Raw:    priorState,
 			},
 		}
-		if pm, ok := s.FrameworkServer.Provider.(tfsdk.ProviderWithProviderMeta); ok {
-			logging.FrameworkTrace(ctx, "Provider implements ProviderWithProviderMeta")
-			logging.FrameworkDebug(ctx, "Calling provider defined Provider GetMetaSchema")
-			pmSchema, diags := pm.GetMetaSchema(ctx)
-			logging.FrameworkDebug(ctx, "Called provider defined Provider GetMetaSchema")
-			resp.Diagnostics.Append(diags...)
-			if resp.Diagnostics.HasError() {
-				return
-			}
+
+		providerMetaSchema, diags := s.FrameworkServer.ProviderMetaSchema(ctx)
+
+		resp.Diagnostics.Append(diags...)
+
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		if providerMetaSchema != nil {
 			updateReq.ProviderMeta = tfsdk.Config{
-				Schema: pmSchema,
-				Raw:    tftypes.NewValue(pmSchema.TerraformType(ctx), nil),
+				Schema: *providerMetaSchema,
+				Raw:    tftypes.NewValue(providerMetaSchema.TerraformType(ctx), nil),
 			}
 
 			if req.ProviderMeta != nil {
-				pmValue, err := req.ProviderMeta.Unmarshal(pmSchema.TerraformType(ctx))
+				pmValue, err := req.ProviderMeta.Unmarshal(providerMetaSchema.TerraformType(ctx))
 				if err != nil {
 					resp.Diagnostics.AddError(
 						"Error parsing provider_meta",
@@ -1066,6 +1070,7 @@ func (s *Server) applyResourceChange(ctx context.Context, req *tfprotov6.ApplyRe
 				updateReq.ProviderMeta.Raw = pmValue
 			}
 		}
+
 		updateResp := tfsdk.UpdateResourceResponse{
 			State: tfsdk.State{
 				Schema: resourceSchema,
@@ -1094,22 +1099,23 @@ func (s *Server) applyResourceChange(ctx context.Context, req *tfprotov6.ApplyRe
 				Raw:    priorState,
 			},
 		}
-		if pm, ok := s.FrameworkServer.Provider.(tfsdk.ProviderWithProviderMeta); ok {
-			logging.FrameworkTrace(ctx, "Provider implements ProviderWithProviderMeta")
-			logging.FrameworkDebug(ctx, "Calling provider defined Provider GetMetaSchema")
-			pmSchema, diags := pm.GetMetaSchema(ctx)
-			logging.FrameworkDebug(ctx, "Called provider defined Provider GetMetaSchema")
-			resp.Diagnostics.Append(diags...)
-			if resp.Diagnostics.HasError() {
-				return
-			}
+
+		providerMetaSchema, diags := s.FrameworkServer.ProviderMetaSchema(ctx)
+
+		resp.Diagnostics.Append(diags...)
+
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		if providerMetaSchema != nil {
 			destroyReq.ProviderMeta = tfsdk.Config{
-				Schema: pmSchema,
-				Raw:    tftypes.NewValue(pmSchema.TerraformType(ctx), nil),
+				Schema: *providerMetaSchema,
+				Raw:    tftypes.NewValue(providerMetaSchema.TerraformType(ctx), nil),
 			}
 
 			if req.ProviderMeta != nil {
-				pmValue, err := req.ProviderMeta.Unmarshal(pmSchema.TerraformType(ctx))
+				pmValue, err := req.ProviderMeta.Unmarshal(providerMetaSchema.TerraformType(ctx))
 				if err != nil {
 					resp.Diagnostics.AddError(
 						"Error parsing provider_meta",
@@ -1120,6 +1126,7 @@ func (s *Server) applyResourceChange(ctx context.Context, req *tfprotov6.ApplyRe
 				destroyReq.ProviderMeta.Raw = pmValue
 			}
 		}
+
 		destroyResp := tfsdk.DeleteResourceResponse{
 			State: tfsdk.State{
 				Schema: resourceSchema,
@@ -1246,22 +1253,23 @@ func (s *Server) readDataSource(ctx context.Context, req *tfprotov6.ReadDataSour
 			Schema: dataSourceSchema,
 		},
 	}
-	if pm, ok := s.FrameworkServer.Provider.(tfsdk.ProviderWithProviderMeta); ok {
-		logging.FrameworkTrace(ctx, "Provider implements ProviderWithProviderMeta")
-		logging.FrameworkDebug(ctx, "Calling provider defined Provider GetMetaSchema")
-		pmSchema, diags := pm.GetMetaSchema(ctx)
-		logging.FrameworkDebug(ctx, "Called provider defined Provider GetMetaSchema")
-		resp.Diagnostics.Append(diags...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
+
+	providerMetaSchema, diags := s.FrameworkServer.ProviderMetaSchema(ctx)
+
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if providerMetaSchema != nil {
 		readReq.ProviderMeta = tfsdk.Config{
-			Schema: pmSchema,
-			Raw:    tftypes.NewValue(pmSchema.TerraformType(ctx), nil),
+			Schema: *providerMetaSchema,
+			Raw:    tftypes.NewValue(providerMetaSchema.TerraformType(ctx), nil),
 		}
 
 		if req.ProviderMeta != nil {
-			pmValue, err := req.ProviderMeta.Unmarshal(pmSchema.TerraformType(ctx))
+			pmValue, err := req.ProviderMeta.Unmarshal(providerMetaSchema.TerraformType(ctx))
 			if err != nil {
 				resp.Diagnostics.AddError(
 					"Error parsing provider_meta",
@@ -1272,6 +1280,7 @@ func (s *Server) readDataSource(ctx context.Context, req *tfprotov6.ReadDataSour
 			readReq.ProviderMeta.Raw = pmValue
 		}
 	}
+
 	readResp := tfsdk.ReadDataSourceResponse{
 		State: tfsdk.State{
 			Schema: dataSourceSchema,

--- a/internal/proto6server/serve_test.go
+++ b/internal/proto6server/serve_test.go
@@ -2228,14 +2228,13 @@ func TestServerReadResource(t *testing.T) {
 			}
 			var pmSchema tfsdk.Schema
 			if tc.providerMeta.Type() != nil {
-				sWithMeta := &testServeProviderWithMetaSchema{s}
-				testServer.FrameworkServer.Provider = sWithMeta
-				schema, diags := sWithMeta.GetMetaSchema(context.Background())
+				testServer.FrameworkServer.Provider = &testServeProviderWithMetaSchema{s}
+				schema, diags := testServer.FrameworkServer.ProviderMetaSchema(context.Background())
 				if len(diags) > 0 {
 					t.Errorf("Unexpected diags: %+v", diags)
 					return
 				}
-				pmSchema = schema
+				pmSchema = *schema
 			}
 
 			rt, diags := testServer.FrameworkServer.ResourceType(context.Background(), tc.resource)
@@ -5868,14 +5867,13 @@ func TestServerApplyResourceChange(t *testing.T) {
 			}
 			var pmSchema tfsdk.Schema
 			if tc.providerMeta.Type() != nil {
-				sWithMeta := &testServeProviderWithMetaSchema{s}
-				testServer.FrameworkServer.Provider = sWithMeta
-				schema, diags := sWithMeta.GetMetaSchema(context.Background())
+				testServer.FrameworkServer.Provider = &testServeProviderWithMetaSchema{s}
+				schema, diags := testServer.FrameworkServer.ProviderMetaSchema(context.Background())
 				if len(diags) > 0 {
 					t.Errorf("Unexpected diags: %+v", diags)
 					return
 				}
-				pmSchema = schema
+				pmSchema = *schema
 			}
 
 			rt, diags := testServer.FrameworkServer.ResourceType(context.Background(), tc.resource)
@@ -6396,14 +6394,13 @@ func TestServerReadDataSource(t *testing.T) {
 			}
 			var pmSchema tfsdk.Schema
 			if tc.providerMeta.Type() != nil {
-				sWithMeta := &testServeProviderWithMetaSchema{s}
-				testServer.FrameworkServer.Provider = sWithMeta
-				schema, diags := sWithMeta.GetMetaSchema(context.Background())
+				testServer.FrameworkServer.Provider = &testServeProviderWithMetaSchema{s}
+				schema, diags := testServer.FrameworkServer.ProviderMetaSchema(context.Background())
 				if len(diags) > 0 {
 					t.Errorf("Unexpected diags: %+v", diags)
 					return
 				}
-				pmSchema = schema
+				pmSchema = *schema
 			}
 
 			rt, diags := testServer.FrameworkServer.DataSourceType(context.Background(), tc.dataSource)


### PR DESCRIPTION
This introduces provider meta schema handling, similar to provider schema handling. This will ensure a smoother migration for RPCs that require this information, encapsulate the interface type handling within `internal/fwserver`, and prevent extra executions against the `Provider` `GetMetaSchema()` method.