### PR TITLE
.github: Remove @hashicorp/team-tw-packer-and-terraform from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
 * @hashicorp/terraform-devex
-/website/**/*.mdx @hashicorp/terraform-devex @hashicorp/team-tw-packer-and-terraform


### PR DESCRIPTION
Per team request, removing from automatic review requests.  Will instead request reviews manually when desired.