### PR TITLE
Add `.String()` method to `attr.Value` interface

### DIFF
--- a/.changelog/376.txt
+++ b/.changelog/376.txt
@@ -1,0 +1,7 @@
+```release-note:breaking-change
+attr: The `Value` interface now includes the `String()` method
+```
+
+```release-note:enhancement
+types: Added `String()` method to all types
+```

--- a/attr/value.go
+++ b/attr/value.go
@@ -7,11 +7,13 @@ import (
 )
 
 const (
-	// UnknownString should be returned by Value.String() implementations, when Value.IsUnknown() returns true.
-	UnknownString = "<unknown>"
+	// UnknownValueString should be returned by Value.String() implementations,
+	// when Value.IsUnknown() returns true.
+	UnknownValueString = "<unknown>"
 
-	// NullString should be returned by Value.String() implementations, when Value.IsNull() returns true.
-	NullString = "<null>"
+	// NullValueString should be returned by Value.String() implementations
+	// when Value.IsNull() returns true.
+	NullValueString = "<null>"
 )
 
 // Value defines an interface for describing data associated with an attribute.
@@ -36,10 +38,11 @@ type Value interface {
 	IsUnknown() bool
 
 	// String returns a summary representation of either the underlying Value,
-	// or UnknownString (`<unknown>`) when IsUnknown() returns true,
-	// or NullString (`<null>`) when IsNull() return true.
+	// or UnknownValueString (`<unknown>`) when IsUnknown() returns true,
+	// or NullValueString (`<null>`) when IsNull() return true.
 	//
-	// This is an intentionally lossy representation, that it's best used for
-	// logging and error reporting.
+	// This is an intentionally lossy representation, that are best suited for
+	// logging and error reporting, as they are not protected by
+	// compatibility guarantees within the framework.
 	String() string
 }

--- a/attr/value.go
+++ b/attr/value.go
@@ -6,6 +6,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
+const (
+	// UnknownString should be returned by Value.String() implementations, when Value.IsUnknown() returns true.
+	UnknownString = "<unknown>"
+
+	// NullString should be returned by Value.String() implementations, when Value.IsNull() returns true.
+	NullString = "<null>"
+)
+
 // Value defines an interface for describing data associated with an attribute.
 // Values allow provider developers to specify data in a convenient format, and
 // have it transparently be converted to formats Terraform understands.
@@ -26,4 +34,12 @@ type Value interface {
 
 	// IsUnknown returns true if the value is not yet known.
 	IsUnknown() bool
+
+	// String returns a summary representation of either the underlying Value,
+	// or UnknownString (`<unknown>`) when IsUnknown() returns true,
+	// or NullString (`<null>`) when IsNull() return true.
+	//
+	// This is an intentionally lossy representation, that it's best used for
+	// logging and error reporting.
+	String() string
 }

--- a/internal/reflect/pointer_test.go
+++ b/internal/reflect/pointer_test.go
@@ -117,7 +117,7 @@ func TestFromPointer(t *testing.T) {
 			typ: testtypes.StringTypeWithValidateWarning{},
 			val: reflect.ValueOf(strPtr("hello, world")),
 			expected: testtypes.String{
-				String: types.String{
+				InternalString: types.String{
 					Value: "hello, world",
 				},
 				CreatedBy: testtypes.StringTypeWithValidateWarning{},

--- a/internal/reflect/primitive_test.go
+++ b/internal/reflect/primitive_test.go
@@ -96,7 +96,7 @@ func TestFromString(t *testing.T) {
 			val: "mystring",
 			typ: testtypes.StringTypeWithValidateWarning{},
 			expected: testtypes.String{
-				String: types.String{
+				InternalString: types.String{
 					Value: "mystring",
 				},
 				CreatedBy: testtypes.StringTypeWithValidateWarning{},

--- a/internal/testing/types/bool.go
+++ b/internal/testing/types/bool.go
@@ -87,11 +87,11 @@ func (b Bool) IsUnknown() bool {
 
 func (b Bool) String() string {
 	if b.Bool.IsUnknown() {
-		return attr.UnknownString
+		return attr.UnknownValueString
 	}
 
 	if b.Bool.IsNull() {
-		return attr.NullString
+		return attr.NullValueString
 	}
 
 	return fmt.Sprintf("%t", b.Value)

--- a/internal/testing/types/bool.go
+++ b/internal/testing/types/bool.go
@@ -84,3 +84,15 @@ func (b Bool) IsNull() bool {
 func (b Bool) IsUnknown() bool {
 	return b.Bool.IsUnknown()
 }
+
+func (b Bool) String() string {
+	if b.Bool.IsUnknown() {
+		return attr.UnknownString
+	}
+
+	if b.Bool.IsNull() {
+		return attr.NullString
+	}
+
+	return fmt.Sprintf("%t", b.Value)
+}

--- a/internal/testing/types/string.go
+++ b/internal/testing/types/string.go
@@ -41,14 +41,14 @@ func (t StringType) TerraformType(_ context.Context) tftypes.Type {
 func (t StringType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
 	if !in.IsKnown() {
 		return String{
-			String:    types.String{Unknown: true},
-			CreatedBy: t,
+			InternalString: types.String{Unknown: true},
+			CreatedBy:      t,
 		}, nil
 	}
 	if in.IsNull() {
 		return String{
-			String:    types.String{Null: true},
-			CreatedBy: t,
+			InternalString: types.String{Null: true},
+			CreatedBy:      t,
 		}, nil
 	}
 	var s string
@@ -57,15 +57,19 @@ func (t StringType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (a
 		return nil, err
 	}
 	return String{
-		String:    types.String{Value: s},
-		CreatedBy: t,
+		InternalString: types.String{Value: s},
+		CreatedBy:      t,
 	}, nil
 }
 
 type String struct {
-	types.String
+	InternalString types.String
 
 	CreatedBy attr.Type
+}
+
+func (s String) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	return s.InternalString.ToTerraformValue(ctx)
 }
 
 func (s String) Type(_ context.Context) attr.Type {
@@ -77,13 +81,17 @@ func (s String) Equal(o attr.Value) bool {
 	if !ok {
 		return false
 	}
-	return s.String.Equal(os.String)
+	return s.InternalString.Equal(os.InternalString)
 }
 
 func (s String) IsNull() bool {
-	return s.String.IsNull()
+	return s.InternalString.IsNull()
 }
 
 func (s String) IsUnknown() bool {
-	return s.String.IsUnknown()
+	return s.InternalString.IsUnknown()
+}
+
+func (s String) String() string {
+	return s.InternalString.String()
 }

--- a/tfsdk/config_test.go
+++ b/tfsdk/config_test.go
@@ -106,7 +106,7 @@ func TestConfigGet_testTypes(t *testing.T) {
 				},
 			},
 			expected: testConfigGetData{
-				Name: testtypes.String{String: types.String{Value: ""}, CreatedBy: testtypes.StringTypeWithValidateError{}},
+				Name: testtypes.String{InternalString: types.String{Value: ""}, CreatedBy: testtypes.StringTypeWithValidateError{}},
 			},
 			expectedDiags: diag.Diagnostics{testtypes.TestErrorDiagnostic(tftypes.NewAttributePath().WithAttributeName("name"))},
 		},
@@ -129,7 +129,7 @@ func TestConfigGet_testTypes(t *testing.T) {
 				},
 			},
 			expected: testConfigGetData{
-				Name: testtypes.String{String: types.String{Value: "namevalue"}, CreatedBy: testtypes.StringTypeWithValidateWarning{}},
+				Name: testtypes.String{InternalString: types.String{Value: "namevalue"}, CreatedBy: testtypes.StringTypeWithValidateWarning{}},
 			},
 			expectedDiags: diag.Diagnostics{testtypes.TestWarningDiagnostic(tftypes.NewAttributePath().WithAttributeName("name"))},
 		},
@@ -332,7 +332,7 @@ func TestConfigGetAttribute(t *testing.T) {
 				},
 			},
 			target:        new(testtypes.String),
-			expected:      &testtypes.String{String: types.String{Value: "namevalue"}, CreatedBy: testtypes.StringTypeWithValidateWarning{}},
+			expected:      &testtypes.String{InternalString: types.String{Value: "namevalue"}, CreatedBy: testtypes.StringTypeWithValidateWarning{}},
 			expectedDiags: diag.Diagnostics{testtypes.TestWarningDiagnostic(tftypes.NewAttributePath().WithAttributeName("name"))},
 		},
 	}
@@ -1708,7 +1708,7 @@ func TestConfigGetAttributeValue(t *testing.T) {
 				},
 			},
 			path:          tftypes.NewAttributePath().WithAttributeName("test"),
-			expected:      testtypes.String{String: types.String{Value: "value"}, CreatedBy: testtypes.StringTypeWithValidateWarning{}},
+			expected:      testtypes.String{InternalString: types.String{Value: "value"}, CreatedBy: testtypes.StringTypeWithValidateWarning{}},
 			expectedDiags: diag.Diagnostics{testtypes.TestWarningDiagnostic(tftypes.NewAttributePath().WithAttributeName("test"))},
 		},
 	}

--- a/tfsdk/convert_test.go
+++ b/tfsdk/convert_test.go
@@ -26,14 +26,14 @@ func TestConvert(t *testing.T) {
 			val: types.String{Value: "hello"},
 			typ: testtypes.StringType{},
 			expected: testtypes.String{
-				String:    types.String{Value: "hello"},
-				CreatedBy: testtypes.StringType{},
+				InternalString: types.String{Value: "hello"},
+				CreatedBy:      testtypes.StringType{},
 			},
 		},
 		"testtype-string-to-string": {
 			val: testtypes.String{
-				String:    types.String{Value: "hello"},
-				CreatedBy: testtypes.StringType{},
+				InternalString: types.String{Value: "hello"},
+				CreatedBy:      testtypes.StringType{},
 			},
 			typ:      types.StringType,
 			expected: types.String{Value: "hello"},

--- a/tfsdk/plan_test.go
+++ b/tfsdk/plan_test.go
@@ -106,7 +106,7 @@ func TestPlanGet_testTypes(t *testing.T) {
 				},
 			},
 			expected: testPlanGetDataTestTypes{
-				Name: testtypes.String{String: types.String{Value: ""}, CreatedBy: testtypes.StringTypeWithValidateError{}},
+				Name: testtypes.String{InternalString: types.String{Value: ""}, CreatedBy: testtypes.StringTypeWithValidateError{}},
 			},
 			expectedDiags: diag.Diagnostics{testtypes.TestErrorDiagnostic(tftypes.NewAttributePath().WithAttributeName("name"))},
 		},
