### PR TITLE
Replace deprecated linters with unused

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,7 +5,6 @@ issues:
 linters:
   disable-all: true
   enable:
-    - deadcode
     - durationcheck
     - errcheck
     - exportloopref
@@ -20,5 +19,5 @@ linters:
     - tenv
     - unconvert
     - unparam
-    - varcheck
+    - unused
     - vet


### PR DESCRIPTION
Previously:

```
$ golangci-lint run ./...
WARN [runner] The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
WARN [runner] The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
```