### PR TITLE
website: Add Provider Servers page and adjust content for protocol version 5 support

### DIFF
--- a/website/data/plugin-framework-nav-data.json
+++ b/website/data/plugin-framework-nav-data.json
@@ -11,6 +11,10 @@
     "href": "https://learn.hashicorp.com/tutorials/terraform/plugin-framework-create?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS"
   },
   {
+    "title": "Provider Servers",
+    "path": "provider-servers"
+  },
+  {
     "title": "Providers",
     "path": "providers"
   },

--- a/website/docs/plugin/framework/acctests.mdx
+++ b/website/docs/plugin/framework/acctests.mdx
@@ -11,31 +11,22 @@ You can implement testing with the [acceptance test framework](/plugin/sdkv2/tes
 
 Writing and running tests is similar to SDKv2 providers, with the following exceptions:
 
-- [`TestCase`](/plugin/sdkv2/testing/acceptance-tests/testcase): Specify the provider with [`ProtoV6ProviderFactories`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource#TestCase.ProtoV6ProviderFactories).
+- [`TestCase`](/plugin/sdkv2/testing/acceptance-tests/testcase): Specify the provider with [`ProtoV6ProviderFactories`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource#TestCase.ProtoV6ProviderFactories) or [`ProtoV5ProviderFactories`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource#TestCase.ProtoV5ProviderFactories), depending on the intended [provider server](/plugin/framework/provider-servers) setup.
 - [`Schema`](/plugin/framework/schemas): A root level `id` attribute is required for resources and data sources.
 
 ## Specify Providers
 
-In SDKv2, providers were specified by using the [`Providers` property of the
-`resource.TestCase`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource#TestCase.Providers) to supply a map of
-[`schema.Provider`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema/#Provider)s.
+Use one of the [`resource.TestCase` type](/plugin/sdkv2/testing/acceptance-tests/testcase) [`ProtoV6ProviderFactories` field](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource#TestCase.ProtoV6ProviderFactories) for [protocol version 6](/plugin/how-terraform-works#protocol-version-6) or [`ProtoV5ProviderFactories` field](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource#TestCase.ProtoV5ProviderFactories) for [protocol version 5](/plugin/how-terraform-works#protocol-version-5). It is only necessary to test with the single protocol version matching the intended provider server.
 
-For the framework, the same pattern applies, but instead use the
-[`ProtoV6ProviderFactories` property of
-`resource.TestCase`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource#TestCase.ProtoV6ProviderFactories)
-to supply a map of functions that return a
-[`tfprotov6.ProviderServer`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-go/tfprotov6/#ProviderServer).
-To get a `tfprotov6.ProviderServer` from a
-[`tfsdk.Provider`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/tfsdk#Provider),
-you need to use the
-[`providerserver.NewProtocol6WithError`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/providerserver#NewProtocol6WithError)
-helper. For example:
+### Protocol Version 6
+
+Use the [`providerserver.NewProtocol6WithError`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/providerserver#NewProtocol6WithError) helper function to implement the provider server in the [`ProtoV6ProviderFactories` field](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource#TestCase.ProtoV6ProviderFactories).
 
 ```go
 resource.Test(t, resource.TestCase{
 	PreCheck: func() { testAccPreCheck(t) },
 	ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error) {
-		// newProvider is your function that returns a tfsdk.Provider
+		// newProvider is an example function that returns a tfsdk.Provider
 		"example_provider": providerserver.NewProtocol6WithError(newProvider()),
 	},
 	CheckDestroy: testAccCheckExampleResourceDestroy,
@@ -48,9 +39,26 @@ resource.Test(t, resource.TestCase{
 })
 ```
 
-See the [`TestCase`
-documentation](/plugin/sdkv2/testing/acceptance-tests/testcase) for more
-information on using `resource.TestCase`.
+### Protocol Version 5
+
+Use the [`providerserver.NewProtocol5WithError`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/providerserver#NewProtocol5WithError) helper function to implement the provider server in the [`ProtoV5ProviderFactories` field](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource#TestCase.ProtoV5ProviderFactories).
+
+```go
+resource.Test(t, resource.TestCase{
+	PreCheck: func() { testAccPreCheck(t) },
+	ProtoV5ProviderFactories: map[string]func() (tfprotov5.ProviderServer, error) {
+		// newProvider is an example function that returns a tfsdk.Provider
+		"example_provider": providerserver.NewProtocol5WithError(newProvider()),
+	},
+	CheckDestroy: testAccCheckExampleResourceDestroy,
+	Steps: []resource.TestStep{
+		{
+			Config: testAccExampleResource,
+			Check: testAccCheckExampleResourceExists,
+		},
+	},
+})
+```
 
 ## Implement id Attribute
 

--- a/website/docs/plugin/framework/debugging.mdx
+++ b/website/docs/plugin/framework/debugging.mdx
@@ -5,13 +5,13 @@ description: How to implement debugger support in Framework Terraform providers.
 
 # Debugging Framework Providers
 
-This page contains implementation details for inspecting runtime information of a Terraform provider developed with Framework via a debugger tool. Review the top level [Debugging](/plugin/debugging) page for information pertaining to the overall Terraform provider debugging process and other inspection options, such as log-based debugging.
+This page contains implementation details for inspecting runtime information of a Terraform provider developed with Framework via a debugger tool by adjusting the [provider server](/plugin/framework/provider-servers) implementation. Review the top level [Debugging](/plugin/debugging) page for information pertaining to the overall Terraform provider debugging process and other inspection options, such as log-based debugging.
 
 ## Code Implementation
 
 Update the `main` function for the project to conditionally enable the [`providerserver/ServeOpts.Debug` field](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/providerserver#ServeOpts.Debug). Conventionally, a `-debug` flag is used to control the `Debug` value.
 
-This example uses a `-debug` flag to enable debugging, otherwise starting the provider normally:
+This example uses a `-debug` flag to enable debugging, otherwise starting the provider normally on protocol version 6:
 
 ```go
 func main() {
@@ -30,5 +30,16 @@ func main() {
 	if err != nil {
 		log.Fatal(err.Error())
 	}
+}
+```
+
+To configure the provider server for protocol version 5, set the [`providerserver.ServeOpts` type `ProtocolVersion` field](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/providerserver#ServeOpts.ProtocolVersion) to `5`:
+
+```go
+opts := providerserver.ServeOpts{
+	// TODO: Update this string with the published name of your provider.
+	Address:         "registry.terraform.io/example-namespace/example",
+	Debug:           debug,
+	ProtocolVersion: 5,
 }
 ```

--- a/website/docs/plugin/framework/debugging.mdx
+++ b/website/docs/plugin/framework/debugging.mdx
@@ -32,14 +32,3 @@ func main() {
 	}
 }
 ```
-
-To configure the provider server for protocol version 5, set the [`providerserver.ServeOpts` type `ProtocolVersion` field](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/providerserver#ServeOpts.ProtocolVersion) to `5`:
-
-```go
-opts := providerserver.ServeOpts{
-	// TODO: Update this string with the published name of your provider.
-	Address:         "registry.terraform.io/example-namespace/example",
-	Debug:           debug,
-	ProtocolVersion: 5,
-}
-```

--- a/website/docs/plugin/framework/index.mdx
+++ b/website/docs/plugin/framework/index.mdx
@@ -7,7 +7,7 @@ description: |-
 
 # Terraform Plugin Framework
 
-The plugin framework is a new way to develop Terraform Plugins on [protocol version 6](/plugin/how-terraform-works#protocol-version-6). It offers improvements and new features from [Teraform Plugin SDKv2](/plugin/sdkv2).
+The plugin framework is a new way to develop Terraform Plugins on [protocol version 6](/plugin/how-terraform-works#protocol-version-6) or [protocol version 5](/plugin/how-terraform-works#protocol-version-5). It offers improvements and new features from [Teraform Plugin SDKv2](/plugin/sdkv2).
 
 ~> **Important**: [Which SDK Should I Use?](/plugin/which-sdk) explains the differences between [Teraform Plugin SDKv2](/plugin/sdkv2) and Terraform Plugin Framework to help you decide which option is right for your provider.
 
@@ -18,7 +18,8 @@ The plugin framework is a new way to develop Terraform Plugins on [protocol vers
 
 ## Key Concepts
 
-- [Providers](/plugin/framework/providers) are Terraform plugins that supply resources and data sources for practitioners to use. They are implemented as binaries that the Terraform CLI downloads, starts, and stops.
+- [Provider Servers](/plugin/framework/provider-servers) encapsulate all Terraform plugin details and handle all calls for provider, resource, and data source operations by implementing the [Terraform Plugin Protocol](/plugin/how-terraform-works#terraform-plugin-protocol). They are implemented as binaries that the Terraform CLI downloads, starts, and stops.
+- [Providers](/plugin/framework/providers) are the top level abstraction that define the available resources and data sources for practitioners to use and may accept its own configuration, such as authentication information.
 - [Schemas](/plugin/framework/schemas) define available fields for provider, resource, or provisioner configuration block, and give Terraform metadata about those fields.
 - [Resources](/plugin/framework/resources) are an abstraction that allow Terraform to manage infrastructure objects, such as a compute instance, an access policy, or disk. Providers act as a translation layer between Terraform and an API, offering one or more resources for practitioners to define in a configuration.
 - [Data Sources](/plugin/framework/data-sources) are an abstraction that allow Terraform to reference external data. Providers have data sources that tell Terraform how to request external data and how to convert the response into a format that practitioners can interpolate.
@@ -30,5 +31,5 @@ The plugin framework is a new way to develop Terraform Plugins on [protocol vers
 
 ## Combine or Translate
 
-- [Combine your provider](/plugin/mux/combining-protocol-version-6-providers) with other [protocol version 6](/plugin/how-terraform-works#protocol-version-6) providers.
-- [Translate your provider](/plugin/mux/translating-protocol-version-6-to-5) into a [protocol version 5](/plugin/how-terraform-works#protocol-version-5) provider for compatibility with Terraform 0.12 and later. [Protocol version 6](/plugin/how-terraform-works#protocol-version-6) features cannot be used.
+- [Combine your provider with other SDKv2 providers](/plugin/mux/combining-protocol-version-5-providers) using [protocol version 5](/plugin/how-terraform-works#protocol-version-5).
+- [Combine your provider with other framework providers](/plugin/mux/combining-protocol-version-6-providers) using [protocol version 6](/plugin/how-terraform-works#protocol-version-6).

--- a/website/docs/plugin/framework/provider-servers.mdx
+++ b/website/docs/plugin/framework/provider-servers.mdx
@@ -1,0 +1,95 @@
+---
+page_title: 'Plugin Development - Framework: Provider Servers'
+description: >-
+  How to implement a provider server in the provider development framework.
+  Provider servers are plugins that allow Terraform to interact with APIs.
+---
+
+# Provider Servers
+
+Before a [provider](/plugin/framework/providers) can be used with Terraform, it must implement a [gRPC server](https://grpc.io) that supports Terraform-specific connection and handshake handling on startup. The server must then implement the [Terraform Plugin Protocol](/plugin/how-terraform-works#terraform-plugin-protocol).
+
+The framework handles the majority of the server implementation details, however it is useful from a provider developer perspective to understand the provider server details at least at a high level.
+
+## Protocol Version
+
+The [Terraform Plugin Protocol](/plugin/how-terraform-works#terraform-plugin-protocol) defines the compatibility between Terraform CLI and the underlying provider. It is versioned, with newer versions implementing support for enhanced provider functionality but also requiring newer Terraform CLI versions. The framework implements two versions of the protocol.
+
+* **Version 6**: The latest and recommended version, [protocol version 6](/plugin/how-terraform-works#protocol-version-6) implements enhanced provider functionality and requires Terraform CLI 1.0 or later.
+* **Version 5**: The prior version, [protocol version 5](/plugin/how-terraform-works#protocol-version-5) implements base provider functionality and requires Terraform CLI 0.12 or later.
+
+Provider developers must choose either version 6 or version 5 and should consistently use that one version across implementations.
+
+## Implementations
+
+Terraform and provider developers have multiple ways to interact with the provider server implementation:
+
+* **Production**: Terraform CLI expects a binary that starts the provider server on process startup and stops the provider when called.
+* **Developer Overrides Testing**: The [CLI configuration file](/cli/config/config-file#development-overrides-for-provider-developers) maps provider addresses to locally built binaries, which then operate similar to production.
+* **Acceptance Testing**: The [acceptance testing framework](/plugin/framework/acctests) maps provider names to functions that directly start the provider server and will automatically stop the provider between test steps.
+* **Debugging**: Provider developers, typically via a code editor or debugger tool, manually start a provider server for [debugging](/plugin/framework/debugging) which Terraform CLI is then configured to use rather than a normal binary.
+
+### Production and Developer Overrides
+
+Go language programs implement startup logic via a `main` function. Conventionally, this is done in a `main.go` file at the root of a project. The `main` function must eventually call the framework functionality for managing provider servers in the [`providerserver` package](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/providerserver).
+
+An example `main.go` file for starting a protocol version 6 provider server:
+
+```go
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+
+	"github.com/example-namespace/terraform-provider-example/internal/provider"
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+)
+
+var (
+	// Example version string that can be overwritten by a release process
+	version string = "dev"
+)
+
+func main() {
+	var debug bool
+
+	flag.BoolVar(&debug, "debug", false, "set to true to run the provider with support for debuggers like delve")
+	flag.Parse()
+
+	opts := providerserver.ServeOpts{
+		// TODO: Update this string with the published name of your provider.
+		Address: "registry.terraform.io/example-namespace/example",
+		Debug:   debug,
+	}
+
+	err := providerserver.Serve(context.Background(), provider.New(version), opts)
+
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+}
+```
+
+To configure the provider server for protocol version 5, set the [`providerserver.ServeOpts` type `ProtocolVersion` field](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/providerserver#ServeOpts.ProtocolVersion) to `5`:
+
+```go
+opts := providerserver.ServeOpts{
+	// TODO: Update this string with the published name of your provider.
+	Address:         "registry.terraform.io/example-namespace/example",
+	Debug:           debug,
+	ProtocolVersion: 5,
+}
+```
+
+It is also possible to combine provider server implementations, such as migrating resources and data sources individually from [terraform-plugin-sdk/v2](/plugin/sdkv2) to the framework. This advanced use case would alter the `main.go` code further. Refer to the [Combining and Translating Providers](/plugin/mux) page for implementation details.
+
+### Acceptance Testing
+
+Refer to the [acceptance testing](/plugin/framework/acctests) page for implementation details.
+
+### Debugging
+
+Refer to the [debugging](/plugin/framework/) page for implementation details.
+

--- a/website/docs/plugin/framework/provider-servers.mdx
+++ b/website/docs/plugin/framework/provider-servers.mdx
@@ -53,15 +53,9 @@ var (
 )
 
 func main() {
-	var debug bool
-
-	flag.BoolVar(&debug, "debug", false, "set to true to run the provider with support for debuggers like delve")
-	flag.Parse()
-
 	opts := providerserver.ServeOpts{
 		// TODO: Update this string with the published name of your provider.
 		Address: "registry.terraform.io/example-namespace/example",
-		Debug:   debug,
 	}
 
 	err := providerserver.Serve(context.Background(), provider.New(version), opts)
@@ -78,7 +72,6 @@ To configure the provider server for protocol version 5, set the [`providerserve
 opts := providerserver.ServeOpts{
 	// TODO: Update this string with the published name of your provider.
 	Address:         "registry.terraform.io/example-namespace/example",
-	Debug:           debug,
 	ProtocolVersion: 5,
 }
 ```
@@ -92,4 +85,3 @@ Refer to the [acceptance testing](/plugin/framework/acctests) page for implement
 ### Debugging
 
 Refer to the [debugging](/plugin/framework/) page for implementation details.
-

--- a/website/docs/plugin/framework/providers.mdx
+++ b/website/docs/plugin/framework/providers.mdx
@@ -24,9 +24,14 @@ var _ tfsdk.Provider = &exampleProvider{}
 // will be passed to data sources and resources as the tfsdk.Provider parameter
 // in each NewDataSource and NewResource method call respectively.
 type exampleProvider struct{
-		// Typically fields including API clients or configuration necessary for
-		// resource and data source operations. For example:
-		client exampleApiClient
+	// Typically fields including API clients or configuration necessary for
+	// resource and data source operations. For example:
+	Client exampleApiClient
+
+	// version is an example field that can be set with an actual provider
+	// version on release, "dev" when the provider is built and ran locally,
+	// and "test" when running acceptance testing.
+	Version string
 }
 
 // GetSchema satisfies the tfsdk.Provider interface for exampleProvider.
@@ -55,6 +60,18 @@ func (p *exampleProvider) GetResources(ctx context.Context) (map[string]tfsdk.Re
 	return map[string]tfsdk.ResourceType{
 		// Provider specific implementation
 	}, nil
+}
+```
+
+Conventionally, many providers also create a helper function named `New` which can simplify [provider server](/plugin/framework/provider-servers) implementations.
+
+```go
+func New(version string) func() tfsdk.Provider {
+	return func() tfsdk.Provider {
+		return &exampleProvider{
+			Version: version,
+		}
+	}
 }
 ```
 

--- a/website/docs/plugin/framework/providers.mdx
+++ b/website/docs/plugin/framework/providers.mdx
@@ -1,31 +1,62 @@
 ---
 page_title: 'Plugin Development - Framework: Providers'
 description: >-
-  How to implement a provider in the provider development framework. Providers
-  are plugins that allow Terraform to interact with APIs.
+  How to implement a provider in the provider development framework. Providers,
+  wrapped by a provider server, are plugins that allow Terraform to interact
+  with APIs.
 ---
 
 # Providers
 
-Providers are Terraform plugins that supply
-[resources](/plugin/framework/resources) and [data
-sources](/plugin/framework/data-sources) for practitioners to use.
-They are implemented as binaries that the Terraform CLI downloads, starts,
-and stops. The provider is responsible for:
-
-- providing a [gRPC](https://grpc.io) server that can correctly handle
-  Terraform's handshake.
-- providing Terraform with information about how to connect to the server.
+Providers are Terraform plugins that define [resources](/plugin/framework/resources) and [data sources](/plugin/framework/data-sources) for practitioners to use. Providers are wrapped by a [provider server](/plugin/framework/provider-servers) for interacting with Terraform.
 
 ## Implement Provider Interface
 
-Any type that fills an
-[interface](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/tfsdk#Provider)
-can be a provider. We recommend that you define a `struct` type to fill this
-interface.
+Any type that fills the [tfsdk.Provider interface](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/tfsdk#Provider) can be a provider. The provider interface has four required methods: `GetSchema`, `Configure`, `GetResources`, and `GetDataSources`. We recommend that you define a `struct` type to fill this interface.
 
-The provider has four methods it needs to handle: `GetSchema`, `Configure`,
-`GetResources`, and `GetDataSources`.
+An example provider implementation with a field storing an example API client:
+
+```go
+// Ensure the implementation satisfies the tfsdk.Provider interface.
+var _ tfsdk.Provider = &exampleProvider{}
+
+// exampleProvider implements the tfsdk.Provider interface. This implementation
+// will be passed to data sources and resources as the tfsdk.Provider parameter
+// in each NewDataSource and NewResource method call respectively.
+type exampleProvider struct{
+		// Typically fields including API clients or configuration necessary for
+		// resource and data source operations. For example:
+		client exampleApiClient
+}
+
+// GetSchema satisfies the tfsdk.Provider interface for exampleProvider.
+func (p *exampleProvider) GetSchema(ctx context.Context) (tfsdk.Schema, diag.Diagnostics) {
+	return tfsdk.Schema{
+		Attributes: map[string]tfsdk.Attribute{
+			// Provider specific implementation.
+		},
+	}, nil
+}
+
+// Configure satisfies the tfsdk.Provider interface for exampleProvider.
+func (p *exampleProvider) Configure(ctx context.Context, req tfsdk.ConfigureProviderRequest, resp *tfsdk.ConfigureProviderResponse) {
+	// Provider specific implementation.
+}
+
+// GetDataSources satisfies the tfsdk.Provider interface for exampleProvider.
+func (p *exampleProvider) GetDataSources(ctx context.Context) (map[string]tfsdk.DataSourceType, diag.Diagnostics) {
+	return map[string]tfsdk.DataSourceType{
+		// Provider specific implementation
+	}, nil
+}
+
+// GetResources satisfies the tfsdk.Provider interface for exampleProvider.
+func (p *exampleProvider) GetResources(ctx context.Context) (map[string]tfsdk.ResourceType, diag.Diagnostics) {
+	return map[string]tfsdk.ResourceType{
+		// Provider specific implementation
+	}, nil
+}
+```
 
 ### GetSchema
 


### PR DESCRIPTION
Closes #373

Previously, the sdk/v2 and framework documentation have glossed over the difference between a "provider" and the server that actually handles a lot of the implementation details to interface correctly with Terraform CLI and the acceptance testing framework. This page introduces the concept up front so provider developers are aware of this Terraform-specific implementation detail, introduces the Terraform Plugin Protocol with its versioning implications, and provides some reference code.

Other pages are updated to include protocol version 5 information.

Separately, the existing providers page could use some additional details to better describe the methods and their implementation, but that exercise is left for future changes.