### PR TITLE
internal/fwserver: Prevent two sources of errors/panics

### DIFF
--- a/internal/fwschemadata/data_value_test.go
+++ b/internal/fwschemadata/data_value_test.go
@@ -48,7 +48,7 @@ func TestDataValueAtPath(t *testing.T) {
 				},
 			},
 			path:     path.Root("test"),
-			expected: nil,
+			expected: types.String{Null: true},
 		},
 		"WithAttributeName-nonexistent": {
 			data: fwschemadata.Data{

--- a/internal/fwserver/attr_value.go
+++ b/internal/fwserver/attr_value.go
@@ -68,7 +68,7 @@ func listElemObject(ctx context.Context, schemaPath path.Path, list types.List, 
 		return listElemObjectFromTerraformValue(ctx, schemaPath, list, description, tftypes.UnknownValue)
 	}
 
-	if index > len(list.Elems) {
+	if index >= len(list.Elems) {
 		return listElemObjectFromTerraformValue(ctx, schemaPath, list, description, nil)
 	}
 
@@ -156,7 +156,7 @@ func setElemObject(ctx context.Context, schemaPath path.Path, set types.Set, ind
 		return setElemObjectFromTerraformValue(ctx, schemaPath, set, description, tftypes.UnknownValue)
 	}
 
-	if index > len(set.Elems) {
+	if index >= len(set.Elems) {
 		return setElemObjectFromTerraformValue(ctx, schemaPath, set, description, nil)
 	}
 

--- a/internal/fwserver/block_plan_modification_test.go
+++ b/internal/fwserver/block_plan_modification_test.go
@@ -344,6 +344,161 @@ func TestBlockModifyPlan(t *testing.T) {
 				Private: testProviderData,
 			},
 		},
+		"block-list-null-plan": {
+			block: tfsdk.Block{
+				Attributes: map[string]tfsdk.Attribute{
+					"nested_attr": {
+						Type:     types.StringType,
+						Required: true,
+						PlanModifiers: tfsdk.AttributePlanModifiers{
+							planmodifiers.TestAttrPlanPrivateModifierGet{},
+						},
+					},
+				},
+				NestingMode: tfsdk.BlockNestingModeList,
+				PlanModifiers: tfsdk.AttributePlanModifiers{
+					planmodifiers.TestAttrPlanPrivateModifierSet{},
+				},
+			},
+			req: tfsdk.ModifyAttributePlanRequest{
+				AttributeConfig: types.List{
+					ElemType: types.ObjectType{
+						AttrTypes: map[string]attr.Type{
+							"nested_attr": types.StringType,
+						},
+					},
+					Elems: []attr.Value{
+						types.Object{
+							AttrTypes: map[string]attr.Type{
+								"nested_attr": types.StringType,
+							},
+							Attrs: map[string]attr.Value{
+								"nested_attr": types.String{Value: "testvalue"},
+							},
+						},
+					},
+				},
+				AttributePath: path.Root("test"),
+				AttributePlan: types.List{
+					ElemType: types.ObjectType{
+						AttrTypes: map[string]attr.Type{
+							"nested_attr": types.StringType,
+						},
+					},
+					Null: true,
+				},
+				AttributeState: types.List{
+					ElemType: types.ObjectType{
+						AttrTypes: map[string]attr.Type{
+							"nested_attr": types.StringType,
+						},
+					},
+					Elems: []attr.Value{
+						types.Object{
+							AttrTypes: map[string]attr.Type{
+								"nested_attr": types.StringType,
+							},
+							Attrs: map[string]attr.Value{
+								"nested_attr": types.String{Value: "testvalue"},
+							},
+						},
+					},
+				},
+			},
+			expectedResp: ModifyAttributePlanResponse{
+				AttributePlan: types.List{
+					ElemType: types.ObjectType{
+						AttrTypes: map[string]attr.Type{
+							"nested_attr": types.StringType,
+						},
+					},
+					Null: true,
+				},
+				Private: testProviderData,
+			},
+		},
+		"block-list-null-state": {
+			block: tfsdk.Block{
+				Attributes: map[string]tfsdk.Attribute{
+					"nested_attr": {
+						Type:     types.StringType,
+						Required: true,
+						PlanModifiers: tfsdk.AttributePlanModifiers{
+							planmodifiers.TestAttrPlanPrivateModifierGet{},
+						},
+					},
+				},
+				NestingMode: tfsdk.BlockNestingModeList,
+				PlanModifiers: tfsdk.AttributePlanModifiers{
+					planmodifiers.TestAttrPlanPrivateModifierSet{},
+				},
+			},
+			req: tfsdk.ModifyAttributePlanRequest{
+				AttributeConfig: types.List{
+					ElemType: types.ObjectType{
+						AttrTypes: map[string]attr.Type{
+							"nested_attr": types.StringType,
+						},
+					},
+					Elems: []attr.Value{
+						types.Object{
+							AttrTypes: map[string]attr.Type{
+								"nested_attr": types.StringType,
+							},
+							Attrs: map[string]attr.Value{
+								"nested_attr": types.String{Value: "testvalue"},
+							},
+						},
+					},
+				},
+				AttributePath: path.Root("test"),
+				AttributePlan: types.List{
+					ElemType: types.ObjectType{
+						AttrTypes: map[string]attr.Type{
+							"nested_attr": types.StringType,
+						},
+					},
+					Elems: []attr.Value{
+						types.Object{
+							AttrTypes: map[string]attr.Type{
+								"nested_attr": types.StringType,
+							},
+							Attrs: map[string]attr.Value{
+								"nested_attr": types.String{Value: "testvalue"},
+							},
+						},
+					},
+				},
+				AttributeState: types.List{
+					ElemType: types.ObjectType{
+						AttrTypes: map[string]attr.Type{
+							"nested_attr": types.StringType,
+						},
+					},
+					Null: true,
+				},
+			},
+			expectedResp: ModifyAttributePlanResponse{
+				AttributePlan: types.List{
+					ElemType: types.ObjectType{
+						AttrTypes: map[string]attr.Type{
+							"nested_attr": types.StringType,
+						},
+					},
+					Elems: []attr.Value{
+						types.Object{
+							AttrTypes: map[string]attr.Type{
+								"nested_attr": types.StringType,
+							},
+							Attrs: map[string]attr.Value{
+								"nested_attr": types.String{Value: "testvalue"},
+							},
+						},
+					},
+				},
+				Private: testProviderData,
+			},
+		},
 		"block-list-nested-private": {
 			block: tfsdk.Block{
 				Attributes: map[string]tfsdk.Attribute{
@@ -416,6 +571,161 @@ func TestBlockModifyPlan(t *testing.T) {
 			},
 			expectedResp: ModifyAttributePlanResponse{
 				AttributePlan: types.List{
+					ElemType: types.ObjectType{
+						AttrTypes: map[string]attr.Type{
+							"nested_attr": types.StringType,
+						},
+					},
+					Elems: []attr.Value{
+						types.Object{
+							AttrTypes: map[string]attr.Type{
+								"nested_attr": types.StringType,
+							},
+							Attrs: map[string]attr.Value{
+								"nested_attr": types.String{Value: "testvalue"},
+							},
+						},
+					},
+				},
+				Private: testProviderData,
+			},
+		},
+		"block-set-null-plan": {
+			block: tfsdk.Block{
+				Attributes: map[string]tfsdk.Attribute{
+					"nested_attr": {
+						Type:     types.StringType,
+						Required: true,
+						PlanModifiers: tfsdk.AttributePlanModifiers{
+							planmodifiers.TestAttrPlanPrivateModifierGet{},
+						},
+					},
+				},
+				NestingMode: tfsdk.BlockNestingModeSet,
+				PlanModifiers: tfsdk.AttributePlanModifiers{
+					planmodifiers.TestAttrPlanPrivateModifierSet{},
+				},
+			},
+			req: tfsdk.ModifyAttributePlanRequest{
+				AttributeConfig: types.Set{
+					ElemType: types.ObjectType{
+						AttrTypes: map[string]attr.Type{
+							"nested_attr": types.StringType,
+						},
+					},
+					Elems: []attr.Value{
+						types.Object{
+							AttrTypes: map[string]attr.Type{
+								"nested_attr": types.StringType,
+							},
+							Attrs: map[string]attr.Value{
+								"nested_attr": types.String{Value: "testvalue"},
+							},
+						},
+					},
+				},
+				AttributePath: path.Root("test"),
+				AttributePlan: types.Set{
+					ElemType: types.ObjectType{
+						AttrTypes: map[string]attr.Type{
+							"nested_attr": types.StringType,
+						},
+					},
+					Null: true,
+				},
+				AttributeState: types.Set{
+					ElemType: types.ObjectType{
+						AttrTypes: map[string]attr.Type{
+							"nested_attr": types.StringType,
+						},
+					},
+					Elems: []attr.Value{
+						types.Object{
+							AttrTypes: map[string]attr.Type{
+								"nested_attr": types.StringType,
+							},
+							Attrs: map[string]attr.Value{
+								"nested_attr": types.String{Value: "testvalue"},
+							},
+						},
+					},
+				},
+			},
+			expectedResp: ModifyAttributePlanResponse{
+				AttributePlan: types.Set{
+					ElemType: types.ObjectType{
+						AttrTypes: map[string]attr.Type{
+							"nested_attr": types.StringType,
+						},
+					},
+					Null: true,
+				},
+				Private: testProviderData,
+			},
+		},
+		"block-set-null-state": {
+			block: tfsdk.Block{
+				Attributes: map[string]tfsdk.Attribute{
+					"nested_attr": {
+						Type:     types.StringType,
+						Required: true,
+						PlanModifiers: tfsdk.AttributePlanModifiers{
+							planmodifiers.TestAttrPlanPrivateModifierGet{},
+						},
+					},
+				},
+				NestingMode: tfsdk.BlockNestingModeSet,
+				PlanModifiers: tfsdk.AttributePlanModifiers{
+					planmodifiers.TestAttrPlanPrivateModifierSet{},
+				},
+			},
+			req: tfsdk.ModifyAttributePlanRequest{
+				AttributeConfig: types.Set{
+					ElemType: types.ObjectType{
+						AttrTypes: map[string]attr.Type{
+							"nested_attr": types.StringType,
+						},
+					},
+					Elems: []attr.Value{
+						types.Object{
+							AttrTypes: map[string]attr.Type{
+								"nested_attr": types.StringType,
+							},
+							Attrs: map[string]attr.Value{
+								"nested_attr": types.String{Value: "testvalue"},
+							},
+						},
+					},
+				},
+				AttributePath: path.Root("test"),
+				AttributePlan: types.Set{
+					ElemType: types.ObjectType{
+						AttrTypes: map[string]attr.Type{
+							"nested_attr": types.StringType,
+						},
+					},
+					Elems: []attr.Value{
+						types.Object{
+							AttrTypes: map[string]attr.Type{
+								"nested_attr": types.StringType,
+							},
+							Attrs: map[string]attr.Value{
+								"nested_attr": types.String{Value: "testvalue"},
+							},
+						},
+					},
+				},
+				AttributeState: types.Set{
+					ElemType: types.ObjectType{
+						AttrTypes: map[string]attr.Type{
+							"nested_attr": types.StringType,
+						},
+					},
+					Null: true,
+				},
+			},
+			expectedResp: ModifyAttributePlanResponse{
+				AttributePlan: types.Set{
 					ElemType: types.ObjectType{
 						AttrTypes: map[string]attr.Type{
 							"nested_attr": types.StringType,


### PR DESCRIPTION
Reference: #468 (unreleased bugs)

Previously, it was possible to get a `Attribute Plan Modification Walk Error` diagnostic when a resource was being created and the `req.AttributeState` was set to `nil` instead of a null value for the given `attr.Value`. This changes the logic to always return a proper `attr.Value`.

Previously, it was possible that while iterating through the plan elements for a list or set collection, that configuration or state elements at the same index may not exist. The logic was off-by-one due to Go's 0-based slice indexing to return early with a null value in those cases.