### PR TITLE
Prevent `ToTerraformValue` panic when the underlying `attr.Value` types doesn't have type information for its fields

### DIFF
--- a/.changelog/354.txt
+++ b/.changelog/354.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+types: Prevented panic being thrown when `.ToTerraformValue` is called on an `attr.Value` type where `ElemType / AttrsType` were not set.
+```

--- a/types/list.go
+++ b/types/list.go
@@ -163,7 +163,7 @@ func (l List) Type(ctx context.Context) attr.Type {
 // a tftypes.Value.
 func (l List) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
 	if l.ElemType == nil {
-		return tftypes.Value{}, fmt.Errorf("cannot convert List to Terraform Value if ElemType field is null")
+		return tftypes.Value{}, fmt.Errorf("cannot convert List to tftypes.Value if ElemType field is not set")
 	}
 	listType := tftypes.List{ElementType: l.ElemType.TerraformType(ctx)}
 	if l.Unknown {

--- a/types/list.go
+++ b/types/list.go
@@ -162,6 +162,9 @@ func (l List) Type(ctx context.Context) attr.Type {
 // ToTerraformValue returns the data contained in the AttributeValue as
 // a tftypes.Value.
 func (l List) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	if l.ElemType == nil {
+		return tftypes.Value{}, fmt.Errorf("cannot convert List to Terraform Value if ElemType field is null")
+	}
 	listType := tftypes.List{ElementType: l.ElemType.TerraformType(ctx)}
 	if l.Unknown {
 		return tftypes.NewValue(listType, tftypes.UnknownValue), nil

--- a/types/list_test.go
+++ b/types/list_test.go
@@ -369,7 +369,7 @@ func TestListToTerraformValue(t *testing.T) {
 					String{Value: "hello, world"},
 				},
 			},
-			expectedErr: "cannot convert List to Terraform Value if ElemType field is null",
+			expectedErr: "cannot convert List to tftypes.Value if ElemType field is not set",
 			expectation: tftypes.Value{},
 		},
 	}
@@ -379,16 +379,24 @@ func TestListToTerraformValue(t *testing.T) {
 			t.Parallel()
 
 			got, gotErr := test.input.ToTerraformValue(context.Background())
-			if gotErr != nil {
-				if test.expectedErr == "" {
-					t.Errorf("Unexpected error: %s", gotErr)
+
+			if test.expectedErr == "" && gotErr != nil {
+				t.Errorf("Unexpected error: %s", gotErr)
+				return
+			}
+
+			if test.expectedErr != "" {
+				if gotErr == nil {
+					t.Errorf("Expected error to be %q, got none", test.expectedErr)
 					return
 				}
-				if gotErr.Error() != test.expectedErr {
+
+				if test.expectedErr != gotErr.Error() {
 					t.Errorf("Expected error to be %q, got %q", test.expectedErr, gotErr.Error())
 					return
 				}
 			}
+
 			if diff := cmp.Diff(got, test.expectation); diff != "" {
 				t.Errorf("Unexpected result (+got, -expected): %s", diff)
 			}

--- a/types/map.go
+++ b/types/map.go
@@ -167,7 +167,7 @@ func (m Map) Type(ctx context.Context) attr.Type {
 // tftypes.Value.
 func (m Map) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
 	if m.ElemType == nil {
-		return tftypes.Value{}, fmt.Errorf("cannot convert Map to Terraform Value if ElemType field is null")
+		return tftypes.Value{}, fmt.Errorf("cannot convert Map to tftypes.Value if ElemType field is not set")
 	}
 	mapType := tftypes.Map{ElementType: m.ElemType.TerraformType(ctx)}
 	if m.Unknown {

--- a/types/map.go
+++ b/types/map.go
@@ -166,6 +166,9 @@ func (m Map) Type(ctx context.Context) attr.Type {
 // ToTerraformValue returns the data contained in the AttributeValue as a
 // tftypes.Value.
 func (m Map) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	if m.ElemType == nil {
+		return tftypes.Value{}, fmt.Errorf("cannot convert Map to Terraform Value if ElemType field is null")
+	}
 	mapType := tftypes.Map{ElementType: m.ElemType.TerraformType(ctx)}
 	if m.Unknown {
 		return tftypes.NewValue(mapType, tftypes.UnknownValue), nil

--- a/types/map_test.go
+++ b/types/map_test.go
@@ -351,7 +351,7 @@ func TestMapToTerraformValue(t *testing.T) {
 					"hw": String{Value: "hello, world"},
 				},
 			},
-			expectedErr: "cannot convert Map to Terraform Value if ElemType field is null",
+			expectedErr: "cannot convert Map to tftypes.Value if ElemType field is not set",
 			expectation: tftypes.Value{},
 		},
 	}
@@ -361,16 +361,24 @@ func TestMapToTerraformValue(t *testing.T) {
 			t.Parallel()
 
 			got, gotErr := test.input.ToTerraformValue(context.Background())
-			if gotErr != nil {
-				if test.expectedErr == "" {
-					t.Errorf("Unexpected error: %s", gotErr)
+
+			if test.expectedErr == "" && gotErr != nil {
+				t.Errorf("Unexpected error: %s", gotErr)
+				return
+			}
+
+			if test.expectedErr != "" {
+				if gotErr == nil {
+					t.Errorf("Expected error to be %q, got none", test.expectedErr)
 					return
 				}
-				if gotErr.Error() != test.expectedErr {
+
+				if test.expectedErr != gotErr.Error() {
 					t.Errorf("Expected error to be %q, got %q", test.expectedErr, gotErr.Error())
 					return
 				}
 			}
+
 			if diff := cmp.Diff(got, test.expectation); diff != "" {
 				t.Errorf("Unexpected result (+got, -expected): %s", diff)
 			}

--- a/types/object.go
+++ b/types/object.go
@@ -208,6 +208,9 @@ func (o Object) Type(_ context.Context) attr.Type {
 // ToTerraformValue returns the data contained in the AttributeValue as
 // a tftypes.Value.
 func (o Object) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	if o.AttrTypes == nil {
+		return tftypes.Value{}, fmt.Errorf("cannot convert Object to Terraform Value if AttrTypes field is null")
+	}
 	attrTypes := map[string]tftypes.Type{}
 	for attr, typ := range o.AttrTypes {
 		attrTypes[attr] = typ.TerraformType(ctx)

--- a/types/object.go
+++ b/types/object.go
@@ -209,7 +209,7 @@ func (o Object) Type(_ context.Context) attr.Type {
 // a tftypes.Value.
 func (o Object) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
 	if o.AttrTypes == nil {
-		return tftypes.Value{}, fmt.Errorf("cannot convert Object to Terraform Value if AttrTypes field is null")
+		return tftypes.Value{}, fmt.Errorf("cannot convert Object to tftypes.Value if AttrTypes field is not set")
 	}
 	attrTypes := map[string]tftypes.Type{}
 	for attr, typ := range o.AttrTypes {

--- a/types/object_test.go
+++ b/types/object_test.go
@@ -1105,7 +1105,7 @@ func TestObjectToTerraformValue(t *testing.T) {
 				},
 			},
 			expected:    tftypes.Value{},
-			expectedErr: "cannot convert Object to Terraform Value if AttrTypes field is null",
+			expectedErr: "cannot convert Object to tftypes.Value if AttrTypes field is not set",
 		},
 	}
 
@@ -1114,22 +1114,25 @@ func TestObjectToTerraformValue(t *testing.T) {
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			got, err := test.receiver.ToTerraformValue(context.Background())
-			if err != nil {
-				if test.expectedErr == "" {
-					t.Errorf("unexpected error: %s", err)
-					return
-				}
-				if test.expectedErr != err.Error() {
-					t.Errorf("expected error to be %q, got %q", test.expectedErr, err.Error())
-					return
-				}
+			got, gotErr := test.receiver.ToTerraformValue(context.Background())
+
+			if test.expectedErr == "" && gotErr != nil {
+				t.Errorf("Unexpected error: %s", gotErr)
 				return
 			}
-			if err == nil && test.expectedErr != "" {
-				t.Errorf("expected error to be %q, got nil", test.expectedErr)
-				return
+
+			if test.expectedErr != "" {
+				if gotErr == nil {
+					t.Errorf("Expected error to be %q, got none", test.expectedErr)
+					return
+				}
+
+				if test.expectedErr != gotErr.Error() {
+					t.Errorf("Expected error to be %q, got %q", test.expectedErr, gotErr.Error())
+					return
+				}
 			}
+
 			if diff := cmp.Diff(test.expected, got); diff != "" {
 				t.Errorf("Unexpected diff (+wanted, -got): %s", diff)
 			}

--- a/types/object_test.go
+++ b/types/object_test.go
@@ -1074,6 +1074,39 @@ func TestObjectToTerraformValue(t *testing.T) {
 				}),
 			}),
 		},
+		"no-attr-types": {
+			receiver: Object{
+				Attrs: map[string]attr.Value{
+					"a": List{
+						ElemType: StringType,
+						Elems: []attr.Value{
+							String{Value: "hello"},
+							String{Value: "world"},
+						},
+					},
+					"b": String{Value: "woohoo"},
+					"c": Bool{Value: true},
+					"d": Number{Value: big.NewFloat(1234)},
+					"e": Object{
+						AttrTypes: map[string]attr.Type{
+							"name": StringType,
+						},
+						Attrs: map[string]attr.Value{
+							"name": String{Value: "testing123"},
+						},
+					},
+					"f": Set{
+						ElemType: StringType,
+						Elems: []attr.Value{
+							String{Value: "hello"},
+							String{Value: "world"},
+						},
+					},
+				},
+			},
+			expected:    tftypes.Value{},
+			expectedErr: "cannot convert Object to Terraform Value if AttrTypes field is null",
+		},
 	}
 
 	for name, test := range tests {

--- a/types/set.go
+++ b/types/set.go
@@ -224,7 +224,7 @@ func (s Set) Type(ctx context.Context) attr.Type {
 // a tftypes.Value.
 func (s Set) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
 	if s.ElemType == nil {
-		return tftypes.Value{}, fmt.Errorf("cannot convert Set to Terraform Value if ElemType field is null")
+		return tftypes.Value{}, fmt.Errorf("cannot convert Set to tftypes.Value if ElemType field is not set")
 	}
 	setType := tftypes.Set{ElementType: s.ElemType.TerraformType(ctx)}
 	if s.Unknown {

--- a/types/set.go
+++ b/types/set.go
@@ -223,6 +223,9 @@ func (s Set) Type(ctx context.Context) attr.Type {
 // ToTerraformValue returns the data contained in the AttributeValue as
 // a tftypes.Value.
 func (s Set) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	if s.ElemType == nil {
+		return tftypes.Value{}, fmt.Errorf("cannot convert Set to Terraform Value if ElemType field is null")
+	}
 	setType := tftypes.Set{ElementType: s.ElemType.TerraformType(ctx)}
 	if s.Unknown {
 		return tftypes.NewValue(setType, tftypes.UnknownValue), nil

--- a/types/set_test.go
+++ b/types/set_test.go
@@ -633,7 +633,7 @@ func TestSetToTerraformValue(t *testing.T) {
 				},
 			},
 			expectation: tftypes.Value{},
-			expectedErr: "cannot convert Set to Terraform Value if ElemType field is null",
+			expectedErr: "cannot convert Set to tftypes.Value if ElemType field is not set",
 		},
 	}
 	for name, test := range tests {
@@ -642,16 +642,24 @@ func TestSetToTerraformValue(t *testing.T) {
 			t.Parallel()
 
 			got, gotErr := test.input.ToTerraformValue(context.Background())
-			if gotErr != nil {
-				if test.expectedErr == "" {
-					t.Errorf("Unexpected error: %s", gotErr)
+
+			if test.expectedErr == "" && gotErr != nil {
+				t.Errorf("Unexpected error: %s", gotErr)
+				return
+			}
+
+			if test.expectedErr != "" {
+				if gotErr == nil {
+					t.Errorf("Expected error to be %q, got none", test.expectedErr)
 					return
 				}
-				if gotErr.Error() != test.expectedErr {
+
+				if test.expectedErr != gotErr.Error() {
 					t.Errorf("Expected error to be %q, got %q", test.expectedErr, gotErr.Error())
 					return
 				}
 			}
+
 			if diff := cmp.Diff(got, test.expectation); diff != "" {
 				t.Errorf("Unexpected result (+got, -expected): %s", diff)
 			}

--- a/types/set_test.go
+++ b/types/set_test.go
@@ -560,6 +560,7 @@ func TestSetToTerraformValue(t *testing.T) {
 	type testCase struct {
 		input       Set
 		expectation tftypes.Value
+		expectedErr string
 	}
 	tests := map[string]testCase{
 		"value": {
@@ -624,16 +625,32 @@ func TestSetToTerraformValue(t *testing.T) {
 				tftypes.NewValue(tftypes.String, "hello, world"),
 			}),
 		},
+		"no-elem-type": {
+			input: Set{
+				Elems: []attr.Value{
+					String{Value: "hello"},
+					String{Value: "world"},
+				},
+			},
+			expectation: tftypes.Value{},
+			expectedErr: "cannot convert Set to Terraform Value if ElemType field is null",
+		},
 	}
 	for name, test := range tests {
 		name, test := name, test
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := test.input.ToTerraformValue(context.Background())
-			if err != nil {
-				t.Errorf("Unexpected error: %s", err)
-				return
+			got, gotErr := test.input.ToTerraformValue(context.Background())
+			if gotErr != nil {
+				if test.expectedErr == "" {
+					t.Errorf("Unexpected error: %s", gotErr)
+					return
+				}
+				if gotErr.Error() != test.expectedErr {
+					t.Errorf("Expected error to be %q, got %q", test.expectedErr, gotErr.Error())
+					return
+				}
 			}
 			if diff := cmp.Diff(got, test.expectation); diff != "" {
 				t.Errorf("Unexpected result (+got, -expected): %s", diff)


### PR DESCRIPTION
`ToTerraformValue` in all the non _primitive_ types of `attr.Value`, relies on it containing `ElemType` or `AttrsType` to do the conversion to TF types.

But if by mistake one omits setting that, the framework was throwing a panic as it wasn't checking for those fields being not null. Now it does.