### PR TITLE
tfsdk: Adjust Validate method naming in DataSourceConfigValidator, ProviderConfigValidator, and ResourceConfigValidator interfaces

### DIFF
--- a/.changelog/pending.txt
+++ b/.changelog/pending.txt
@@ -1,0 +1,11 @@
+```release-note:breaking-change
+tfsdk: The `DataSourceConfigValidator` interface `Validate` method is now `ValidateDataSource` to support generic validators that satisfy `DataSourceConfigValidator`, `ProviderConfigValidator`, and `ResourceConfigValidator`
+```
+
+```release-note:breaking-change
+tfsdk: The `ProviderConfigValidator` interface `Validate` method is now `ValidateProvider` to support generic validators that satisfy `DataSourceConfigValidator`, `ProviderConfigValidator`, and `ResourceConfigValidator`
+```
+
+```release-note:breaking-change
+tfsdk: The `ResourceConfigValidator` interface `Validate` method is now `ValidateResource` to support generic validators that satisfy `DataSourceConfigValidator`, `ProviderConfigValidator`, and `ResourceConfigValidator`
+```

--- a/internal/fwserver/server_validatedatasourceconfig.go
+++ b/internal/fwserver/server_validatedatasourceconfig.go
@@ -57,7 +57,7 @@ func (s *Server) ValidateDataSourceConfig(ctx context.Context, req *ValidateData
 					logging.KeyDescription: configValidator.Description(ctx),
 				},
 			)
