### PR TITLE
Consider Allowing Usage of Custom Types for Structural Elements

### DIFF
--- a/attr/value.go
+++ b/attr/value.go
@@ -46,3 +46,11 @@ type Value interface {
 	// compatibility guarantees within the framework.
 	String() string
 }
+
+type ValueWithAttrs interface {
+	Value
+
+	GetAttrs() map[string]Value
+
+	SetAttrs(map[string]Value) ValueWithAttrs
+}

--- a/internal/fwserver/attribute_plan_modification.go
+++ b/internal/fwserver/attribute_plan_modification.go
@@ -151,7 +151,11 @@ func AttributeModifyPlan(ctx context.Context, a fwschema.Attribute, req tfsdk.Mo
 				return
 			}
 
-			planObjectAttrs := planObject.Type(ctx).(attr.TypeWithAttributeTypes).AttributeTypes()
+			planObjectAttrs := planObject.(attr.ValueWithAttrs).GetAttrs()
+
+			if planObjectAttrs == nil {
+				planObjectAttrs = make(map[string]attr.Value)
+			}
 
 			for name, attr := range a.GetAttributes().GetAttributes() {
 				attrConfig, diags := objectAttributeValue(ctx, configObject, name, fwschemadata.DataDescriptionConfiguration)
@@ -197,19 +201,13 @@ func AttributeModifyPlan(ctx context.Context, a fwschema.Attribute, req tfsdk.Mo
 
 				AttributeModifyPlan(ctx, attr, attrReq, &attrResp)
 
-				planObjectAttrs[name] = attrResp.AttributePlan.Type(ctx)
+				planObjectAttrs[name] = attrResp.AttributePlan
 				resp.Diagnostics.Append(attrResp.Diagnostics...)
 				resp.RequiresReplace = attrResp.RequiresReplace
 				resp.Private = attrResp.Private
 			}
 
-			planElements[idx], diags = types.ObjectValue(planObject.AttributeTypes(ctx), planAttributes)
-
-			resp.Diagnostics.Append(diags...)
-
-			if resp.Diagnostics.HasError() {
-				return
-			}
+			planList.Elems[idx] = planObject.(attr.ValueWithAttrs).SetAttrs(planObjectAttrs)
 		}
 
 		resp.AttributePlan, diags = types.ListValue(planList.ElementType(ctx), planElements)
@@ -273,7 +271,11 @@ func AttributeModifyPlan(ctx context.Context, a fwschema.Attribute, req tfsdk.Mo
 				return
 			}
 
-			planObjectAttrs := planObject.Type(ctx).(attr.TypeWithAttributeTypes).AttributeTypes()
+			planObjectAttrs := planObject.(attr.ValueWithAttrs).GetAttrs()
+
+			if planObjectAttrs == nil {
+				planObjectAttrs = make(map[string]attr.Value)
+			}
 
 			for name, attr := range a.GetAttributes().GetAttributes() {
 				attrConfig, diags := objectAttributeValue(ctx, configObject, name, fwschemadata.DataDescriptionConfiguration)
@@ -319,19 +321,13 @@ func AttributeModifyPlan(ctx context.Context, a fwschema.Attribute, req tfsdk.Mo
 
 				AttributeModifyPlan(ctx, attr, attrReq, &attrResp)
 
-				planObjectAttrs[name] = attrResp.AttributePlan.Type(ctx)
+				planObjectAttrs[name] = attrResp.AttributePlan
 				resp.Diagnostics.Append(attrResp.Diagnostics...)
 				resp.RequiresReplace = attrResp.RequiresReplace
 				resp.Private = attrResp.Private
 			}
 
-			planElements[idx], diags = types.ObjectValue(planObject.AttributeTypes(ctx), planAttributes)
-
-			resp.Diagnostics.Append(diags...)
-
-			if resp.Diagnostics.HasError() {
-				return
-			}
+			planSet.Elems[idx] = planObject.(attr.ValueWithAttrs).SetAttrs(planObjectAttrs)
 		}
 
 		resp.AttributePlan, diags = types.SetValue(planSet.ElementType(ctx), planElements)
@@ -395,7 +391,11 @@ func AttributeModifyPlan(ctx context.Context, a fwschema.Attribute, req tfsdk.Mo
 				return
 			}
 
