### PR TITLE
tfsdk: Add missing Resource interface declaration in ResourceWithImportState and ResourceWithUpgradeState

### DIFF
--- a/tfsdk/resource_import.go
+++ b/tfsdk/resource_import.go
@@ -11,6 +11,8 @@ import (
 // `terraform import` command is executed. Afterwards, the ReadResource RPC
 // is executed to allow providers to fully populate the resource state.
 type ResourceWithImportState interface {
+	Resource
+
 	// ImportState is called when the provider must import the state of a
 	// resource instance. This method must return enough state so the Read
 	// method can properly refresh the full resource.

--- a/tfsdk/resource_upgrade_state.go
+++ b/tfsdk/resource_upgrade_state.go
@@ -19,6 +19,8 @@ import (
 // existing state. In this situation the framework will not execute any
 // provider defined logic, so declaring it for this version is extraneous.
 type ResourceWithUpgradeState interface {
+	Resource
+
 	// A mapping of prior state version to current schema version state upgrade
 	// implementations. Only the specified state upgrader for the prior state
 	// version is called, rather than each version in between, so it must


### PR DESCRIPTION
This was brought up from internal feedback and is done for consistency with other "optional" interface types across the framework. These interfaces are meant to be extensions to the parent interface type, so they should already support the parent interface methods.