### PR TITLE
all: Run Go 1.19 fmt

### DIFF
--- a/datasource/data_source.go
+++ b/datasource/data_source.go
@@ -7,9 +7,8 @@ import "context"
 //
 // Data sources can optionally implement these additional concepts:
 //
-//     - Validation: Schema-based via tfsdk.Attribute or entire configuration
-//       via DataSourceWithConfigValidators or DataSourceWithValidateConfig.
-//
+//   - Validation: Schema-based via tfsdk.Attribute or entire configuration
+//     via DataSourceWithConfigValidators or DataSourceWithValidateConfig.
 type DataSource interface {
 	// Read is called when the provider must read data source values in
 	// order to update state. Config values should be read from the

--- a/internal/fromproto5/providermeta.go
+++ b/internal/fromproto5/providermeta.go
@@ -13,8 +13,8 @@ import (
 // *tfsdk.Schema. This data handling is different than Config to simplify
 // implementors, in that:
 //
-//     - Missing Schema will return nil, rather than an error
-//     - Missing DynamicValue will return nil typed Value, rather than an error
+//   - Missing Schema will return nil, rather than an error
+//   - Missing DynamicValue will return nil typed Value, rather than an error
 func ProviderMeta(ctx context.Context, proto5DynamicValue *tfprotov5.DynamicValue, schema *tfsdk.Schema) (*tfsdk.Config, diag.Diagnostics) {
 	if schema == nil {
 		return nil, nil

--- a/internal/fromproto6/providermeta.go
+++ b/internal/fromproto6/providermeta.go
@@ -13,8 +13,8 @@ import (
 // *tfsdk.Schema. This data handling is different than Config to simplify
 // implementors, in that:
 //
-//     - Missing Schema will return nil, rather than an error
-//     - Missing DynamicValue will return nil typed Value, rather than an error
+//   - Missing Schema will return nil, rather than an error
+//   - Missing DynamicValue will return nil typed Value, rather than an error
 func ProviderMeta(ctx context.Context, proto6DynamicValue *tfprotov6.DynamicValue, schema *tfsdk.Schema) (*tfsdk.Config, diag.Diagnostics) {
 	if schema == nil {
 		return nil, nil

--- a/path/expression.go
+++ b/path/expression.go
@@ -20,19 +20,19 @@ import (
 // construct a full expression. The available traversal steps after Expression
 // creation are:
 //
-//     - AtAnyListIndex(): Step into a list at any index
-//     - AtAnyMapKey(): Step into a map at any key
-//     - AtAnySetValue(): Step into a set at any attr.Value element
-//     - AtListIndex(): Step into a list at a specific index
-//     - AtMapKey(): Step into a map at a specific key
-//     - AtName(): Step into an attribute or block with a specific name
-//     - AtParent(): Step backwards one step
-//     - AtSetValue(): Step into a set at a specific attr.Value element
+//   - AtAnyListIndex(): Step into a list at any index
+//   - AtAnyMapKey(): Step into a map at any key
+//   - AtAnySetValue(): Step into a set at any attr.Value element
+//   - AtListIndex(): Step into a list at a specific index
+//   - AtMapKey(): Step into a map at a specific key
+//   - AtName(): Step into an attribute or block with a specific name
+//   - AtParent(): Step backwards one step
+//   - AtSetValue(): Step into a set at a specific attr.Value element
 //
 // For example, to express any list element with a root list attribute named
 // "some_attribute":
 //
-//     path.MatchRoot("some_attribute").AtAnyListIndex()
+//	path.MatchRoot("some_attribute").AtAnyListIndex()
 //
 // An Expression is generally preferable over a Path in schema-defined
 // functionality that is intended to accept paths as parameters, such as

--- a/path/path.go
+++ b/path/path.go
@@ -13,15 +13,15 @@ import (
 // calls to construct a full path. The available traversal steps after Path
 // creation are:
 //
-//     - AtListIndex(): Step into a list at a specific 0-based index
-//     - AtMapKey(): Step into a map at a specific key
-//     - AtName(): Step into an attribute or block with a specific name
-//     - AtSetValue(): Step into a set at a specific attr.Value element
+//   - AtListIndex(): Step into a list at a specific 0-based index
+//   - AtMapKey(): Step into a map at a specific key
+//   - AtName(): Step into an attribute or block with a specific name
+//   - AtSetValue(): Step into a set at a specific attr.Value element
 //
 // For example, to represent the first list element with a root list attribute
 // named "some_attribute":
 //
-//     path.MatchRoot("some_attribute").AtListIndex(0)
+//	path.MatchRoot("some_attribute").AtListIndex(0)
 //
 // Path is used for functionality which must exactly match the underlying
 // schema structure and types, such as diagnostics that are intended for a

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -11,10 +11,9 @@ import (
 //
 // Providers can optionally implement these additional concepts:
 //
-//     - Validation: Schema-based via tfsdk.Attribute or entire configuration
-//       via ProviderWithConfigValidators or ProviderWithValidateConfig.
-//     - Meta Schema: ProviderWithMetaSchema
-//
+//   - Validation: Schema-based via tfsdk.Attribute or entire configuration
+//     via ProviderWithConfigValidators or ProviderWithValidateConfig.
+//   - Meta Schema: ProviderWithMetaSchema
 type Provider interface {
 	// GetSchema returns the schema for this provider's configuration. If
 	// this provider has no configuration, return an empty schema.Schema.

--- a/providerserver/serve_opts.go
+++ b/providerserver/serve_opts.go
@@ -59,9 +59,9 @@ func (opts ServeOpts) validateAddress(_ context.Context) error {
 //
 // Current checks which return errors:
 //
-//    - If Address is not set
-//    - Address is a valid full provider address
-//    - ProtocolVersion, if set, is 5 or 6
+//   - If Address is not set
+//   - Address is a valid full provider address
+//   - ProtocolVersion, if set, is 5 or 6
 func (opts ServeOpts) validate(ctx context.Context) error {
 	if opts.Address == "" {
 		return fmt.Errorf("Address must be provided")

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -9,12 +9,12 @@ import (
 //
 // Resources can optionally implement these additional concepts:
 //
-//     - Import: ResourceWithImportState
-//     - Validation: Schema-based via tfsdk.Attribute or entire configuration
-//       via ResourceWithConfigValidators or ResourceWithValidateConfig.
-//     - Plan Modification: Schema-based via tfsdk.Attribute or entire plan
-//       via ResourceWithModifyPlan.
-//     - State Upgrades: ResourceWithUpgradeState
+//   - Import: ResourceWithImportState
+//   - Validation: Schema-based via tfsdk.Attribute or entire configuration
+//     via ResourceWithConfigValidators or ResourceWithValidateConfig.
+//   - Plan Modification: Schema-based via tfsdk.Attribute or entire plan
+//     via ResourceWithModifyPlan.
+//   - State Upgrades: ResourceWithUpgradeState
 //
 // Although not required, it is conventional for resources to implement the
 // ResourceWithImportState interface.


### PR DESCRIPTION
For whatever reason, the latest release of `golangci-lint` that runs in CI seems to be applying Go 1.19 fmt checks, even though we are pinned on 1.17 still. This is a quick code update to prevent CI failures from existing issues.