### PR TITLE
Add convenience functions for `ErrorsCount`, `WarningsCount`, `Errors` and`Warnings`

### DIFF
--- a/.changelog/392.txt
+++ b/.changelog/392.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+diag: `ErrorsCount`, `WarningsCount`, `Errors` and `Warnings` functions have been added to `diag.Diagnostics`
+```

--- a/.changelog/392.txt
+++ b/.changelog/392.txt
@@ -1,3 +1,3 @@
-```release-note:feature
+```release-note:enhancement
 diag: `ErrorsCount`, `WarningsCount`, `Errors` and `Warnings` functions have been added to `diag.Diagnostics`
 ```

--- a/diag/diagnostics.go
+++ b/diag/diagnostics.go
@@ -70,3 +70,55 @@ func (diags Diagnostics) HasError() bool {
 
 	return false
 }
+
+// ErrorsCount returns the number of Diagnostic in Diagnostics that are SeverityError.
+func (diags Diagnostics) ErrorsCount() int {
+	count := 0
+
+	for _, d := range diags {
+		if SeverityError == d.Severity() {
+			count++
+		}
+	}
+
+	return count
+}
+
+// WarningsCount returns the number of Diagnostic in Diagnostics that are SeverityWarning.
+func (diags Diagnostics) WarningsCount() int {
+	count := 0
+
+	for _, d := range diags {
+		if SeverityWarning == d.Severity() {
+			count++
+		}
+	}
+
+	return count
+}
+
+// Errors returns all the Diagnostic in Diagnostics that are SeverityError.
+func (diags Diagnostics) Errors() Diagnostics {
+	var dd Diagnostics
+
+	for _, d := range diags {
+		if SeverityError == d.Severity() {
+			dd = append(dd, d)
+		}
+	}
+
+	return dd
+}
+
+// Warnings returns all the Diagnostic in Diagnostics that are SeverityWarning.
+func (diags Diagnostics) Warnings() Diagnostics {
+	var dd Diagnostics
+
+	for _, d := range diags {
+		if SeverityWarning == d.Severity() {
+			dd = append(dd, d)
+		}
+	}
+
+	return dd
+}

