### PR TITLE
website: Fix old code examples to tfsdk.ModifyResourcePlanRe(quest|sponse)

### DIFF
--- a/website/docs/plugin/framework/resources/plan-modification.mdx
+++ b/website/docs/plugin/framework/resources/plan-modification.mdx
@@ -121,11 +121,11 @@ Resources also support plan modification across all attributes. This is helpful 
 ```go
 // Ensure the Resource satisfies the resource.ResourceWithModifyPlan interface.
 // Other methods to implement the resource.Resource interface are omitted for brevity
-var _ resource.ResourceWithModifyPlan = exampleResource{}
+var _ resource.ResourceWithModifyPlan = ThingResource{}
 
-type exampleResource struct {}
+type ThingResource struct {}
 
-func (r exampleResource) ModifyPlan(ctx context.Context, req tfsdk.ModifyResourcePlanRequest, resp *tfsdk.ModifyResourcePlanResponse) {
+func (r ThingResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
     // Fill in logic.
 }
 ```
@@ -134,10 +134,10 @@ func (r exampleResource) ModifyPlan(ctx context.Context, req tfsdk.ModifyResourc
 
 -> Support for handling resource destruction during planning is available in Terraform 1.3 and later.
 
-Implement the `ModifyPlan` method by checking if the [`tfsdk.ModifyResourcePlanRequest` type `Plan` field](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/tfsdk#ModifyResourcePlanRequest.Plan) is a `null` value:
+Implement the `ModifyPlan` method by checking if the [`resource.ModifyPlanRequest` type `Plan` field](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#ModifyPlanRequest.Plan) is a `null` value:
 
 ```go
-func (r exampleResource) ModifyPlan(ctx context.Context, req tfsdk.ModifyResourcePlanRequest, resp *tfsdk.ModifyResourcePlanResponse) {
+func (r ThingResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
     // If the entire plan is null, the resource is planned for destruction.
     if req.Plan.Raw.IsNull() {
         // Return an example warning diagnostic to practitioners.


### PR DESCRIPTION
Reference: https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#ModifyPlanRequest
Reference: https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#ModifyPlanResponse

This was missed when the `resource` package was initially created.