-			planObjectAttrs := planObject.Type(ctx).(attr.TypeWithAttributeTypes).AttributeTypes()
+			planObjectAttrs := planObject.(attr.ValueWithAttrs).GetAttrs()
+
+			if planObjectAttrs == nil {
+				planObjectAttrs = make(map[string]attr.Value)
+			}
 
 			for name, attr := range a.GetAttributes().GetAttributes() {
 				attrConfig, diags := objectAttributeValue(ctx, configObject, name, fwschemadata.DataDescriptionConfiguration)
@@ -441,19 +441,13 @@ func AttributeModifyPlan(ctx context.Context, a fwschema.Attribute, req tfsdk.Mo
 
 				AttributeModifyPlan(ctx, attr, attrReq, &attrResp)
 
-				planObjectAttrs[name] = attrResp.AttributePlan.Type(ctx)
+				planObjectAttrs[name] = attrResp.AttributePlan
 				resp.Diagnostics.Append(attrResp.Diagnostics...)
 				resp.RequiresReplace = attrResp.RequiresReplace
 				resp.Private = attrResp.Private
 			}
 
-			planElements[key], diags = types.ObjectValue(planObject.AttributeTypes(ctx), planAttributes)
-
-			resp.Diagnostics.Append(diags...)
-
-			if resp.Diagnostics.HasError() {
-				return
-			}
+			planMap.Elems[key] = planObject.(attr.ValueWithAttrs).SetAttrs(planObjectAttrs)
 		}
 
 		resp.AttributePlan, diags = types.MapValue(planMap.ElementType(ctx), planElements)
@@ -488,7 +482,7 @@ func AttributeModifyPlan(ctx context.Context, a fwschema.Attribute, req tfsdk.Mo
 			return
 		}
 
