### PR TITLE
Remove unnecessary conversion to `tftypes` in `AttributePlanModifier`s implementations

### DIFF
--- a/tfsdk/attribute_plan_modification.go
+++ b/tfsdk/attribute_plan_modification.go
@@ -140,15 +140,7 @@ func (r RequiresReplaceModifier) Modify(ctx context.Context, req ModifyAttribute
 		return
 	}
 
-	configRaw, err := req.AttributeConfig.ToTerraformValue(ctx)
-	if err != nil {
-		resp.Diagnostics.AddAttributeError(req.AttributePath,
-			"Error converting config value",
-			fmt.Sprintf("An unexpected error was encountered converting a %s to its equivalent Terraform representation. This is always a bug in the provider.\n\nError: %s", req.AttributeConfig.Type(ctx), err),
-		)
-		return
-	}
-	if configRaw.IsNull() && attrSchema.Computed {
+	if req.AttributeConfig.IsNull() && attrSchema.Computed {
 		// if the config is null and the attribute is computed, this
 		// could be an out of band change, don't require replace
 		return
@@ -280,15 +272,7 @@ func (r RequiresReplaceIfModifier) Modify(ctx context.Context, req ModifyAttribu
 		return
 	}
 
-	configRaw, err := req.AttributeConfig.ToTerraformValue(ctx)
-	if err != nil {
-		resp.Diagnostics.AddAttributeError(req.AttributePath,
-			"Error converting config value",
-			fmt.Sprintf("An unexpected error was encountered converting a %s to its equivalent Terraform representation. This is always a bug in the provider.\n\nError: %s", req.AttributeConfig.Type(ctx), err),
-		)
-		return
-	}
-	if configRaw.IsNull() && attrSchema.Computed {
+	if req.AttributeConfig.IsNull() && attrSchema.Computed {
 		// if the config is null and the attribute is computed, this
 		// could be an out of band change, don't require replace
 		return
@@ -345,47 +329,18 @@ func (r UseStateForUnknownModifier) Modify(ctx context.Context, req ModifyAttrib
 		return
 	}
 
-	val, err := req.AttributeState.ToTerraformValue(ctx)
-	if err != nil {
-		resp.Diagnostics.AddAttributeError(req.AttributePath,
-			"Error converting state value",
-			fmt.Sprintf("An unexpected error was encountered converting a %s to its equivalent Terraform representation. This is always a bug in the provider.\n\nError: %s", req.AttributeState.Type(ctx), err),
-		)
-		return
-	}
-
 	// if we have no state value, there's nothing to preserve
-	if val.IsNull() {
+	if req.AttributeState.IsNull() {
 		return
 	}
 
-	val, err = resp.AttributePlan.ToTerraformValue(ctx)
-	if err != nil {
-		resp.Diagnostics.AddAttributeError(req.AttributePath,
-			"Error converting plan value",
-			fmt.Sprintf("An unexpected error was encountered converting a %s to its equivalent Terraform representation. This is always a bug in the provider.\n\nError: %s", resp.AttributePlan.Type(ctx), err),
-		)
+	// if it's not planned to be the unknown value, stick with the concrete plan
+	if !resp.AttributePlan.IsUnknown() {
 		return
 	}
 
-	// if it's not planned to be the unknown value, stick with
-	// the concrete plan
-	if val.IsKnown() {
-		return
-	}
-
-	val, err = req.AttributeConfig.ToTerraformValue(ctx)
-	if err != nil {
-		resp.Diagnostics.AddAttributeError(req.AttributePath,
-			"Error converting config value",
-			fmt.Sprintf("An unexpected error was encountered converting a %s to its equivalent Terraform representation. This is always a bug in the provider.\n\nError: %s", req.AttributeConfig.Type(ctx), err),
-		)
-		return
-	}
-
-	// if the config is the unknown value, use the unknown value
-	// otherwise, interpolation gets messed up
-	if !val.IsKnown() {
+	// if the config is the unknown value, use the unknown value otherwise, interpolation gets messed up
+	if req.AttributeConfig.IsUnknown() {
 		return
 	}
 


### PR DESCRIPTION
Small follow up from #335 