### PR TITLE
Add Validate() to all collections

### DIFF
--- a/.changelog/481.txt
+++ b/.changelog/481.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+types: Ensured `List`, `Map`, and `Set` types with `xattr.TypeWithValidate` elements run validation on those elements
+```

--- a/internal/fwserver/attribute_validation_test.go
+++ b/internal/fwserver/attribute_validation_test.go
@@ -147,12 +147,6 @@ func TestAttributeValidate(t *testing.T) {
 						"An unexpected error was encountered trying to validate an attribute value. This is always an error in the provider. Please report the following to the provider developer:\n\n"+
 							"expected List value, received tftypes.Value with value: tftypes.String<\"testvalue\">",
 					),
-					diag.NewAttributeErrorDiagnostic(
-						path.Root("test"),
-						"List Type Validation Error",
-						"An unexpected error was encountered trying to validate an attribute value. This is always an error in the provider. Please report the following to the provider developer:\n\n"+
-							"can't unmarshal tftypes.String into *[]tftypes.Value expected []tftypes.Value",
-					),
 				},
 			},
 		},

--- a/internal/fwserver/attribute_validation_test.go
+++ b/internal/fwserver/attribute_validation_test.go
@@ -144,8 +144,14 @@ func TestAttributeValidate(t *testing.T) {
 					diag.NewAttributeErrorDiagnostic(
 						path.Root("test"),
 						"List Type Validation Error",
-						"An unexpected error was encountered trying to convert an attribute value from the configuration. This is always an error in the provider. Please report the following to the provider developer:\n\n"+
-							"Error: can't use tftypes.String<\"testvalue\"> as value of List with ElementType types.primitive, can only use tftypes.String values",
+						"An unexpected error was encountered trying to validate an attribute value. This is always an error in the provider. Please report the following to the provider developer:\n\n"+
+							"expected List value, received tftypes.Value with value: tftypes.String<\"testvalue\">",
+					),
+					diag.NewAttributeErrorDiagnostic(
+						path.Root("test"),
+						"List Type Validation Error",
+						"An unexpected error was encountered trying to validate an attribute value. This is always an error in the provider. Please report the following to the provider developer:\n\n"+
+							"can't unmarshal tftypes.String into *[]tftypes.Value expected []tftypes.Value",
 					),
 				},
 			},

--- a/internal/fwserver/attribute_validation_test.go
+++ b/internal/fwserver/attribute_validation_test.go
@@ -143,7 +143,7 @@ func TestAttributeValidate(t *testing.T) {
 				Diagnostics: diag.Diagnostics{
 					diag.NewAttributeErrorDiagnostic(
 						path.Root("test"),
-						"Configuration Read Error",
+						"List Type Validation Error",
 						"An unexpected error was encountered trying to convert an attribute value from the configuration. This is always an error in the provider. Please report the following to the provider developer:\n\n"+
 							"Error: can't use tftypes.String<\"testvalue\"> as value of List with ElementType types.primitive, can only use tftypes.String values",
 					),

--- a/internal/fwserver/schema_plan_modification_test.go
+++ b/internal/fwserver/schema_plan_modification_test.go
@@ -89,7 +89,7 @@ func TestSchemaModifyPlan(t *testing.T) {
 				Diagnostics: diag.Diagnostics{
 					diag.NewAttributeErrorDiagnostic(
 						path.Root("test"),
-						"Configuration Read Error",
+						"List Type Validation Error",
 						"An unexpected error was encountered trying to convert an attribute value from the configuration. This is always an error in the provider. Please report the following to the provider developer:\n\n"+
 							"Error: can't use tftypes.String<\"testvalue\"> as value of List with ElementType types.primitive, can only use tftypes.String values",
 					),
@@ -175,7 +175,7 @@ func TestSchemaModifyPlan(t *testing.T) {
 					),
 					diag.NewAttributeErrorDiagnostic(
 						path.Root("test"),
-						"Configuration Read Error",
+						"List Type Validation Error",
 						"An unexpected error was encountered trying to convert an attribute value from the configuration. This is always an error in the provider. Please report the following to the provider developer:\n\n"+
 							"Error: can't use tftypes.String<\"testvalue\"> as value of List with ElementType types.primitive, can only use tftypes.String values",
 					),

--- a/internal/reflect/map.go
+++ b/internal/reflect/map.go
@@ -145,7 +145,7 @@ func FromMap(ctx context.Context, typ attr.TypeWithElementType, val reflect.Valu
 			return nil, append(diags, toTerraformValueErrorDiag(err, path))
 		}
 
-		if typeWithValidate, ok := typ.(xattr.TypeWithValidate); ok {
+		if typeWithValidate, ok := elemType.(xattr.TypeWithValidate); ok {
 			diags.Append(typeWithValidate.Validate(ctx, tfVal, path.AtMapKey(key.String()))...)
 
 			if diags.HasError() {

--- a/types/list.go
+++ b/types/list.go
@@ -129,6 +129,7 @@ func (l ListType) Validate(ctx context.Context, in tftypes.Value, path path.Path
 			"List Type Validation Error",
 			"An unexpected error was encountered trying to validate an attribute value. This is always an error in the provider. Please report the following to the provider developer:\n\n"+err.Error(),
 		)
+		return diags
 	}
 
 	if !in.IsKnown() || in.IsNull() {

--- a/types/list.go
+++ b/types/list.go
@@ -146,8 +146,8 @@ func (l ListType) Validate(ctx context.Context, in tftypes.Value, path path.Path
 		return diags
 	}
 
-	validatableType, ok := l.ElemType.(xattr.TypeWithValidate)
-	if !ok {
+	validatableType, isValidatable := l.ElemType.(xattr.TypeWithValidate)
+	if !isValidatable {
 		return diags
 	}
 

--- a/types/list.go
+++ b/types/list.go
@@ -6,8 +6,10 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/attr/xattr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/reflect"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
@@ -109,6 +111,54 @@ func (l ListType) ApplyTerraform5AttributePathStep(step tftypes.AttributePathSte
 // String returns a human-friendly description of the ListType.
 func (l ListType) String() string {
 	return "types.ListType[" + l.ElemType.String() + "]"
+}
+
+// Validate validates all elements of the list that are of type
+// xattr.TypeWithValidate.
+func (l ListType) Validate(ctx context.Context, in tftypes.Value, path path.Path) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	if in.Type() == nil {
+		return diags
+	}
+
+	if !in.Type().Is(tftypes.List{}) {
+		err := fmt.Errorf("expected List value, received %T with value: %v", in, in)
+		diags.AddAttributeError(
+			path,
+			"List Type Validation Error",
+			"An unexpected error was encountered trying to validate an attribute value. This is always an error in the provider. Please report the following to the provider developer:\n\n"+err.Error(),
+		)
+	}
+
+	if !in.IsKnown() || in.IsNull() {
+		return diags
+	}
+
+	var elems []tftypes.Value
+
+	if err := in.As(&elems); err != nil {
+		diags.AddAttributeError(
+			path,
+			"List Type Validation Error",
+			"An unexpected error was encountered trying to validate an attribute value. This is always an error in the provider. Please report the following to the provider developer:\n\n"+err.Error(),
+		)
+		return diags
+	}
+
+	validatableType, ok := l.ElemType.(xattr.TypeWithValidate)
+	if !ok {
+		return diags
+	}
+
+	for index, elem := range elems {
+		if !elem.IsFullyKnown() {
+			continue
+		}
+		diags = append(diags, validatableType.Validate(ctx, elem, path.AtListIndex(index))...)
+	}
+
+	return diags
 }
 
 // List represents a list of attr.Values, all of the same type, indicated

--- a/types/map.go
+++ b/types/map.go
@@ -133,6 +133,7 @@ func (m MapType) Validate(ctx context.Context, in tftypes.Value, path path.Path)
 			"Map Type Validation Error",
 			"An unexpected error was encountered trying to validate an attribute value. This is always an error in the provider. Please report the following to the provider developer:\n\n"+err.Error(),
 		)
+		return diags
 	}
 
 	if !in.IsKnown() || in.IsNull() {

--- a/types/map.go
+++ b/types/map.go
@@ -121,6 +121,9 @@ func (m MapType) String() string {
 // xattr.TypeWithValidate.
 func (m MapType) Validate(ctx context.Context, in tftypes.Value, path path.Path) diag.Diagnostics {
 	var diags diag.Diagnostics
+	if true {
+		return diags
+	}
 
 	if in.Type() == nil {
 		return diags

--- a/types/map.go
+++ b/types/map.go
@@ -150,8 +150,8 @@ func (m MapType) Validate(ctx context.Context, in tftypes.Value, path path.Path)
 		return diags
 	}
 
-	validatableType, ok := m.ElemType.(xattr.TypeWithValidate)
-	if !ok {
+	validatableType, isValidatable := m.ElemType.(xattr.TypeWithValidate)
+	if !isValidatable {
 		return diags
 	}
 

--- a/types/map.go
+++ b/types/map.go
@@ -121,9 +121,6 @@ func (m MapType) String() string {
 // xattr.TypeWithValidate.
 func (m MapType) Validate(ctx context.Context, in tftypes.Value, path path.Path) diag.Diagnostics {
 	var diags diag.Diagnostics
-	if true {
-		return diags
-	}
 
 	if in.Type() == nil {
 		return diags

--- a/types/set.go
+++ b/types/set.go
@@ -161,7 +161,7 @@ func (st SetType) Validate(ctx context.Context, in tftypes.Value, path path.Path
 
 		// Validate the element first
 		if isValidatable {
-			diags = append(diags, validatableType.Validate(ctx, elemOuter, path.AtListIndex(indexOuter))...)
+			diags = append(diags, validatableType.Validate(ctx, elemOuter, path.AtSetValue(elemOuter))...)
 		}
 
 		// Then check for duplicates

--- a/types/set.go
+++ b/types/set.go
@@ -161,7 +161,16 @@ func (st SetType) Validate(ctx context.Context, in tftypes.Value, path path.Path
 
 		// Validate the element first
 		if isValidatable {
-			diags = append(diags, validatableType.Validate(ctx, elemOuter, path.AtSetValue(elemOuter))...)
+			elemValue, err := st.ElemType.ValueFromTerraform(ctx, elemOuter)
+			if err != nil {
+				diags.AddAttributeError(
+					path,
+					"Set Type Validation Error",
+					"An unexpected error was encountered trying to validate an attribute value. This is always an error in the provider. Please report the following to the provider developer:\n\n"+err.Error(),
+				)
+				return diags
+			}
+			diags = append(diags, validatableType.Validate(ctx, elemOuter, path.AtSetValue(elemValue))...)
 		}
 
 		// Then check for duplicates

--- a/types/set_test.go
+++ b/types/set_test.go
@@ -540,6 +540,21 @@ func TestSetTypeValidate(t *testing.T) {
 				),
 			},
 		},
+		"wrong-value-type": {
+			in: tftypes.NewValue(tftypes.List{
+				ElementType: tftypes.String,
+			}, []tftypes.Value{
+				tftypes.NewValue(tftypes.String, "testvalue"),
+			}),
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("test"),
+					"Set Type Validation Error",
+					"An unexpected error was encountered trying to validate an attribute value. This is always an error in the provider. Please report the following to the provider developer:\n\n"+
+						"expected Set value, received tftypes.Value with value: tftypes.List[tftypes.String]<tftypes.String<\"testvalue\">>",
+				),
+			},
+		},
 	}
 	for name, testCase := range testCases {
 		name, testCase := name, testCase


### PR DESCRIPTION
This also fixes a bug in `internal/reflect/map.go` where it used the map's own type to Validate elements, which does not seem correct at all.

Fixes https://github.com/hashicorp/terraform-plugin-framework/issues/467