### PR TITLE
diag: Move tfprotov6.DiagnosticSeverity conversion to internal/toproto6

### DIFF
--- a/diag/severity.go
+++ b/diag/severity.go
@@ -1,7 +1,5 @@
 package diag
 
-import "github.com/hashicorp/terraform-plugin-go/tfprotov6"
-
 // Severity represents the level of feedback for a diagnostic.
 //
 // Each severity implies behavior changes for the feedback and potentially the
@@ -36,20 +34,5 @@ func (s Severity) String() string {
 		return "Warning"
 	default:
 		return "Invalid"
-	}
-}
-
-// ToTfprotov6DiagnosticSeverity converts the severity into the tfprotov6 type.
-//
-// Usage of this method outside the framework is not supported nor considered
-// for backwards compatibility promises.
-func (s Severity) ToTfprotov6DiagnosticSeverity() tfprotov6.DiagnosticSeverity {
-	switch s {
-	case SeverityError:
-		return tfprotov6.DiagnosticSeverityError
-	case SeverityWarning:
-		return tfprotov6.DiagnosticSeverityWarning
-	default:
-		return tfprotov6.DiagnosticSeverityInvalid
 	}
 }

--- a/internal/toproto6/diagnostics.go
+++ b/internal/toproto6/diagnostics.go
@@ -5,6 +5,18 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 )
 
+// DiagnosticSeverity converts diag.Severity into tfprotov6.DiagnosticSeverity.
+func DiagnosticSeverity(s diag.Severity) tfprotov6.DiagnosticSeverity {
+	switch s {
+	case diag.SeverityError:
+		return tfprotov6.DiagnosticSeverityError
+	case diag.SeverityWarning:
+		return tfprotov6.DiagnosticSeverityWarning
+	default:
+		return tfprotov6.DiagnosticSeverityInvalid
+	}
+}
+
 // Diagnostics converts the diagnostics into the tfprotov6 collection type.
 func Diagnostics(diagnostics diag.Diagnostics) []*tfprotov6.Diagnostic {
 	var results []*tfprotov6.Diagnostic
@@ -12,7 +24,7 @@ func Diagnostics(diagnostics diag.Diagnostics) []*tfprotov6.Diagnostic {
 	for _, diagnostic := range diagnostics {
 		tfprotov6Diagnostic := &tfprotov6.Diagnostic{
 			Detail:   diagnostic.Detail(),
-			Severity: diagnostic.Severity().ToTfprotov6DiagnosticSeverity(),
+			Severity: DiagnosticSeverity(diagnostic.Severity()),
 			Summary:  diagnostic.Summary(),
 		}
 

--- a/internal/toproto6/diagnostics_test.go
+++ b/internal/toproto6/diagnostics_test.go
@@ -10,6 +10,42 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
+func TestDiagnosticSeverity(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		severity diag.Severity
+		expected tfprotov6.DiagnosticSeverity
+	}{
+		"error": {
+			severity: diag.SeverityError,
+			expected: tfprotov6.DiagnosticSeverityError,
+		},
+		"invalid": {
+			severity: diag.SeverityInvalid,
+			expected: tfprotov6.DiagnosticSeverityInvalid,
+		},
+		"warning": {
+			severity: diag.SeverityWarning,
+			expected: tfprotov6.DiagnosticSeverityWarning,
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := toproto6.DiagnosticSeverity(testCase.severity)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
 func TestDiagnostics(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Technical debt cleanup now that the `internal/toproto6` package exists. No CHANGELOG entry necessary as this was not intended for provider developer usage.
