### PR TITLE
tfsdk: Ensure Config, Plan, and State PathMatches will return null and unknown parent paths

### DIFF
--- a/path/expression.go
+++ b/path/expression.go
@@ -131,6 +131,15 @@ func (e Expression) Matches(path Path) bool {
 	return e.steps.Matches(path.Steps())
 }
 
+// MatchesParent returns true if the given Path is a valid parent for the
+// Expression. This is helpful for determining if a child Path would
+// potentially match the full Expression during depth-first traversal. Any
+// relative expression steps, such as ExpressionStepParent, are automatically
+// resolved before matching.
+func (e Expression) MatchesParent(path Path) bool {
+	return e.steps.MatchesParent(path.Steps())
+}
+
 // Merge returns a copied expression either with the steps of the given
 // expression added to the end of the existing steps, or overwriting the
 // steps if the given expression was a root expression.
@@ -150,6 +159,24 @@ func (e Expression) Merge(other Expression) Expression {
 	copiedExpression.steps.Append(other.steps...)
 
 	return copiedExpression
+}
+
+// MergeExpressions returns collection of expressions that calls Merge() on
+// the current expression with each of the others.
+func (e Expression) MergeExpressions(others ...Expression) Expressions {
+	var result Expressions
+
+	if len(others) == 0 {
+		result.Append(e)
+
+		return result
+	}
+
+	for _, other := range others {
+		result.Append(e.Merge(other))
+	}
+
+	return result
 }
 
 // Resolve returns a copied expression with any relative steps, such as

--- a/path/expression_steps.go
+++ b/path/expression_steps.go
@@ -84,6 +84,37 @@ func (s ExpressionSteps) Matches(pathSteps PathSteps) bool {
 	return true
 }
 
