### PR TITLE
.github/workflows: Use new setup-go go-version-file input

### DIFF
--- a/.github/workflows/ci-github-actions.yml
+++ b/.github/workflows/ci-github-actions.yml
@@ -14,11 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - id: go-version
-        # Reference: https://github.com/actions/setup-go/issues/23
-        run: echo "::set-output name=version::$(cat ./.go-version)"
       - uses: actions/setup-go@v3
         with:
-          go-version: ${{ steps.go-version.outputs.version }}
+          go-version-file: 'go.mod'
       - run: go install github.com/rhysd/actionlint/cmd/actionlint@latest
       - run: actionlint

--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -6,7 +6,6 @@ on:
     paths:
       - .github/workflows/ci-go.yml
       - .golangci.yml
-      - .go-version
       - go.mod
       - '**.go'
 
@@ -18,12 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - id: go-version
-        # Reference: https://github.com/actions/setup-go/issues/23
-        run: echo "::set-output name=version::$(cat ./.go-version)"
       - uses: actions/setup-go@v3
         with:
-          go-version: ${{ steps.go-version.outputs.version }}
+          go-version-file: 'go.mod'
       - run: go mod download
       - uses: golangci/golangci-lint-action@v3.2.0
   terraform-provider-corner:
@@ -37,13 +33,9 @@ jobs:
         with:
           path: terraform-provider-corner
           repository: hashicorp/terraform-provider-corner
-      - id: go-version
-        # Reference: https://github.com/actions/setup-go/issues/23
-        run: echo "::set-output name=version::$(cat ./.go-version)"
-        working-directory: .
       - uses: actions/setup-go@v3
         with:
-          go-version: ${{ steps.go-version.outputs.version }}
+          go-version-file: 'go.mod'
       - run: go mod edit -replace=github.com/hashicorp/terraform-plugin-framework=../
       - run: go mod tidy
       - run: go test -v ./internal/frameworkprovider

--- a/.github/workflows/ci-goreleaser.yml
+++ b/.github/workflows/ci-goreleaser.yml
@@ -14,12 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - id: go-version
-        # Reference: https://github.com/actions/setup-go/issues/23
-        run: echo "::set-output name=version::$(cat ./.go-version)"
       - uses: actions/setup-go@v3
         with:
-          go-version: ${{ steps.go-version.outputs.version }}
+          go-version-file: 'go.mod'
       - uses: goreleaser/goreleaser-action@v3
         with:
           args: check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,12 +19,9 @@ jobs:
         with:
           # Required for release notes
           fetch-depth: 0
-      - id: go-version
-        # Reference: https://github.com/actions/setup-go/issues/23
-        run: echo "::set-output name=version::$(cat ./.go-version)"
       - uses: actions/setup-go@v3
         with:
-          go-version: ${{ steps.go-version.outputs.version }}
+          go-version-file: 'go.mod'
       - name: Generate Release Notes
         # Fetch CHANGELOG.md contents up to Git tag prior to this release, skipping top two lines
         run: sed -n -e "1{/# /d;}" -e "2{/^$/d;}" -e "/# $(git describe --abbrev=0 --exclude="$(git describe --abbrev=0 --match='v*.*.*' --tags)" --match='v*.*.*' --tags | tr -d v)/q;p" CHANGELOG.md > /tmp/release-notes.txt


### PR DESCRIPTION
Reference: https://github.com/actions/setup-go/releases/tag/v3.1.0