-		planObjectAttrs := planObject.Type(ctx).(attr.TypeWithAttributeTypes).AttributeTypes()
+		planObjectAttrs := planObject.(attr.ValueWithAttrs).GetAttrs()
 
 		if len(planObjectAttrs) == 0 {
 			return
@@ -540,19 +534,13 @@ func AttributeModifyPlan(ctx context.Context, a fwschema.Attribute, req tfsdk.Mo
 
 			AttributeModifyPlan(ctx, attr, attrReq, &attrResp)
 
-			planObjectAttrs[name] = attrResp.AttributePlan.Type(ctx)
+			planObjectAttrs[name] = attrResp.AttributePlan
 			resp.Diagnostics.Append(attrResp.Diagnostics...)
 			resp.RequiresReplace = attrResp.RequiresReplace
 			resp.Private = attrResp.Private
 		}
 
-		resp.AttributePlan, diags = types.ObjectValue(planObject.AttributeTypes(ctx), planAttributes)
-
-		resp.Diagnostics.Append(diags...)
-
-		if resp.Diagnostics.HasError() {
-			return
-		}
+		resp.AttributePlan = planObject.(attr.ValueWithAttrs).SetAttrs(planObjectAttrs)
 	default:
 		err := fmt.Errorf("unknown attribute nesting mode (%T: %v) at path: %s", nm, nm, req.AttributePath)
 		resp.Diagnostics.AddAttributeError(

--- a/internal/fwserver/attribute_plan_modification.go
+++ b/internal/fwserver/attribute_plan_modification.go
@@ -488,8 +488,6 @@ func AttributeModifyPlan(ctx context.Context, a fwschema.Attribute, req tfsdk.Mo
 			return
 		}
 
-		planAttributes := planObject.Attributes()
-
 		for name, attr := range a.GetAttributes().GetAttributes() {
 			attrConfig, diags := objectAttributeValue(ctx, configObject, name, fwschemadata.DataDescriptionConfiguration)
 

--- a/internal/fwserver/attribute_plan_modification.go
+++ b/internal/fwserver/attribute_plan_modification.go
@@ -151,7 +151,7 @@ func AttributeModifyPlan(ctx context.Context, a fwschema.Attribute, req tfsdk.Mo
 				return
 			}
 
-			planAttributes := planObject.Attributes()
+			planObjectAttrs := planObject.Type(ctx).(attr.TypeWithAttributeTypes).AttributeTypes()
 
 			for name, attr := range a.GetAttributes().GetAttributes() {
 				attrConfig, diags := objectAttributeValue(ctx, configObject, name, fwschemadata.DataDescriptionConfiguration)
@@ -197,7 +197,7 @@ func AttributeModifyPlan(ctx context.Context, a fwschema.Attribute, req tfsdk.Mo
 
 				AttributeModifyPlan(ctx, attr, attrReq, &attrResp)
 
-				planAttributes[name] = attrResp.AttributePlan
+				planObjectAttrs[name] = attrResp.AttributePlan.Type(ctx)
 				resp.Diagnostics.Append(attrResp.Diagnostics...)
 				resp.RequiresReplace = attrResp.RequiresReplace
 				resp.Private = attrResp.Private
@@ -273,7 +273,7 @@ func AttributeModifyPlan(ctx context.Context, a fwschema.Attribute, req tfsdk.Mo
 				return
 			}
 
-			planAttributes := planObject.Attributes()
+			planObjectAttrs := planObject.Type(ctx).(attr.TypeWithAttributeTypes).AttributeTypes()
 
 			for name, attr := range a.GetAttributes().GetAttributes() {
 				attrConfig, diags := objectAttributeValue(ctx, configObject, name, fwschemadata.DataDescriptionConfiguration)
@@ -319,7 +319,7 @@ func AttributeModifyPlan(ctx context.Context, a fwschema.Attribute, req tfsdk.Mo
 
 				AttributeModifyPlan(ctx, attr, attrReq, &attrResp)
 
-				planAttributes[name] = attrResp.AttributePlan
+				planObjectAttrs[name] = attrResp.AttributePlan.Type(ctx)
 				resp.Diagnostics.Append(attrResp.Diagnostics...)
 				resp.RequiresReplace = attrResp.RequiresReplace
 				resp.Private = attrResp.Private
@@ -395,7 +395,7 @@ func AttributeModifyPlan(ctx context.Context, a fwschema.Attribute, req tfsdk.Mo
 				return
 			}
 
-			planAttributes := planObject.Attributes()
+			planObjectAttrs := planObject.Type(ctx).(attr.TypeWithAttributeTypes).AttributeTypes()
 
 			for name, attr := range a.GetAttributes().GetAttributes() {
 				attrConfig, diags := objectAttributeValue(ctx, configObject, name, fwschemadata.DataDescriptionConfiguration)
@@ -441,7 +441,7 @@ func AttributeModifyPlan(ctx context.Context, a fwschema.Attribute, req tfsdk.Mo
 
 				AttributeModifyPlan(ctx, attr, attrReq, &attrResp)
 
-				planAttributes[name] = attrResp.AttributePlan
+				planObjectAttrs[name] = attrResp.AttributePlan.Type(ctx)
 				resp.Diagnostics.Append(attrResp.Diagnostics...)
 				resp.RequiresReplace = attrResp.RequiresReplace
 				resp.Private = attrResp.Private
@@ -488,7 +488,9 @@ func AttributeModifyPlan(ctx context.Context, a fwschema.Attribute, req tfsdk.Mo
 			return
 		}
 
-		if len(planObject.Attributes()) == 0 {
+		planObjectAttrs := planObject.Type(ctx).(attr.TypeWithAttributeTypes).AttributeTypes()
+
+		if len(planObjectAttrs) == 0 {
 			return
 		}
 
@@ -538,7 +540,7 @@ func AttributeModifyPlan(ctx context.Context, a fwschema.Attribute, req tfsdk.Mo
 
 			AttributeModifyPlan(ctx, attr, attrReq, &attrResp)
 
-			planAttributes[name] = attrResp.AttributePlan
+			planObjectAttrs[name] = attrResp.AttributePlan.Type(ctx)
 			resp.Diagnostics.Append(attrResp.Diagnostics...)
 			resp.RequiresReplace = attrResp.RequiresReplace
 			resp.Private = attrResp.Private

--- a/internal/fwserver/block_plan_modification.go
+++ b/internal/fwserver/block_plan_modification.go
@@ -117,7 +117,11 @@ func BlockModifyPlan(ctx context.Context, b fwschema.Block, req tfsdk.ModifyAttr
 				return
 			}
 
-			planObjectAttrs := planObject.Type(ctx).(attr.TypeWithAttributeTypes).AttributeTypes()
+			planObjectAttrs := planObject.(attr.ValueWithAttrs).GetAttrs()
+
+			if planObjectAttrs == nil {
+				planObjectAttrs = make(map[string]attr.Value)
+			}
 
 			for name, attr := range b.GetAttributes() {
 				attrConfig, diags := objectAttributeValue(ctx, configObject, name, fwschemadata.DataDescriptionConfiguration)
@@ -163,7 +167,7 @@ func BlockModifyPlan(ctx context.Context, b fwschema.Block, req tfsdk.ModifyAttr
 
 				AttributeModifyPlan(ctx, attr, attrReq, &attrResp)
 
-				planObjectAttrs[name] = attrResp.AttributePlan.Type(ctx)
+				planObjectAttrs[name] = attrResp.AttributePlan
 				resp.Diagnostics.Append(attrResp.Diagnostics...)
 				resp.RequiresReplace = attrResp.RequiresReplace
 				resp.Private = attrResp.Private
@@ -213,19 +217,13 @@ func BlockModifyPlan(ctx context.Context, b fwschema.Block, req tfsdk.ModifyAttr
 
 				BlockModifyPlan(ctx, block, blockReq, &blockResp)
 
-				planObjectAttrs[name] = blockResp.AttributePlan.Type(ctx)
+				planObjectAttrs[name] = blockResp.AttributePlan
 				resp.Diagnostics.Append(blockResp.Diagnostics...)
 				resp.RequiresReplace = blockResp.RequiresReplace
 				resp.Private = blockResp.Private
 			}
 
-			planElements[idx], diags = types.ObjectValue(planObject.AttributeTypes(ctx), planAttributes)
-
-			resp.Diagnostics.Append(diags...)
-
-			if resp.Diagnostics.HasError() {
-				return
-			}
+			planList.Elems[idx] = planObject.(attr.ValueWithAttrs).SetAttrs(planObjectAttrs)
 		}
 
 		resp.AttributePlan, diags = types.ListValue(planList.ElementType(ctx), planElements)
@@ -289,7 +287,11 @@ func BlockModifyPlan(ctx context.Context, b fwschema.Block, req tfsdk.ModifyAttr
 				return
 			}
 
-			planObjectAttrs := planObject.Type(ctx).(attr.TypeWithAttributeTypes).AttributeTypes()
+			planObjectAttrs := planObject.(attr.ValueWithAttrs).GetAttrs()
+
+			if planObjectAttrs == nil {
+				planObjectAttrs = make(map[string]attr.Value)
+			}
 
 			for name, attr := range b.GetAttributes() {
 				attrConfig, diags := objectAttributeValue(ctx, configObject, name, fwschemadata.DataDescriptionConfiguration)
@@ -335,7 +337,7 @@ func BlockModifyPlan(ctx context.Context, b fwschema.Block, req tfsdk.ModifyAttr
 
 				AttributeModifyPlan(ctx, attr, attrReq, &attrResp)
 
-				planObjectAttrs[name] = attrResp.AttributePlan.Type(ctx)
+				planObjectAttrs[name] = attrResp.AttributePlan
 				resp.Diagnostics.Append(attrResp.Diagnostics...)
 				resp.RequiresReplace = attrResp.RequiresReplace
 				resp.Private = attrResp.Private
@@ -385,19 +387,13 @@ func BlockModifyPlan(ctx context.Context, b fwschema.Block, req tfsdk.ModifyAttr
 
 				BlockModifyPlan(ctx, block, blockReq, &blockResp)
 
-				planObjectAttrs[name] = blockResp.AttributePlan.Type(ctx)
+				planObjectAttrs[name] = blockResp.AttributePlan
 				resp.Diagnostics.Append(blockResp.Diagnostics...)
 				resp.RequiresReplace = blockResp.RequiresReplace
 				resp.Private = blockResp.Private
 			}
 
-			planElements[idx], diags = types.ObjectValue(planObject.AttributeTypes(ctx), planAttributes)
-
-			resp.Diagnostics.Append(diags...)
-
-			if resp.Diagnostics.HasError() {
-				return
-			}
+			planSet.Elems[idx] = planObject.(attr.ValueWithAttrs).SetAttrs(planObjectAttrs)
 		}
 
 		resp.AttributePlan, diags = types.SetValue(planSet.ElementType(ctx), planElements)
@@ -432,11 +428,11 @@ func BlockModifyPlan(ctx context.Context, b fwschema.Block, req tfsdk.ModifyAttr
 			return
 		}
 
-		if planObject.Type(ctx).(attr.TypeWithAttributeTypes).AttributeTypes() == nil {
-			planObject.Type(ctx).(attr.TypeWithAttributeTypes).WithAttributeTypes(make(map[string]attr.Type))
-		}
+		planObjectAttrs := planObject.(attr.ValueWithAttrs).GetAttrs()
 
-		planObjectAttrs := planObject.Type(ctx).(attr.TypeWithAttributeTypes).AttributeTypes()
+		if planObjectAttrs == nil {
+			planObjectAttrs = make(map[string]attr.Value)
+		}
 
 		for name, attr := range b.GetAttributes() {
 			attrConfig, diags := objectAttributeValue(ctx, configObject, name, fwschemadata.DataDescriptionConfiguration)
@@ -482,7 +478,7 @@ func BlockModifyPlan(ctx context.Context, b fwschema.Block, req tfsdk.ModifyAttr
 
 			AttributeModifyPlan(ctx, attr, attrReq, &attrResp)
 
-			planObjectAttrs[name] = attrResp.AttributePlan.Type(ctx)
+			planObjectAttrs[name] = attrResp.AttributePlan
 			resp.Diagnostics.Append(attrResp.Diagnostics...)
 			resp.RequiresReplace = attrResp.RequiresReplace
 			resp.Private = attrResp.Private
@@ -532,19 +528,13 @@ func BlockModifyPlan(ctx context.Context, b fwschema.Block, req tfsdk.ModifyAttr
 
 			BlockModifyPlan(ctx, block, blockReq, &blockResp)
 
-			planObjectAttrs[name] = blockResp.AttributePlan.Type(ctx)
+			planObjectAttrs[name] = blockResp.AttributePlan
 			resp.Diagnostics.Append(blockResp.Diagnostics...)
 			resp.RequiresReplace = blockResp.RequiresReplace
 			resp.Private = blockResp.Private
 		}
 
-		resp.AttributePlan, diags = types.ObjectValue(planObject.AttributeTypes(ctx), planAttributes)
-
-		resp.Diagnostics.Append(diags...)
-
-		if resp.Diagnostics.HasError() {
-			return
-		}
+		resp.AttributePlan = planObject.(attr.ValueWithAttrs).SetAttrs(planObjectAttrs)
 	default:
 		err := fmt.Errorf("unknown block plan modification nesting mode (%T: %v) at path: %s", nm, nm, req.AttributePath)
 		resp.Diagnostics.AddAttributeError(

--- a/internal/fwserver/block_plan_modification.go
+++ b/internal/fwserver/block_plan_modification.go
@@ -117,7 +117,7 @@ func BlockModifyPlan(ctx context.Context, b fwschema.Block, req tfsdk.ModifyAttr
 				return
 			}
 
-			planAttributes := planObject.Attributes()
+			planObjectAttrs := planObject.Type(ctx).(attr.TypeWithAttributeTypes).AttributeTypes()
 
 			for name, attr := range b.GetAttributes() {
 				attrConfig, diags := objectAttributeValue(ctx, configObject, name, fwschemadata.DataDescriptionConfiguration)
@@ -163,7 +163,7 @@ func BlockModifyPlan(ctx context.Context, b fwschema.Block, req tfsdk.ModifyAttr
 
 				AttributeModifyPlan(ctx, attr, attrReq, &attrResp)
 
-				planAttributes[name] = attrResp.AttributePlan
+				planObjectAttrs[name] = attrResp.AttributePlan.Type(ctx)
 				resp.Diagnostics.Append(attrResp.Diagnostics...)
 				resp.RequiresReplace = attrResp.RequiresReplace
 				resp.Private = attrResp.Private
@@ -213,7 +213,7 @@ func BlockModifyPlan(ctx context.Context, b fwschema.Block, req tfsdk.ModifyAttr
 
 				BlockModifyPlan(ctx, block, blockReq, &blockResp)
 
-				planAttributes[name] = blockResp.AttributePlan
+				planObjectAttrs[name] = blockResp.AttributePlan.Type(ctx)
 				resp.Diagnostics.Append(blockResp.Diagnostics...)
 				resp.RequiresReplace = blockResp.RequiresReplace
 				resp.Private = blockResp.Private
@@ -289,7 +289,7 @@ func BlockModifyPlan(ctx context.Context, b fwschema.Block, req tfsdk.ModifyAttr
 				return
 			}
 
-			planAttributes := planObject.Attributes()
+			planObjectAttrs := planObject.Type(ctx).(attr.TypeWithAttributeTypes).AttributeTypes()
 
 			for name, attr := range b.GetAttributes() {
 				attrConfig, diags := objectAttributeValue(ctx, configObject, name, fwschemadata.DataDescriptionConfiguration)
@@ -335,7 +335,7 @@ func BlockModifyPlan(ctx context.Context, b fwschema.Block, req tfsdk.ModifyAttr
 
 				AttributeModifyPlan(ctx, attr, attrReq, &attrResp)
 
-				planAttributes[name] = attrResp.AttributePlan
+				planObjectAttrs[name] = attrResp.AttributePlan.Type(ctx)
 				resp.Diagnostics.Append(attrResp.Diagnostics...)
 				resp.RequiresReplace = attrResp.RequiresReplace
 				resp.Private = attrResp.Private
@@ -385,7 +385,7 @@ func BlockModifyPlan(ctx context.Context, b fwschema.Block, req tfsdk.ModifyAttr
 
 				BlockModifyPlan(ctx, block, blockReq, &blockResp)
 
-				planAttributes[name] = blockResp.AttributePlan
+				planObjectAttrs[name] = blockResp.AttributePlan.Type(ctx)
 				resp.Diagnostics.Append(blockResp.Diagnostics...)
 				resp.RequiresReplace = blockResp.RequiresReplace
 				resp.Private = blockResp.Private
@@ -432,11 +432,11 @@ func BlockModifyPlan(ctx context.Context, b fwschema.Block, req tfsdk.ModifyAttr
 			return
 		}
 
-		planAttributes := planObject.Attributes()
-
-		if planAttributes == nil {
-			planAttributes = make(map[string]attr.Value)
+		if planObject.Type(ctx).(attr.TypeWithAttributeTypes).AttributeTypes() == nil {
+			planObject.Type(ctx).(attr.TypeWithAttributeTypes).WithAttributeTypes(make(map[string]attr.Type))
 		}
+
+		planObjectAttrs := planObject.Type(ctx).(attr.TypeWithAttributeTypes).AttributeTypes()
 
 		for name, attr := range b.GetAttributes() {
 			attrConfig, diags := objectAttributeValue(ctx, configObject, name, fwschemadata.DataDescriptionConfiguration)
@@ -482,7 +482,7 @@ func BlockModifyPlan(ctx context.Context, b fwschema.Block, req tfsdk.ModifyAttr
 
 			AttributeModifyPlan(ctx, attr, attrReq, &attrResp)
 
-			planAttributes[name] = attrResp.AttributePlan
+			planObjectAttrs[name] = attrResp.AttributePlan.Type(ctx)
 			resp.Diagnostics.Append(attrResp.Diagnostics...)
 			resp.RequiresReplace = attrResp.RequiresReplace
 			resp.Private = attrResp.Private
@@ -532,7 +532,7 @@ func BlockModifyPlan(ctx context.Context, b fwschema.Block, req tfsdk.ModifyAttr
 
 			BlockModifyPlan(ctx, block, blockReq, &blockResp)
 
-			planAttributes[name] = blockResp.AttributePlan
+			planObjectAttrs[name] = blockResp.AttributePlan.Type(ctx)
 			resp.Diagnostics.Append(blockResp.Diagnostics...)
 			resp.RequiresReplace = blockResp.RequiresReplace
 			resp.Private = blockResp.Private

--- a/internal/fwserver/block_validation.go
+++ b/internal/fwserver/block_validation.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema/fwxschema"
@@ -185,8 +186,7 @@ func BlockValidate(ctx context.Context, b fwschema.Block, req tfsdk.ValidateAttr
 			resp.Diagnostics.Append(blockMinItemsDiagnostic(req.AttributePath, b.GetMinItems(), len(s.Elements())))
 		}
 	case fwschema.BlockNestingModeSingle:
-		s, ok := req.AttributeConfig.(types.Object)
-
+		_, ok := req.AttributeConfig.Type(ctx).(attr.TypeWithAttributeTypes)
 		if !ok {
 			err := fmt.Errorf("unknown block value type (%s) for nesting mode (%T) at path: %s", req.AttributeConfig.Type(ctx), nm, req.AttributePath)
 			resp.Diagnostics.AddAttributeError(
@@ -228,7 +228,7 @@ func BlockValidate(ctx context.Context, b fwschema.Block, req tfsdk.ValidateAttr
 			resp.Diagnostics = nestedAttrResp.Diagnostics
 		}
 
-		if b.GetMinItems() == 1 && s.IsNull() {
+		if b.GetMinItems() == 1 && req.AttributeConfig.IsNull() {
 			resp.Diagnostics.Append(blockMinItemsDiagnostic(req.AttributePath, b.GetMinItems(), 0))
 		}
 	default:

--- a/tfsdk/block.go
+++ b/tfsdk/block.go
@@ -25,6 +25,9 @@ var _ fwschema.Block = Block{}
 // The NestingMode field must be set or a runtime error will be raised by the
 // framework when fetching the schema.
 type Block struct {
+	// Typ is an optional field that defines the type of the Block. It defaults
+	// to types.ObjectType but, any type that fills the attr.TypeWithAttributeTypes
+	// interface can be used.
 	Typ attr.TypeWithAttributeTypes
 
 	// Attributes are value fields inside the block. This map of attributes
@@ -211,7 +214,7 @@ func (b Block) GetValidators() []AttributeValidator {
 	return b.Validators
 }
 
-// attributeType returns an attr.Type corresponding to the block.
+// Type returns an attr.Type corresponding to the block.
 func (b Block) Type() attr.Type {
 	var attrType attr.TypeWithAttributeTypes
 	attrType = types.ObjectType{}

--- a/tfsdk/block_test.go
+++ b/tfsdk/block_test.go
@@ -30,19 +30,8 @@ func (t CustomType) Equal(candidate attr.Type) bool {
 	if !ok {
 		return false
 	}
-	if len(other.AttrTypes) != len(t.AttrTypes) {
-		return false
-	}
-	for k, v := range t.AttrTypes {
-		attrType, ok := other.AttrTypes[k]
-		if !ok {
-			return false
-		}
-		if !v.Equal(attrType) {
-			return false
-		}
-	}
-	return true
+
+	return t.ObjectType.Equal(other.ObjectType)
 }
 
 func TestBlockType(t *testing.T) {

--- a/tfsdk/block_test.go
+++ b/tfsdk/block_test.go
@@ -4,9 +4,46 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
+
+var (
+	_ attr.Type = CustomType{}
+)
+
+type CustomType struct {
+	types.ObjectType
+}
+
+func (t CustomType) WithAttributeTypes(typs map[string]attr.Type) attr.TypeWithAttributeTypes {
+	return CustomType{
+		types.ObjectType{
+			AttrTypes: typs,
+		},
+	}
+}
+
+func (t CustomType) Equal(candidate attr.Type) bool {
+	other, ok := candidate.(CustomType)
+	if !ok {
+		return false
+	}
+	if len(other.AttrTypes) != len(t.AttrTypes) {
+		return false
+	}
+	for k, v := range t.AttrTypes {
+		attrType, ok := other.AttrTypes[k]
+		if !ok {
+			return false
+		}
+		if !v.Equal(attrType) {
+			return false
+		}
+	}
+	return true
+}
 
 func TestBlockType(t *testing.T) {
 	t.Parallel()
@@ -51,6 +88,45 @@ func TestBlockType(t *testing.T) {
 				},
 			},
 		},
+		"NestingMode-List-CustomType": {
+			block: Block{
+				Attributes: map[string]Attribute{
+					"test_attribute": {
+						Required: true,
+						Type:     types.StringType,
+					},
+				},
+				Blocks: map[string]Block{
+					"test_block": {
+						Typ: CustomType{},
+						Attributes: map[string]Attribute{
+							"test_block_attribute": {
+								Required: true,
+								Type:     types.StringType,
+							},
+						},
+						NestingMode: BlockNestingModeList,
+					},
+				},
+				NestingMode: BlockNestingModeList,
+			},
+			expected: types.ListType{
+				ElemType: types.ObjectType{
+					AttrTypes: map[string]attr.Type{
+						"test_attribute": types.StringType,
+						"test_block": types.ListType{
+							ElemType: CustomType{
+								types.ObjectType{
+									AttrTypes: map[string]attr.Type{
+										"test_block_attribute": types.StringType,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 		"NestingMode-Set": {
 			block: Block{
 				Attributes: map[string]Attribute{
@@ -87,6 +163,45 @@ func TestBlockType(t *testing.T) {
 				},
 			},
 		},
+		"NestingMode-Set-CustomType": {
+			block: Block{
+				Attributes: map[string]Attribute{
+					"test_attribute": {
+						Required: true,
+						Type:     types.StringType,
+					},
+				},
+				Blocks: map[string]Block{
+					"test_block": {
+						Typ: CustomType{},
+						Attributes: map[string]Attribute{
+							"test_block_attribute": {
+								Required: true,
+								Type:     types.StringType,
+							},
+						},
+						NestingMode: BlockNestingModeSet,
+					},
+				},
+				NestingMode: BlockNestingModeSet,
+			},
+			expected: types.SetType{
+				ElemType: types.ObjectType{
+					AttrTypes: map[string]attr.Type{
+						"test_attribute": types.StringType,
+						"test_block": types.SetType{
+							ElemType: CustomType{
+								types.ObjectType{
+									AttrTypes: map[string]attr.Type{
+										"test_block_attribute": types.StringType,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 		"NestingMode-Single": {
 			block: Block{
 				Attributes: map[string]Attribute{
@@ -114,6 +229,41 @@ func TestBlockType(t *testing.T) {
 					"test_block": types.ObjectType{
 						AttrTypes: map[string]attr.Type{
 							"test_block_attribute": types.StringType,
+						},
+					},
+				},
+			},
+		},
+		"NestingMode-Single-CustomType": {
+			block: Block{
+				Attributes: map[string]Attribute{
+					"test_attribute": {
+						Required: true,
+						Type:     types.StringType,
+					},
+				},
+				Blocks: map[string]Block{
+					"test_block": {
+						Typ: CustomType{},
+						Attributes: map[string]Attribute{
+							"test_block_attribute": {
+								Required: true,
+								Type:     types.StringType,
+							},
+						},
+						NestingMode: BlockNestingModeSingle,
+					},
+				},
+				NestingMode: BlockNestingModeSingle,
+			},
+			expected: types.ObjectType{
+				AttrTypes: map[string]attr.Type{
+					"test_attribute": types.StringType,
+					"test_block": CustomType{
+						types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"test_block_attribute": types.StringType,
+							},
 						},
 					},
 				},

--- a/types/object.go
+++ b/types/object.go
@@ -300,6 +300,10 @@ func ObjectValueMust(attributeTypes map[string]attr.Type, attributes map[string]
 	return object
 }
 
+var (
+	_ attr.ValueWithAttrs = Object{}
+)
+
 // Object represents an object
 type Object struct {
 	// Unknown will be set to true if the entire object is an unknown value.
@@ -359,6 +363,16 @@ type Object struct {
 	// updates take effect. The zero-value will be changed to null in a future
 	// version.
 	state valueState
+}
+
+func (o Object) GetAttrs() map[string]attr.Value {
+	return o.Attrs
+}
+
+func (o Object) SetAttrs(attrs map[string]attr.Value) attr.ValueWithAttrs {
+	o.Attrs = attrs
+
+	return o
 }
 
 // ObjectAsOptions is a collection of toggles to control the behavior of


### PR DESCRIPTION
Closes: #508 

So far (2022-10-07) this draft PR only addresses allowing optionally specifying the type on a block. Further changes will be required for equivalent functionality with nested attributes.  