-			configValidator.Validate(ctx, vdscReq, vdscResp)
+			configValidator.ValidateDataSource(ctx, vdscReq, vdscResp)
 			logging.FrameworkDebug(
 				ctx,
 				"Called provider defined DataSourceConfigValidator",

--- a/internal/fwserver/server_validatedatasourceconfig_test.go
+++ b/internal/fwserver/server_validatedatasourceconfig_test.go
@@ -170,7 +170,7 @@ func TestServerValidateDataSourceConfig(t *testing.T) {
 							ConfigValidatorsMethod: func(ctx context.Context) []tfsdk.DataSourceConfigValidator {
 								return []tfsdk.DataSourceConfigValidator{
 									&testprovider.DataSourceConfigValidator{
-										ValidateMethod: func(ctx context.Context, req tfsdk.ValidateDataSourceConfigRequest, resp *tfsdk.ValidateDataSourceConfigResponse) {
+										ValidateDataSourceMethod: func(ctx context.Context, req tfsdk.ValidateDataSourceConfigRequest, resp *tfsdk.ValidateDataSourceConfigResponse) {
 											var got types.String
 
 											resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("test"), &got)...)
@@ -208,7 +208,7 @@ func TestServerValidateDataSourceConfig(t *testing.T) {
 							ConfigValidatorsMethod: func(ctx context.Context) []tfsdk.DataSourceConfigValidator {
 								return []tfsdk.DataSourceConfigValidator{
 									&testprovider.DataSourceConfigValidator{
-										ValidateMethod: func(ctx context.Context, req tfsdk.ValidateDataSourceConfigRequest, resp *tfsdk.ValidateDataSourceConfigResponse) {
+										ValidateDataSourceMethod: func(ctx context.Context, req tfsdk.ValidateDataSourceConfigRequest, resp *tfsdk.ValidateDataSourceConfigResponse) {
 											resp.Diagnostics.AddError("error summary", "error detail")
 										},
 									},

--- a/internal/fwserver/server_validateproviderconfig.go
+++ b/internal/fwserver/server_validateproviderconfig.go
@@ -46,7 +46,7 @@ func (s *Server) ValidateProviderConfig(ctx context.Context, req *ValidateProvid
 					logging.KeyDescription: configValidator.Description(ctx),
 				},
 			)
-			configValidator.Validate(ctx, vpcReq, vpcRes)
+			configValidator.ValidateProvider(ctx, vpcReq, vpcRes)
 			logging.FrameworkDebug(
 				ctx,
 				"Called provider defined ProviderConfigValidator",

--- a/internal/fwserver/server_validateproviderconfig_test.go
+++ b/internal/fwserver/server_validateproviderconfig_test.go
@@ -167,7 +167,7 @@ func TestServerValidateProviderConfig(t *testing.T) {
 					ConfigValidatorsMethod: func(ctx context.Context) []tfsdk.ProviderConfigValidator {
 						return []tfsdk.ProviderConfigValidator{
 							&testprovider.ProviderConfigValidator{
-								ValidateMethod: func(ctx context.Context, req tfsdk.ValidateProviderConfigRequest, resp *tfsdk.ValidateProviderConfigResponse) {
+								ValidateProviderMethod: func(ctx context.Context, req tfsdk.ValidateProviderConfigRequest, resp *tfsdk.ValidateProviderConfigResponse) {
 									var got types.String
 
 									resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("test"), &got)...)
@@ -203,7 +203,7 @@ func TestServerValidateProviderConfig(t *testing.T) {
 					ConfigValidatorsMethod: func(ctx context.Context) []tfsdk.ProviderConfigValidator {
 						return []tfsdk.ProviderConfigValidator{
 							&testprovider.ProviderConfigValidator{
-								ValidateMethod: func(ctx context.Context, req tfsdk.ValidateProviderConfigRequest, resp *tfsdk.ValidateProviderConfigResponse) {
+								ValidateProviderMethod: func(ctx context.Context, req tfsdk.ValidateProviderConfigRequest, resp *tfsdk.ValidateProviderConfigResponse) {
 									resp.Diagnostics.AddError("error summary", "error detail")
 								},
 							},

--- a/internal/fwserver/server_validateresourceconfig.go
+++ b/internal/fwserver/server_validateresourceconfig.go
@@ -57,7 +57,7 @@ func (s *Server) ValidateResourceConfig(ctx context.Context, req *ValidateResour
 					logging.KeyDescription: configValidator.Description(ctx),
 				},
 			)
-			configValidator.Validate(ctx, vdscReq, vdscResp)
+			configValidator.ValidateResource(ctx, vdscReq, vdscResp)
 			logging.FrameworkDebug(
 				ctx,
 				"Called provider defined ResourceConfigValidator",

--- a/internal/fwserver/server_validateresourceconfig_test.go
+++ b/internal/fwserver/server_validateresourceconfig_test.go
@@ -170,7 +170,7 @@ func TestServerValidateResourceConfig(t *testing.T) {
 							ConfigValidatorsMethod: func(ctx context.Context) []tfsdk.ResourceConfigValidator {
 								return []tfsdk.ResourceConfigValidator{
 									&testprovider.ResourceConfigValidator{
-										ValidateMethod: func(ctx context.Context, req tfsdk.ValidateResourceConfigRequest, resp *tfsdk.ValidateResourceConfigResponse) {
+										ValidateResourceMethod: func(ctx context.Context, req tfsdk.ValidateResourceConfigRequest, resp *tfsdk.ValidateResourceConfigResponse) {
 											var got types.String
 
 											resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("test"), &got)...)
@@ -208,7 +208,7 @@ func TestServerValidateResourceConfig(t *testing.T) {
 							ConfigValidatorsMethod: func(ctx context.Context) []tfsdk.ResourceConfigValidator {
 								return []tfsdk.ResourceConfigValidator{
 									&testprovider.ResourceConfigValidator{
-										ValidateMethod: func(ctx context.Context, req tfsdk.ValidateResourceConfigRequest, resp *tfsdk.ValidateResourceConfigResponse) {
+										ValidateResourceMethod: func(ctx context.Context, req tfsdk.ValidateResourceConfigRequest, resp *tfsdk.ValidateResourceConfigResponse) {
 											resp.Diagnostics.AddError("error summary", "error detail")
 										},
 									},

--- a/internal/testing/testprovider/datasourceconfigvalidator.go
+++ b/internal/testing/testprovider/datasourceconfigvalidator.go
@@ -13,7 +13,7 @@ type DataSourceConfigValidator struct {
 	// DataSourceConfigValidator interface methods
 	DescriptionMethod         func(context.Context) string
 	MarkdownDescriptionMethod func(context.Context) string
-	ValidateMethod            func(context.Context, tfsdk.ValidateDataSourceConfigRequest, *tfsdk.ValidateDataSourceConfigResponse)
+	ValidateDataSourceMethod  func(context.Context, tfsdk.ValidateDataSourceConfigRequest, *tfsdk.ValidateDataSourceConfigResponse)
 }
 
 // Description satisfies the tfsdk.DataSourceConfigValidator interface.
@@ -35,10 +35,10 @@ func (v *DataSourceConfigValidator) MarkdownDescription(ctx context.Context) str
 }
 
 // Validate satisfies the tfsdk.DataSourceConfigValidator interface.
-func (v *DataSourceConfigValidator) Validate(ctx context.Context, req tfsdk.ValidateDataSourceConfigRequest, resp *tfsdk.ValidateDataSourceConfigResponse) {
-	if v.ValidateMethod == nil {
+func (v *DataSourceConfigValidator) ValidateDataSource(ctx context.Context, req tfsdk.ValidateDataSourceConfigRequest, resp *tfsdk.ValidateDataSourceConfigResponse) {
+	if v.ValidateDataSourceMethod == nil {
 		return
 	}
 
-	v.ValidateMethod(ctx, req, resp)
+	v.ValidateDataSourceMethod(ctx, req, resp)
 }

--- a/internal/testing/testprovider/providerconfigvalidator.go
+++ b/internal/testing/testprovider/providerconfigvalidator.go
@@ -13,7 +13,7 @@ type ProviderConfigValidator struct {
 	// ProviderConfigValidator interface methods
 	DescriptionMethod         func(context.Context) string
 	MarkdownDescriptionMethod func(context.Context) string
-	ValidateMethod            func(context.Context, tfsdk.ValidateProviderConfigRequest, *tfsdk.ValidateProviderConfigResponse)
+	ValidateProviderMethod    func(context.Context, tfsdk.ValidateProviderConfigRequest, *tfsdk.ValidateProviderConfigResponse)
 }
 
 // Description satisfies the tfsdk.ProviderConfigValidator interface.
@@ -35,10 +35,10 @@ func (v *ProviderConfigValidator) MarkdownDescription(ctx context.Context) strin
 }
 
 // Validate satisfies the tfsdk.ProviderConfigValidator interface.
-func (v *ProviderConfigValidator) Validate(ctx context.Context, req tfsdk.ValidateProviderConfigRequest, resp *tfsdk.ValidateProviderConfigResponse) {
-	if v.ValidateMethod == nil {
+func (v *ProviderConfigValidator) ValidateProvider(ctx context.Context, req tfsdk.ValidateProviderConfigRequest, resp *tfsdk.ValidateProviderConfigResponse) {
+	if v.ValidateProviderMethod == nil {
 		return
 	}
 
-	v.ValidateMethod(ctx, req, resp)
+	v.ValidateProviderMethod(ctx, req, resp)
 }

--- a/internal/testing/testprovider/resourceconfigvalidator.go
+++ b/internal/testing/testprovider/resourceconfigvalidator.go
@@ -13,7 +13,7 @@ type ResourceConfigValidator struct {
 	// ResourceConfigValidator interface methods
 	DescriptionMethod         func(context.Context) string
 	MarkdownDescriptionMethod func(context.Context) string
-	ValidateMethod            func(context.Context, tfsdk.ValidateResourceConfigRequest, *tfsdk.ValidateResourceConfigResponse)
+	ValidateResourceMethod    func(context.Context, tfsdk.ValidateResourceConfigRequest, *tfsdk.ValidateResourceConfigResponse)
 }
 
 // Description satisfies the tfsdk.ResourceConfigValidator interface.
@@ -35,10 +35,10 @@ func (v *ResourceConfigValidator) MarkdownDescription(ctx context.Context) strin
 }
 
 // Validate satisfies the tfsdk.ResourceConfigValidator interface.
-func (v *ResourceConfigValidator) Validate(ctx context.Context, req tfsdk.ValidateResourceConfigRequest, resp *tfsdk.ValidateResourceConfigResponse) {
-	if v.ValidateMethod == nil {
+func (v *ResourceConfigValidator) ValidateResource(ctx context.Context, req tfsdk.ValidateResourceConfigRequest, resp *tfsdk.ValidateResourceConfigResponse) {
+	if v.ValidateResourceMethod == nil {
 		return
 	}
 
-	v.ValidateMethod(ctx, req, resp)
+	v.ValidateResourceMethod(ctx, req, resp)
 }

--- a/tfsdk/data_source_validation.go
+++ b/tfsdk/data_source_validation.go
@@ -18,8 +18,8 @@ type DataSourceConfigValidator interface {
 	// descriptions by external tooling.
 	MarkdownDescription(context.Context) string
 
-	// Validate performs the validation.
-	Validate(context.Context, ValidateDataSourceConfigRequest, *ValidateDataSourceConfigResponse)
+	// ValidateDataSource performs the validation.
+	ValidateDataSource(context.Context, ValidateDataSourceConfigRequest, *ValidateDataSourceConfigResponse)
 }
 
 // DataSourceWithConfigValidators is an interface type that extends DataSource to include declarative validations.

--- a/tfsdk/provider_validation.go
+++ b/tfsdk/provider_validation.go
@@ -18,8 +18,8 @@ type ProviderConfigValidator interface {
 	// descriptions by external tooling.
 	MarkdownDescription(context.Context) string
 
-	// Validate performs the validation.
-	Validate(context.Context, ValidateProviderConfigRequest, *ValidateProviderConfigResponse)
+	// ValidateProvider performs the validation.
+	ValidateProvider(context.Context, ValidateProviderConfigRequest, *ValidateProviderConfigResponse)
 }
 
 // ProviderWithConfigValidators is an interface type that extends Provider to include declarative validations.

--- a/tfsdk/resource_validation.go
+++ b/tfsdk/resource_validation.go
@@ -18,8 +18,8 @@ type ResourceConfigValidator interface {
 	// descriptions by external tooling.
 	MarkdownDescription(context.Context) string
 
-	// Validate performs the validation.
-	Validate(context.Context, ValidateResourceConfigRequest, *ValidateResourceConfigResponse)
+	// ValidateResource performs the validation.
+	ValidateResource(context.Context, ValidateResourceConfigRequest, *ValidateResourceConfigResponse)
 }
 
 // ResourceWithConfigValidators is an interface type that extends Resource to include declarative validations.


### PR DESCRIPTION
Closes #404