### PR TITLE
[docs] Typo in resources index: s/Read/Delete/

### DIFF
--- a/website/docs/plugin/framework/resources/index.mdx
+++ b/website/docs/plugin/framework/resources/index.mdx
@@ -98,7 +98,7 @@ func (r *ThingResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
-func (r *ThingResource) Delete(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+func (r *ThingResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	var data ThingResourceModel
 
 	// Read Terraform prior state data into the model

--- a/website/docs/plugin/framework/resources/index.mdx
+++ b/website/docs/plugin/framework/resources/index.mdx
@@ -98,7 +98,7 @@ func (r *ThingResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
-func (r *ThingResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+func (r *ThingResource) Delete(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var data ThingResourceModel
 
 	// Read Terraform prior state data into the model


### PR DESCRIPTION
When reading the documentation on the website while preparing to migrate an existing small-ish provider, I noticed this typo which seems like it was introduced two days ago (https://github.com/hashicorp/terraform-plugin-framework/commit/7541ab15654b00837015180ecdb7f439e604c6cf).

I was expecting to find a Delete function in that example and ended up scrolling up and down for a couple of minutes until I realised there was a typo in the function name.

I did notice the contribution guidelines indicate that typo PR aren't generally accepted, but hopefully this one is more than an innocent typo since it can really confuse people reading the documentation expecting to find a Delete function in that first overview example. If not, I am sorry for the noise.