### PR TITLE
.github/workflows: Remove obsolete golangci-lint-action input

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -4,7 +4,7 @@ name: ci-go
 on:
   pull_request:
     paths:
-      - .github/workflows/test.yml
+      - .github/workflows/ci-go.yml
       - .golangci.yml
       - .go-version
       - go.mod
@@ -26,8 +26,6 @@ jobs:
           go-version: ${{ steps.go-version.outputs.version }}
       - run: go mod download
       - uses: golangci/golangci-lint-action@v3.2.0
-        with:
-          skip-go-installation: true
   terraform-provider-corner:
     defaults:
       run:


### PR DESCRIPTION
Reference: https://github.com/golangci/golangci-lint-action/releases/tag/v3.0.0

Removes this warning on invocation:

```
Warning: Unexpected input(s) 'skip-go-installation', valid inputs are ['version', 'args', 'working-directory', 'github-token', 'only-new-issues', 'skip-cache', 'skip-pkg-cache', 'skip-build-cache']
```