@@ -129,7 +129,7 @@ func TestPlanGet_testTypes(t *testing.T) {
 				},
 			},
 			expected: testPlanGetDataTestTypes{
-				Name: testtypes.String{String: types.String{Value: "namevalue"}, CreatedBy: testtypes.StringTypeWithValidateWarning{}},
+				Name: testtypes.String{InternalString: types.String{Value: "namevalue"}, CreatedBy: testtypes.StringTypeWithValidateWarning{}},
 			},
 			expectedDiags: diag.Diagnostics{testtypes.TestWarningDiagnostic(tftypes.NewAttributePath().WithAttributeName("name"))},
 		},
@@ -332,7 +332,7 @@ func TestPlanGetAttribute(t *testing.T) {
 				},
 			},
 			target:        new(testtypes.String),
-			expected:      &testtypes.String{String: types.String{Value: "namevalue"}, CreatedBy: testtypes.StringTypeWithValidateWarning{}},
+			expected:      &testtypes.String{InternalString: types.String{Value: "namevalue"}, CreatedBy: testtypes.StringTypeWithValidateWarning{}},
 			expectedDiags: diag.Diagnostics{testtypes.TestWarningDiagnostic(tftypes.NewAttributePath().WithAttributeName("name"))},
 		},
 	}
@@ -1708,7 +1708,7 @@ func TestPlanGetAttributeValue(t *testing.T) {
 				},
 			},
 			path:          tftypes.NewAttributePath().WithAttributeName("test"),
-			expected:      testtypes.String{String: types.String{Value: "value"}, CreatedBy: testtypes.StringTypeWithValidateWarning{}},
+			expected:      testtypes.String{InternalString: types.String{Value: "value"}, CreatedBy: testtypes.StringTypeWithValidateWarning{}},
 			expectedDiags: diag.Diagnostics{testtypes.TestWarningDiagnostic(tftypes.NewAttributePath().WithAttributeName("test"))},
 		},
 	}

--- a/tfsdk/state_test.go
+++ b/tfsdk/state_test.go
@@ -551,7 +551,7 @@ func TestStateGet_testTypes(t *testing.T) {
 				},
 			},
 			expected: testStateGetDataTestTypes{
-				Name:        testtypes.String{String: types.String{Value: ""}, CreatedBy: testtypes.StringTypeWithValidateError{}},
+				Name:        testtypes.String{InternalString: types.String{Value: ""}, CreatedBy: testtypes.StringTypeWithValidateError{}},
 				MachineType: "",
 				Tags:        types.List{},
 				TagsSet:     types.Set{},
@@ -768,7 +768,7 @@ func TestStateGet_testTypes(t *testing.T) {
 				},
 			},
 			expected: testStateGetDataTestTypes{
-				Name:        testtypes.String{String: types.String{Value: "namevalue"}, CreatedBy: testtypes.StringTypeWithValidateWarning{}},
+				Name:        testtypes.String{InternalString: types.String{Value: "namevalue"}, CreatedBy: testtypes.StringTypeWithValidateWarning{}},
 				MachineType: "e2-medium",
 				Tags: types.List{
 					ElemType: types.StringType,
@@ -1029,7 +1029,7 @@ func TestStateGetAttribute(t *testing.T) {
 				},
 			},
 			target:        new(testtypes.String),
-			expected:      &testtypes.String{String: types.String{Value: "namevalue"}, CreatedBy: testtypes.StringTypeWithValidateWarning{}},
+			expected:      &testtypes.String{InternalString: types.String{Value: "namevalue"}, CreatedBy: testtypes.StringTypeWithValidateWarning{}},
 			expectedDiags: diag.Diagnostics{testtypes.TestWarningDiagnostic(tftypes.NewAttributePath().WithAttributeName("name"))},
 		},
 	}
