### PR TITLE
all: Add missing package-level Go documentation

### DIFF
--- a/diag/doc.go
+++ b/diag/doc.go
@@ -1,0 +1,5 @@
+// Package diag implements diagnostic functionality, which is a practitioner
+// feedback mechanism for providers. It is designed for display in Terraform
+// user interfaces, rather than logging based feedback, which is generally
+// saved to a file for later inspection and troubleshooting.
+package diag

--- a/internal/logging/doc.go
+++ b/internal/logging/doc.go
@@ -1,0 +1,3 @@
+// Package logging contains framework internal helpers for consistent logger
+// and log entry handling.
+package logging

--- a/internal/reflect/doc.go
+++ b/internal/reflect/doc.go
@@ -1,0 +1,3 @@
+// Package reflect contains the implementation for converting framework-defined
+// data into and from provider-defined Go types.
+package reflect

--- a/internal/testing/doc.go
+++ b/internal/testing/doc.go
@@ -1,0 +1,2 @@
+// Package testing contains internal framework helpers for unit testing.
+package testing

--- a/internal/testing/planmodifiers/doc.go
+++ b/internal/testing/planmodifiers/doc.go
@@ -1,0 +1,2 @@
+// Package planmodifiers contains plan modifiers for testing.
+package planmodifiers

--- a/internal/testing/testprovider/doc.go
+++ b/internal/testing/testprovider/doc.go
@@ -1,0 +1,2 @@
+// Package testprovider contains a fully declarative provider for testing.
+package testprovider

--- a/path/doc.go
+++ b/path/doc.go
@@ -1,0 +1,3 @@
+// Package path implements attribute path functionality, which defines
+// transversals into schema-based data.
+package path

--- a/providerserver/doc.go
+++ b/providerserver/doc.go
@@ -1,0 +1,4 @@
+// Package providerserver implements functionality for serving a provider,
+// such as directly starting a server in a production binary and conversion
+// functions for testing.
+package providerserver

--- a/tfsdk/doc.go
+++ b/tfsdk/doc.go
@@ -1,0 +1,3 @@
+// Package tfsdk contains core framework functionality for data sources,
+// providers, resources, schemas, and schema data.
+package tfsdk

--- a/types/doc.go
+++ b/types/doc.go
@@ -1,0 +1,4 @@
+// Package types contains the framework-defined data types and values, such as
+// boolean, floating point, integer, list, map, object, set, and string. These
+// types can be extended by providers for custom use cases.
+package types


### PR DESCRIPTION
Reference: https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework

This ensures all current Go packages have Go comment-based documentation for display in editors and on the pkg.go.dev website.