+// MatchesParent returns true if the given PathSteps match each ExpressionStep
+// until there are no more PathSteps. This is helpful for determining if the
+// PathSteps would potentially match the full ExpressionSteps during
+// depth-first traversal.
+//
+// Any ExpressionStepParent will automatically be resolved.
+func (s ExpressionSteps) MatchesParent(pathSteps PathSteps) bool {
+	resolvedExpressionSteps := s.Resolve()
+
+	// Empty expression should not match anything to prevent false positives.
+	// Ensure to not return false on an empty path since walking a path always
+	// starts with no steps.
+	if len(resolvedExpressionSteps) == 0 {
+		return false
+	}
+
+	// Path steps deeper than or equal to the expression steps should not match
+	// as a potential parent.
+	if len(pathSteps) >= len(resolvedExpressionSteps) {
+		return false
+	}
+
+	for stepIndex, pathStep := range pathSteps {
+		if !resolvedExpressionSteps[stepIndex].Matches(pathStep) {
+			return false
+		}
+	}
+
+	return true
+}
+
 // NextStep returns the first ExpressionStep and the remaining ExpressionSteps.
 func (s ExpressionSteps) NextStep() (ExpressionStep, ExpressionSteps) {
 	if len(s) == 0 {

--- a/path/expression_steps_test.go
+++ b/path/expression_steps_test.go
@@ -663,6 +663,422 @@ func TestExpressionStepsMatches(t *testing.T) {
 	}
 }
 
+func TestExpressionStepsMatchesParent(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		steps     path.ExpressionSteps
+		pathSteps path.PathSteps
+		expected  bool
+	}{
+		"empty-empty": {
+			steps:     path.ExpressionSteps{},
+			pathSteps: path.PathSteps{},
+			expected:  false,
+		},
+		"empty-nonempty": {
+			steps: path.ExpressionSteps{},
+			pathSteps: path.PathSteps{
+				path.PathStepAttributeName("test"),
+			},
+			expected: false,
+		},
+		"nonempty-empty": {
+			steps: path.ExpressionSteps{
+				path.ExpressionStepAttributeNameExact("test"),
+			},
+			pathSteps: path.PathSteps{},
+			expected:  true,
+		},
+		"AttributeNameExact-different": {
+			steps: path.ExpressionSteps{
+				path.ExpressionStepAttributeNameExact("test"),
+			},
+			pathSteps: path.PathSteps{
+				path.PathStepAttributeName("not-test"),
+			},
+			expected: false,
+		},
+		"AttributeNameExact-equal": {
+			steps: path.ExpressionSteps{
+				path.ExpressionStepAttributeNameExact("test"),
+			},
+			pathSteps: path.PathSteps{
+				path.PathStepAttributeName("test"),
+			},
+			expected: false,
+		},
+		"AttributeNameExact-parent": {
+			steps: path.ExpressionSteps{
+				path.ExpressionStepAttributeNameExact("test1"),
+				path.ExpressionStepAttributeNameExact("test2"),
+			},
+			pathSteps: path.PathSteps{
+				path.PathStepAttributeName("test1"),
+			},
+			expected: true,
+		},
+		"AttributeNameExact-AttributeNameExact-different-firststep": {
+			steps: path.ExpressionSteps{
+				path.ExpressionStepAttributeNameExact("test1"),
+				path.ExpressionStepAttributeNameExact("test2"),
+			},
+			pathSteps: path.PathSteps{
+				path.PathStepAttributeName("test2"),
+				path.PathStepAttributeName("test2"),
+			},
+			expected: false,
+		},
+		"AttributeNameExact-AttributeNameExact-different-laststep": {
+			steps: path.ExpressionSteps{
+				path.ExpressionStepAttributeNameExact("test1"),
+				path.ExpressionStepAttributeNameExact("test2"),
+			},
+			pathSteps: path.PathSteps{
+				path.PathStepAttributeName("test1"),
+				path.PathStepAttributeName("test3"),
+			},
+			expected: false,
+		},
+		"AttributeNameExact-AttributeNameExact-equal": {
+			steps: path.ExpressionSteps{
+				path.ExpressionStepAttributeNameExact("test1"),
+				path.ExpressionStepAttributeNameExact("test2"),
+			},
+			pathSteps: path.PathSteps{
+				path.PathStepAttributeName("test1"),
+				path.PathStepAttributeName("test2"),
+			},
+			expected: false,
+		},
+		"AttributeNameExact-AttributeNameExact-parent": {
+			steps: path.ExpressionSteps{
+				path.ExpressionStepAttributeNameExact("test1"),
+				path.ExpressionStepAttributeNameExact("test2"),
+				path.ExpressionStepAttributeNameExact("test3"),
+			},
+			pathSteps: path.PathSteps{
+				path.PathStepAttributeName("test1"),
+				path.PathStepAttributeName("test2"),
+			},
+			expected: true,
+		},
+		"AttributeNameExact-AttributeNameExact-Parent-different": {
+			steps: path.ExpressionSteps{
+				path.ExpressionStepAttributeNameExact("test1"),
+				path.ExpressionStepAttributeNameExact("test2"),
+				path.ExpressionStepParent{},
+			},
+			pathSteps: path.PathSteps{
+				path.PathStepAttributeName("test2"),
+			},
+			expected: false,
+		},
+		"AttributeNameExact-AttributeNameExact-Parent-equal": {
+			steps: path.ExpressionSteps{
+				path.ExpressionStepAttributeNameExact("test1"),
+				path.ExpressionStepAttributeNameExact("test2"),
+				path.ExpressionStepParent{},
+			},
+			pathSteps: path.PathSteps{
+				path.PathStepAttributeName("test1"),
+			},
+			expected: false,
+		},
+		"AttributeNameExact-AttributeNameExact-Parent-parent": {
+			steps: path.ExpressionSteps{
+				path.ExpressionStepAttributeNameExact("test1"),
+				path.ExpressionStepAttributeNameExact("test2"),
+				path.ExpressionStepParent{},
+				path.ExpressionStepAttributeNameExact("test3"),
+			},
+			pathSteps: path.PathSteps{
+				path.PathStepAttributeName("test1"),
+			},
+			expected: true,
+		},
+		"AttributeNameExact-AttributeNameExact-Parent-AttributeNameExact-different": {
+			steps: path.ExpressionSteps{
+				path.ExpressionStepAttributeNameExact("test1"),
+				path.ExpressionStepAttributeNameExact("test2"),
+				path.ExpressionStepParent{},
+				path.ExpressionStepAttributeNameExact("test3"),
+			},
+			pathSteps: path.PathSteps{
+				path.PathStepAttributeName("test1"),
+				path.PathStepAttributeName("test2"),
+			},
+			expected: false,
+		},
+		"AttributeNameExact-AttributeNameExact-Parent-AttributeNameExact-equal": {
+			steps: path.ExpressionSteps{
+				path.ExpressionStepAttributeNameExact("test1"),
+				path.ExpressionStepAttributeNameExact("test2"),
+				path.ExpressionStepParent{},
+				path.ExpressionStepAttributeNameExact("test3"),
+			},
+			pathSteps: path.PathSteps{
+				path.PathStepAttributeName("test1"),
+				path.PathStepAttributeName("test3"),
+			},
+			expected: false,
+		},
+		"AttributeNameExact-AttributeNameExact-Parent-AttributeNameExact-parent": {
+			steps: path.ExpressionSteps{
+				path.ExpressionStepAttributeNameExact("test1"),
+				path.ExpressionStepAttributeNameExact("test2"),
+				path.ExpressionStepParent{},
+				path.ExpressionStepAttributeNameExact("test3"),
+				path.ExpressionStepAttributeNameExact("test4"),
+			},
+			pathSteps: path.PathSteps{
+				path.PathStepAttributeName("test1"),
+				path.PathStepAttributeName("test3"),
+			},
+			expected: true,
+		},
+		"AttributeNameExact-ElementKeyIntAny": {
+			steps: path.ExpressionSteps{
+				path.ExpressionStepAttributeNameExact("test"),
+				path.ExpressionStepElementKeyIntAny{},
+			},
+			pathSteps: path.PathSteps{
+				path.PathStepAttributeName("test"),
+				path.PathStepElementKeyInt(0),
+			},
+			expected: false,
+		},
+		"AttributeNameExact-ElementKeyIntAny-parent": {
+			steps: path.ExpressionSteps{
+				path.ExpressionStepAttributeNameExact("test1"),
+				path.ExpressionStepElementKeyIntAny{},
+				path.ExpressionStepAttributeNameExact("test2"),
+			},
+			pathSteps: path.PathSteps{
+				path.PathStepAttributeName("test1"),
+				path.PathStepElementKeyInt(0),
+			},
+			expected: true,
+		},
+		"AttributeNameExact-ElementKeyIntExact-different": {
+			steps: path.ExpressionSteps{
+				path.ExpressionStepAttributeNameExact("test"),
+				path.ExpressionStepElementKeyIntExact(0),
+			},
+			pathSteps: path.PathSteps{
+				path.PathStepAttributeName("test"),
+				path.PathStepElementKeyInt(1),
+			},
+			expected: false,
+		},
+		"AttributeNameExact-ElementKeyIntExact-equal": {
+			steps: path.ExpressionSteps{
+				path.ExpressionStepAttributeNameExact("test"),
+				path.ExpressionStepElementKeyIntExact(0),
+			},
+			pathSteps: path.PathSteps{
+				path.PathStepAttributeName("test"),
+				path.PathStepElementKeyInt(0),
+			},
+			expected: false,
+		},
+		"AttributeNameExact-ElementKeyIntExact-parent": {
+			steps: path.ExpressionSteps{
+				path.ExpressionStepAttributeNameExact("test1"),
+				path.ExpressionStepElementKeyIntExact(0),
+				path.ExpressionStepAttributeNameExact("test2"),
+			},
+			pathSteps: path.PathSteps{
+				path.PathStepAttributeName("test1"),
+				path.PathStepElementKeyInt(0),
+			},
+			expected: true,
+		},
+		"AttributeNameExact-ElementKeyStringAny": {
+			steps: path.ExpressionSteps{
+				path.ExpressionStepAttributeNameExact("test"),
+				path.ExpressionStepElementKeyStringAny{},
+			},
+			pathSteps: path.PathSteps{
+				path.PathStepAttributeName("test"),
+				path.PathStepElementKeyString("test-key"),
+			},
+			expected: false,
+		},
+		"AttributeNameExact-ElementKeyStringAny-parent": {
+			steps: path.ExpressionSteps{
+				path.ExpressionStepAttributeNameExact("test1"),
+				path.ExpressionStepElementKeyStringAny{},
+				path.ExpressionStepAttributeNameExact("test2"),
+			},
+			pathSteps: path.PathSteps{
+				path.PathStepAttributeName("test1"),
+				path.PathStepElementKeyString("test-key"),
+			},
+			expected: true,
+		},
+		"AttributeNameExact-ElementKeyStringExact-different": {
+			steps: path.ExpressionSteps{
+				path.ExpressionStepAttributeNameExact("test"),
+				path.ExpressionStepElementKeyStringExact("test-key"),
+			},
+			pathSteps: path.PathSteps{
+				path.PathStepAttributeName("test"),
+				path.PathStepElementKeyString("not-test-key"),
+			},
+			expected: false,
+		},
+		"AttributeNameExact-ElementKeyStringExact-equal": {
+			steps: path.ExpressionSteps{
+				path.ExpressionStepAttributeNameExact("test"),
+				path.ExpressionStepElementKeyStringExact("test-key"),
+			},
+			pathSteps: path.PathSteps{
+				path.PathStepAttributeName("test"),
+				path.PathStepElementKeyString("test-key"),
+			},
+			expected: false,
+		},
+		"AttributeNameExact-ElementKeyStringExact-parent": {
+			steps: path.ExpressionSteps{
+				path.ExpressionStepAttributeNameExact("test1"),
+				path.ExpressionStepElementKeyStringExact("test-key"),
+				path.ExpressionStepAttributeNameExact("test2"),
+			},
+			pathSteps: path.PathSteps{
+				path.PathStepAttributeName("test1"),
+				path.PathStepElementKeyString("test-key"),
+			},
+			expected: true,
+		},
+		"AttributeNameExact-ElementKeyValueAny": {
+			steps: path.ExpressionSteps{
+				path.ExpressionStepAttributeNameExact("test"),
+				path.ExpressionStepElementKeyValueAny{},
+			},
+			pathSteps: path.PathSteps{
+				path.PathStepAttributeName("test"),
+				path.PathStepElementKeyValue{Value: types.String{Value: "test-value"}},
+			},
+			expected: false,
+		},
+		"AttributeNameExact-ElementKeyValueAny-parent": {
+			steps: path.ExpressionSteps{
+				path.ExpressionStepAttributeNameExact("test1"),
+				path.ExpressionStepElementKeyValueAny{},
+				path.ExpressionStepAttributeNameExact("test2"),
+			},
+			pathSteps: path.PathSteps{
+				path.PathStepAttributeName("test1"),
+				path.PathStepElementKeyValue{Value: types.String{Value: "test-value"}},
+			},
+			expected: true,
+		},
+		"AttributeNameExact-ElementKeyValueExact-different": {
+			steps: path.ExpressionSteps{
+				path.ExpressionStepAttributeNameExact("test"),
+				path.ExpressionStepElementKeyValueExact{Value: types.String{Value: "test-value"}},
+			},
+			pathSteps: path.PathSteps{
+				path.PathStepAttributeName("test"),
+				path.PathStepElementKeyValue{Value: types.String{Value: "not-test-value"}},
+			},
+			expected: false,
+		},
+		"AttributeNameExact-ElementKeyValueExact-equal": {
+			steps: path.ExpressionSteps{
+				path.ExpressionStepAttributeNameExact("test"),
+				path.ExpressionStepElementKeyValueExact{Value: types.String{Value: "test-value"}},
+			},
+			pathSteps: path.PathSteps{
+				path.PathStepAttributeName("test"),
+				path.PathStepElementKeyValue{Value: types.String{Value: "test-value"}},
+			},
+			expected: false,
+		},
+		"AttributeNameExact-ElementKeyValueExact-parent": {
+			steps: path.ExpressionSteps{
+				path.ExpressionStepAttributeNameExact("test1"),
+				path.ExpressionStepElementKeyValueExact{Value: types.String{Value: "test-value"}},
+				path.ExpressionStepAttributeNameExact("test2"),
+			},
+			pathSteps: path.PathSteps{
+				path.PathStepAttributeName("test1"),
+				path.PathStepElementKeyValue{Value: types.String{Value: "test-value"}},
+			},
+			expected: true,
+		},
+		"AttributeNameExact-Parent": {
+			steps: path.ExpressionSteps{
+				path.ExpressionStepAttributeNameExact("test1"),
+				path.ExpressionStepParent{},
+			},
+			pathSteps: path.PathSteps{
+				path.PathStepAttributeName("test1"),
+			},
+			expected: false,
+		},
+		"AttributeNameExact-Parent-AttributeNameExact-different": {
+			steps: path.ExpressionSteps{
+				path.ExpressionStepAttributeNameExact("test1"),
+				path.ExpressionStepParent{},
+				path.ExpressionStepAttributeNameExact("test2"),
+			},
+			pathSteps: path.PathSteps{
+				path.PathStepAttributeName("test1"),
+			},
+			expected: false,
+		},
+		"AttributeNameExact-Parent-AttributeNameExact-equal": {
+			steps: path.ExpressionSteps{
+				path.ExpressionStepAttributeNameExact("test1"),
+				path.ExpressionStepParent{},
+				path.ExpressionStepAttributeNameExact("test2"),
+			},
+			pathSteps: path.PathSteps{
+				path.PathStepAttributeName("test2"),
+			},
+			expected: false,
+		},
+		"AttributeNameExact-Parent-AttributeNameExact-parent": {
+			steps: path.ExpressionSteps{
+				path.ExpressionStepAttributeNameExact("test1"),
+				path.ExpressionStepParent{},
+				path.ExpressionStepAttributeNameExact("test2"),
+				path.ExpressionStepAttributeNameExact("test3"),
+			},
+			pathSteps: path.PathSteps{
+				path.PathStepAttributeName("test2"),
+			},
+			expected: true,
+		},
+		"Parent-AttributeNameExact": {
+			steps: path.ExpressionSteps{
+				path.ExpressionStepParent{},
+				path.ExpressionStepAttributeNameExact("test"),
+			},
+			pathSteps: path.PathSteps{
+				path.PathStepAttributeName("test"),
+			},
+			expected: false,
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.steps.MatchesParent(testCase.pathSteps)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
 func TestExpressionStepsNextStep(t *testing.T) {
 	t.Parallel()
 

--- a/tfsdk/config.go
+++ b/tfsdk/config.go
@@ -60,6 +60,10 @@ func (c Config) GetAttribute(ctx context.Context, path path.Path, target interfa
 }
 
 // PathMatches returns all matching path.Paths from the given path.Expression.
+//
+// If a parent path is null or unknown, which would prevent a full expression
+// from matching, the parent path is returned rather than no match to prevent
+// false positives.
 func (c Config) PathMatches(ctx context.Context, pathExpr path.Expression) (path.Paths, diag.Diagnostics) {
 	return pathMatches(ctx, c.Schema, c.Raw, pathExpr)
 }

--- a/tfsdk/config_test.go
+++ b/tfsdk/config_test.go
@@ -1795,6 +1795,15 @@ func TestConfigPathMatches(t *testing.T) {
 			},
 			expression: path.MatchRoot("not-test"),
 			expected:   nil,
+			expectedDiags: diag.Diagnostics{
+				diag.NewErrorDiagnostic(
+					"Invalid Path Expression for Schema Data",
+					"The Terraform Provider unexpectedly matched no paths with the given path expression and current schema data. "+
+						"This can happen if the path expression does not correctly follow the schema in structure or types. "+
+						"Please report this to the provider developers.\n\n"+
+						"Path Expression: not-test",
+				),
+			},
 		},
 	}
 

--- a/tfsdk/path_matches.go
+++ b/tfsdk/path_matches.go
@@ -10,6 +10,10 @@ import (
 
 // pathMatches returns all matching path.Paths from the given path.Expression.
 //
+// If a parent path is null or unknown, which would prevent a full expression
+// from matching, the parent path is returned rather than no match to prevent
+// false positives.
+//
 // TODO: This function should be part of a internal/schemadata package
 // except that doing so would currently introduce an import cycle due to the
 // Schema parameter here and Config/Plan/State.PathMatches needing to

--- a/tfsdk/path_matches.go
+++ b/tfsdk/path_matches.go
@@ -26,15 +26,54 @@ func pathMatches(ctx context.Context, schema Schema, tfTypeValue tftypes.Value, 
 		diags.Append(fwPathDiags...)
 
 		if diags.HasError() {
+			// If there was an error with conversion of the path at this level,
+			// no need to traverse further since a deeper path will error.
 			return false, nil
 		}
 
 		if pathExpr.Matches(fwPath) {
-			paths = append(paths, fwPath)
+			paths.Append(fwPath)
+
+			// If we matched, there is no need to traverse further since a
+			// deeper path will never match.
+			return false, nil
+		}
+
+		// If current path cannot be parent path, there is no need to traverse
+		// further since a deeper path will never match.
+		if !pathExpr.MatchesParent(fwPath) {
+			return false, nil
+		}
+
+		// If value at current path (now known to be a parent path of the
+		// expression) is null or unknown, return it as a valid path match
+		// since Walk will stop traversing deeper anyways and we want
+		// consumers to know about the path with the null or unknown value.
+		//
+		// This behavior may be confusing for consumers as fetching the value
+		// at this parent path will return a potentially unexpected type,
+		// however this is an implementation tradeoff to prevent false
+		// positives of missing null or unknown values.
+		if tfTypeValue.IsNull() || !tfTypeValue.IsKnown() {
+			paths.Append(fwPath)
+
+			return false, nil
 		}
 
 		return true, nil
 	})
+
+	// If there were no matches, including no parent path matches, it should be
+	// safe to assume the path expression was invalid for the schema.
+	if len(paths) == 0 {
+		diags.AddError(
+			"Invalid Path Expression for Schema Data",
+			"The Terraform Provider unexpectedly matched no paths with the given path expression and current schema data. "+
+				"This can happen if the path expression does not correctly follow the schema in structure or types. "+
+				"Please report this to the provider developers.\n\n"+
+				"Path Expression: "+pathExpr.String(),
+		)
+	}
 
 	return paths, diags
 }

--- a/tfsdk/path_matches_test.go
+++ b/tfsdk/path_matches_test.go
@@ -64,6 +64,178 @@ func TestPathMatches(t *testing.T) {
 			),
 			expression: path.MatchRoot("not-test"),
 			expected:   nil,
+			expectedDiags: diag.Diagnostics{
+				diag.NewErrorDiagnostic(
+					"Invalid Path Expression for Schema Data",
+					"The Terraform Provider unexpectedly matched no paths with the given path expression and current schema data. "+
+						"This can happen if the path expression does not correctly follow the schema in structure or types. "+
+						"Please report this to the provider developers.\n\n"+
+						"Path Expression: not-test",
+				),
+			},
+		},
+		"AttributeNameExact-AttributeNameExact-match": {
+			schema: Schema{
+				Attributes: map[string]Attribute{
+					"test_parent": {
+						Attributes: SingleNestedAttributes(map[string]Attribute{
+							"test_child": {
+								Type: types.StringType,
+							},
+						}),
+					},
+				},
+			},
+			tfTypeValue: tftypes.NewValue(
+				tftypes.Object{
+					AttributeTypes: map[string]tftypes.Type{
+						"test_parent": tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test_child": tftypes.String,
+							},
+						},
+					},
+				},
+				map[string]tftypes.Value{
+					"test_parent": tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test_child": tftypes.String,
+							},
+						},
+						map[string]tftypes.Value{
+							"test_child": tftypes.NewValue(tftypes.String, "test-value"),
+						},
+					),
+				},
+			),
+			expression: path.MatchRoot("test_parent").AtName("test_child"),
+			expected: path.Paths{
+				path.Root("test_parent").AtName("test_child"),
+			},
+		},
+		"AttributeNameExact-AttributeNameExact-mismatch": {
+			schema: Schema{
+				Attributes: map[string]Attribute{
+					"test_parent": {
+						Attributes: SingleNestedAttributes(map[string]Attribute{
+							"test_child": {
+								Type: types.StringType,
+							},
+						}),
+					},
+				},
+			},
+			tfTypeValue: tftypes.NewValue(
+				tftypes.Object{
+					AttributeTypes: map[string]tftypes.Type{
+						"test_parent": tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test_child": tftypes.String,
+							},
+						},
+					},
+				},
+				map[string]tftypes.Value{
+					"test_parent": tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test_child": tftypes.String,
+							},
+						},
+						map[string]tftypes.Value{
+							"test_child": tftypes.NewValue(tftypes.String, "test-value"),
+						},
+					),
+				},
+			),
+			expression: path.MatchRoot("test_parent").AtName("not_test_child"),
+			expected:   nil,
+			expectedDiags: diag.Diagnostics{
+				diag.NewErrorDiagnostic(
+					"Invalid Path Expression for Schema Data",
+					"The Terraform Provider unexpectedly matched no paths with the given path expression and current schema data. "+
+						"This can happen if the path expression does not correctly follow the schema in structure or types. "+
+						"Please report this to the provider developers.\n\n"+
+						"Path Expression: test_parent.not_test_child",
+				),
+			},
+		},
+		"AttributeNameExact-AttributeNameExact-parent-null": {
+			schema: Schema{
+				Attributes: map[string]Attribute{
+					"test_parent": {
+						Attributes: SingleNestedAttributes(map[string]Attribute{
+							"test_child": {
+								Type: types.StringType,
+							},
+						}),
+					},
+				},
+			},
+			tfTypeValue: tftypes.NewValue(
+				tftypes.Object{
+					AttributeTypes: map[string]tftypes.Type{
+						"test_parent": tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test_child": tftypes.String,
+							},
+						},
+					},
+				},
+				map[string]tftypes.Value{
+					"test_parent": tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test_child": tftypes.String,
+							},
+						},
+						nil,
+					),
+				},
+			),
+			expression: path.MatchRoot("test_parent").AtName("test_child"),
+			expected: path.Paths{
+				path.Root("test_parent"),
+			},
+		},
+		"AttributeNameExact-AttributeNameExact-parent-unknown": {
+			schema: Schema{
+				Attributes: map[string]Attribute{
+					"test_parent": {
+						Attributes: SingleNestedAttributes(map[string]Attribute{
+							"test_child": {
+								Type: types.StringType,
+							},
+						}),
+					},
+				},
+			},
+			tfTypeValue: tftypes.NewValue(
+				tftypes.Object{
+					AttributeTypes: map[string]tftypes.Type{
+						"test_parent": tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test_child": tftypes.String,
+							},
+						},
+					},
+				},
+				map[string]tftypes.Value{
+					"test_parent": tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test_child": tftypes.String,
+							},
+						},
+						tftypes.UnknownValue,
+					),
+				},
+			),
+			expression: path.MatchRoot("test_parent").AtName("test_child"),
+			expected: path.Paths{
+				path.Root("test_parent"),
+			},
 		},
 		"AttributeNameExact-ElementKeyIntAny-match": {
 			schema: Schema{
@@ -136,6 +308,79 @@ func TestPathMatches(t *testing.T) {
 			),
 			expression: path.MatchRoot("test").AtAnyListIndex(),
 			expected:   nil,
+			expectedDiags: diag.Diagnostics{
+				diag.NewErrorDiagnostic(
+					"Invalid Path Expression for Schema Data",
+					"The Terraform Provider unexpectedly matched no paths with the given path expression and current schema data. "+
+						"This can happen if the path expression does not correctly follow the schema in structure or types. "+
+						"Please report this to the provider developers.\n\n"+
+						"Path Expression: test[*]",
+				),
+			},
+		},
+		"AttributeNameExact-ElementKeyIntAny-parent-null": {
+			schema: Schema{
+				Attributes: map[string]Attribute{
+					"test": {
+						Type: types.ListType{
+							ElemType: types.StringType,
+						},
+					},
+				},
+			},
+			tfTypeValue: tftypes.NewValue(
+				tftypes.Object{
+					AttributeTypes: map[string]tftypes.Type{
+						"test": tftypes.List{
+							ElementType: tftypes.String,
+						},
+					},
+				},
+				map[string]tftypes.Value{
+					"test": tftypes.NewValue(
+						tftypes.List{
+							ElementType: tftypes.String,
+						},
+						nil,
+					),
+				},
+			),
+			expression: path.MatchRoot("test").AtAnyListIndex(),
+			expected: path.Paths{
+				path.Root("test"),
+			},
+		},
+		"AttributeNameExact-ElementKeyIntAny-parent-unknown": {
+			schema: Schema{
+				Attributes: map[string]Attribute{
+					"test": {
+						Type: types.ListType{
+							ElemType: types.StringType,
+						},
+					},
+				},
+			},
+			tfTypeValue: tftypes.NewValue(
+				tftypes.Object{
+					AttributeTypes: map[string]tftypes.Type{
+						"test": tftypes.List{
+							ElementType: tftypes.String,
+						},
+					},
+				},
+				map[string]tftypes.Value{
+					"test": tftypes.NewValue(
+						tftypes.List{
+							ElementType: tftypes.String,
+						},
+						tftypes.UnknownValue,
+					),
+				},
+			),
+			expression: path.MatchRoot("test").AtAnyListIndex(),
+			expected: path.Paths{
+				path.Root("test"),
+			},
 		},
 		"AttributeNameExact-ElementKeyIntExact-match": {
 			schema: Schema{
@@ -246,6 +491,146 @@ func TestPathMatches(t *testing.T) {
 				path.Root("test_parent").AtListIndex(1).AtName("test_child2"),
 			},
 		},
+		"AttributeNameExact-ElementKeyIntExact-AttributeNameExact-Parent-AttributeNameExact-parent-null": {
+			schema: Schema{
+				Attributes: map[string]Attribute{
+					"test_parent": {
+						Attributes: ListNestedAttributes(map[string]Attribute{
+							"test_child1": {
+								Type: types.StringType,
+							},
+							"test_child2": {
+								Type: types.StringType,
+							},
+						}),
+					},
+				},
+			},
+			tfTypeValue: tftypes.NewValue(
+				tftypes.Object{
+					AttributeTypes: map[string]tftypes.Type{
+						"test_parent": tftypes.List{
+							ElementType: tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"test_child1": tftypes.String,
+									"test_child2": tftypes.String,
+								},
+							},
+						},
+					},
+				},
+				map[string]tftypes.Value{
+					"test_parent": tftypes.NewValue(
+						tftypes.List{
+							ElementType: tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"test_child1": tftypes.String,
+									"test_child2": tftypes.String,
+								},
+							},
+						},
+						[]tftypes.Value{
+							tftypes.NewValue(
+								tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"test_child1": tftypes.String,
+										"test_child2": tftypes.String,
+									},
+								},
+								map[string]tftypes.Value{
+									"test_child1": tftypes.NewValue(tftypes.String, "test-value-list-0-child-1"),
+									"test_child2": tftypes.NewValue(tftypes.String, "test-value-list-0-child-2"),
+								},
+							),
+							tftypes.NewValue(
+								tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"test_child1": tftypes.String,
+										"test_child2": tftypes.String,
+									},
+								},
+								nil,
+							),
+						},
+					),
+				},
+			),
+			// e.g. Something that would be created in an attribute plan modifier or validator
+			expression: path.MatchRoot("test_parent").AtListIndex(1).AtName("test_child1").AtParent().AtName("test_child2"),
+			expected: path.Paths{
+				path.Root("test_parent").AtListIndex(1),
+			},
+		},
+		"AttributeNameExact-ElementKeyIntExact-AttributeNameExact-Parent-AttributeNameExact-parent-unknown": {
+			schema: Schema{
+				Attributes: map[string]Attribute{
+					"test_parent": {
+						Attributes: ListNestedAttributes(map[string]Attribute{
+							"test_child1": {
+								Type: types.StringType,
+							},
+							"test_child2": {
+								Type: types.StringType,
+							},
+						}),
+					},
+				},
+			},
+			tfTypeValue: tftypes.NewValue(
+				tftypes.Object{
+					AttributeTypes: map[string]tftypes.Type{
+						"test_parent": tftypes.List{
+							ElementType: tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"test_child1": tftypes.String,
+									"test_child2": tftypes.String,
+								},
+							},
+						},
+					},
+				},
+				map[string]tftypes.Value{
+					"test_parent": tftypes.NewValue(
+						tftypes.List{
+							ElementType: tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"test_child1": tftypes.String,
+									"test_child2": tftypes.String,
+								},
+							},
+						},
+						[]tftypes.Value{
+							tftypes.NewValue(
+								tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"test_child1": tftypes.String,
+										"test_child2": tftypes.String,
+									},
+								},
+								map[string]tftypes.Value{
+									"test_child1": tftypes.NewValue(tftypes.String, "test-value-list-0-child-1"),
+									"test_child2": tftypes.NewValue(tftypes.String, "test-value-list-0-child-2"),
+								},
+							),
+							tftypes.NewValue(
+								tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"test_child1": tftypes.String,
+										"test_child2": tftypes.String,
+									},
+								},
+								tftypes.UnknownValue,
+							),
+						},
+					),
+				},
+			),
+			// e.g. Something that would be created in an attribute plan modifier or validator
+			expression: path.MatchRoot("test_parent").AtListIndex(1).AtName("test_child1").AtParent().AtName("test_child2"),
+			expected: path.Paths{
+				path.Root("test_parent").AtListIndex(1),
+			},
+		},
 		"AttributeNameExact-ElementKeyIntExact-mismatch": {
 			schema: Schema{
 				Attributes: map[string]Attribute{
@@ -279,6 +664,79 @@ func TestPathMatches(t *testing.T) {
 			),
 			expression: path.MatchRoot("test").AtListIndex(4),
 			expected:   nil,
+			expectedDiags: diag.Diagnostics{
+				diag.NewErrorDiagnostic(
+					"Invalid Path Expression for Schema Data",
+					"The Terraform Provider unexpectedly matched no paths with the given path expression and current schema data. "+
+						"This can happen if the path expression does not correctly follow the schema in structure or types. "+
+						"Please report this to the provider developers.\n\n"+
+						"Path Expression: test[4]",
+				),
+			},
+		},
+		"AttributeNameExact-ElementKeyIntExact-parent-null": {
+			schema: Schema{
+				Attributes: map[string]Attribute{
+					"test": {
+						Type: types.ListType{
+							ElemType: types.StringType,
+						},
+					},
+				},
+			},
+			tfTypeValue: tftypes.NewValue(
+				tftypes.Object{
+					AttributeTypes: map[string]tftypes.Type{
+						"test": tftypes.List{
+							ElementType: tftypes.String,
+						},
+					},
+				},
+				map[string]tftypes.Value{
+					"test": tftypes.NewValue(
+						tftypes.List{
+							ElementType: tftypes.String,
+						},
+						nil,
+					),
+				},
+			),
+			expression: path.MatchRoot("test").AtListIndex(1),
+			expected: path.Paths{
+				path.Root("test"),
+			},
+		},
+		"AttributeNameExact-ElementKeyIntExact-parent-unknown": {
+			schema: Schema{
+				Attributes: map[string]Attribute{
+					"test": {
+						Type: types.ListType{
+							ElemType: types.StringType,
+						},
+					},
+				},
+			},
+			tfTypeValue: tftypes.NewValue(
+				tftypes.Object{
+					AttributeTypes: map[string]tftypes.Type{
+						"test": tftypes.List{
+							ElementType: tftypes.String,
+						},
+					},
+				},
+				map[string]tftypes.Value{
+					"test": tftypes.NewValue(
+						tftypes.List{
+							ElementType: tftypes.String,
+						},
+						tftypes.UnknownValue,
+					),
+				},
+			),
+			expression: path.MatchRoot("test").AtListIndex(1),
+			expected: path.Paths{
+				path.Root("test"),
+			},
 		},
 		"AttributeNameExact-ElementKeyStringAny-match": {
 			schema: Schema{
@@ -350,6 +808,79 @@ func TestPathMatches(t *testing.T) {
 			),
 			expression: path.MatchRoot("test").AtAnyMapKey(),
 			expected:   nil,
+			expectedDiags: diag.Diagnostics{
+				diag.NewErrorDiagnostic(
+					"Invalid Path Expression for Schema Data",
+					"The Terraform Provider unexpectedly matched no paths with the given path expression and current schema data. "+
+						"This can happen if the path expression does not correctly follow the schema in structure or types. "+
+						"Please report this to the provider developers.\n\n"+
+						"Path Expression: test[\"*\"]",
+				),
+			},
+		},
+		"AttributeNameExact-ElementKeyStringAny-parent-null": {
+			schema: Schema{
+				Attributes: map[string]Attribute{
+					"test": {
+						Type: types.MapType{
+							ElemType: types.StringType,
+						},
+					},
+				},
+			},
+			tfTypeValue: tftypes.NewValue(
+				tftypes.Object{
+					AttributeTypes: map[string]tftypes.Type{
+						"test": tftypes.Map{
+							ElementType: tftypes.String,
+						},
+					},
+				},
+				map[string]tftypes.Value{
+					"test": tftypes.NewValue(
+						tftypes.Map{
+							ElementType: tftypes.String,
+						},
+						nil,
+					),
+				},
+			),
+			expression: path.MatchRoot("test").AtAnyMapKey(),
+			expected: path.Paths{
+				path.Root("test"),
+			},
+		},
+		"AttributeNameExact-ElementKeyStringAny-parent-unknown": {
+			schema: Schema{
+				Attributes: map[string]Attribute{
+					"test": {
+						Type: types.MapType{
+							ElemType: types.StringType,
+						},
+					},
+				},
+			},
+			tfTypeValue: tftypes.NewValue(
+				tftypes.Object{
+					AttributeTypes: map[string]tftypes.Type{
+						"test": tftypes.Map{
+							ElementType: tftypes.String,
+						},
+					},
+				},
+				map[string]tftypes.Value{
+					"test": tftypes.NewValue(
+						tftypes.Map{
+							ElementType: tftypes.String,
+						},
+						tftypes.UnknownValue,
+					),
+				},
+			),
+			expression: path.MatchRoot("test").AtAnyMapKey(),
+			expected: path.Paths{
+				path.Root("test"),
+			},
 		},
 		"AttributeNameExact-ElementKeyStringExact-match": {
 			schema: Schema{
@@ -420,6 +951,79 @@ func TestPathMatches(t *testing.T) {
 			),
 			expression: path.MatchRoot("test").AtMapKey("test-key4"),
 			expected:   nil,
+			expectedDiags: diag.Diagnostics{
+				diag.NewErrorDiagnostic(
+					"Invalid Path Expression for Schema Data",
+					"The Terraform Provider unexpectedly matched no paths with the given path expression and current schema data. "+
+						"This can happen if the path expression does not correctly follow the schema in structure or types. "+
+						"Please report this to the provider developers.\n\n"+
+						"Path Expression: test[\"test-key4\"]",
+				),
+			},
+		},
+		"AttributeNameExact-ElementKeyStringExact-parent-null": {
+			schema: Schema{
+				Attributes: map[string]Attribute{
+					"test": {
+						Type: types.MapType{
+							ElemType: types.StringType,
+						},
+					},
+				},
+			},
+			tfTypeValue: tftypes.NewValue(
+				tftypes.Object{
+					AttributeTypes: map[string]tftypes.Type{
+						"test": tftypes.Map{
+							ElementType: tftypes.String,
+						},
+					},
+				},
+				map[string]tftypes.Value{
+					"test": tftypes.NewValue(
+						tftypes.Map{
+							ElementType: tftypes.String,
+						},
+						nil,
+					),
+				},
+			),
+			expression: path.MatchRoot("test").AtMapKey("test-key2"),
+			expected: path.Paths{
+				path.Root("test"),
+			},
+		},
+		"AttributeNameExact-ElementKeyStringExact-parent-unknown": {
+			schema: Schema{
+				Attributes: map[string]Attribute{
+					"test": {
+						Type: types.MapType{
+							ElemType: types.StringType,
+						},
+					},
+				},
+			},
+			tfTypeValue: tftypes.NewValue(
+				tftypes.Object{
+					AttributeTypes: map[string]tftypes.Type{
+						"test": tftypes.Map{
+							ElementType: tftypes.String,
+						},
+					},
+				},
+				map[string]tftypes.Value{
+					"test": tftypes.NewValue(
+						tftypes.Map{
+							ElementType: tftypes.String,
+						},
+						tftypes.UnknownValue,
+					),
+				},
+			),
+			expression: path.MatchRoot("test").AtMapKey("test-key2"),
+			expected: path.Paths{
+				path.Root("test"),
+			},
 		},
 		"AttributeNameExact-ElementKeyValueAny-match": {
 			schema: Schema{
@@ -492,6 +1096,79 @@ func TestPathMatches(t *testing.T) {
 			),
 			expression: path.MatchRoot("test").AtAnySetValue(),
 			expected:   nil,
+			expectedDiags: diag.Diagnostics{
+				diag.NewErrorDiagnostic(
+					"Invalid Path Expression for Schema Data",
+					"The Terraform Provider unexpectedly matched no paths with the given path expression and current schema data. "+
+						"This can happen if the path expression does not correctly follow the schema in structure or types. "+
+						"Please report this to the provider developers.\n\n"+
+						"Path Expression: test[Value(*)]",
+				),
+			},
+		},
+		"AttributeNameExact-ElementKeyValueAny-parent-null": {
+			schema: Schema{
+				Attributes: map[string]Attribute{
+					"test": {
+						Type: types.SetType{
+							ElemType: types.StringType,
+						},
+					},
+				},
+			},
+			tfTypeValue: tftypes.NewValue(
+				tftypes.Object{
+					AttributeTypes: map[string]tftypes.Type{
+						"test": tftypes.Set{
+							ElementType: tftypes.String,
+						},
+					},
+				},
+				map[string]tftypes.Value{
+					"test": tftypes.NewValue(
+						tftypes.Set{
+							ElementType: tftypes.String,
+						},
+						nil,
+					),
+				},
+			),
+			expression: path.MatchRoot("test").AtAnySetValue(),
+			expected: path.Paths{
+				path.Root("test"),
+			},
+		},
+		"AttributeNameExact-ElementKeyValueAny-parent-unknown": {
+			schema: Schema{
+				Attributes: map[string]Attribute{
+					"test": {
+						Type: types.SetType{
+							ElemType: types.StringType,
+						},
+					},
+				},
+			},
+			tfTypeValue: tftypes.NewValue(
+				tftypes.Object{
+					AttributeTypes: map[string]tftypes.Type{
+						"test": tftypes.Set{
+							ElementType: tftypes.String,
+						},
+					},
+				},
+				map[string]tftypes.Value{
+					"test": tftypes.NewValue(
+						tftypes.Set{
+							ElementType: tftypes.String,
+						},
+						tftypes.UnknownValue,
+					),
+				},
+			),
+			expression: path.MatchRoot("test").AtAnySetValue(),
+			expected: path.Paths{
+				path.Root("test"),
+			},
 		},
 		"AttributeNameExact-ElementKeyValueExact-match": {
 			schema: Schema{
@@ -562,6 +1239,79 @@ func TestPathMatches(t *testing.T) {
 			),
 			expression: path.MatchRoot("test").AtSetValue(types.String{Value: "test-value4"}),
 			expected:   nil,
+			expectedDiags: diag.Diagnostics{
+				diag.NewErrorDiagnostic(
+					"Invalid Path Expression for Schema Data",
+					"The Terraform Provider unexpectedly matched no paths with the given path expression and current schema data. "+
+						"This can happen if the path expression does not correctly follow the schema in structure or types. "+
+						"Please report this to the provider developers.\n\n"+
+						"Path Expression: test[Value(\"test-value4\")]",
+				),
+			},
+		},
+		"AttributeNameExact-ElementKeyValueExact-parent-null": {
+			schema: Schema{
+				Attributes: map[string]Attribute{
+					"test": {
+						Type: types.SetType{
+							ElemType: types.StringType,
+						},
+					},
+				},
+			},
+			tfTypeValue: tftypes.NewValue(
+				tftypes.Object{
+					AttributeTypes: map[string]tftypes.Type{
+						"test": tftypes.Set{
+							ElementType: tftypes.String,
+						},
+					},
+				},
+				map[string]tftypes.Value{
+					"test": tftypes.NewValue(
+						tftypes.Set{
+							ElementType: tftypes.String,
+						},
+						nil,
+					),
+				},
+			),
+			expression: path.MatchRoot("test").AtSetValue(types.String{Value: "test-value2"}),
+			expected: path.Paths{
+				path.Root("test"),
+			},
+		},
+		"AttributeNameExact-ElementKeyValueExact-parent-unknown": {
+			schema: Schema{
+				Attributes: map[string]Attribute{
+					"test": {
+						Type: types.SetType{
+							ElemType: types.StringType,
+						},
+					},
+				},
+			},
+			tfTypeValue: tftypes.NewValue(
+				tftypes.Object{
+					AttributeTypes: map[string]tftypes.Type{
+						"test": tftypes.Set{
+							ElementType: tftypes.String,
+						},
+					},
+				},
+				map[string]tftypes.Value{
+					"test": tftypes.NewValue(
+						tftypes.Set{
+							ElementType: tftypes.String,
+						},
+						tftypes.UnknownValue,
+					),
+				},
+			),
+			expression: path.MatchRoot("test").AtSetValue(types.String{Value: "test-value2"}),
+			expected: path.Paths{
+				path.Root("test"),
+			},
 		},
 		"AttributeNameExact-Parent": {
 			schema: Schema{
@@ -583,6 +1333,15 @@ func TestPathMatches(t *testing.T) {
 			),
 			expression: path.MatchRoot("test").AtParent(),
 			expected:   nil,
+			expectedDiags: diag.Diagnostics{
+				diag.NewErrorDiagnostic(
+					"Invalid Path Expression for Schema Data",
+					"The Terraform Provider unexpectedly matched no paths with the given path expression and current schema data. "+
+						"This can happen if the path expression does not correctly follow the schema in structure or types. "+
+						"Please report this to the provider developers.\n\n"+
+						"Path Expression: test.<",
+				),
+			},
 		},
 		"AttributeNameExact-Parent-Parent": {
 			schema: Schema{
@@ -604,6 +1363,15 @@ func TestPathMatches(t *testing.T) {
 			),
 			expression: path.MatchRoot("test").AtParent().AtParent(),
 			expected:   nil,
+			expectedDiags: diag.Diagnostics{
+				diag.NewErrorDiagnostic(
+					"Invalid Path Expression for Schema Data",
+					"The Terraform Provider unexpectedly matched no paths with the given path expression and current schema data. "+
+						"This can happen if the path expression does not correctly follow the schema in structure or types. "+
+						"Please report this to the provider developers.\n\n"+
+						"Path Expression: test.<.<",
+				),
+			},
 		},
 	}
 

--- a/tfsdk/plan.go
+++ b/tfsdk/plan.go
@@ -131,6 +131,10 @@ func (p Plan) getAttributeValue(ctx context.Context, path path.Path) (attr.Value
 }
 
 // PathMatches returns all matching path.Paths from the given path.Expression.
+//
+// If a parent path is null or unknown, which would prevent a full expression
+// from matching, the parent path is returned rather than no match to prevent
+// false positives.
 func (p Plan) PathMatches(ctx context.Context, pathExpr path.Expression) (path.Paths, diag.Diagnostics) {
 	return pathMatches(ctx, p.Schema, p.Raw, pathExpr)
 }

--- a/tfsdk/plan_test.go
+++ b/tfsdk/plan_test.go
@@ -2226,6 +2226,15 @@ func TestPlanPathMatches(t *testing.T) {
 			},
 			expression: path.MatchRoot("not-test"),
 			expected:   nil,
+			expectedDiags: diag.Diagnostics{
+				diag.NewErrorDiagnostic(
+					"Invalid Path Expression for Schema Data",
+					"The Terraform Provider unexpectedly matched no paths with the given path expression and current schema data. "+
+						"This can happen if the path expression does not correctly follow the schema in structure or types. "+
+						"Please report this to the provider developers.\n\n"+
+						"Path Expression: not-test",
+				),
+			},
 		},
 	}
 

--- a/tfsdk/state.go
+++ b/tfsdk/state.go
@@ -131,6 +131,10 @@ func (s State) getAttributeValue(ctx context.Context, path path.Path) (attr.Valu
 }
 
 // PathMatches returns all matching path.Paths from the given path.Expression.
+//
+// If a parent path is null or unknown, which would prevent a full expression
+// from matching, the parent path is returned rather than no match to prevent
+// false positives.
 func (s State) PathMatches(ctx context.Context, pathExpr path.Expression) (path.Paths, diag.Diagnostics) {
 	return pathMatches(ctx, s.Schema, s.Raw, pathExpr)
 }

--- a/tfsdk/state_test.go
+++ b/tfsdk/state_test.go
@@ -2923,6 +2923,15 @@ func TestStatePathMatches(t *testing.T) {
 			},
 			expression: path.MatchRoot("not-test"),
 			expected:   nil,
+			expectedDiags: diag.Diagnostics{
+				diag.NewErrorDiagnostic(
+					"Invalid Path Expression for Schema Data",
+					"The Terraform Provider unexpectedly matched no paths with the given path expression and current schema data. "+
+						"This can happen if the path expression does not correctly follow the schema in structure or types. "+
+						"Please report this to the provider developers.\n\n"+
+						"Path Expression: not-test",
+				),
+			},
 		},
 	}
 


### PR DESCRIPTION
This will also now return an error diagnostic if a given path expression is invalid for the schema data.

The `(path.Expression).MergeExpressions(...path.Expression) Expressions` is a helper method for the common use case of combining an attribute path expression with an incoming collection of expressions to perform generic validation across attributes.

This requires no CHANGELOG entries as it is unreleased functionality.