@@ -2405,7 +2405,7 @@ func TestStateGetAttributeValue(t *testing.T) {
 				},
 			},
 			path:          tftypes.NewAttributePath().WithAttributeName("test"),
-			expected:      testtypes.String{String: types.String{Value: "value"}, CreatedBy: testtypes.StringTypeWithValidateWarning{}},
+			expected:      testtypes.String{InternalString: types.String{Value: "value"}, CreatedBy: testtypes.StringTypeWithValidateWarning{}},
 			expectedDiags: diag.Diagnostics{testtypes.TestWarningDiagnostic(tftypes.NewAttributePath().WithAttributeName("test"))},
 		},
 	}

--- a/types/bool.go
+++ b/types/bool.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
@@ -84,4 +85,16 @@ func (b Bool) IsNull() bool {
 
 func (b Bool) IsUnknown() bool {
 	return b.Unknown
+}
+
+func (b Bool) String() string {
+	if b.Unknown {
+		return attr.UnknownString
+	}
+
+	if b.Null {
+		return attr.NullString
+	}
+
+	return fmt.Sprintf("%t", b.Value)
 }

--- a/types/bool.go
+++ b/types/bool.go
@@ -89,11 +89,11 @@ func (b Bool) IsUnknown() bool {
 
 func (b Bool) String() string {
 	if b.Unknown {
-		return attr.UnknownString
+		return attr.UnknownValueString
 	}
 
 	if b.Null {
-		return attr.NullString
+		return attr.NullValueString
 	}
 
 	return fmt.Sprintf("%t", b.Value)

--- a/types/bool_test.go
+++ b/types/bool_test.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -265,6 +266,49 @@ func TestBoolEqual(t *testing.T) {
 			got := test.input.Equal(test.candidate)
 			if !cmp.Equal(got, test.expectation) {
 				t.Errorf("Expected %v, got %v", test.expectation, got)
+			}
+		})
+	}
+}
+
+func TestBoolString(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		input       Bool
+		expectation string
+	}
+	tests := map[string]testCase{
+		"true": {
+			input:       Bool{Value: true},
+			expectation: "true",
+		},
+		"false": {
+			input:       Bool{Value: false},
+			expectation: "false",
+		},
+		"unknown": {
+			input:       Bool{Unknown: true},
+			expectation: "<unknown>",
+		},
+		"null": {
+			input:       Bool{Null: true},
+			expectation: "<null>",
+		},
+		"default-false": {
+			input:       Bool{},
+			expectation: "false",
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := fmt.Sprintf("%s", test.input)
+			if !cmp.Equal(got, test.expectation) {
+				t.Errorf("Expected %q, got %q", test.expectation, got)
 			}
 		})
 	}

--- a/types/bool_test.go
+++ b/types/bool_test.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -306,7 +305,7 @@ func TestBoolString(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			got := fmt.Sprintf("%s", test.input)
+			got := test.input.String()
 			if !cmp.Equal(got, test.expectation) {
 				t.Errorf("Expected %q, got %q", test.expectation, got)
 			}

--- a/types/float64.go
+++ b/types/float64.go
@@ -150,3 +150,15 @@ func (f Float64) IsNull() bool {
 func (f Float64) IsUnknown() bool {
 	return f.Unknown
 }
+
+func (f Float64) String() string {
+	if f.Unknown {
+		return attr.UnknownString
+	}
+
+	if f.Null {
+		return attr.NullString
+	}
+
+	return fmt.Sprintf("%g", f.Value)
+}

--- a/types/float64.go
+++ b/types/float64.go
@@ -153,12 +153,12 @@ func (f Float64) IsUnknown() bool {
 
 func (f Float64) String() string {
 	if f.Unknown {
-		return attr.UnknownString
+		return attr.UnknownValueString
 	}
 
 	if f.Null {
-		return attr.NullString
+		return attr.NullValueString
 	}
 
-	return fmt.Sprintf("%g", f.Value)
+	return fmt.Sprintf("%f", f.Value)
 }

--- a/types/float64_test.go
+++ b/types/float64_test.go
@@ -2,6 +2,8 @@ package types
 
 import (
 	"context"
+	"fmt"
+	"math"
 	"math/big"
 	"testing"
 
@@ -226,6 +228,65 @@ func TestFloat64Equal(t *testing.T) {
 			got := test.input.Equal(test.candidate)
 			if !cmp.Equal(got, test.expectation) {
 				t.Errorf("Expected %v, got %v", test.expectation, got)
+			}
+		})
+	}
+}
+
+func TestFloat64String(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		input       Float64
+		expectation string
+	}
+	tests := map[string]testCase{
+		"less-than-one": {
+			input:       Float64{Value: 0.12340984302980000},
+			expectation: "0.1234098430298",
+		},
+		"more-than-one": {
+			input:       Float64{Value: 92387938173219.327663},
+			expectation: "9.238793817321933e+13",
+		},
+		"negative-more-than-one": {
+			input:       Float64{Value: -0.12340984302980000},
+			expectation: "-0.1234098430298",
+		},
+		"negative-less-than-one": {
+			input:       Float64{Value: -92387938173219.327663},
+			expectation: "-9.238793817321933e+13",
+		},
+		"min-float64": {
+			input:       Float64{Value: math.SmallestNonzeroFloat64},
+			expectation: "5e-324",
+		},
+		"max-float64": {
+			input:       Float64{Value: math.MaxFloat64},
+			expectation: "1.7976931348623157e+308",
+		},
+		"unknown": {
+			input:       Float64{Unknown: true},
+			expectation: "<unknown>",
+		},
+		"null": {
+			input:       Float64{Null: true},
+			expectation: "<null>",
+		},
+		"default-0": {
+			input:       Float64{},
+			expectation: "0",
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := fmt.Sprintf("%s", test.input)
+			if !cmp.Equal(got, test.expectation) {
+				t.Errorf("Expected %q, got %q", test.expectation, got)
 			}
 		})
 	}

--- a/types/float64_test.go
+++ b/types/float64_test.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"context"
-	"fmt"
 	"math"
 	"math/big"
 	"testing"
