### PR TITLE
Update Docs for DevDot Migration

### DIFF
--- a/website/docs/plugin/framework/index.mdx
+++ b/website/docs/plugin/framework/index.mdx
@@ -13,7 +13,7 @@ The plugin framework is a new way to develop Terraform Plugins on [protocol vers
 
 ## Get Started
 
-- Try the [Implement Create and Read with the Terraform Plugin Framework](https://learn.hashicorp.com/tutorials/terraform/plugin-framework-create?in=terraform/providers) tutorial on HashiCorp Learn.
+- Try the [Implement Create and Read with the Terraform Plugin Framework](https://learn.hashicorp.com/tutorials/terraform/plugin-framework-create?in=terraform/providers) tutorial.
 - Clone the [terraform-provider-scaffolding-framework](https://github.com/hashicorp/terraform-provider-scaffolding-framework) template repository on GitHub.
 
 ## Key Concepts


### PR DESCRIPTION
Docs changes to support migration to devdot. Updated with the following goals:

- Remove "Learn" and "Collection" as a term from docs
- Remove references to docs nav itself
- Remove user-facing URLs that contain the learn or docs domain ([learn.hashicorp.com](https://learn.hashicorp.com/) or [terraform.io](https://terraform.io/)/docs)