### PR TITLE
path: Ensure Expression root flag is appropriately set and checked

### DIFF
--- a/.changelog/420.txt
+++ b/.changelog/420.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+path: Ensured `Expression` type `Copy()` method appropriately copied root expressions and `Equal()` checked for root versus relative expressions
+```

--- a/path/expression.go
+++ b/path/expression.go
@@ -139,12 +139,17 @@ func (e Expression) AtSetValue(value attr.Value) Expression {
 // affecting the original.
 func (e Expression) Copy() Expression {
 	return Expression{
+		root:  e.root,
 		steps: e.Steps().Copy(),
 	}
 }
 
 // Equal returns true if the given expression is exactly equivalent.
 func (e Expression) Equal(o Expression) bool {
+	if e.root != o.root {
+		return false
+	}
+
 	if e.steps == nil && o.steps == nil {
 		return true
 	}

--- a/path/path.go
+++ b/path/path.go
@@ -107,6 +107,7 @@ func (p Path) Equal(o Path) bool {
 // Expression returns an Expression which exactly matches the Path.
 func (p Path) Expression() Expression {
 	return Expression{
+		root:  true,
 		steps: p.steps.ExpressionSteps(),
 	}
 }


### PR DESCRIPTION
Closes #419

Since the `(Expression).Equal()` method was not checking this additional flag, it was missing the fact it wasn't handled with `Copy()`. The `(Path).Expression()` method should always set that flag to true, since paths are always root path expressions.