### PR TITLE
website: Split resource lifecycle management into separate pages

### DIFF
--- a/website/data/plugin-framework-nav-data.json
+++ b/website/data/plugin-framework-nav-data.json
@@ -35,6 +35,22 @@
         "path": "resources"
       },
       {
+        "title": "Create",
+        "path": "resources/create"
+      },
+      {
+        "title": "Read",
+        "path": "resources/read"
+      },
+      {
+        "title": "Update",
+        "path": "resources/update"
+      },
+      {
+        "title": "Delete",
+        "path": "resources/delete"
+      },
+      {
         "title": "Configure Clients",
         "path": "resources/configure"
       },

--- a/website/docs/plugin/framework/resources/create.mdx
+++ b/website/docs/plugin/framework/resources/create.mdx
@@ -1,0 +1,176 @@
+---
+page_title: 'Plugin Development - Framework: Create Resources'
+description: >-
+  How to implement resource creation in the provider development framework.
+---
+
+# Create Resources
+
+-> **Note:** The Plugin Framework is in beta.
+
+Creation is part of the basic Terraform lifecycle for managing resources. During the [`terraform apply` command](/cli/commands/apply), Terraform calls the provider `ApplyResourceChange` RPC, in which the framework calls the [`resource.Resource` interface `Create` method](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#Resource.Create). The request contains Terraform configuration and plan data. The response expects the applied Terraform state data, including any computed values. The data is defined by the [schema](/plugin/framework/schemas) of the resource.
+
+Other resource lifecycle implementations include:
+
+- [Read](/plugin/framework/resources/read) resources by receiving Terraform prior state data, performing read logic, and saving refreshed Terraform state data.
+- [Update](/plugin/framework/resources/update) resources in-place by receiving Terraform prior state, configuration, and plan data, performing update logic, and saving updated Terraform state data.
+- [Delete](/plugin/framework/resources/delete) resources by receiving Terraform prior state data and performing deletion logic.
+
+## Define Create Method
+
+Implement the `Create` method by:
+
+1. [Accessing the data](/plugin/framework/accessing-values) from the [`resource.CreateRequest` type](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#CreateRequest). Most use cases should access the plan data in the [`resource.CreateRequest.Plan` field](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#CreateRequest.Plan).
+1. Performing logic or external calls to create and/or run the resource.
+1. [Writing state data](/plugin/framework/writing-state) into the [`resource.CreateResponse.State` field](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#CreateResponse.State).
+
+If the logic needs to return [warning or error diagnostics](/plugin/framework/diagnostics), they can added into the [`resource.CreateResponse.Diagnostics` field](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#CreateResponse.Diagnostics).
+
+In this example, the resource is setup to accept a configuration value that is sent in a service API creation call:
+
+```go
+// ThingResource defines the resource implementation.
+// Some resource.Resource interface methods are omitted for brevity.
+type ThingResource struct {
+	// client is configured via a Configure method, which is not shown in this
+	// example for brevity. Refer to the Configure Resources documentation for
+	// additional details for setting up resources with external clients.
+	client *http.Client
+}
+
+// ThingResourceModel describes the Terraform resource data model to match the
+// resource schema.
+type ThingResourceModel struct {
+	Name types.String `tfsdk:"name"`
+	Id   types.String `tfsdk:"id"`
+}
+
+// ThingResourceAPIModel describes the API data model.
+type ThingResourceAPIModel struct {
+	Name string `json:"name"`
+	Id   string `json:"id"`
+}
+
+func (r ThingResource) GetSchema(ctx context.Context) (tfsdk.Schema, diag.Diagnostics) {
+	return tfsdk.Schema{
+		Attributes: map[string]tfsdk.Attribute{
+			"name": {
+				MarkdownDescription: "Name of the thing to be saved in the service.",
+				Required:            true,
+				Type:                types.StringType,
+			},
+			"id": {
+				Computed:            true,
+				MarkdownDescription: "Service generated identifier for the thing.",
+				PlanModifiers: tfsdk.AttributePlanModifiers{
+					resource.UseStateForUnknown(),
+				},
+				Type: types.StringType,
+			},
+		},
+		MarkdownDescription: "Manages a thing.",
+	}, nil
+}
+
+func (r ThingResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data *ThingResourceModel
+
+	// Read Terraform plan data into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Convert from Terraform data model into API data model
+	createReq := ThingResourceAPIModel{
+		Name: data.Name.ValueString(),
+	}
+
+	httpReqBody, err := json.Marshal(createReq)
+
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Create Resource",
+			"An unexpected error occurred while creating the resource create request. "+
+				"Please report this issue to the provider developers.\n\n"+
+				"JSON Error: "+err.Error(),
+		)
+
+		return
+	}
+
+	// Create HTTP request
+	httpReq := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		"http://example.com/things",
+		bytes.NewBuffer(httpReqBody),
+	)
+
+	// Send HTTP request
+	httpResp, err := d.client.Do(httpReq)
+	defer httpResp.Body.Close()
+
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Create Resource",
+			"An unexpected error occurred while attempting to create the resource. "+
+				"Please retry the operation or report this issue to the provider developers.\n\n"+
+				"HTTP Error: "+err.Error(),
+		)
+
+		return
+	}
+
+	// Return error if the HTTP status code is not 200 OK
+	if httpResp.StatusCode != http.StatusOK {
+		resp.Diagnostics.AddError(
+			"Unable to Create Resource",
+			"An unexpected error occurred while attempting to create the resource. "+
+				"Please retry the operation or report this issue to the provider developers.\n\n"+
+				"HTTP Status: "+httpResp.Status,
+		)
+
+		return
+	}
+
+	var createResp ThingResourceAPIModel
+
+	err := json.NewDecoder(httpResp.Body).Decode(&createResp)
+
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Create Resource",
+			"An unexpected error occurred while parsing the resource creation response. "+
+				"Please report this issue to the provider developers.\n\n"+
+				"JSON Error: "+err.Error(),
+		)
+
+		return
+	}
+
+	// Convert from the API data model to the Terraform data model
+	// and set any unknown attribute values.
+	data.Id = types.StringValue(createResp.Id)
+
+	// Save data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+```
+
+## Caveats
+
+Note these caveats when implementing the `Create` method:
+
+* An error is returned if the response state contains unknown values. Set all attributes to either null or known values in the response.
+* An error is returned if the response state has the `RemoveResource()` method called. This method is not valid during creation.
+* An error is returned unless every null or known value in the request plan is saved exactly as-is into the response state. Only unknown plan values can be modified.
+* Any response errors will cause Terraform to mark the resource as tainted for recreation on the next Terraform plan.
+
+## Recommendations
+
+Note these recommendations when implementing the `Create` method:
+
+* Get request data from the Terraform plan data over configuration data as the schema or resource may include [plan modification](/plugin/framework/resources/plan-modification) logic which sets plan values.
+* Return errors that signify there is an existing resource. Terraform practitioners expect to be notified if an existing resource needs to be imported into Terraform rather than created. This prevents situations where multiple Terraform configurations unexpectedly manage the same underlying resource.

--- a/website/docs/plugin/framework/resources/delete.mdx
+++ b/website/docs/plugin/framework/resources/delete.mdx
@@ -150,3 +150,4 @@ Note these caveats when implementing the `Delete` method:
 Note these recommendations when implementing the `Delete` method:
 
 * Ignore errors that signify the resource is no longer existent.
+* Skip calling the response state `RemoveResource()` method. The framework automatically handles this logic with the response state if there are no error diagnostics.

--- a/website/docs/plugin/framework/resources/delete.mdx
+++ b/website/docs/plugin/framework/resources/delete.mdx
@@ -1,0 +1,152 @@
+---
+page_title: 'Plugin Development - Framework: Delete Resources'
+description: >-
+  How to implement resource deletion in the provider development framework.
+---
+
+# Delete Resources
+
+-> **Note:** The Plugin Framework is in beta.
+
+Deletion is part of the basic Terraform lifecycle for managing resources. During the [`terraform apply` command](/cli/commands/apply), Terraform calls the provider `ApplyResourceChange` RPC, in which the framework calls the [`resource.Resource` interface `Delete` method](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#Resource.Delete). The request contains Terraform prior state data. The response is only for returning diagnostics. The data is defined by the [schema](/plugin/framework/schemas) of the resource.
+
+Terraform 1.3 and later enables deletion planning, which resources can implement to return warning and error diagnostics. For additional information, refer to the [resource plan modification documentation](/plugin/framework/resources/plan-modification#resource-destroy-plan-diagnostics).
+
+Other resource lifecycle implementations include:
+
+- [Create](/plugin/framework/resources/create) resources by receiving Terraform configuration and plan data, performing creation logic, and saving Terraform state data.
+- [Read](/plugin/framework/resources/read) resources by receiving Terraform prior state data, performing read logic, and saving refreshed Terraform state data.
+- [Update](/plugin/framework/resources/update) resources in-place by receiving Terraform prior state, configuration, and plan data, performing update logic, and saving updated Terraform state data.
+
+## Define Delete Method
+
+Implement the `Delete` method by:
+
+1. [Accessing prior state data](/plugin/framework/accessing-values) from the [`resource.DeleteRequest.State` field](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#DeleteRequest.State).
+1. Performing logic or external calls to destroy the resource.
+
+If the logic needs to return [warning or error diagnostics](/plugin/framework/diagnostics), they can added into the [`resource.DeleteResponse.Diagnostics` field](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#DeleteResponse.Diagnostics).
+
+In this example, the `Delete` function makes a HTTP call and returns successfully if the status code was 200 OK or 404 Not Found:
+
+```go
+// ThingResource defines the resource implementation.
+// Some resource.Resource interface methods are omitted for brevity.
+type ThingResource struct {
+	// client is configured via a Configure method, which is not shown in this
+	// example for brevity. Refer to the Configure Resources documentation for
+	// additional details for setting up resources with external clients.
+	client *http.Client
+}
+
+// ThingResourceModel describes the Terraform resource data model to match the
+// resource schema.
+type ThingResourceModel struct {
+	Name types.String `tfsdk:"name"`
+	Id   types.String `tfsdk:"id"`
+}
+
+// ThingResourceAPIModel describes the API data model.
+type ThingResourceAPIModel struct {
+	Name string `json:"name"`
+	Id   string `json:"id"`
+}
+
+func (r ThingResource) GetSchema(ctx context.Context) (tfsdk.Schema, diag.Diagnostics) {
+	return tfsdk.Schema{
+		Attributes: map[string]tfsdk.Attribute{
+			"name": {
+				MarkdownDescription: "Name of the thing to be saved in the service.",
+				Required:            true,
+				Type:                types.StringType,
+			},
+			"id": {
+				Computed:            true,
+				MarkdownDescription: "Service generated identifier for the thing.",
+				PlanModifiers: tfsdk.AttributePlanModifiers{
+					resource.UseStateForUnknown(),
+				},
+				Type: types.StringType,
+			},
+		},
+		MarkdownDescription: "Manages a thing.",
+	}, nil
+}
+
+func (r ThingResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data ThingResourceModel
+
+	// Read Terraform prior state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+	// Convert from Terraform data model into API data model
+	readReq := ThingResourceAPIModel{
+		Id:   data.Id.ValueString(),
+		Name: data.Name.ValueString(),
+	}
+
+	httpReqBody, err := json.Marshal(readReq)
+
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Delete Resource",
+			"An unexpected error occurred while creating the resource d request. "+
+				"Please report this issue to the provider developers.\n\n"+
+				"JSON Error: "+err.Error(),
+		)
+
+		return
+	}
+
+	// Create HTTP request
+	httpReq := http.NewRequestWithContext(
+		ctx,
+		http.MethodDelete,
+		"http://example.com/things",
+		bytes.NewBuffer(httpReqBody),
+	)
+
+	// Send HTTP request
+	httpResp, err := d.client.Do(httpReq)
+	defer httpResp.Body.Close()
+
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Delete Resource",
+			"An unexpected error occurred while attempting to delete the resource. "+
+				"Please retry the operation or report this issue to the provider developers.\n\n"+
+				"HTTP Error: "+err.Error(),
+		)
+
+		return
+	}
+
+	// Return error if the HTTP status code is not 200 OK or 404 Not Found
+	if httpResp.StatusCode != http.StatusNotFound && httpResp.StatusCode != http.StatusOK {
+		resp.Diagnostics.AddError(
+			"Unable to Delete Resource",
+			"An unexpected error occurred while attempting to delete the resource. "+
+				"Please retry the operation or report this issue to the provider developers.\n\n"+
+				"HTTP Status: "+httpResp.Status,
+		)
+
+		return
+	}
+
+	// If the logic reaches here, it implicitly succeeded and will remove
+	// the resource from state if there are no other errors.
+}
+```
+
+## Caveats
+
+Note these caveats when implementing the `Delete` method:
+
+* An error is returned if the response state is set to anything other than null.
+* Any response errors will cause Terraform to keep the resource under management.
+
+## Recommendations
+
+Note these recommendations when implementing the `Delete` method:
+
+* Ignore errors that signify the resource is no longer existent.

--- a/website/docs/plugin/framework/resources/index.mdx
+++ b/website/docs/plugin/framework/resources/index.mdx
@@ -15,7 +15,14 @@ description: >-
 - needs only one API call to update or return its state.
 - can be be created, read, updated, and deleted.
 
-This page describes the basic implementation details required for supporting a resource within the provider. Further documentation is available for deeper resource concepts:
+This page describes the initial implementation details required for supporting a resource within the provider. Resource lifecycle management functionality is also required:
+
+- [Create](/plugin/framework/resources/create) resources by receiving Terraform configuration and plan data, performing creation logic, and saving Terraform state data.
+- [Read](/plugin/framework/resources/read) resources by receiving Terraform prior state data, performing read logic, and saving refreshed Terraform state data.
+- [Update](/plugin/framework/resources/update) resources in-place by receiving Terraform prior state, configuration, and plan data, performing update logic, and saving updated Terraform state data.
+- [Delete](/plugin/framework/resources/delete) resources by receiving Terraform prior state data and performing deletion logic.
+
+Further documentation is available for deeper resource concepts:
 
 - [Configure](/plugin/framework/resources/configure) resources with provider-level data types or clients.
 - [Import state](/plugin/framework/resources/import) so practitioners can bring existing resources under Terraform lifecycle management.
@@ -27,94 +34,11 @@ This page describes the basic implementation details required for supporting a r
 
 ## Define Resource Type
 
-Implement the [`resource.Resource` interface](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#Resource). Each of the methods is described in more detail below.
-
-In this example, a resource named `examplecloud_thing` with sample lifecycle management behavior is defined:
-
-```go
-// Ensure the implementation satisfies the desired interfaces.
-var _ resource.Resource = &ThingResource{}
-
-type ThingResource struct {}
-
-type ThingResourceModel struct {
-	ExampleAttribute types.String `tfsdk:"example_attribute"`
-	ID               types.String `tfsdk:"id"`
-}
-
-func (r *ThingResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
-	resp.TypeName = "examplecloud_thing"
-}
-
-func (r *ThingResource) GetSchema(ctx context.Context) (fwschema.Schema, diag.Diagnostics) {
-	return tfsdk.Schema{
-		Attributes: map[string]tfsdk.Attribute{
-			"example_attribute": {
-				Required: true,
-				Type:     types.StringType,
-			},
-			"id": {
-				Computed: true,
-				Type:     types.StringType,
-			},
-		},
-	}, nil
-}
-
-func (r *ThingResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	var data ThingResourceModel
-
-	// Read Terraform plan data into the model
-	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
-
-	// Typically resources will make external calls, however this example
-	// hardcodes setting the id attribute to a specific value for brevity.
-	data.ID = types.StringValue("example-id")
-
-	// Save data into Terraform state
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
-}
-
-func (r *ThingResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	var data ThingResourceModel
-
-	// Read Terraform prior state data into the model
-	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
-
-	// Typically resources will make external calls, however this example
-	// omits any refreshed data updates for brevity.
-
-	// Save updated data into Terraform state
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
-}
-
-func (r *ThingResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var data ThingResourceModel
-
-	// Read Terraform plan data into the model
-	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
-
-	// Typically resources will make external calls, however this example
-	// omits any update calls for brevity.
-
-	// Save updated data into Terraform state
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
-}
-
-func (r *ThingResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	var data ThingResourceModel
-
-	// Read Terraform prior state data into the model
-	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
-
-	// Typically resources will make external calls, however this example
-	// omits any deletion calls for brevity.
-}
-```
+Implement the [`resource.Resource` interface](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#Resource). Ensure the [Add Resource To Provider](#add-resource-to-provider) documentation is followed so the resource becomes part of the provider implementation, and therefore available to practitioners.
 
 ### Metadata Method
 
-The [`resource.Resource` interface `Metadata` method](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#Resource.Metadata) defines the resource name as it would appear in Terraform configurations. This name should include the provider type prefix, an underscore, then the resource specific name. For example, a provider named `examplecloud` and a resource that reads "thing" resources would be named `examplecloud_thing`. Ensure the [Add Data Source To Provider](#add-data-source-to-provider) documentation is followed so the resource becomes part of the provider implementation, and therefore available to practitioners.
+The [`resource.Resource` interface `Metadata` method](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#Resource.Metadata) defines the resource name as it would appear in Terraform configurations. This name should include the provider type prefix, an underscore, then the resource specific name. For example, a provider named `examplecloud` and a resource that reads "thing" resources would be named `examplecloud_thing`.
 
 In this example, the resource name in an `examplecloud` provider that reads "thing" resources is hardcoded to `examplecloud_thing`:
 
@@ -145,198 +69,9 @@ func (d *ThingDataSource) Metadata(ctx context.Context, req resource.MetadataReq
 
 The [`resource.Resource` interface `GetSchema` method](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#Resource.GetSchema) defines a [schema](/plugin/framework/schemas) describing what data is available in the resource's configuration, plan, and state.
 
-### Create
-
-The [`resource.Resource` interface `Create` method](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#Resource.Create) makes the necessary API calls to create the resource and then persist that resource's data into the Terraform state.
-
-Implement the `Create` method by:
-
-1. [Accessing the data](/plugin/framework/accessing-values) from the [`resource.CreateRequest` type](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#CreateRequest). Most use cases should access the plan data in the [`resource.CreateRequest.Plan` field](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#CreateRequest.Plan).
-1. Performing logic or external calls to create and/or run the resource.
-1. [Writing state data](/plugin/framework/writing-state) into the [`resource.CreateResponse.State` field](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#CreateResponse.State).
-
-It is very important that every known value in the plan ends up in state as a
-byte-for-byte match, or Terraform will throw errors. The plan is the provider's
-contract with Terraform: the provider can only change values that are
-[unknown](/plugin/framework/types#unknown) in the plan. It's also
-very important that every unknown value in the plan gets a known, concrete
-value when it's set in the state; the state can never hold any unknown values.
-
-If the logic needs to return [warning or error diagnostics](/plugin/framework/diagnostics), they can added into the [`resource.CreateResponse.Diagnostics` field](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#CreateResponse.Diagnostics). Any errors will trigger Terraform to mark the resource as tainted for recreation on the next Terraform plan.
-
-### Read
-
-The [`resource.Resource` interface `Read` method](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#Resource.Read) makes the necessary calls to retrieve the latest resource state and then persist that updated state into the Terraform state. There is no plan or configuration data in `Read`.
-
-Implement the `Read` method by:
-
-1. [Accessing prior state data](/plugin/framework/accessing-values) from the [`resource.ReadRequest.State` field](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#ReadRequest.State).
-1. Retriving updated resource state, such as remote system information.
-1. [Writing state data](/plugin/framework/writing-state) into the [`resource.ReadResponse.State` field](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#ReadResponse.State).
-
-The provider can set any value in state, but you should be mindful of values that:
-
-- represent "drift," or instances when the API's state has
-  deviated from the source of truth defined in the configuration file. This is
-  usually (but not always) the result of someone or something other than
-  Terraform modifying a resource Terraform "owns". When this happens, the value
-  should always be updated in state to reflect the drifted value.
-- are semantically equivalent with values
-  currently in state. Some values are semantically the same even if they are not a byte-for-byte match. JSON strings that change the order of keys or change the
-  semantically-insignificant whitespace, for example, may not represent drift but
-  are just different representations of the same value. When this happens, the
-  _existing_ value should always be maintained in state and should not be
-  replaced with the new representation that the API is returning.
-
-If the logic needs to return [warning or error diagnostics](/plugin/framework/diagnostics), they can added into the [`resource.ReadResponse.Diagnostics` field](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#ReadResponse.Diagnostics).
-
-If the logic needs to signal that the resource no longer exists and should be recreated, call the [`RemoveResource` method](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/tfsdk#State.RemoveResource) on the [`resource.ReadResponse.State` field](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#ReadResponse.State).
-
-In this example, the `Read` function catches a HTTP 404 Not Found status and returns early to signal resource recreation:
-
-```go
-type ThingResource struct {
-	// client is configured via a Configure method, which is not shown in this
-	// example for brevity. Refer to the Configure Resources documentation for
-	// additional details for setting up resources with external clients.
-	client *http.Client
-}
-
-func (r *ThingResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	var data ThingResourceModel
-
-	// Read Terraform prior state data into the model
-	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
-
-	httpReq := http.NewRequestWithContext(
-		ctx,
-		http.MethodGet,
-		fmt.Sprintf("http://example.com/thing/%s", data.ID),
-		nil,
-	)
-
-	httpResp, err := d.client.Do(httpReq)
-	defer httpResp.Body.Close()
-
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to Refresh Resource",
-			"An unexpected error occurred while attempting to refresh resource state. "+
-				"Please retry the operation or report this issue to the provider developers.\n\n"+
-				"HTTP Error: "+err.Error(),
-		)
-
-		return
-	}
-
-	// Treat HTTP 404 Not Found status as a signal to recreate resource
-	// and return early
-	if httpResp.StatusCode == http.StatusNotFound {
-		resp.State.RemoveResource(ctx)
-
-		return
-	}
-
-	// Update data from httpResp
-
-	// Save updated data into Terraform state
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
-}
-```
-
-### Update
-
-The [`resource.Resource` interface `Update` method](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#Resource.Update) makes the necessary calls to modify the existing resource to match the configuration and then persist the updated state.
-
-If the resource does not support modification and should always be recreated on configuration value updates, this method logic can be left empty and ensure all configurable schema attributes implement the [`resource.RequiresReplace` plan modifier](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#RequiresReplace).
-
-Implement the `Update` method by:
-
-1. [Accessing the data](/plugin/framework/accessing-values) from the [`resource.UpdateRequest` type](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#UpdateRequest). Most use cases should access the plan data in the [`resource.UpdateRequest.Plan` field](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#UpdateRequest.Plan).
-1. Performing logic or external calls to modify the resource.
-1. [Writing state data](/plugin/framework/writing-state) into the [`resource.UpdateResponse.State` field](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#UpdateResponse.State).
-
-It is very important that every known value in the plan ends up in state as a
-byte-for-byte match, or Terraform will throw errors. The plan is the provider's
-contract with Terraform: the provider can only change values that are
-[unknown](/plugin/framework/types#unknown) in the plan. It's also
-very important that every unknown value in the plan gets a known, concrete
-value when it's set in the state; the state can never hold any unknown values.
-
-If the logic needs to return [warning or error diagnostics](/plugin/framework/diagnostics), they can added into the [`resource.UpdateResponse.Diagnostics` field](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#UpdateResponse.Diagnostics). Only successfully modified parts of the resource should be return updated data in the state response.
-
-### Delete
-
-The [`resource.Resource` interface `Delete` method](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#Resource.Delete) makes the necessary API calls to destroy a resource and then to remove that resource from the Terraform state.
-
-Implement the `Delete` method by:
-
-1. [Accessing prior state data](/plugin/framework/accessing-values) from the [`resource.DeleteRequest.State` field](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#DeleteRequest.State).
-1. Performing logic or external calls to destroy the resource.
-
-Terraform 1.3 and later enables deletion planning, which resources can implement to return warning and error diagnostics. For additional information, refer to the [resource plan modification documentation](/plugin/framework/resources/plan-modification#resource-destroy-plan-diagnostics).
-
-If the logic needs to return [warning or error diagnostics](/plugin/framework/diagnostics), they can added into the [`resource.DeleteResponse.Diagnostics` field](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#DeleteResponse.Diagnostics). Any errors will prevent the framework from automatically calling the [`RemoveResource` method](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/tfsdk#State.RemoveResource) on the [`resource.DeleteResponse.State` field](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#DeleteResponse.State). If the resource should still be removed from state, call the `RemoveResource` method manually.
-
-If the logic needs to skip a condition, such as an API error, where the resource no longer exists then the logic can return early.
-
-In this example, the `Delete` function allows HTTP 200 OK and 404 Not Found statuses to complete successfully without raising any errors:
-
-```go
-type ThingResource struct {
-	// client is configured via a Configure method, which is not shown in this
-	// example for brevity. Refer to the Configure Resources documentation for
-	// additional details for setting up resources with external clients.
-	client *http.Client
-}
-
-func (r *ThingResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	var data ThingResourceModel
-
-	// Read Terraform prior state data into the model
-	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
-
-	httpReq := http.NewRequestWithContext(
-		ctx,
-		http.MethodDelete,
-		fmt.Sprintf("http://example.com/thing/%s", data.ID),
-		nil,
-	)
-
-	httpResp, err := d.client.Do(httpReq)
-	defer httpResp.Body.Close()
-
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to Delete Resource",
-			"An unexpected error occurred while attempting to delete the resource. "+
-				"Please retry the operation or report this issue to the provider developers.\n\n"+
-				"HTTP Error: "+err.Error(),
-		)
-
-		return
-	}
-
-	// Treat HTTP 404 Not Found status as a signal to return early
-	if httpResp.StatusCode != http.StatusNotFound && httpResp.StatusCode != http.StatusOK {
-		resp.Diagnostics.AddError(
-			"Unable to Delete Resource",
-			"An unexpected error occurred while attempting to delete the resource. "+
-				"Please retry the operation or report this issue to the provider developers.\n\n"+
-				"HTTP Status: "+httpResp.Status,
-		)
-
-		return
-	}
-
-	// If the logic reaches here, it implicitly succeeded and will remove
-	// the resource from state if there are no other errors.
-}
-```
-
 ## Add Resource to Provider
 
-Resources become available to practitioners when they are included in the [provider](/plugin/framework/providers) implementation via the [`provider.ProviderWithResources` interface `Resources` method](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider#ProviderWithResources.Resources).
+Resources become available to practitioners when they are included in the [provider](/plugin/framework/providers) implementation via the [`provider.Provider` interface `Resources` method](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider#Provider.Resources).
 
 In this example, the `ThingResource` type, which implements the `resource.Resource` interface, is added to the provider implementation:
 

--- a/website/docs/plugin/framework/resources/read.mdx
+++ b/website/docs/plugin/framework/resources/read.mdx
@@ -1,0 +1,160 @@
+---
+page_title: 'Plugin Development - Framework: Read Resources'
+description: >-
+  How to implement resource read in the provider development framework.
+---
+
+# Read Resources
+
+-> **Note:** The Plugin Framework is in beta.
+
+Read (refresh) is part of the basic Terraform lifecycle for managing resources. During the [`terraform apply`](/cli/commands/apply), [`terraform plan`](/cli/commands/plan), and [`terraform refresh`](/cli/commands/refresh) commands, Terraform calls the provider `ReadResource` RPC, in which the framework calls the [`resource.Resource` interface `Read` method](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#Resource.Read). The `Read` method is also executed after [resource import](/plugin/framework/resources/import). The request contains Terraform prior state data. The response contains the refreshed state data. The data is defined by the [schema](/plugin/framework/schemas) of the resource.
+
+Other resource lifecycle implementations include:
+
+- [Create](/plugin/framework/resources/create) resources by receiving Terraform configuration and plan data, performing creation logic, and saving Terraform state data.
+- [Update](/plugin/framework/resources/update) resources in-place by receiving Terraform prior state, configuration, and plan data, performing update logic, and saving updated Terraform state data.
+- [Delete](/plugin/framework/resources/delete) resources by receiving Terraform prior state data and performing deletion logic.
+
+## Define Read Method
+
+Implement the `Read` method by:
+
+1. [Accessing prior state data](/plugin/framework/accessing-values) from the [`resource.ReadRequest.State` field](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#ReadRequest.State).
+1. Retriving updated resource state, such as remote system information.
+1. [Writing state data](/plugin/framework/writing-state) into the [`resource.ReadResponse.State` field](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#ReadResponse.State).
+
+If the logic needs to return [warning or error diagnostics](/plugin/framework/diagnostics), they can added into the [`resource.DeleteResponse.Diagnostics` field](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#DeleteResponse.Diagnostics).
+
+In this example, the `Read` function makes a HTTP call and refreshes the state data if the status code was 200 OK or removes the resource if 404 Not Found:
+
+```go
+// ThingResource defines the resource implementation.
+// Some resource.Resource interface methods are omitted for brevity.
+type ThingResource struct {
+	// client is configured via a Configure method, which is not shown in this
+	// example for brevity. Refer to the Configure Resources documentation for
+	// additional details for setting up resources with external clients.
+	client *http.Client
+}
+
+// ThingResourceModel describes the Terraform resource data model to match the
+// resource schema.
+type ThingResourceModel struct {
+	Name types.String `tfsdk:"name"`
+	Id   types.String `tfsdk:"id"`
+}
+
+// ThingResourceAPIModel describes the API data model.
+type ThingResourceAPIModel struct {
+	Name string `json:"name"`
+	Id   string `json:"id"`
+}
+
+func (r ThingResource) GetSchema(ctx context.Context) (tfsdk.Schema, diag.Diagnostics) {
+	return tfsdk.Schema{
+		Attributes: map[string]tfsdk.Attribute{
+			"name": {
+				MarkdownDescription: "Name of the thing to be saved in the service.",
+				Required:            true,
+				Type:                types.StringType,
+			},
+			"id": {
+				Computed:            true,
+				MarkdownDescription: "Service generated identifier for the thing.",
+				PlanModifiers: tfsdk.AttributePlanModifiers{
+					resource.UseStateForUnknown(),
+				},
+				Type: types.StringType,
+			},
+		},
+		MarkdownDescription: "Manages a thing.",
+	}, nil
+}
+
+func (r *ThingResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data ThingResourceModel
+
+	// Read Terraform prior state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+	// Convert from Terraform data model into API data model
+	readReq := ThingResourceAPIModel{
+		Id:   data.Id.ValueString(),
+		Name: data.Name.ValueString(),
+	}
+
+	httpReqBody, err := json.Marshal(readReq)
+
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Refresh Resource",
+			"An unexpected error occurred while creating the resource read request. "+
+				"Please report this issue to the provider developers.\n\n"+
+				"JSON Error: "+err.Error(),
+		)
+
+		return
+	}
+
+	// Create HTTP request
+	httpReq := http.NewRequestWithContext(
+		ctx,
+		http.MethodPut,
+		"http://example.com/things",
+		bytes.NewBuffer(httpReqBody),
+	)
+
+	httpResp, err := d.client.Do(httpReq)
+	defer httpResp.Body.Close()
+
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Refresh Resource",
+			"An unexpected error occurred while attempting to refresh resource state. "+
+				"Please retry the operation or report this issue to the provider developers.\n\n"+
+				"HTTP Error: "+err.Error(),
+		)
+
+		return
+	}
+
+	// Treat HTTP 404 Not Found status as a signal to recreate resource
+	// and return early
+	if httpResp.StatusCode == http.StatusNotFound {
+		resp.State.RemoveResource(ctx)
+
+		return
+	}
+
+	var readResp ThingResourceAPIModel
+
+	err := json.NewDecoder(httpResp.Body).Decode(&readResp)
+
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Refresh Resource",
+			"An unexpected error occurred while parsing the resource read response. "+
+				"Please report this issue to the provider developers.\n\n"+
+				"JSON Error: "+err.Error(),
+		)
+
+		return
+	}
+
+	// Convert from the API data model to the Terraform data model
+	// and refresh any attribute values.
+	data.Name = types.StringValue(readResp.Name)
+
+	// Save updated data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+```
+
+## Recommendations
+
+Note these recommendations when implementing the `Read` method:
+
+* Ignore returning errors that signify the resource is no longer existent, call the response state `RemoveResource()` method, and return early. The next Terraform plan will recreate the resource.
+* Refresh all possible values. This will ensure Terraform shows configuration drift and reduces import logic.
+* Preserve the prior state value if the updated value is semantically equal. For example, JSON strings that have inconsequential object property reordering or whitespace differences. This prevents Terraform from showing extraneous drift in plans.

--- a/website/docs/plugin/framework/resources/update.mdx
+++ b/website/docs/plugin/framework/resources/update.mdx
@@ -1,0 +1,214 @@
+---
+page_title: 'Plugin Development - Framework: Update Resources'
+description: >-
+  How to implement resource in-place update in the provider development framework.
+---
+
+# Update Resources
+
+-> **Note:** The Plugin Framework is in beta.
+
+In-place update is part of the basic Terraform lifecycle for managing resources. During the [`terraform apply` command](/cli/commands/apply), Terraform calls the provider `ApplyResourceChange` RPC, in which the framework calls the [`resource.Resource` interface `Update` method](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#Resource.Update). The request contains Terraform prior state, configuration, and plan data. The response contains updated state data. The data is defined by the [schema](/plugin/framework/schemas) of the resource.
+
+To ensure that Terraform plans replacement of a resource, rather than perform an in-place update, use the [`resource.RequiresReplace()` attribute plan modifier](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#RequiresReplace) in the schema or implement [resource plan modification](/plugin/framework/resources/plan-modification).
+
+Other resource lifecycle implementations include:
+
+- [Create](/plugin/framework/resources/create) resources by receiving Terraform configuration and plan data, performing creation logic, and saving Terraform state data.
+- [Read](/plugin/framework/resources/read) resources by receiving Terraform prior state data, performing read logic, and saving refreshed Terraform state data.
+- [Delete](/plugin/framework/resources/delete) resources by receiving Terraform prior state data and performing deletion logic.
+
+## Define Update Method
+
+Implement the `Update` method by:
+
+1. [Accessing the data](/plugin/framework/accessing-values) from the [`resource.UpdateRequest` type](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#UpdateRequest). Most use cases should access the plan data in the [`resource.UpdateRequest.Plan` field](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#UpdateRequest.Plan).
+1. Performing logic or external calls to modify the resource.
+1. [Writing state data](/plugin/framework/writing-state) into the [`resource.UpdateResponse.State` field](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#UpdateResponse.State).
+
+If the logic needs to return [warning or error diagnostics](/plugin/framework/diagnostics), they can added into the [`resource.UpdateResponse.Diagnostics` field](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#UpdateResponse.Diagnostics).
+
+In this example, the `Update` function makes a HTTP call and returns successfully if the status code was 200 OK:
+
+```go
+// ThingResource defines the resource implementation.
+// Some resource.Resource interface methods are omitted for brevity.
+type ThingResource struct {
+	// client is configured via a Configure method, which is not shown in this
+	// example for brevity. Refer to the Configure Resources documentation for
+	// additional details for setting up resources with external clients.
+	client *http.Client
+}
+
+// ThingResourceModel describes the Terraform resource data model to match the
+// resource schema.
+type ThingResourceModel struct {
+	Name types.String `tfsdk:"name"`
+	Id   types.String `tfsdk:"id"`
+}
+
+// ThingResourceAPIModel describes the API data model.
+type ThingResourceAPIModel struct {
+	Name string `json:"name"`
+	Id   string `json:"id"`
+}
+
+func (r ThingResource) GetSchema(ctx context.Context) (tfsdk.Schema, diag.Diagnostics) {
+	return tfsdk.Schema{
+		Attributes: map[string]tfsdk.Attribute{
+			"name": {
+				MarkdownDescription: "Name of the thing to be saved in the service.",
+				Required:            true,
+				Type:                types.StringType,
+			},
+			"id": {
+				Computed:            true,
+				MarkdownDescription: "Service generated identifier for the thing.",
+				PlanModifiers: tfsdk.AttributePlanModifiers{
+					resource.UseStateForUnknown(),
+				},
+				Type: types.StringType,
+			},
+		},
+		MarkdownDescription: "Manages a thing.",
+	}, nil
+}
+
+func (r ThingResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data ThingResourceModel
+
+	// Read Terraform plan data into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
+	// Convert from Terraform data model into API data model
+	updateReq := ThingResourceAPIModel{
+		Id:   data.Id.StringValue(),
+		Name: data.Name.StringValue(),
+	}
+
+	httpReqBody, err := json.Marshal(updateReq)
+
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Update Resource",
+			"An unexpected error occurred while creating the resource update request. "+
+				"Please report this issue to the provider developers.\n\n"+
+				"JSON Error: "+err.Error(),
+		)
+
+		return
+	}
+
+	// Create HTTP request
+	httpReq := http.NewRequestWithContext(
+		ctx,
+		http.MethodPut,
+		"http://example.com/things",
+		bytes.NewBuffer(httpReqBody),
+	)
+
+	// Send HTTP request
+	httpResp, err := d.client.Do(httpReq)
+	defer httpResp.Body.Close()
+
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Update Resource",
+			"An unexpected error occurred while attempting to update the resource. "+
+				"Please retry the operation or report this issue to the provider developers.\n\n"+
+				"HTTP Error: "+err.Error(),
+		)
+
+		return
+	}
+
+	// Return error if the HTTP status code is not 200 OK
+	if httpResp.StatusCode != http.StatusOK {
+		resp.Diagnostics.AddError(
+			"Unable to Update Resource",
+			"An unexpected error occurred while attempting to update the resource. "+
+				"Please retry the operation or report this issue to the provider developers.\n\n"+
+				"HTTP Status: "+httpResp.Status,
+		)
+
+		return
+	}
+
+	// Save updated data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+```
+
+## Caveats
+
+Note these caveats when implementing the `Update` method:
+
+* An error is returned if the response state is not set when `Update` is called by the framework. If the resource does not support modification and should always be recreated on configuration value updates, the `Update` logic can be left empty and ensure all configurable schema attributes implement the [`resource.RequiresReplace()` attribute plan modifier](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#RequiresReplace).
+* An error is returned if the response state contains unknown values. Set all attributes to either null or known values in the response.
+* An error is returned if the response state has the `RemoveResource()` method called. This method is not valid during update. Return an error if the resource is no longer exists.
+* An error is returned unless every null or known value in the request plan is saved exactly as-is into the response state. Only unknown plan values can be modified.
+
+## Recommendations
+
+Note these recommendations when implementing the `Update` method:
+
+* Get request data from the Terraform plan data over configuration data as the schema or resource may include [plan modification](/plugin/framework/resources/plan-modification) logic which sets plan values.
+* Only successfully modified parts of the resource should be return updated data in the state response.
+* Use the [`resource.UseStateForUnknown()` attribute plan modifier](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#UseStateForUnknown) for `Computed` attributes that are known to not change during resource updates. This will enhance the Terraform plan to not show `=> (known after apply)` differences.
+
+## Additional Use Cases
+
+This section highlights implementation details for specific use cases.
+
+### Detect Specific Attribute Changes
+
+Certain update APIs require that only value changes are sent in the update request or require individual update API calls. Compare the attribute plan value to the attribute prior state value to determine individual attribute changes.
+
+In this example, the entire plan and prior state are fetched then the attribute values are compared:
+
+```go
+type ThingResourceModel struct {
+	Name types.String `tfsdk:"name"`
+	// ... other attributes ...
+}
+
+func (r ThingResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan, state ThingResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Compare name attribute value between plan and prior state
+	if !plan.Name.Equal(state.Name) {
+		// name attribute was changed
+	}
+
+	// ... further logic ...
+}
+```
+
+In this example, the attribute is individually fetched from the plan and prior state then the values are compared:
+
+```go
+func (r ThingResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var namePlan, nameState types.String
+
+	resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, path.Root("name"), &namePlan)...)
+	resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("name"), &nameState)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Compare name attribute value between plan and prior state
+	if !namePlan.Equal(nameState) {
+		// name attribute was changed
+	}
+
+	// ... further logic ...
+}
+```


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/258
Closes #527

Each lifecycle operation has its own set of caveats, recommendations, and specific use cases. These individualized pages will clarify and enable the additional documentation requirements. This change also adds update documentation to show how to determine whether an individual attribute value was changed during update, to show the new layout in action.