### PR TITLE
path+website: Additional Go documentation and initial website documentation for paths and path expressions

### DIFF
--- a/path/expressions.go
+++ b/path/expressions.go
@@ -3,6 +3,8 @@ package path
 import "strings"
 
 // Expressions is a collection of attribute path expressions.
+//
+// Refer to the Expression documentation for more details about intended usage.
 type Expressions []Expression
 
 // Append adds the given Expressions to the collection without duplication and

--- a/path/path.go
+++ b/path/path.go
@@ -4,9 +4,33 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 )
 
-// Path represents an attribute path with exact steps. Only exact path
-// transversals are supported with this implementation as it must remain
-// compatible with all protocol implementations.
+// Path represents exact traversal steps into a schema or schema-based data.
+// These steps always start from the root of the schema, which is an object
+// with zero or more attributes and blocks.
+//
+// Use the Root() function to create a Path with an initial AtName() step. Path
+// functionality follows a builder pattern, which allows for chaining method
+// calls to construct a full path. The available traversal steps after Path
+// creation are:
+//
+//     - AtListIndex(): Step into a list at a specific 0-based index
+//     - AtMapKey(): Step into a map at a specific key
+//     - AtName(): Step into an attribute or block with a specific name
+//     - AtSetValue(): Step into a set at a specific attr.Value element
+//
+// For example, to represent the first list element with a root list attribute
+// named "some_attribute":
+//
+//     path.MatchRoot("some_attribute").AtListIndex(0)
+//
+// Path is used for functionality which must exactly match the underlying
+// schema structure and types, such as diagnostics that are intended for a
+// specific attribute or working with specific attribute values in a schema
+// based data structure such as tfsdk.Config, tfsdk.Plan, or tfsdk.State.
+//
+// Refer to Expression for situations where relative or wildcard step logic is
+// desirable for schema defined functionality, such as attribute validators or
+// attribute plan modifiers.
 type Path struct {
 	// steps is the transversals included with the path. In general, operations
 	// against the path should protect against modification of the original.
@@ -15,6 +39,8 @@ type Path struct {
 
 // AtListIndex returns a copied path with a new list index step at the end.
 // The returned path is safe to modify without affecting the original.
+//
+// List indices are 0-based. The first element of a list is 0.
 func (p Path) AtListIndex(index int) Path {
 	copiedPath := p.Copy()
 

--- a/path/paths.go
+++ b/path/paths.go
@@ -3,6 +3,8 @@ package path
 import "strings"
 
 // Paths is a collection of exact attribute paths.
+//
+// Refer to the Path documentation for more details about intended usage.
 type Paths []Path
 
 // Append adds the given Paths to the collection without duplication and

--- a/website/data/plugin-framework-nav-data.json
+++ b/website/data/plugin-framework-nav-data.json
@@ -45,6 +45,14 @@
     "path": "schemas"
   },
   {
+    "title": "Paths",
+    "path": "paths"
+  },
+  {
+    "title": "Path Expressions",
+    "path": "path-expressions"
+  },
+  {
     "title": "Attribute Types",
     "path": "types"
   },

--- a/website/docs/plugin/framework/path-expressions.mdx
+++ b/website/docs/plugin/framework/path-expressions.mdx
@@ -1,0 +1,182 @@
+---
+page_title: 'Plugin Development - Framework: Path Expressions'
+description: >-
+  How to implement path expressions in the provider development framework.
+  Path expressions are logic built on top of paths, which may represent one or
+  more actual paths within schema data.
+---
+
+# Path Expressions
+
+Path expressions are logic built on top of [paths](/plugin/framework/paths), which may represent one or more actual paths within a schema or schema-based data. Expressions enable providers to work outside the restrictions of absolute paths and steps.
+
+## Usage
+
+Example uses include:
+
+- [Path based attribute validators](/plugin/framework/validation#path-based-attribute-validators), such as those in the [`terraform-plugin-framework-validators` module `schemavalidator` package](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/schemavalidator).
+
+Use cases which require exact locations, such as [diagnostics](/plugin/framework/diagnostics), implement [paths](/plugin/framework/paths).
+
+## Concepts
+
+Path expressions are an abstraction above [paths](/plugin/framework/paths). This page assumes knowledge of path concepts and implementations.
+
+At its core, expressions implement the following on top of paths:
+
+- Information that designates whether path information is intended to be absolute, similar to paths, or relative, where it is assumed it will be merged with other absolute path information.
+- Parent steps, which enables backwards traversal towards the root of a schema in relative paths, after being merged with other absolute path information.
+- Path matching, which enables path information to logically return one or more actual paths.
+
+Similar to paths, expressions are built using steps. There are expression steps which directly correspond to exact path steps, such as `AtListIndex()`, `AtMapKey()`, `AtName()`, `AtSetValue()`. Their implementation is the same. However, there are additional expression steps, such as `AtAnyListIndex()`, which cannot be represented in paths due to the potential for ambiguity.
+
+Path matching is the notion that each expression step implements a method that logically determines if a given exact path step should match. For example, the `AtAnyListIndex()` expression step will accept any exact path step for a list index. Path matching with an expression is a collection of matching each expression step against each exact path step, after resolving any potential parent steps.
+
+Every path expression must align with the schema definition or an error diagnostic will be raised when working with path matching within the framework. Provider-defined functionality that is schema-based, such as attribute validation and attribute plan modification, are provided an accurate current path expression since that functionality would not be able to determine its own path expression.
+
+## Building Path Expressions
+
+The framework implementation for path expressions is in the [`path` package](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/path), with the [`path.Expression` type](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/path#Expression) being the main provider developer interaction point.
+
+### Building Absolute Path Expressions
+
+Call the [`path.MatchRoot()` function](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/path#MatchRoot) with an attribute name or block name at the root of the schema to begin an absolute path expression.
+
+Given this example schema with a root attribute named `example_root_attribute`:
+
+```go
+tfsdk.Schema{
+	Attributes: map[string]tfsdk.Attribute{
+		"example_root_attribute": {
+			Required: true,
+			Type:     types.StringType,
+		},
+	},
+}
+```
+
+The call to `path.MatchRoot()` which matches the location of `example_root_attribute` string value is:
+
+```go
+path.MatchRoot("example_root_attribute")
+```
+
+For blocks, the beginning of a path expression is similarly defined. Attribute and block names cannot overlap, so the framework automatically handles whether a path expression is referring to an attribute or block to start.
+
+Given this example schema with a root block named `example_root_block`:
+
+```go
+tfsdk.Schema{
+	Blocks: map[string]tfsdk.Block{
+		"example_root_block": {
+			Attributes: map[string]tfsdk.Attribute{/* ... */},
+			NestingMode: tfsdk.BlockNestingModeList,
+		},
+	},
+}
+```
+
+The call to `path.MatchRoot()` which matches the location of `example_root_block` list value is:
+
+```go
+path.MatchRoot("example_root_block")
+```
+
+Once a `path.Expression` is started, it supports a builder pattern, which allows for chaining method calls to construct a full path.
+
+This example shows a hypothetical path expression that points to any element of a list attribute to highlight the builder pattern:
+
+```go
+path.MatchRoot("example_list_attribute").AtAnyListIndex()
+```
+
+This pattern can be extended to as many calls as necessary. The [Building Expression Steps section](#building-expression-steps) covers the different framework schema types and any special path step methods.
+
+### Building Relative Path Expressions
+
+Relative path expressions are, by nature, contextual to the actual path where they are defined in a schema. Call the [`path.MatchRelative()` function](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/path#MatchRelative) to begin a relative path expression.
+
+This example shows a relative path expression which references a child attribute:
+
+```go
+tfsdk.Schema{
+	Attributes: map[string]tfsdk.Attribute{
+		"root_list_attribute": {
+			Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
+				"nested_list_attribute": {
+					Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
+						"deeply_nested_string_attribute": {
+							Required: true,
+							Type:     types.StringType,
+						},
+					}),
+					Required: true,
+					Validators: []tfsdk.AttributeValidator{
+						exampleValidatorThatAcceptsExpressions(
+							path.MatchRelative().AtAnyListIndex().AtName("deeply_nested_string_attribute"),
+						),
+					},
+				},
+				"nested_string_attribute": {
+					Required: true,
+					Type:     types.StringType,
+				},
+			}),
+			Required: true,
+		},
+	},
+}
+```
+
+This example shows a relative path expression which references a different attribute within the same list index:
+
+```go
+tfsdk.Schema{
+	Attributes: map[string]tfsdk.Attribute{
+		"root_list_attribute": {
+			Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
+				"nested_list_attribute": {
+					Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
+						"deeply_nested_string_attribute": {
+							Required: true,
+							Type:     types.StringType,
+						},
+					}),
+					Required: true,
+					Validators: []tfsdk.AttributeValidator{
+						exampleValidatorThatAcceptsExpressions(
+							path.MatchRelative().AtParent().AtName("nested_string_attribute"),
+						),
+					},
+				},
+				"nested_string_attribute": {
+					Required: true,
+					Type:     types.StringType,
+				},
+			}),
+			Required: true,
+		},
+	},
+}
+```
+
+### Building Expression Steps
+
+Expressions follow similar schema type rules as paths, in particular [Building Attribute Paths](/plugin/framework/paths#building-attribute-paths), [Building Nested Attribute Paths](/plugin/framework/paths#building-nested-attribute-paths), and [Building Block Paths](/plugin/framework/paths#building-block-paths).
+
+The following list shows the [`path.Expression` type](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/path#Expression) methods that behave similar to [`path.Path` type](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/path#Path) methods.
+
+- `AtListIndex()`
+- `AtMapKey()`
+- `AtName()`
+- `AtSetValue()`
+
+The following table shows the additional [`path.Expression` type](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/path#Expression) methods and their descriptions.
+
+| Expression Method  | Description |
+| ------------------ | ----------- |
+| `AtAnyListIndex()` | Will return matches for any list index. Can be used anywhere `AtListIndex()` can be used. |
+| `AtAnyMapKey()`    | Will return matches for any map key. Can be used anywhere `AtMapKey()` can be used. |
+| `AtAnySetValue()`  | Will return matches for any set value. Can be used anywhere `AtSetValue()` can be used. |
+| `AtParent()`       | Will remove the last expression step, or put differently, will match the path closer to the root of the schema. |
+

--- a/website/docs/plugin/framework/paths.mdx
+++ b/website/docs/plugin/framework/paths.mdx
@@ -1,0 +1,483 @@
+---
+page_title: 'Plugin Development - Framework: Paths'
+description: >-
+  How to implement paths in the provider development framework.
+  Paths represent a location within a schema or schema-based data.
+---
+
+# Paths
+
+An exact location within a [schema](/plugin/framework/schemas) or schema-based data such as [`tfsdk.Config`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/tfsdk#Config), [`tfsdk.Plan`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/tfsdk#Plan), or [`tfsdk.State`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/tfsdk#State), is referred to as a path.
+
+## Usage
+
+Example uses in the framework include:
+
+- [Diagnostics](/plugin/framework/diagnostics) intended for a specific attribute, which allows Terraform to show the configuration file and line information.
+- [Accessing configuration, plan, or state data](/plugin/framework/accessing-values) for a specific attribute.
+- [Writing plan or state data](/plugin/framework/writing-state) for a specific attribute.
+
+More advanced use cases, such as [path based attribute validators](/plugin/framework/validation#path-based-attribute-validators), typically implement [path expressions](/plugin/framework/path-expressions) which enables additional logic beyond exact paths.
+
+## Concepts
+
+Paths are designed around the underlying Terraform implementation of a schema and schema-based data. Terraform schemas are a tree structure based on value storing attributes, which may have their own structural component, and structural blocks. Both attributes and blocks are associated with specific data types, some of which represent structural or collection types which hold further information which can be traversed. Each traversal into that further information is referred to as a path step. Paths are always absolute and start from the root, or top level, of a schema.
+
+Given the tree structure of Terraform schemas, descriptions of paths and their steps borrow certain hierarchy terminology such as parent and child. A parent path describes a path without one or more of the final steps of a given path, or put differently, a partial path closer to the root of the schema. A child path describes a path with one or more additional steps beyond a given path, or put differently, a path containing the given path but further from the root of the schema.
+
+Every path must align with the schema definition or an error diagnostic will be raised when working with paths within the framework. Provider-defined functionality that is schema-based, such as attribute validation and attribute plan modification, are provided an accurate current path since that functionality would not be able to determine its own path.
+
+[Path expressions](/plugin/framework/path-expressions) are an abstraction on top of paths, which enable additional use cases with provider-defined functionality, such as relative path, parent step, and wildcard step support.
+
+## Building Paths
+
+The framework implementation for paths is in the [`path` package](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/path), with the [`path.Path` type](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/path#Path) being the main provider developer interaction point. Call the [`path.Root()` function](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/path#Root) with an attribute name or block name at the root of the schema to begin a path.
+
+Given this example schema with a root attribute named `example_root_attribute`:
+
+```go
+tfsdk.Schema{
+	Attributes: map[string]tfsdk.Attribute{
+		"example_root_attribute": {
+			Required: true,
+			Type:     types.StringType,
+		},
+	},
+}
+```
+
+The call to `path.Root()` which matches the location of `example_root_attribute` string value is:
+
+```go
+path.Root("example_root_attribute")
+```
+
+For blocks, the beginning of a path is similarly defined. Attribute and block names cannot overlap, so the framework automatically handles whether a path is referring to an attribute or block to start.
+
+Given this example schema with a root block named `example_root_block`:
+
+```go
+tfsdk.Schema{
+	Blocks: map[string]tfsdk.Block{
+		"example_root_block": {
+			Attributes: map[string]tfsdk.Attribute{/* ... */},
+			NestingMode: tfsdk.BlockNestingModeList,
+		},
+	},
+}
+```
+
+The call to `path.Root()` which matches the location of `example_root_block` list value is:
+
+```go
+path.Root("example_root_block")
+```
+
+Once a `path.Path` is started, it supports a builder pattern, which allows for chaining method calls to construct a full path.
+
+This example shows a hypothetical path that points to the first element of a list attribute to highlight the builder pattern:
+
+```go
+path.Root("example_list_attribute").AtListIndex(0)
+```
+
+This pattern can be extended to as many calls as necessary. The different framework schema types and their associated path step methods are shown in the following sections.
+
+### Building Attribute Paths
+
+The following table shows the different [`path.Path` type](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/path#Path) methods associated with building paths for [`tfsdk.Attribute` type](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/tfsdk#Attribute) implementations using the `Type` field. Attribute types that cannot be traversed further are shown with N/A (not applicable).
+
+| Attribute Type      | Child Path Method |
+| ------------------- | ----------------- |
+| `types.BoolType`    | N/A               |
+| `types.Float64Type` | N/A               |
+| `types.Int64Type`   | N/A               |
+| `types.ListType`    | `AtListIndex()`   |
+| `types.MapType`     | `AtMapKey()`      |
+| `types.NumberType`  | N/A               |
+| `types.ObjectType`  | `AtName()`        |
+| `types.SetType`     | `AtSetValue()`    |
+| `types.StringType`  | N/A               |
+
+Given following schema example:
+
+```go
+tfsdk.Schema{
+	Attributes: map[string]tfsdk.Attribute{
+		"root_map_attribute": {
+			Required: true,
+			Type: types.MapType{
+				ElemType: types.StringType,
+			},
+		},
+	},
+}
+```
+
+The path which matches the string value associated with a hypothetical map key of `example-key` of the `root_map_attribute` attribute is:
+
+```go
+path.Root("root_map_attribute").AtMapKey("example-key")
+```
+
+Any type that supports a child path may define an element type that also supports a child path. Paths can continue to be built using the associated method with each level of the attribute type.
+
+Given following schema example:
+
+```go
+tfsdk.Schema{
+	Attributes: map[string]tfsdk.Attribute{
+		"root_map_attribute": {
+			Required: true,
+			Type: types.MapType{
+				ElemType: types.ListType{
+					ElemType: types.StringType,
+				},
+			},
+		},
+	},
+}
+```
+
+The path which matches the third string value associated with the list value of a hypothetical map key of `example-key` of the `root_map_attribute` attribute is:
+
+```go
+path.Root("root_map_attribute").AtMapKey("example-key").AtListIndex(2)
+```
+
+Unless there is a very well defined data structure involved, the level of path specificity in the example above is fairly uncommon to manually build in provider logic though. Most provider logic will typically build a path to the value of an attribute (e.g. its first `Type`) and work with that data, or potentially one level deeper in well known cases, since each level introduces additional complexity associated with potentially null or unknown values. Provider logic can instead use an iterative path building approach when dealing with attributes that have multiple levels.
+
+This example shows an iterative path building approach to handle any map keys and list indices in the above schema:
+
+```go
+attributePath := path.Root("root_map_attribute")
+
+// attributeValue is an example types.Map value which was previously fetched,
+// potentially using the path above.
+for mapKey, mapValue := range attributeValue.Value {
+	mapKeyPath := attributePath.AtMapKey(mapKey)
+
+	// ...
+
+	for listIndex, listValue := range mapValue.Value {
+		listIndexPath := mapKeyPath.AtListIndex(listIndex)
+
+		// ...
+	}
+}
+```
+
+### Building Nested Attribute Paths
+
+The following table shows the different [`path.Path` type](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/path#Path) methods associated with building paths for [`tfsdk.Attribute` type](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/tfsdk#Attribute) implementations using the `Attributes` field ([`tfsdk.NestedAttibutes` interface](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/tfsdk#NestedAttributes) implementations).
+
+| Nested Attribute Type          | Child Path Method |
+| ------------------------------ | ----------------- |
+| `tfsdk.ListNestedAttributes`   | `AtListIndex()`   |
+| `tfsdk.MapNestedAttributes`    | `AtMapKey()`      |
+| `tfsdk.SetNestedAttributes`    | `AtSetValue()`    |
+| `tfsdk.SingleNestedAttributes` | `AtName()`        |
+
+Nested attributes eventually implement attributes at child paths, which follow the methods shown in the [Building Attribute Paths section](#building-attribute-paths).
+
+#### Building List Nested Attributes Paths
+
+An attribute that implements `tfsdk.ListNestedAttributes` conceptually is a list containing objects with attribute names.
+
+Given the following schema example:
+
+```go
+tfsdk.Schema{
+	Attributes: map[string]tfsdk.Attribute{
+		"root_list_attribute": {
+			Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
+				"nested_string_attribute": {
+					Required: true,
+					Type:     types.StringType,
+				},
+			}),
+			Required: true,
+		},
+	},
+}
+```
+
+The path which matches the list associated with the `root_list_attribute` attribute is:
+
+```go
+path.Root("root_list_attribute")
+```
+
+The path which matches the first object in the list associated with the `root_list_attribute` attribute is:
+
+```go
+path.Root("root_list_attribute").AtListIndex(0)
+```
+
+The path which matches the `nested_string_attribute` string value in the first object in the list associated with `root_list_attribute` attribute is:
+
+```go
+path.Root("root_list_attribute").AtListIndex(0).AtName("nested_string_attribute")
+```
+
+#### Building Map Nested Attributes Paths
+
+An attribute that implements `tfsdk.MapNestedAttributes` conceptually is a map containing values of objects with attribute names.
+
+Given the following schema example:
+
+```go
+tfsdk.Schema{
+	Attributes: map[string]tfsdk.Attribute{
+		"root_map_attribute": {
+			Attributes: tfsdk.MapNestedAttributes(map[string]tfsdk.Attribute{
+				"nested_string_attribute": {
+					Required: true,
+					Type:     types.StringType,
+				},
+			}),
+			Required: true,
+		},
+	},
+}
+```
+
+The path which matches the map associated with the `root_map_attribute` attribute is:
+
+```go
+path.Root("root_map_attribute")
+```
+
+The path which matches the a hypothetical `"example-key"` object in the map associated with the `root_map_attribute` attribute is:
+
+```go
+path.Root("root_map_attribute").AtMapKey("example-key")
+```
+
+The path which matches the `nested_string_attribute` string value in a hypothetical `"example-key"` object in the map associated with `root_map_attribute` attribute is:
+
+```go
+path.Root("root_map_attribute").AtMapKey("example-key").AtName("nested_string_attribute")
+```
+
+#### Building Set Nested Attributes Paths
+
+An attribute that implements `tfsdk.SetNestedAttributes` conceptually is a set containing objects with attribute names. Attempting to build set nested attribute paths is extremely tedius as set element selection is based on the entire value of the element, including any null or unknown values. Avoid manual set-based path building. Instead, use functionality which supports [path expressions](/plugin/framework/path-expressions) as that supports wildcard path matching ([`path.Expression` type `AtAnySetValue()` method](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/path#Expression.AtAnySetValue)) or relative paths.
+
+Given the following schema example:
+
+```go
+tfsdk.Schema{
+	Attributes: map[string]tfsdk.Attribute{
+		"root_set_attribute": {
+			Attributes: tfsdk.SetNestedAttributes(map[string]tfsdk.Attribute{
+				"nested_string_attribute": {
+					Required: true,
+					Type:     types.StringType,
+				},
+			}),
+			Required: true,
+		},
+	},
+}
+```
+
+The path which matches the set associated with the `root_set_attribute` attribute is:
+
+```go
+path.Root("root_set_attribute")
+```
+
+Examples below will presume a `nested_string_attribute` string value of `types.String{Value: "example"}` for brevity. In real world usage, the string value may be `types.String{Null: true}`, `types.String{Unknown: true}` or `types.String{Value: "something-else"}`, which are all considered different set paths from each other. Each additional attribute or block introduces exponentially more possible paths given each attribute or block value may be null, unknown, or a unique known value.
+
+The path which matches the object associated with the `root_set_attribute` block is:
+
+```go
+path.Root("root_set_attribute").AtSetValue(types.Object{
+	AttrTypes: map[string]attr.Type{
+		"nested_string_attribute": types.StringType,
+	},
+	Attrs: map[string]attr.Value{
+		"nested_string_attribute": types.String{Value: "example"},
+	}
+})
+```
+
+The path which matches the `nested_string_attribute` string value associated with `root_set_attribute` block is:
+
+```go
+path.Root("root_set_attribute").AtSetValue(types.Object{
+	AttrTypes: map[string]attr.Type{
+		"nested_string_attribute": types.StringType,
+	},
+	Attrs: map[string]attr.Value{
+		"nested_string_attribute": types.String{Value: "example"},
+	}
+}).AtName("nested_string_attribute")
+```
+
+#### Building Single Nested Attributes Paths
+
+An attribute that implements `tfsdk.SingleNestedAttributes` conceptually is an object with attribute names.
+
+Given the following schema example:
+
+```go
+tfsdk.Schema{
+	Attributes: map[string]tfsdk.Attribute{
+		"root_grouped_attributes": {
+			Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
+				"nested_string_attribute": {
+					Required: true,
+					Type:     types.StringType,
+				},
+			}),
+			Required: true,
+		},
+	},
+}
+```
+
+The path which matches the object associated with the `root_grouped_attributes` attribute is:
+
+```go
+path.Root("root_grouped_attributes")
+```
+
+The path which matches the `nested_string_attribute` string value in the object associated with the `root_grouped_attributes` attribute is:
+
+```go
+path.Root("root_grouped_attributes").AtName("nested_string_attribute")
+```
+
+### Building Block Paths
+
+The following table shows the different [`path.Path` type](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/path#Path) methods associated with building paths for [`tfsdk.Block` type](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/tfsdk#Block) implementations based on the `NestingMode` field.
+
+| Block NestingMode              | Child Path Method |
+| ------------------------------ | ----------------- |
+| `tfsdk.BlockNestingModeList`   | `AtListIndex()`   |
+| `tfsdk.BlockNestingModeSet`    | `AtSetValue()`    |
+
+Blocks can implement nested blocks. Paths can continue to be built using the associated method with each level of the block type.
+
+Blocks eventually implement attributes at child paths, which follow the methods shown in the [Building Attribute Paths section](#building-attribute-paths). Blocks cannot contain nested attributes.
+
+#### Building List Block Paths
+
+A block defined with `tfsdk.BlockNestingModeList` conceptually is a list containing objects with attribute or block names.
+
+Given following schema example:
+
+```go
+tfsdk.Schema{
+	Blocks: map[string]tfsdk.Block{
+		"root_list_block": {
+			Attributes: map[string]tfsdk.Attribute{
+				"block_string_attribute": {
+					Required: true,
+					Type:     types.StringType,
+				},
+			},
+			Blocks: map[string]tfsdk.Block{
+				"nested_list_block": {
+					Attributes: map[string]tfsdk.Attribute{
+						"nested_block_string_attribute": {
+							Required: true,
+							Type:     types.StringType,
+						},
+					},
+					NestingMode: tfsdk.BlockNestingModeList,
+				},
+			},
+			NestingMode: tfsdk.BlockNestingModeList,
+		},
+	},
+}
+```
+
+The path which matches the list associated with the `root_list_block` block is:
+
+```go
+path.Root("root_list_block")
+```
+
+The path which matches the first object in the list associated with the `root_list_block` block is:
+
+```go
+path.Root("root_list_block").AtListIndex(0)
+```
+
+The path which matches the `block_string_attribute` string value in the first object in the list associated with `root_list_block` block is:
+
+```go
+path.Root("root_list_block").AtListIndex(0).AtName("block_string_attribute")
+```
+
+The path which matches the `nested_list_block` list in the first object in the list associated with `root_list_block` block is:
+
+```go
+path.Root("root_list_block").AtListIndex(0).AtName("nested_list_block")
+```
+
+The path which matches the `nested_block_string_attribute` string value in the first object in the list associated with the `nested_list_block` list in the first object in the list associated with `root_list_block` block is:
+
+```go
+path.Root("root_list_block").AtListIndex(0).AtName("nested_list_block").AtListIndex(0).AtName("nested_block_string_attribute")
+```
+
+#### Building Set Block Paths
+
+A block defined with `tfsdk.BlockNestingModeSet` conceptually is a set containing objects with attribute or block names. Attempting to build set block paths is extremely tedius as set element selection is based on the entire value of the element, including any null or unknown values. Avoid manual set-based path building. Instead, use functionality which supports [path expressions](/plugin/framework/path-expressions) as that supports wildcard path matching ([`path.Expression` type `AtAnySetValue()` method](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/path#Expression.AtAnySetValue)) or relative paths.
+
+Given following schema example:
+
+```go
+tfsdk.Schema{
+	Blocks: map[string]tfsdk.Block{
+		"root_set_block": {
+			Attributes: map[string]tfsdk.Attribute{
+				"block_string_attribute": {
+					Optional: true,
+					Type:     types.StringType,
+				},
+			},
+			NestingMode: tfsdk.BlockNestingModeSet,
+		},
+	},
+}
+```
+
+The path which matches the set associated with the `root_set_block` block is:
+
+```go
+path.Root("root_set_block")
+```
+
+Examples below will presume a `block_string_attribute` string value of `types.String{Value: "example"}` for brevity. In real world usage, the string value may be `types.String{Null: true}`, `types.String{Unknown: true}` or `types.String{Value: "something-else"}`, which are all considered different set paths from each other. Each additional attribute or block introduces exponentially more possible paths given each attribute or block value may be null, unknown, or a unique known value.
+
+The path which matches the object associated with the `root_set_block` block is:
+
+```go
+path.Root("root_set_block").AtSetValue(types.Object{
+	AttrTypes: map[string]attr.Type{
+		"block_string_attribute": types.StringType,
+	},
+	Attrs: map[string]attr.Value{
+		"block_string_attribute": types.String{Value: "example"},
+	}
+})
+```
+
+The path which matches the `block_string_attribute` string value associated with `root_set_block` block is:
+
+```go
+path.Root("root_set_block").AtSetValue(types.Object{
+	AttrTypes: map[string]attr.Type{
+		"block_string_attribute": types.StringType,
+	},
+	Attrs: map[string]attr.Value{
+		"block_string_attribute": types.String{Value: "example"},
+	}
+}).AtName("block_string_attribute")
+```

--- a/website/docs/plugin/framework/validation.mdx
+++ b/website/docs/plugin/framework/validation.mdx
@@ -114,11 +114,11 @@ Path expressions may represent one or more actual paths in the data. To find tho
 
 The general structure for working with path expressions in an attribute validator is:
 
-- Merge the given path expression(s) with the current attribute path expression, such as calling the [`tfsdk.ValidateAttributeRequest` type `AttributePathExpression` field `MergeExpressions()` method]().
-- Loop through each merged path expression to get the matching paths within the data, such as calling the [`tfsdk.ValidateAttributeRequest` type `Config` field `PathMatches()` method]().
-- Loop through each matched path to get the generic `attr.Value` value, such as calling the [`tfsdk.ValidateAttributeRequest` type `Config` field `GetAttribute()` method]().
-- Perform null and unknown value checks on the `attr.Value`, such as the [`IsNull()` method]() and [`IsUnknown()` method]().
-- If the `attr.Value` is not null and not unknown, then it is safe to attempt to either use type assertion for the expected value implementation or call `GetAttribute()` again using the expected value implementation as the target.
+- Merge the given path expression(s) with the current attribute path expression, such as calling the [`tfsdk.ValidateAttributeRequest` type `AttributePathExpression` field `MergeExpressions()` method](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/path#Expression.MergeExpressions).
+- Loop through each merged path expression to get the matching paths within the data, such as calling the [`tfsdk.ValidateAttributeRequest` type `Config` field `PathMatches()` method](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/tfsdk#Config.PathMatches).
+- Loop through each matched path to get the generic `attr.Value` value, such as calling the [`tfsdk.ValidateAttributeRequest` type `Config` field `GetAttribute()` method](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/tfsdk#Config.GetAttribute).
+- Perform null and unknown value checks on the `attr.Value`, such as the [`IsNull()` method](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/attr#Value.IsNull) and [`IsUnknown()` method](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/attr#Value.IsUnknown).
+- If the `attr.Value` is not null and not unknown, then use [`tfsdk.ValueAs()`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/tfsdk#ValueAs) using the expected value implementation as the target.
 
 The following example shows a generic path based attribute validator that returns an error if `types.Int64` values at the given path expressions are less than the current attribute `types.Int64` value.
 

--- a/website/docs/plugin/framework/validation.mdx
+++ b/website/docs/plugin/framework/validation.mdx
@@ -106,6 +106,142 @@ func stringLengthBetween(minLength int, maxLength int) stringLengthBetweenValida
 }
 ```
 
+#### Path Based Attribute Validators
+
+Attribute validators that need to accept [paths](/plugin/framework/paths) to reference other attribute data should instead prefer [path expressions](/plugin/framework/path-expressions). This allows consumers to use either absolute paths starting at the root of a [schema](/plugin/framework/schemas), or relative paths based on the current attribute path where the validator is called.
+
+Path expressions may represent one or more actual paths in the data. To find those paths, the process is called path matching. Depending on the actual data, a path match may return a parent path for null or unknown values, since any underlying paths of those null or unknown values would also represent the same value. This framework behavior is used to prevent false positives of returning no paths for null or unknown values.
+
+The general structure for working with path expressions in an attribute validator is:
+
+- Merge the given path expression(s) with the current attribute path expression, such as calling the [`tfsdk.ValidateAttributeRequest` type `AttributePathExpression` field `MergeExpressions()` method]().
+- Loop through each merged path expression to get the matching paths within the data, such as calling the [`tfsdk.ValidateAttributeRequest` type `Config` field `PathMatches()` method]().
+- Loop through each matched path to get the generic `attr.Value` value, such as calling the [`tfsdk.ValidateAttributeRequest` type `Config` field `GetAttribute()` method]().
+- Perform null and unknown value checks on the `attr.Value`, such as the [`IsNull()` method]() and [`IsUnknown()` method]().
+- If the `attr.Value` is not null and not unknown, then it is safe to attempt to either use type assertion for the expected value implementation or call `GetAttribute()` again using the expected value implementation as the target.
+
+The following example shows a generic path based attribute validator that returns an error if `types.Int64` values at the given path expressions are less than the current attribute `types.Int64` value.
+
+```go
+// Ensure our implementation satisfies the tfsdk.AttributeValidator interface.
+var _ tfsdk.AttributeValidator = &int64IsGreaterThanValidator{}
+
+// int64IsGreaterThanValidator is the underlying type implementing Int64IsGreaterThan.
+type int64IsGreaterThanValidator struct {
+	expressions path.Expressions
+}
+
+// Description returns a plaintext string describing the validator.
+func (v int64IsGreaterThanValidator) Description(_ context.Context) string {
+	return fmt.Sprintf("If configured, must be greater than %s attributes", v.expressions)
+}
+
+// MarkdownDescription returns a Markdown formatted string describing the validator.
+func (v int64IsGreaterThanValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+// Validate performs the validation logic for the validator.
+func (v int64IsGreaterThanValidator) Validate(ctx context.Context, req tfsdk.ValidateAttributeRequest, resp *tfsdk.ValidateAttributeResponse) {
+	// If the current attribute configuration is null or unknown, there
+	// cannot be any value comparisons, so exit early without error.
+	if req.AttributeConfig.IsNull() || req.AttributeConfig.IsUnknown() {
+		return
+	}
+
+	// Convert the current attribute configuration to our expected attr.Value
+	// implementation. This will raise an error if the validator is not put
+	// on an attribute that is types.Int64Type.
+	var attributeConfig types.Int64
+
+	diags := tftypes.ValueAs(ctx, req.AttributeConfig, &attributeConfig)
+
+	resp.Diagnostics.Append(diags...)
+
+	// If the current attribute configuration is not valid, there cannot be
+	// any value comparisons, so exit early.
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Combine the given path expressions with the current attribute path
+	// expression. This call automatically handles relative and absolute
+	// expressions.
+	expressions := req.AttributePathExpression.MergeExpressions(v.expressions...)
+
+	// For each expression, find matching paths.
+	for _, expression := range expressions {
+		// Find paths matching the expression in the configuration data.
+		matchedPaths, diags := req.Config.PathMatches(ctx, expression)
+
+		resp.Diagnostics.Append(diags...)
+
+		// Collect all errors
+		if diags.HasError() {
+			continue
+		}
+
+		// For each matched path, get the data and compare.
+		for _, matchedPath := range matchedPaths {
+			// Fetch the generic attr.Value at the given path. This ensures any
+			// potential parent value of a different type, which can be a null
+			// or unknown value, can be safely checked without raising a type
+			// conversion error.
+			var matchedPathValue attr.Value
+
+			diags := req.Config.GetAttribute(ctx, matchedPath, &matchedPathValue)
+
+			resp.Diagnostics.Append(diags...)
+
+			// Collect all errors
+			if diags.HasError() {
+				continue
+			}
+
+			// If the matched path value is null or unknown, we cannot compare
+			// values, so continue to other matched paths.
+			if matchedPathValue.IsNull() || matchedPathValue.IsUnknown() {
+				continue
+			}
+
+			// Now that we know the matched path value is not null or unknown,
+			// it is safe to attempt converting it to the intended attr.Value
+			// implementation, in this case a types.Int64 value.
+			var matchedPathConfig types.Int64
+
+			diags = tftypes.ValueAs(ctx, matchedPathValue, &matchedPathConfig)
+
+			resp.Diagnostics.Append(diags...)
+
+			// If the matched path value was not able to be converted from
+			// attr.Value to the intended types.Int64 implementation, it most
+			// likely means that the path expression was not pointing at a
+			// types.Int64Type attribute. Collect the error and continue to
+			// other matched paths.
+			if diags.HasError() {
+				continue
+			}
+
+			if matchedPathConfig.Value >= attributeConfig.Value {
+				resp.Diagnostics.AddAttributeError(
+					matchedPath,
+					"Invalid Attribute Value",
+					fmt.Sprintf("Must be less than %s value: %d", req.AttributePath, attributeConfig.Value),
+				)
+			}
+		}
+	}
+}
+
+// Int64IsGreaterThan checks that any Int64 values in the paths described by the
+// path.Expression are less than the current attribute value.
+func Int64IsGreaterThan(expressions ...path.Expression) tfsdk.AttributeValidator {
+	return &int64IsGreaterThanValidator{
+		expressions: expressions,
+	}
+}
+```
+
 ## Type Validation
 
 You may want to create a custom type to simplify schemas if your provider contains common attribute values with consistent validation rules. When you implement validation on a type, you do not need to declare the same validation on the attribute, but you can supply additional validations in that manner. For example:


### PR DESCRIPTION
Closes #81

The website documentation is less than ideal as it introduces these new path and path expression pages as top-level in the already lengthy navigation, however refactoring the website documentation to bundle together and fix wording/flow for all the concepts/pages around schemas, schema-based data such as Config/Plan/State, and paths in a new dedicated section felt out of scope to this feature specific documentation addition.