--- a/diag/diagnostics.go
+++ b/diag/diagnostics.go
@@ -83,7 +83,7 @@ func (diags Diagnostics) WarningsCount() int {
 
 // Errors returns all the Diagnostic in Diagnostics that are SeverityError.
 func (diags Diagnostics) Errors() Diagnostics {
-	var dd Diagnostics
+	dd := Diagnostics{}
 
 	for _, d := range diags {
 		if SeverityError == d.Severity() {
@@ -96,7 +96,7 @@ func (diags Diagnostics) Errors() Diagnostics {
 
 // Warnings returns all the Diagnostic in Diagnostics that are SeverityWarning.
 func (diags Diagnostics) Warnings() Diagnostics {
-	var dd Diagnostics
+	dd := Diagnostics{}
 
 	for _, d := range diags {
 		if SeverityWarning == d.Severity() {

--- a/diag/diagnostics.go
+++ b/diag/diagnostics.go
@@ -73,28 +73,12 @@ func (diags Diagnostics) HasError() bool {
 
 // ErrorsCount returns the number of Diagnostic in Diagnostics that are SeverityError.
 func (diags Diagnostics) ErrorsCount() int {
-	count := 0
-
-	for _, d := range diags {
-		if SeverityError == d.Severity() {
-			count++
-		}
-	}
-
-	return count
+	return len(diags.Errors())
 }
 
 // WarningsCount returns the number of Diagnostic in Diagnostics that are SeverityWarning.
 func (diags Diagnostics) WarningsCount() int {
-	count := 0
-
-	for _, d := range diags {
-		if SeverityWarning == d.Severity() {
-			count++
-		}
-	}
-
-	return count
+	return len(diags.Warnings())
 }
 
 // Errors returns all the Diagnostic in Diagnostics that are SeverityError.

--- a/diag/diagnostics_test.go
+++ b/diag/diagnostics_test.go
@@ -528,12 +528,26 @@ func TestDiagnosticsErrorsCount(t *testing.T) {
 		expected int
 	}
 	tests := map[string]testCase{
+		"nil": {
+			diags:    nil,
+			expected: 0,
+		},
+		"empty": {
+			diags:    diag.Diagnostics{},
+			expected: 0,
+		},
 		"errors": {
 			diags: diag.Diagnostics{
 				diag.NewErrorDiagnostic("Error Summary", "Error detail."),
 				diag.NewWarningDiagnostic("Warning Summary", "Warning detail."),
 			},
 			expected: 1,
+		},
+		"warnings": {
+			diags: diag.Diagnostics{
+				diag.NewWarningDiagnostic("Error Summary", "Error detail."),
+			},
+			expected: 0,
 		},
 	}
 
@@ -557,12 +571,26 @@ func TestDiagnosticsWarningsCount(t *testing.T) {
 		expected int
 	}
 	tests := map[string]testCase{
+		"nil": {
+			diags:    nil,
+			expected: 0,
+		},
+		"empty": {
+			diags:    diag.Diagnostics{},
+			expected: 0,
+		},
 		"errors": {
 			diags: diag.Diagnostics{
 				diag.NewErrorDiagnostic("Error Summary", "Error detail."),
 				diag.NewWarningDiagnostic("Warning Summary", "Warning detail."),
 			},
 			expected: 1,
+		},
+		"warnings": {
+			diags: diag.Diagnostics{
+				diag.NewErrorDiagnostic("Error Summary", "Error detail."),
+			},
+			expected: 0,
 		},
 	}
 
@@ -586,6 +614,14 @@ func TestDiagnosticsErrors(t *testing.T) {
 		expected diag.Diagnostics
 	}
 	tests := map[string]testCase{
+		"nil": {
+			diags:    nil,
+			expected: diag.Diagnostics{},
+		},
+		"empty": {
+			diags:    diag.Diagnostics{},
+			expected: diag.Diagnostics{},
+		},
 		"errors": {
 			diags: diag.Diagnostics{
 				diag.NewErrorDiagnostic("Error Summary", "Error detail."),
@@ -594,6 +630,12 @@ func TestDiagnosticsErrors(t *testing.T) {
 			expected: diag.Diagnostics{
 				diag.NewErrorDiagnostic("Error Summary", "Error detail."),
 			},
+		},
+		"warnings": {
+			diags: diag.Diagnostics{
+				diag.NewWarningDiagnostic("Warning Summary", "Warning detail."),
+			},
+			expected: diag.Diagnostics{},
 		},
 	}
 
@@ -617,7 +659,21 @@ func TestDiagnosticsWarnings(t *testing.T) {
 		expected diag.Diagnostics
 	}
 	tests := map[string]testCase{
+		"nil": {
+			diags:    nil,
+			expected: diag.Diagnostics{},
+		},
+		"empty": {
+			diags:    diag.Diagnostics{},
+			expected: diag.Diagnostics{},
+		},
 		"errors": {
+			diags: diag.Diagnostics{
+				diag.NewErrorDiagnostic("Error Summary", "Error detail."),
+			},
+			expected: diag.Diagnostics{},
+		},
+		"warnings": {
 			diags: diag.Diagnostics{
 				diag.NewErrorDiagnostic("Error Summary", "Error detail."),
 				diag.NewWarningDiagnostic("Warning Summary", "Warning detail."),

--- a/diag/diagnostics_test.go
+++ b/diag/diagnostics_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 )
@@ -514,6 +515,126 @@ func TestDiagnosticsHasError(t *testing.T) {
 
 			if got != tc.expected {
 				t.Errorf("Unexpected response: got: %t, wanted: %t", got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestDiagnosticsErrorsCount(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		diags    diag.Diagnostics
+		expected int
+	}
+	tests := map[string]testCase{
+		"errors": {
+			diags: diag.Diagnostics{
+				diag.NewErrorDiagnostic("Error Summary", "Error detail."),
+				diag.NewWarningDiagnostic("Warning Summary", "Warning detail."),
+			},
+			expected: 1,
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			got := test.diags.ErrorsCount()
+
+			if diff := cmp.Diff(test.expected, got); diff != "" {
+				t.Fatalf("expected: %q, got: %q", test.expected, got)
+			}
+		})
+	}
+}
+
+func TestDiagnosticsWarningsCount(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		diags    diag.Diagnostics
+		expected int
+	}
+	tests := map[string]testCase{
+		"errors": {
+			diags: diag.Diagnostics{
+				diag.NewErrorDiagnostic("Error Summary", "Error detail."),
+				diag.NewWarningDiagnostic("Warning Summary", "Warning detail."),
+			},
+			expected: 1,
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			got := test.diags.WarningsCount()
+
+			if diff := cmp.Diff(test.expected, got); diff != "" {
+				t.Fatalf("expected: %q, got: %q", test.expected, got)
+			}
+		})
+	}
+}
+
+func TestDiagnosticsErrors(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		diags    diag.Diagnostics
+		expected diag.Diagnostics
+	}
+	tests := map[string]testCase{
+		"errors": {
+			diags: diag.Diagnostics{
+				diag.NewErrorDiagnostic("Error Summary", "Error detail."),
+				diag.NewWarningDiagnostic("Warning Summary", "Warning detail."),
+			},
+			expected: diag.Diagnostics{
+				diag.NewErrorDiagnostic("Error Summary", "Error detail."),
+			},
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			got := test.diags.Errors()
+
+			if diff := cmp.Diff(test.expected, got); diff != "" {
+				t.Fatalf("expected: %q, got: %q", test.expected, got)
+			}
+		})
+	}
+}
+
+func TestDiagnosticsWarnings(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		diags    diag.Diagnostics
+		expected diag.Diagnostics
+	}
+	tests := map[string]testCase{
+		"errors": {
+			diags: diag.Diagnostics{
+				diag.NewErrorDiagnostic("Error Summary", "Error detail."),
+				diag.NewWarningDiagnostic("Warning Summary", "Warning detail."),
+			},
+			expected: diag.Diagnostics{
+				diag.NewWarningDiagnostic("Warning Summary", "Warning detail."),
+			},
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			got := test.diags.Warnings()
+
+			if diff := cmp.Diff(test.expected, got); diff != "" {
+				t.Fatalf("expected: %q, got: %q", test.expected, got)
 			}
 		})
 	}


### PR DESCRIPTION
Closes: #391 

Adds the following convenience functions to Diagnostics:

- `ErrorsCount()`
- `WarningsCount()`
- `Errors()`
- `Warnings()`