@@ -284,7 +283,7 @@ func TestFloat64String(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			got := fmt.Sprintf("%s", test.input)
+			got := test.input.String()
 			if !cmp.Equal(got, test.expectation) {
 				t.Errorf("Expected %q, got %q", test.expectation, got)
 			}

--- a/types/float64_test.go
+++ b/types/float64_test.go
@@ -242,27 +242,27 @@ func TestFloat64String(t *testing.T) {
 	tests := map[string]testCase{
 		"less-than-one": {
 			input:       Float64{Value: 0.12340984302980000},
-			expectation: "0.1234098430298",
+			expectation: "0.123410",
 		},
 		"more-than-one": {
 			input:       Float64{Value: 92387938173219.327663},
-			expectation: "9.238793817321933e+13",
+			expectation: "92387938173219.328125",
 		},
 		"negative-more-than-one": {
 			input:       Float64{Value: -0.12340984302980000},
-			expectation: "-0.1234098430298",
+			expectation: "-0.123410",
 		},
 		"negative-less-than-one": {
 			input:       Float64{Value: -92387938173219.327663},
-			expectation: "-9.238793817321933e+13",
+			expectation: "-92387938173219.328125",
 		},
 		"min-float64": {
 			input:       Float64{Value: math.SmallestNonzeroFloat64},
-			expectation: "5e-324",
+			expectation: "0.000000",
 		},
 		"max-float64": {
 			input:       Float64{Value: math.MaxFloat64},
-			expectation: "1.7976931348623157e+308",
+			expectation: "179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368.000000",
 		},
 		"unknown": {
 			input:       Float64{Unknown: true},
@@ -274,7 +274,7 @@ func TestFloat64String(t *testing.T) {
 		},
 		"default-0": {
 			input:       Float64{},
-			expectation: "0",
+			expectation: "0.000000",
 		},
 	}
 

--- a/types/int64.go
+++ b/types/int64.go
@@ -162,3 +162,15 @@ func (i Int64) IsNull() bool {
 func (i Int64) IsUnknown() bool {
 	return i.Unknown
 }
+
+func (i Int64) String() string {
+	if i.Unknown {
+		return attr.UnknownString
+	}
+
+	if i.Null {
+		return attr.NullString
+	}
+
+	return fmt.Sprintf("%d", i.Value)
+}

--- a/types/int64.go
+++ b/types/int64.go
@@ -165,11 +165,11 @@ func (i Int64) IsUnknown() bool {
 
 func (i Int64) String() string {
 	if i.Unknown {
-		return attr.UnknownString
+		return attr.UnknownValueString
 	}
 
 	if i.Null {
-		return attr.NullString
+		return attr.NullValueString
 	}
 
 	return fmt.Sprintf("%d", i.Value)

--- a/types/int64_test.go
+++ b/types/int64_test.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"context"
-	"fmt"
 	"math"
 	"math/big"
 	"testing"
@@ -268,7 +267,7 @@ func TestInt64String(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			got := fmt.Sprintf("%s", test.input)
+			got := test.input.String()
 			if !cmp.Equal(got, test.expectation) {
 				t.Errorf("Expected %q, got %q", test.expectation, got)
 			}

--- a/types/int64_test.go
+++ b/types/int64_test.go
@@ -2,6 +2,8 @@ package types
 
 import (
 	"context"
+	"fmt"
+	"math"
 	"math/big"
 	"testing"
 
@@ -218,6 +220,57 @@ func TestInt64Equal(t *testing.T) {
 			got := test.input.Equal(test.candidate)
 			if !cmp.Equal(got, test.expectation) {
 				t.Errorf("Expected %v, got %v", test.expectation, got)
+			}
+		})
+	}
+}
+
+func TestInt64String(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		input       Int64
+		expectation string
+	}
+	tests := map[string]testCase{
+		"less-than-one": {
+			input:       Int64{Value: -12340984302980000},
+			expectation: "-12340984302980000",
+		},
+		"more-than-one": {
+			input:       Int64{Value: 92387938173219327},
+			expectation: "92387938173219327",
+		},
+		"min-int64": {
+			input:       Int64{Value: math.MinInt64},
+			expectation: "-9223372036854775808",
+		},
+		"max-int64": {
+			input:       Int64{Value: math.MaxInt64},
+			expectation: "9223372036854775807",
+		},
+		"unknown": {
+			input:       Int64{Unknown: true},
+			expectation: "<unknown>",
+		},
+		"null": {
+			input:       Int64{Null: true},
+			expectation: "<null>",
+		},
+		"default-0": {
+			input:       Int64{},
+			expectation: "0",
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := fmt.Sprintf("%s", test.input)
+			if !cmp.Equal(got, test.expectation) {
+				t.Errorf("Expected %q, got %q", test.expectation, got)
 			}
 		})
 	}

--- a/types/list.go
+++ b/types/list.go
@@ -228,11 +228,11 @@ func (l List) IsUnknown() bool {
 
 func (l List) String() string {
 	if l.Unknown {
-		return attr.UnknownString
+		return attr.UnknownValueString
 	}
 
 	if l.Null {
-		return attr.NullString
+		return attr.NullValueString
 	}
 
 	var res strings.Builder

--- a/types/list.go
+++ b/types/list.go
@@ -3,6 +3,7 @@ package types
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -223,4 +224,27 @@ func (l List) IsNull() bool {
 
 func (l List) IsUnknown() bool {
 	return l.Unknown
+}
+
+func (l List) String() string {
+	if l.Unknown {
+		return attr.UnknownString
+	}
+
+	if l.Null {
+		return attr.NullString
+	}
+
+	var res strings.Builder
+
+	res.WriteString("[")
+	for i, e := range l.Elems {
+		if i != 0 {
+			res.WriteString(",")
+		}
+		res.WriteString(e.String())
+	}
+	res.WriteString("]")
+
+	return res.String()
 }

--- a/types/list_test.go
+++ b/types/list_test.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -762,7 +761,7 @@ func TestListString(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			got := fmt.Sprintf("%s", test.input)
+			got := test.input.String()
 			if !cmp.Equal(got, test.expectation) {
 				t.Errorf("Expected %q, got %q", test.expectation, got)
 			}

--- a/types/list_test.go
+++ b/types/list_test.go
@@ -716,7 +716,7 @@ func TestListString(t *testing.T) {
 					String{Value: "world"},
 				},
 			},
-			expectation: "[hello,world]",
+			expectation: `["hello","world"]`,
 		},
 		"list-of-lists": {
 			input: List{
@@ -740,7 +740,7 @@ func TestListString(t *testing.T) {
 					},
 				},
 			},
-			expectation: "[[hello,world],[foo,bar]]",
+			expectation: `[["hello","world"],["foo","bar"]]`,
 		},
 		"unknown": {
 			input:       List{Unknown: true},

--- a/types/list_test.go
+++ b/types/list_test.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -695,6 +696,75 @@ func TestListEqual(t *testing.T) {
 			got := test.receiver.Equal(test.input)
 			if got != test.expected {
 				t.Errorf("Expected %v, got %v", test.expected, got)
+			}
+		})
+	}
+}
+
+func TestListString(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		input       List
+		expectation string
+	}
+	tests := map[string]testCase{
+		"simple": {
+			input: List{
+				ElemType: StringType,
+				Elems: []attr.Value{
+					String{Value: "hello"},
+					String{Value: "world"},
+				},
+			},
+			expectation: "[hello,world]",
+		},
+		"list-of-lists": {
+			input: List{
+				ElemType: ListType{
+					ElemType: StringType,
+				},
+				Elems: []attr.Value{
+					List{
+						ElemType: StringType,
+						Elems: []attr.Value{
+							String{Value: "hello"},
+							String{Value: "world"},
+						},
+					},
+					List{
+						ElemType: StringType,
+						Elems: []attr.Value{
+							String{Value: "foo"},
+							String{Value: "bar"},
+						},
+					},
+				},
+			},
+			expectation: "[[hello,world],[foo,bar]]",
+		},
+		"unknown": {
+			input:       List{Unknown: true},
+			expectation: "<unknown>",
+		},
+		"null": {
+			input:       List{Null: true},
+			expectation: "<null>",
+		},
+		"default-empty": {
+			input:       List{},
+			expectation: "[]",
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := fmt.Sprintf("%s", test.input)
+			if !cmp.Equal(got, test.expectation) {
+				t.Errorf("Expected %q, got %q", test.expectation, got)
 			}
 		})
 	}

--- a/types/map.go
+++ b/types/map.go
@@ -242,7 +242,7 @@ func (m Map) String() string {
 
 	// We want the output to be consistent, so we sort the output by key
 	keys := make([]string, 0, len(m.Elems))
-	for k, _ := range m.Elems {
+	for k := range m.Elems {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)

--- a/types/map.go
+++ b/types/map.go
@@ -3,6 +3,8 @@ package types
 import (
 	"context"
 	"fmt"
+	"sort"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -227,4 +229,34 @@ func (m Map) IsNull() bool {
 
 func (m Map) IsUnknown() bool {
 	return m.Unknown
+}
+
+func (m Map) String() string {
+	if m.Unknown {
+		return attr.UnknownString
+	}
+
+	if m.Null {
+		return attr.NullString
+	}
+
+	// We want the output to be consistent, so we sort the output by key
+	keys := make([]string, 0, len(m.Elems))
+	for k, _ := range m.Elems {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var res strings.Builder
+
+	res.WriteString("[")
+	for i, k := range keys {
+		if i != 0 {
+			res.WriteString(",")
+		}
+		res.WriteString(fmt.Sprintf("%s:%s", k, m.Elems[k].String()))
+	}
+	res.WriteString("]")
+
+	return res.String()
 }

--- a/types/map.go
+++ b/types/map.go
@@ -233,11 +233,11 @@ func (m Map) IsUnknown() bool {
 
 func (m Map) String() string {
 	if m.Unknown {
-		return attr.UnknownString
+		return attr.UnknownValueString
 	}
 
 	if m.Null {
-		return attr.NullString
+		return attr.NullValueString
 	}
 
 	// We want the output to be consistent, so we sort the output by key
@@ -249,14 +249,14 @@ func (m Map) String() string {
 
 	var res strings.Builder
 
-	res.WriteString("[")
+	res.WriteString("{")
 	for i, k := range keys {
 		if i != 0 {
 			res.WriteString(",")
 		}
-		res.WriteString(fmt.Sprintf("%s:%s", k, m.Elems[k].String()))
+		res.WriteString(fmt.Sprintf(`"%s":%s`, k, m.Elems[k].String()))
 	}
-	res.WriteString("]")
+	res.WriteString("}")
 
 	return res.String()
 }

--- a/types/map_test.go
+++ b/types/map_test.go
@@ -717,7 +717,7 @@ func TestMapString(t *testing.T) {
 					"sigma": Int64{Value: 62534},
 				},
 			},
-			expectation: "[alpha:1234,beta:56789,gamma:9817,sigma:62534]",
+			expectation: `{"alpha":1234,"beta":56789,"gamma":9817,"sigma":62534}`,
 		},
 		"map-of-maps": {
 			input: Map{
@@ -735,17 +735,17 @@ func TestMapString(t *testing.T) {
 						},
 					},
 					"second": Map{
-						ElemType: StringType,
+						ElemType: Int64Type,
 						Elems: map[string]attr.Value{
-							"x": String{Value: "0"},
-							"y": String{Value: "0"},
-							"z": String{Value: "0"},
-							"t": String{Value: "0"},
+							"x": Int64{Value: 0},
+							"y": Int64{Value: 0},
+							"z": Int64{Value: 0},
+							"t": Int64{Value: 0},
 						},
 					},
 				},
 			},
-			expectation: "[first:[alpha:hello,beta:world,gamma:foo,sigma:bar],second:[t:0,x:0,y:0,z:0]]",
+			expectation: `{"first":{"alpha":"hello","beta":"world","gamma":"foo","sigma":"bar"},"second":{"t":0,"x":0,"y":0,"z":0}}`,
 		},
 		"unknown": {
 			input:       Map{Unknown: true},
@@ -757,7 +757,7 @@ func TestMapString(t *testing.T) {
 		},
 		"default-empty": {
 			input:       Map{},
-			expectation: "[]",
+			expectation: "{}",
 		},
 	}
 

--- a/types/map_test.go
+++ b/types/map_test.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -694,6 +695,81 @@ func TestMapEqual(t *testing.T) {
 			got := test.receiver.Equal(test.input)
 			if got != test.expected {
 				t.Errorf("Expected %v, got %v", test.expected, got)
+			}
+		})
+	}
+}
+
+func TestMapString(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		input       Map
+		expectation string
+	}
+	tests := map[string]testCase{
+		"simple": {
+			input: Map{
+				ElemType: Int64Type,
+				Elems: map[string]attr.Value{
+					"alpha": Int64{Value: 1234},
+					"beta":  Int64{Value: 56789},
+					"gamma": Int64{Value: 9817},
+					"sigma": Int64{Value: 62534},
+				},
+			},
+			expectation: "[alpha:1234,beta:56789,gamma:9817,sigma:62534]",
+		},
+		"map-of-maps": {
+			input: Map{
+				ElemType: MapType{
+					ElemType: StringType,
+				},
+				Elems: map[string]attr.Value{
+					"first": Map{
+						ElemType: StringType,
+						Elems: map[string]attr.Value{
+							"alpha": String{Value: "hello"},
+							"beta":  String{Value: "world"},
+							"gamma": String{Value: "foo"},
+							"sigma": String{Value: "bar"},
+						},
+					},
+					"second": Map{
+						ElemType: StringType,
+						Elems: map[string]attr.Value{
+							"x": String{Value: "0"},
+							"y": String{Value: "0"},
+							"z": String{Value: "0"},
+							"t": String{Value: "0"},
+						},
+					},
+				},
+			},
+			expectation: "[first:[alpha:hello,beta:world,gamma:foo,sigma:bar],second:[t:0,x:0,y:0,z:0]]",
+		},
+		"unknown": {
+			input:       Map{Unknown: true},
+			expectation: "<unknown>",
+		},
+		"null": {
+			input:       Map{Null: true},
+			expectation: "<null>",
+		},
+		"default-empty": {
+			input:       Map{},
+			expectation: "[]",
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := fmt.Sprintf("%s", test.input)
+			if !cmp.Equal(got, test.expectation) {
+				t.Errorf("Expected %q, got %q", test.expectation, got)
 			}
 		})
 	}

--- a/types/map_test.go
+++ b/types/map_test.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"context"
-	"fmt"
 	"math/big"
 	"testing"
 
@@ -767,7 +766,7 @@ func TestMapString(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			got := fmt.Sprintf("%s", test.input)
+			got := test.input.String()
 			if !cmp.Equal(got, test.expectation) {
 				t.Errorf("Expected %q, got %q", test.expectation, got)
 			}

--- a/types/number.go
+++ b/types/number.go
@@ -96,15 +96,15 @@ func (n Number) IsUnknown() bool {
 
 func (n Number) String() string {
 	if n.Unknown {
-		return attr.UnknownString
+		return attr.UnknownValueString
 	}
 
 	if n.Null {
-		return attr.NullString
+		return attr.NullValueString
 	}
 
 	if n.Value == nil {
-		return attr.NullString
+		return attr.NullValueString
 	}
 
 	return n.Value.String()

--- a/types/number.go
+++ b/types/number.go
@@ -93,3 +93,19 @@ func (n Number) IsNull() bool {
 func (n Number) IsUnknown() bool {
 	return n.Unknown
 }
+
+func (n Number) String() string {
+	if n.Unknown {
+		return attr.UnknownString
+	}
+
+	if n.Null {
+		return attr.NullString
+	}
+
+	if n.Value == nil {
+		return attr.NullString
+	}
+
+	return n.Value.String()
+}

--- a/types/number_test.go
+++ b/types/number_test.go
@@ -2,6 +2,8 @@ package types
 
 import (
 	"context"
+	"fmt"
+	"math"
 	"math/big"
 	"testing"
 
@@ -241,6 +243,65 @@ func TestNumberEqual(t *testing.T) {
 			got := test.input.Equal(test.candidate)
 			if !cmp.Equal(got, test.expectation) {
 				t.Errorf("Expected %v, got %v", test.expectation, got)
+			}
+		})
+	}
+}
+
+func TestNumberString(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		input       Number
+		expectation string
+	}
+	tests := map[string]testCase{
+		"less-than-one": {
+			input:       Number{Value: big.NewFloat(0.12340984302980000)},
+			expectation: "0.123409843",
+		},
+		"more-than-one": {
+			input:       Number{Value: big.NewFloat(92387938173219.327663)},
+			expectation: "9.238793817e+13",
+		},
+		"negative-more-than-one": {
+			input:       Number{Value: big.NewFloat(-0.12340984302980000)},
+			expectation: "-0.123409843",
+		},
+		"negative-less-than-one": {
+			input:       Number{Value: big.NewFloat(-92387938173219.327663)},
+			expectation: "-9.238793817e+13",
+		},
+		"min-float64": {
+			input:       Number{Value: big.NewFloat(math.SmallestNonzeroFloat64)},
+			expectation: "4.940656458e-324",
+		},
+		"max-float64": {
+			input:       Number{Value: big.NewFloat(math.MaxFloat64)},
+			expectation: "1.797693135e+308",
+		},
+		"unknown": {
+			input:       Number{Unknown: true},
+			expectation: "<unknown>",
+		},
+		"null": {
+			input:       Number{Null: true},
+			expectation: "<null>",
+		},
+		"default-null": {
+			input:       Number{},
+			expectation: "<null>",
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := fmt.Sprintf("%s", test.input)
+			if !cmp.Equal(got, test.expectation) {
+				t.Errorf("Expected %q, got %q", test.expectation, got)
 			}
 		})
 	}

--- a/types/number_test.go
+++ b/types/number_test.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"context"
-	"fmt"
 	"math"
 	"math/big"
 	"testing"
@@ -299,7 +298,7 @@ func TestNumberString(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			got := fmt.Sprintf("%s", test.input)
+			got := test.input.String()
 			if !cmp.Equal(got, test.expectation) {
 				t.Errorf("Expected %q, got %q", test.expectation, got)
 			}

--- a/types/object.go
+++ b/types/object.go
@@ -285,3 +285,33 @@ func (o Object) IsNull() bool {
 func (o Object) IsUnknown() bool {
 	return o.Unknown
 }
+
+func (o Object) String() string {
+	if o.Unknown {
+		return attr.UnknownString
+	}
+
+	if o.Null {
+		return attr.NullString
+	}
+
+	// We want the output to be consistent, so we sort the output by key
+	keys := make([]string, 0, len(o.Attrs))
+	for k, _ := range o.Attrs {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var res strings.Builder
+
+	res.WriteString("(")
+	for i, k := range keys {
+		if i != 0 {
+			res.WriteString(",")
+		}
+		res.WriteString(fmt.Sprintf("%s:%s", k, o.Attrs[k].String()))
+	}
+	res.WriteString(")")
+
+	return res.String()
+}

--- a/types/object.go
+++ b/types/object.go
@@ -297,7 +297,7 @@ func (o Object) String() string {
 
 	// We want the output to be consistent, so we sort the output by key
 	keys := make([]string, 0, len(o.Attrs))
-	for k, _ := range o.Attrs {
+	for k := range o.Attrs {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)

--- a/types/object.go
+++ b/types/object.go
@@ -288,11 +288,11 @@ func (o Object) IsUnknown() bool {
 
 func (o Object) String() string {
 	if o.Unknown {
-		return attr.UnknownString
+		return attr.UnknownValueString
 	}
 
 	if o.Null {
-		return attr.NullString
+		return attr.NullValueString
 	}
 
 	// We want the output to be consistent, so we sort the output by key
@@ -304,14 +304,14 @@ func (o Object) String() string {
 
 	var res strings.Builder
 
-	res.WriteString("(")
+	res.WriteString("{")
 	for i, k := range keys {
 		if i != 0 {
 			res.WriteString(",")
 		}
-		res.WriteString(fmt.Sprintf("%s:%s", k, o.Attrs[k].String()))
+		res.WriteString(fmt.Sprintf(`"%s":%s`, k, o.Attrs[k].String()))
 	}
-	res.WriteString(")")
+	res.WriteString("}")
 
 	return res.String()
 }

--- a/types/object_test.go
+++ b/types/object_test.go
@@ -1533,7 +1533,7 @@ func TestObjectString(t *testing.T) {
 					"theta": Bool{Null: true},
 				},
 			},
-			expectation: "(alpha:hello,beta:98719827987189,gamma:-9876.782378,sigma:<unknown>,theta:<null>)",
+			expectation: `{"alpha":"hello","beta":98719827987189,"gamma":-9876.782378,"sigma":<unknown>,"theta":<null>}`,
 		},
 		"object-of-objects": {
 			input: Object{
@@ -1576,7 +1576,7 @@ func TestObjectString(t *testing.T) {
 					"theta": Bool{Null: true},
 				},
 			},
-			expectation: "(alpha:(one:1,three:0.3,two:true),beta:(due:false,tre:3,uno:1),gamma:-9876.782378,sigma:<unknown>,theta:<null>)",
+			expectation: `{"alpha":{"one":"1","three":0.3,"two":true},"beta":{"due":false,"tre":"3","uno":1},"gamma":-9876.782378,"sigma":<unknown>,"theta":<null>}`,
 		},
 		"unknown": {
 			input:       Object{Unknown: true},
@@ -1588,7 +1588,7 @@ func TestObjectString(t *testing.T) {
 		},
 		"default-empty": {
 			input:       Object{},
-			expectation: "()",
+			expectation: "{}",
 		},
 	}
 

--- a/types/object_test.go
+++ b/types/object_test.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -1503,6 +1504,103 @@ func TestObjectEqual(t *testing.T) {
 			got := test.receiver.Equal(test.arg)
 			if got != test.expected {
 				t.Errorf("Expected %v, got %v", test.expected, got)
+			}
+		})
+	}
+}
+
+func TestObjectString(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		input       Object
+		expectation string
+	}
+	tests := map[string]testCase{
+		"simple": {
+			input: Object{
+				AttrTypes: map[string]attr.Type{
+					"alpha": StringType,
+					"beta":  Int64Type,
+					"gamma": Float64Type,
+					"sigma": NumberType,
+					"theta": BoolType,
+				},
+				Attrs: map[string]attr.Value{
+					"alpha": String{Value: "hello"},
+					"beta":  Int64{Value: 98719827987189},
+					"gamma": Float64{Value: -9876.782378},
+					"sigma": Number{Unknown: true},
+					"theta": Bool{Null: true},
+				},
+			},
+			expectation: "(alpha:hello,beta:98719827987189,gamma:-9876.782378,sigma:<unknown>,theta:<null>)",
+		},
+		"object-of-objects": {
+			input: Object{
+				AttrTypes: map[string]attr.Type{
+					"alpha": ObjectType{
+						AttrTypes: map[string]attr.Type{
+							"one":   StringType,
+							"two":   BoolType,
+							"three": NumberType,
+						},
+					},
+					"beta": ObjectType{
+						AttrTypes: map[string]attr.Type{
+							"uno": Int64Type,
+							"due": BoolType,
+							"tre": StringType,
+						},
+					},
+					"gamma": Float64Type,
+					"sigma": NumberType,
+					"theta": BoolType,
+				},
+				Attrs: map[string]attr.Value{
+					"alpha": Object{
+						Attrs: map[string]attr.Value{
+							"one":   String{Value: "1"},
+							"two":   Bool{Value: true},
+							"three": Number{Value: big.NewFloat(0.3)},
+						},
+					},
+					"beta": Object{
+						Attrs: map[string]attr.Value{
+							"uno": Int64{Value: 1},
+							"due": Bool{Value: false},
+							"tre": String{Value: "3"},
+						},
+					},
+					"gamma": Float64{Value: -9876.782378},
+					"sigma": Number{Unknown: true},
+					"theta": Bool{Null: true},
+				},
+			},
+			expectation: "(alpha:(one:1,three:0.3,two:true),beta:(due:false,tre:3,uno:1),gamma:-9876.782378,sigma:<unknown>,theta:<null>)",
+		},
+		"unknown": {
+			input:       Object{Unknown: true},
+			expectation: "<unknown>",
+		},
+		"null": {
+			input:       Object{Null: true},
+			expectation: "<null>",
+		},
+		"default-empty": {
+			input:       Object{},
+			expectation: "()",
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := fmt.Sprintf("%s", test.input)
+			if !cmp.Equal(got, test.expectation) {
+				t.Errorf("Expected %q, got %q", test.expectation, got)
 			}
 		})
 	}

--- a/types/object_test.go
+++ b/types/object_test.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"context"
-	"fmt"
 	"math/big"
 	"testing"
 
@@ -1598,7 +1597,7 @@ func TestObjectString(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			got := fmt.Sprintf("%s", test.input)
+			got := test.input.String()
 			if !cmp.Equal(got, test.expectation) {
 				t.Errorf("Expected %q, got %q", test.expectation, got)
 			}

--- a/types/set.go
+++ b/types/set.go
@@ -298,23 +298,23 @@ func (s Set) IsUnknown() bool {
 
 func (s Set) String() string {
 	if s.Unknown {
-		return attr.UnknownString
+		return attr.UnknownValueString
 	}
 
 	if s.Null {
-		return attr.NullString
+		return attr.NullValueString
 	}
 
 	var res strings.Builder
 
-	res.WriteString("(")
+	res.WriteString("[")
 	for i, e := range s.Elems {
 		if i != 0 {
 			res.WriteString(",")
 		}
 		res.WriteString(e.String())
 	}
-	res.WriteString(")")
+	res.WriteString("]")
 
 	return res.String()
 }

--- a/types/set.go
+++ b/types/set.go
@@ -3,6 +3,7 @@ package types
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -293,4 +294,27 @@ func (s Set) IsNull() bool {
 
 func (s Set) IsUnknown() bool {
 	return s.Unknown
+}
+
+func (s Set) String() string {
+	if s.Unknown {
+		return attr.UnknownString
+	}
+
+	if s.Null {
+		return attr.NullString
+	}
+
+	var res strings.Builder
+
+	res.WriteString("(")
+	for i, e := range s.Elems {
+		if i != 0 {
+			res.WriteString(",")
+		}
+		res.WriteString(e.String())
+	}
+	res.WriteString(")")
+
+	return res.String()
 }

--- a/types/set_test.go
+++ b/types/set_test.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 	"testing"
 
@@ -1025,7 +1024,7 @@ func TestSetString(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			got := fmt.Sprintf("%s", test.input)
+			got := test.input.String()
 			if !cmp.Equal(got, test.expectation) {
 				t.Errorf("Expected %q, got %q", test.expectation, got)
 			}

--- a/types/set_test.go
+++ b/types/set_test.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"testing"
 
@@ -958,6 +959,75 @@ func TestSetEqual(t *testing.T) {
 			got := test.receiver.Equal(test.input)
 			if got != test.expected {
 				t.Errorf("Expected %v, got %v", test.expected, got)
+			}
+		})
+	}
+}
+
+func TestSetString(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		input       Set
+		expectation string
+	}
+	tests := map[string]testCase{
+		"simple": {
+			input: Set{
+				ElemType: StringType,
+				Elems: []attr.Value{
+					String{Value: "hello"},
+					String{Value: "world"},
+				},
+			},
+			expectation: "(hello,world)",
+		},
+		"list-of-lists": {
+			input: Set{
+				ElemType: SetType{
+					ElemType: StringType,
+				},
+				Elems: []attr.Value{
+					Set{
+						ElemType: StringType,
+						Elems: []attr.Value{
+							String{Value: "hello"},
+							String{Value: "world"},
+						},
+					},
+					Set{
+						ElemType: StringType,
+						Elems: []attr.Value{
+							String{Value: "foo"},
+							String{Value: "bar"},
+						},
+					},
+				},
+			},
+			expectation: "((hello,world),(foo,bar))",
+		},
+		"unknown": {
+			input:       Set{Unknown: true},
+			expectation: "<unknown>",
+		},
+		"null": {
+			input:       Set{Null: true},
+			expectation: "<null>",
+		},
+		"default-empty": {
+			input:       Set{},
+			expectation: "()",
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := fmt.Sprintf("%s", test.input)
+			if !cmp.Equal(got, test.expectation) {
+				t.Errorf("Expected %q, got %q", test.expectation, got)
 			}
 		})
 	}

--- a/types/set_test.go
+++ b/types/set_test.go
@@ -981,7 +981,7 @@ func TestSetString(t *testing.T) {
 			},
 			expectation: "(hello,world)",
 		},
-		"list-of-lists": {
+		"set-of-sets": {
 			input: Set{
 				ElemType: SetType{
 					ElemType: StringType,

--- a/types/set_test.go
+++ b/types/set_test.go
@@ -979,7 +979,7 @@ func TestSetString(t *testing.T) {
 					String{Value: "world"},
 				},
 			},
-			expectation: "(hello,world)",
+			expectation: `["hello","world"]`,
 		},
 		"set-of-sets": {
 			input: Set{
@@ -1003,7 +1003,7 @@ func TestSetString(t *testing.T) {
 					},
 				},
 			},
-			expectation: "((hello,world),(foo,bar))",
+			expectation: `[["hello","world"],["foo","bar"]]`,
 		},
 		"unknown": {
 			input:       Set{Unknown: true},
@@ -1015,7 +1015,7 @@ func TestSetString(t *testing.T) {
 		},
 		"default-empty": {
 			input:       Set{},
-			expectation: "()",
+			expectation: "[]",
 		},
 	}
 

--- a/types/string.go
+++ b/types/string.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
@@ -85,12 +86,12 @@ func (s String) IsUnknown() bool {
 
 func (s String) String() string {
 	if s.Unknown {
-		return attr.UnknownString
+		return attr.UnknownValueString
 	}
 
 	if s.Null {
-		return attr.NullString
+		return attr.NullValueString
 	}
 
-	return s.Value
+	return fmt.Sprintf(`"%s"`, s.Value)
 }

--- a/types/string.go
+++ b/types/string.go
@@ -82,3 +82,15 @@ func (s String) IsNull() bool {
 func (s String) IsUnknown() bool {
 	return s.Unknown
 }
+
+func (s String) String() string {
+	if s.Unknown {
+		return attr.UnknownString
+	}
+
+	if s.Null {
+		return attr.NullString
+	}
+
+	return s.Value
+}

--- a/types/string_test.go
+++ b/types/string_test.go
@@ -233,15 +233,15 @@ func TestStringString(t *testing.T) {
 	tests := map[string]testCase{
 		"simple": {
 			input:       String{Value: "simple"},
-			expectation: "simple",
+			expectation: `"simple"`,
 		},
 		"long-string": {
 			input:       String{Value: "a really, really, really long string"},
-			expectation: "a really, really, really long string",
+			expectation: `"a really, really, really long string"`,
 		},
-		"empty-stirng": {
+		"empty-string": {
 			input:       String{Value: ""},
-			expectation: "",
+			expectation: `""`,
 		},
 		"unknown": {
 			input:       String{Unknown: true},
@@ -253,7 +253,7 @@ func TestStringString(t *testing.T) {
 		},
 		"default-0": {
 			input:       String{},
-			expectation: "",
+			expectation: `""`,
 		},
 	}
 

--- a/types/string_test.go
+++ b/types/string_test.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -218,6 +219,53 @@ func TestStringEqual(t *testing.T) {
 			got := test.input.Equal(test.candidate)
 			if !cmp.Equal(got, test.expectation) {
 				t.Errorf("Expected %v, got %v", test.expectation, got)
+			}
+		})
+	}
+}
+
+func TestStringString(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		input       String
+		expectation string
+	}
+	tests := map[string]testCase{
+		"simple": {
+			input:       String{Value: "simple"},
+			expectation: "simple",
+		},
+		"long-string": {
+			input:       String{Value: "a really, really, really long string"},
+			expectation: "a really, really, really long string",
+		},
+		"empty-stirng": {
+			input:       String{Value: ""},
+			expectation: "",
+		},
+		"unknown": {
+			input:       String{Unknown: true},
+			expectation: "<unknown>",
+		},
+		"null": {
+			input:       String{Null: true},
+			expectation: "<null>",
+		},
+		"default-0": {
+			input:       String{},
+			expectation: "",
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := fmt.Sprintf("%s", test.input)
+			if !cmp.Equal(got, test.expectation) {
+				t.Errorf("Expected %q, got %q", test.expectation, got)
 			}
 		})
 	}

--- a/types/string_test.go
+++ b/types/string_test.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"context"
-	"fmt"
 	"math/big"
 	"testing"
 
@@ -263,7 +262,7 @@ func TestStringString(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			got := fmt.Sprintf("%s", test.input)
+			got := test.input.String()
 			if !cmp.Equal(got, test.expectation) {
 				t.Errorf("Expected %q, got %q", test.expectation, got)
 			}


### PR DESCRIPTION
## Background

At the moment, it can be tricky to log or report errors where the aim is to represent a `attr.Value` concrete type. For a `types.Number` for example, it can look like this:

```
{%!s(bool=false) %!s(bool=false) %!s(*big.Float=6.5)}
```

This is not very practitioner friendly, when the aim is to put such representation in a warning or error diagnostic.

## Proposal

This PR provides a new `.String()` method on the `attr.Value` interface, that aims to address this issue. The representation for each type would follow these formatting "rules":

| Type      | Formatting                                | Unknown     | Null     | Example                                       |
| ---------:|:-----------------------------------------:|:-----------:|:--------:|:----------------------------------------------|
| `Bool`    | `true`/`false`                            | `<unknown>` | `<null>` | `true`                                        |
| `Int64`   | `%d`                                      | `<unknown>` | `<null>` | `123456`                                      |
| `Float64` | `%f`                                      | `<unknown>` | `<null>` | `123.456`                                     |
| `Number`  | `big.Float.String()`                      | `<unknown>` | `<null>` | `9.238793817e+13`                             |
| `String`  | `"__VALUE__"`                             | `<unknown>` | `<null>` | `"hello world"`                               |
| `List`    | `[v1.String(),v2.String(),...]`           | `<unknown>` | `<null>` | `["hello","world"]`                           |
| `Set`     | `[v2.String(),v1.String(),...]`           | `<unknown>` | `<null>` | `["hello","world"]`                           |
| `Map`     | `{"k1":v1.String(),"k2":v2.String(),...}` | `<unknown>` | `<null>` | `{"alpha":1234,"beta":56789}`                 |
| `Object`  | `{"k1":v1.String(),"k2":v2.String(),...}` | `<unknown>` | `<null>` | `{"alpha":1234,"beta":56789,"gamma":"ammag"}` |

For collection types `List` and `Set`, we use the delimiters `[ / ]`;
for collection types `Map` and `Object`, we use the delimiters `{ / }`.
This creates a notation _similar_ to how HCL represents those entities.

## Related

Closes #117

