### PR TITLE
tfsdk+website: Point documentation at terraform-plugin-framework-validators Go module

### DIFF
--- a/tfsdk/attribute.go
+++ b/tfsdk/attribute.go
@@ -78,7 +78,16 @@ type Attribute struct {
 	// instructing them on what upgrade steps to take.
 	DeprecationMessage string
 
-	// Validators defines validation functionality for the attribute.
+	// Validators define value validation functionality for the attribute. All
+	// elements of the slice of AttributeValidator are ran, regardless of any
+	// previous error diagnostics.
+	//
+	// Many common use case validators can be found in the
+	// github.com/hashicorp/terraform-plugin-framework-validators Go module.
+	//
+	// If the Type field points to a custom type that implements the
+	// xattr.TypeWithValidate interface, the validators defined in this field
+	// are ran in addition to the validation defined by the type.
 	Validators []AttributeValidator
 
 	// PlanModifiers defines a sequence of modifiers for this attribute at

--- a/website/docs/plugin/framework/schemas.mdx
+++ b/website/docs/plugin/framework/schemas.mdx
@@ -254,3 +254,7 @@ description](#markdowndescription), so too can individual attributes.
 
 Much like [resources, data sources, and providers can be
 deprecated](#deprecationmessage), so too can individual attributes.
+
+### Validators
+
+Each attribute can implement [value validation](/plugin/framework/validation), either by specifying the [`Attribute` type `Validators` field](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/tfsdk#Attribute.Validators) and/or by declaring a custom type in the `Type` field that [implements its own validators](/plugin/framework/validation#type-validation). Common use case validators can be found in the [terraform-plugin-framework-validators Go module](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework-validators).

--- a/website/docs/plugin/framework/validation.mdx
+++ b/website/docs/plugin/framework/validation.mdx
@@ -26,16 +26,25 @@ tfsdk.Attribute{
     // ... other Attribute configuration ...
 
     Validators: []AttributeValidators{
-        // These are example validators
-        stringLengthBetween(10, 256),
-        stringRegularExpression(regexp.MustCompile(`^[a-z0-9]+$`)),
+        // These are example validators from terraform-plugin-framework-validators
+        stringvalidator.LengthBetween(10, 256),
+        stringvalidator.RegexMatches(
+            regexp.MustCompile(`^[a-z0-9]+$`),
+            "must contain only lowercase alphanumeric characters",
+        ),
     },
 }
 ```
 
-All validators will always be run, regardless of whether previous validators returned an error or not.
+All validators in the slice will always be run, regardless of whether previous validators returned an error or not.
+
+### Common Use Case Attribute Validators
+
+You can implement attribute validators from the [terraform-plugin-framework-validators Go module](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework-validators), which contains validation handling for many common use cases such as string contents and integer ranges.
 
 ### Creating Attribute Validators
+
+If there is not an attribute validator in `terraform-plugin-framework-validators` that meets a specific use case, a provider-defined attribute validator can be created.
 
 To create an attribute validator, you must implement the [`tfsdk.AttributeValidator` interface](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/tfsdk#AttributeValidator). For example:
 
@@ -113,7 +122,7 @@ tfsdk.Attribute{
     // This is optional, example validation that is checked in addition
     // to any validation performed by the type
     Validators: []AttributeValidators{
-        stringLengthBetween(10, 256),
+        stringvalidator.LengthBetween(10, 256),
     },
 }
 ```


### PR DESCRIPTION
Closes #240

This updates the Go documentation for `tfsdk.Attribute.Validators` and website documentation to recommend github.com/hashicorp/terraform-plugin-framework-validators as a goto for common use case validation.