### PR TITLE
.github/workflows: Add terraform-provider-corner testing for tfprotov5

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -22,10 +22,11 @@ jobs:
           go-version-file: 'go.mod'
       - run: go mod download
       - uses: golangci/golangci-lint-action@v3.2.0
-  terraform-provider-corner:
+  terraform-provider-corner-tfprotov5:
     defaults:
       run:
         working-directory: terraform-provider-corner
+    name: terraform-provider-corner (tfprotov5 / Terraform ${{ matrix.terraform}})
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -36,9 +37,53 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version-file: 'go.mod'
+      - uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: ${{ matrix.terraform }}
+          terraform_wrapper: false
       - run: go mod edit -replace=github.com/hashicorp/terraform-plugin-framework=../
       - run: go mod tidy
-      - run: go test -v ./internal/frameworkprovider
+      - run: go test -v ./internal/framework5provider
+    strategy:
+      fail-fast: false
+      matrix:
+        terraform:
+          - '0.12.*'
+          - '0.13.*'
+          - '0.14.*'
+          - '0.15.*'
+          - '1.0.*'
+          - '1.1.*'
+          - '1.2.*'
+  terraform-provider-corner-tfprotov6:
+    defaults:
+      run:
+        working-directory: terraform-provider-corner
+    name: terraform-provider-corner (tfprotov6 / Terraform ${{ matrix.terraform}})
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
+        with:
+          path: terraform-provider-corner
+          repository: hashicorp/terraform-provider-corner
+      - uses: actions/setup-go@v3
+        with:
+          go-version-file: 'go.mod'
+      - uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: ${{ matrix.terraform }}
+          terraform_wrapper: false
+      - run: go mod edit -replace=github.com/hashicorp/terraform-plugin-framework=../
+      - run: go mod tidy
+      - run: go test -v ./internal/framework6provider
+    strategy:
+      fail-fast: false
+      matrix:
+        terraform:
+          - '1.0.*'
+          - '1.1.*'
+          - '1.2.*'
   test:
     name: test (Go v${{ matrix.go-version }})
     runs-on: ubuntu-latest


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform-provider-corner/pull/70

The upstream `internal/frameworkprovider` package was migrated to `internal/framework6provider` for disambiguation. This will now also perform integration testing across the matrix of Terraform CLI versions that support each protocol in the hopes of catching any particular version-dependent bugs, especially on pre-1.0 Terraform CLI versions.

Cross-platform testing could also be performed if desired, however platform-dependent bugs in this module (and the previous terraform-plugin-sdk module) have been rare or non-existent so it is omitted for now to reduce the potential for false positives.