### PR TITLE
types: Minor adjustment to string and map key quoting

### DIFF
--- a/types/map.go
+++ b/types/map.go
@@ -254,7 +254,7 @@ func (m Map) String() string {
 		if i != 0 {
 			res.WriteString(",")
 		}
-		res.WriteString(fmt.Sprintf(`"%s":%s`, k, m.Elems[k].String()))
+		res.WriteString(fmt.Sprintf("%q:%s", k, m.Elems[k].String()))
 	}
 	res.WriteString("}")
 

--- a/types/map_test.go
+++ b/types/map_test.go
@@ -747,6 +747,15 @@ func TestMapString(t *testing.T) {
 			},
 			expectation: `{"first":{"alpha":"hello","beta":"world","gamma":"foo","sigma":"bar"},"second":{"t":0,"x":0,"y":0,"z":0}}`,
 		},
+		"key-quotes": {
+			input: Map{
+				ElemType: BoolType,
+				Elems: map[string]attr.Value{
+					`testing is "fun"`: Bool{Value: true},
+				},
+			},
+			expectation: `{"testing is \"fun\"":true}`,
+		},
 		"unknown": {
 			input:       Map{Unknown: true},
 			expectation: "<unknown>",

--- a/types/string.go
+++ b/types/string.go
@@ -93,5 +93,5 @@ func (s String) String() string {
 		return attr.NullValueString
 	}
 
-	return fmt.Sprintf(`"%s"`, s.Value)
+	return fmt.Sprintf("%q", s.Value)
 }

--- a/types/string_test.go
+++ b/types/string_test.go
@@ -243,6 +243,10 @@ func TestStringString(t *testing.T) {
 			input:       String{Value: ""},
 			expectation: `""`,
 		},
+		"quotes": {
+			input:       String{Value: `testing is "fun"`},
+			expectation: `"testing is \"fun\""`,
+		},
 		"unknown": {
 			input:       String{Unknown: true},
 			expectation: "<unknown>",


### PR DESCRIPTION
Reference: https://pkg.go.dev/fmt

Allows the `fmt` package to automatically handle escaping of characters inside a quoted string.