### PR TITLE
Fix Framework allows top-level schema attributes that conflict with Terraform meta-arguments

### DIFF
--- a/.changelog/548.txt
+++ b/.changelog/548.txt
@@ -1,0 +1,15 @@
+```release-note:bug
+provider: Add `Validate` function to `Schema` to prevent usage of reserved and invalid names for attributes and blocks
+```
+
+```release-note:bug
+provider: Add `Validate` function to `MetaSchema` to prevent usage of reserved and invalid names for attributes and blocks
+```
+
+```release-note:bug
+resource: Add `Validate` function to `Schema` to prevent usage of reserved and invalid names for attributes and blocks
+```
+
+```release-note:bug
+datasource: Add `Validate` function to `Schema` to prevent usage of reserved and invalid names for attributes and blocks
+```

--- a/datasource/schema/schema.go
+++ b/datasource/schema/schema.go
@@ -2,12 +2,15 @@ package schema
 
 import (
 	"context"
+	"fmt"
+	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/path"
-	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
 // Schema must satify the fwschema.Schema interface.
@@ -120,6 +123,130 @@ func (s Schema) TypeAtPath(ctx context.Context, p path.Path) (attr.Type, diag.Di
 // TypeAtTerraformPath returns the framework type at the given tftypes path.
 func (s Schema) TypeAtTerraformPath(ctx context.Context, p *tftypes.AttributePath) (attr.Type, error) {
 	return fwschema.SchemaTypeAtTerraformPath(ctx, s, p)
+}
+
+// Validate verifies that the schema is not using a reserved field name for a top-level attribute.
+func (s Schema) Validate() diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	// Raise error diagnostics when data source configuration uses reserved
+	// field names for root-level attributes.
+	reservedFieldNames := map[string]struct{}{
+		"connection":  {},
+		"count":       {},
+		"depends_on":  {},
+		"lifecycle":   {},
+		"provider":    {},
+		"provisioner": {},
+	}
+
+	attributes := s.GetAttributes()
+
+	for k, v := range attributes {
+		if _, ok := reservedFieldNames[k]; ok {
+			diags.AddAttributeError(
+				path.Root(k),
+				"Schema Using Reserved Field Name",
+				fmt.Sprintf("%q is a reserved field name", k),
+			)
+		}
+
+		d := validateAttributeFieldName(path.Root(k), k, v)
+
+		diags.Append(d...)
+	}
+
+	blocks := s.GetBlocks()
+
+	for k, v := range blocks {
+		if _, ok := reservedFieldNames[k]; ok {
+			diags.AddAttributeError(
+				path.Root(k),
+				"Schema Using Reserved Field Name",
+				fmt.Sprintf("%q is a reserved field name", k),
+			)
+		}
+
+		d := validateBlockFieldName(path.Root(k), k, v)
+
+		diags.Append(d...)
+	}
+
+	return diags
+}
+
+// validFieldNameRegex is used to verify that name used for attributes and blocks
+// comply with the defined regular expression.
+var validFieldNameRegex = regexp.MustCompile("^[a-z0-9_]+$")
+
+// validateAttributeFieldName verifies that the name used for an attribute complies with the regular
+// expression defined in validFieldNameRegex.
+func validateAttributeFieldName(path path.Path, name string, attr fwschema.Attribute) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	if !validFieldNameRegex.MatchString(name) {
+		diags.AddAttributeError(
+			path,
+			"Invalid Schema Field Name",
+			fmt.Sprintf("Field name %q is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.", name),
+		)
+	}
+
+	if na, ok := attr.(fwschema.NestedAttribute); ok {
+		nestedObject := na.GetNestedObject()
+
+		if nestedObject == nil {
+			return diags
+		}
+
+		attributes := nestedObject.GetAttributes()
+
+		for k, v := range attributes {
+			d := validateAttributeFieldName(path.AtName(k), k, v)
+
+			diags.Append(d...)
+		}
+	}
+
+	return diags
+}
+
+// validateBlockFieldName verifies that the name used for a block complies with the regular
+// expression defined in validFieldNameRegex.
+func validateBlockFieldName(path path.Path, name string, b fwschema.Block) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	if !validFieldNameRegex.MatchString(name) {
+		diags.AddAttributeError(
+			path,
+			"Invalid Schema Field Name",
+			fmt.Sprintf("Field name %q is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.", name),
+		)
+	}
+
+	nestedObject := b.GetNestedObject()
+
+	if nestedObject == nil {
+		return diags
+	}
+
+	blocks := nestedObject.GetBlocks()
+
+	for k, v := range blocks {
+		d := validateBlockFieldName(path.AtName(k), k, v)
+
+		diags.Append(d...)
+	}
+
+	attributes := nestedObject.GetAttributes()
+
+	for k, v := range attributes {
+		d := validateAttributeFieldName(path.AtName(k), k, v)
+
+		diags.Append(d...)
+	}
+
+	return diags
 }
 
 // schemaAttributes is a datasource to fwschema type conversion function.

--- a/datasource/schema/schema_test.go
+++ b/datasource/schema/schema_test.go
@@ -7,13 +7,14 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
 func TestSchemaApplyTerraform5AttributePathStep(t *testing.T) {
@@ -991,6 +992,395 @@ func TestSchemaTypeAtTerraformPath(t *testing.T) {
 
 			if diff := cmp.Diff(got, testCase.expected); diff != "" {
 				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestSchemaValidate(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		schema        schema.Schema
+		expectedDiags diag.Diagnostics
+	}{
+		"empty-schema": {
+			schema: schema.Schema{},
+		},
+		"attribute-using-reserved-field-name": {
+			schema: schema.Schema{
+				Attributes: map[string]schema.Attribute{
+					"depends_on": schema.StringAttribute{},
+				},
+			},
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("depends_on"),
+					"Schema Using Reserved Field Name",
+					`"depends_on" is a reserved field name`,
+				),
+			},
+		},
+		"block-using-reserved-field-name": {
+			schema: schema.Schema{
+				Blocks: map[string]schema.Block{
+					"connection": schema.ListNestedBlock{},
+				},
+			},
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("connection"),
+					"Schema Using Reserved Field Name",
+					`"connection" is a reserved field name`,
+				),
+			},
+		},
+		"single-nested-attribute-using-nested-reserved-field-name": {
+			schema: schema.Schema{
+				Attributes: map[string]schema.Attribute{
+					"single_nested_attribute": schema.SingleNestedAttribute{
+						Attributes: map[string]schema.Attribute{
+							"depends_on": schema.BoolAttribute{},
+						},
+					},
+				},
+			},
+		},
+		"single-nested-block-using-nested-reserved-field-name": {
+			schema: schema.Schema{
+				Blocks: map[string]schema.Block{
+					"single_nested_block": schema.SingleNestedBlock{
+						Attributes: map[string]schema.Attribute{
+							"connection": schema.BoolAttribute{},
+						},
+					},
+				},
+			},
+		},
+		"list-nested-attribute-using-nested-reserved-field-name": {
+			schema: schema.Schema{
+				Attributes: map[string]schema.Attribute{
+					"list_nested_attribute": schema.ListNestedAttribute{
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"depends_on": schema.Int64Attribute{},
+							},
+						},
+					},
+				},
+			},
+		},
+		"list-nested-block-using-nested-reserved-field-name": {
+			schema: schema.Schema{
+				Blocks: map[string]schema.Block{
+					"list_nested_block": schema.ListNestedBlock{
+						NestedObject: schema.NestedBlockObject{
+							Attributes: map[string]schema.Attribute{
+								"connection": schema.BoolAttribute{},
+							},
+						},
+					},
+				},
+			},
+		},
+		"attribute-and-blocks-using-reserved-field-names": {
+			schema: schema.Schema{
+				Attributes: map[string]schema.Attribute{
+					"depends_on": schema.StringAttribute{},
+				},
+				Blocks: map[string]schema.Block{
+					"connection": schema.ListNestedBlock{},
+				},
+			},
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("depends_on"),
+					"Schema Using Reserved Field Name",
+					`"depends_on" is a reserved field name`,
+				),
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("connection"),
+					"Schema Using Reserved Field Name",
+					`"connection" is a reserved field name`,
+				),
+			},
+		},
+		"attribute-using-invalid-field-name": {
+			schema: schema.Schema{
+				Attributes: map[string]schema.Attribute{
+					"^": schema.StringAttribute{},
+				},
+			},
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("^"),
+					"Invalid Schema Field Name",
+					`Field name "^" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
+				),
+			},
+		},
+		"block-using-invalid-field-name": {
+			schema: schema.Schema{
+				Blocks: map[string]schema.Block{
+					"^": schema.ListNestedBlock{},
+				},
+			},
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("^"),
+					"Invalid Schema Field Name",
+					`Field name "^" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
+				),
+			},
+		},
+		"single-nested-attribute-using-nested-invalid-field-name": {
+			schema: schema.Schema{
+				Attributes: map[string]schema.Attribute{
+					"single_nested_attribute": schema.SingleNestedAttribute{
+						Attributes: map[string]schema.Attribute{
+							"^": schema.BoolAttribute{},
+						},
+					},
+				},
+			},
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("single_nested_attribute").AtName("^"),
+					"Invalid Schema Field Name",
+					`Field name "^" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
+				),
+			},
+		},
+		"single-nested-block-using-nested-invalid-field-name": {
+			schema: schema.Schema{
+				Blocks: map[string]schema.Block{
+					"single_nested_block": schema.SingleNestedBlock{
+						Attributes: map[string]schema.Attribute{
+							"^": schema.BoolAttribute{},
+						},
+					},
+				},
+			},
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("single_nested_block").AtName("^"),
+					"Invalid Schema Field Name",
+					`Field name "^" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
+				),
+			},
+		},
+		"single-nested-attribute-using-invalid-field-names": {
+			schema: schema.Schema{
+				Attributes: map[string]schema.Attribute{
+					"$": schema.SingleNestedAttribute{
+						Attributes: map[string]schema.Attribute{
+							"^": schema.BoolAttribute{},
+						},
+					},
+				},
+			},
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("$"),
+					"Invalid Schema Field Name",
+					`Field name "$" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
+				),
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("$").AtName("^"),
+					"Invalid Schema Field Name",
+					`Field name "^" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
+				),
+			},
+		},
+		"single-nested-block-using-invalid-field-names": {
+			schema: schema.Schema{
+				Blocks: map[string]schema.Block{
+					"$": schema.SingleNestedBlock{
+						Attributes: map[string]schema.Attribute{
+							"^": schema.BoolAttribute{},
+						},
+					},
+				},
+			},
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("$"),
+					"Invalid Schema Field Name",
+					`Field name "$" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
+				),
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("$").AtName("^"),
+					"Invalid Schema Field Name",
+					`Field name "^" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
+				),
+			},
+		},
+		"single-nested-block-with-nested-block-using-invalid-field-names": {
+			schema: schema.Schema{
+				Blocks: map[string]schema.Block{
+					"$": schema.SingleNestedBlock{
+						Blocks: map[string]schema.Block{
+							"^": schema.SingleNestedBlock{
+								Attributes: map[string]schema.Attribute{
+									"!": schema.BoolAttribute{},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("$"),
+					"Invalid Schema Field Name",
+					`Field name "$" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
+				),
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("$").AtName("^"),
+					"Invalid Schema Field Name",
+					`Field name "^" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
+				),
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("$").AtName("^").AtName("!"),
+					"Invalid Schema Field Name",
+					`Field name "!" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
+				),
+			},
+		},
+		"list-nested-attribute-using-nested-invalid-field-name": {
+			schema: schema.Schema{
+				Attributes: map[string]schema.Attribute{
+					"list_nested_attribute": schema.ListNestedAttribute{
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"^": schema.Int64Attribute{},
+							},
+						},
+					},
+				},
+			},
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("list_nested_attribute").AtName("^"),
+					"Invalid Schema Field Name",
+					`Field name "^" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
+				),
+			},
+		},
+		"list-nested-block-using-nested-invalid-field-name": {
+			schema: schema.Schema{
+				Blocks: map[string]schema.Block{
+					"list_nested_block": schema.ListNestedBlock{
+						NestedObject: schema.NestedBlockObject{
+							Attributes: map[string]schema.Attribute{
+								"^": schema.Int64Attribute{},
+							},
+						},
+					},
+				},
+			},
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("list_nested_block").AtName("^"),
+					"Invalid Schema Field Name",
+					`Field name "^" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
+				),
+			},
+		},
+		"list-nested-attribute-using-invalid-field-names": {
+			schema: schema.Schema{
+				Attributes: map[string]schema.Attribute{
+					"$": schema.ListNestedAttribute{
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"^": schema.Int64Attribute{},
+							},
+						},
+					},
+				},
+			},
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("$"),
+					"Invalid Schema Field Name",
+					`Field name "$" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
+				),
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("$").AtName("^"),
+					"Invalid Schema Field Name",
+					`Field name "^" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
+				),
+			},
+		},
+		"list-nested-block-using-invalid-field-names": {
+			schema: schema.Schema{
+				Blocks: map[string]schema.Block{
+					"$": schema.ListNestedBlock{
+						NestedObject: schema.NestedBlockObject{
+							Attributes: map[string]schema.Attribute{
+								"^": schema.Int64Attribute{},
+							},
+						},
+					},
+				},
+			},
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("$"),
+					"Invalid Schema Field Name",
+					`Field name "$" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
+				),
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("$").AtName("^"),
+					"Invalid Schema Field Name",
+					`Field name "^" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
+				),
+			},
+		},
+		"list-nested-block-with-nested-block-using-invalid-field-names": {
+			schema: schema.Schema{
+				Blocks: map[string]schema.Block{
+					"$": schema.ListNestedBlock{
+						NestedObject: schema.NestedBlockObject{
+							Blocks: map[string]schema.Block{
+								"^": schema.SingleNestedBlock{
+									Attributes: map[string]schema.Attribute{
+										"!": schema.BoolAttribute{},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("$"),
+					"Invalid Schema Field Name",
+					`Field name "$" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
+				),
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("$").AtName("^"),
+					"Invalid Schema Field Name",
+					`Field name "^" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
+				),
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("$").AtName("^").AtName("!"),
+					"Invalid Schema Field Name",
+					`Field name "!" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
+				),
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			diags := testCase.schema.Validate()
+
+			if diff := cmp.Diff(diags, testCase.expectedDiags); diff != "" {
+				t.Errorf("Unexpected diagnostics (+wanted, -got): %s", diff)
 			}
 		})
 	}

--- a/internal/fwschema/schema.go
+++ b/internal/fwschema/schema.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/totftypes"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
 // Schema is the core interface required for data sources, providers, and

--- a/internal/fwserver/server.go
+++ b/internal/fwserver/server.go
@@ -245,6 +245,12 @@ func (s *Server) DataSourceSchemas(ctx context.Context) (map[string]fwschema.Sch
 				return s.dataSourceSchemas, s.dataSourceSchemasDiags
 			}
 
+			s.dataSourceSchemasDiags.Append(schemaResp.Schema.Validate()...)
+
+			if s.dataSourceSchemasDiags.HasError() {
+				return s.dataSourceSchemas, s.dataSourceSchemasDiags
+			}
+
 			s.dataSourceSchemas[dataSourceTypeName] = schemaResp.Schema
 		case datasource.DataSourceWithGetSchema:
 			logging.FrameworkDebug(ctx, "Calling provider defined DataSource GetSchema", map[string]interface{}{logging.KeyDataSourceType: dataSourceTypeName})
@@ -293,6 +299,8 @@ func (s *Server) ProviderSchema(ctx context.Context) (fwschema.Schema, diag.Diag
 
 		s.providerSchema = schemaResp.Schema
 		s.providerSchemaDiags = schemaResp.Diagnostics
+
+		s.providerSchemaDiags.Append(schemaResp.Schema.Validate()...)
 	case provider.ProviderWithGetSchema:
 		logging.FrameworkDebug(ctx, "Calling provider defined Provider GetSchema")
 		schema, diags := providerIface.GetSchema(ctx) //nolint:staticcheck // Required internal usage until removal
@@ -339,6 +347,8 @@ func (s *Server) ProviderMetaSchema(ctx context.Context) (fwschema.Schema, diag.
 
 	s.providerMetaSchema = resp.Schema
 	s.providerMetaSchemaDiags = resp.Diagnostics
+
+	s.providerMetaSchemaDiags.Append(resp.Schema.Validate()...)
 
 	return s.providerMetaSchema, s.providerMetaSchemaDiags
 }
@@ -465,6 +475,12 @@ func (s *Server) ResourceSchemas(ctx context.Context) (map[string]fwschema.Schem
 			logging.FrameworkDebug(ctx, "Called provider defined Resource Schema", map[string]interface{}{logging.KeyResourceType: resourceTypeName})
 
 			s.resourceSchemasDiags.Append(schemaResp.Diagnostics...)
+
+			if s.resourceSchemasDiags.HasError() {
+				return s.resourceSchemas, s.resourceSchemasDiags
+			}
+
+			s.resourceSchemasDiags.Append(schemaResp.Schema.Validate()...)
 
 			if s.resourceSchemasDiags.HasError() {
 				return s.resourceSchemas, s.resourceSchemasDiags

--- a/provider/metaschema/schema.go
+++ b/provider/metaschema/schema.go
@@ -2,12 +2,15 @@ package metaschema
 
 import (
 	"context"
+	"fmt"
+	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/path"
-	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
 // Schema must satify the fwschema.Schema interface.
@@ -94,6 +97,72 @@ func (s Schema) TypeAtPath(ctx context.Context, p path.Path) (attr.Type, diag.Di
 // TypeAtTerraformPath returns the framework type at the given tftypes path.
 func (s Schema) TypeAtTerraformPath(ctx context.Context, p *tftypes.AttributePath) (attr.Type, error) {
 	return fwschema.SchemaTypeAtTerraformPath(ctx, s, p)
+}
+
+// Validate verifies that the schema is not using a reserved field name for a top-level attribute.
+func (s Schema) Validate() diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	// Raise error diagnostics when data source configuration uses reserved
+	// field names for root-level attributes.
+	reservedFieldNames := map[string]struct{}{
+		"alias":   {},
+		"version": {},
+	}
+
+	attributes := s.GetAttributes()
+
+	for k, v := range attributes {
+		if _, ok := reservedFieldNames[k]; ok {
+			diags.AddAttributeError(
+				path.Root(k),
+				"Schema Using Reserved Field Name",
+				fmt.Sprintf("%q is a reserved field name", k),
+			)
+		}
+
+		d := validateAttributeFieldName(path.Root(k), k, v)
+
+		diags.Append(d...)
+	}
+
+	return diags
+}
+
+// validFieldNameRegex is used to verify that name used for attributes and blocks
+// comply with the defined regular expression.
+var validFieldNameRegex = regexp.MustCompile("^[a-z0-9_]+$")
+
+// validateAttributeFieldName verifies that the name used for an attribute complies with the regular
+// expression defined in validFieldNameRegex.
+func validateAttributeFieldName(path path.Path, name string, attr fwschema.Attribute) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	if !validFieldNameRegex.MatchString(name) {
+		diags.AddAttributeError(
+			path,
+			"Invalid Schema Field Name",
+			fmt.Sprintf("Field name %q is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.", name),
+		)
+	}
+
+	if na, ok := attr.(fwschema.NestedAttribute); ok {
+		nestedObject := na.GetNestedObject()
+
+		if nestedObject == nil {
+			return diags
+		}
+
+		attributes := nestedObject.GetAttributes()
+
+		for k, v := range attributes {
+			d := validateAttributeFieldName(path.AtName(k), k, v)
+
+			diags.Append(d...)
+		}
+	}
+
+	return diags
 }
 
 // schemaAttributes is a provider to fwschema type conversion function.

--- a/provider/metaschema/schema.go
+++ b/provider/metaschema/schema.go
@@ -103,24 +103,9 @@ func (s Schema) TypeAtTerraformPath(ctx context.Context, p *tftypes.AttributePat
 func (s Schema) Validate() diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	// Raise error diagnostics when data source configuration uses reserved
-	// field names for root-level attributes.
-	reservedFieldNames := map[string]struct{}{
-		"alias":   {},
-		"version": {},
-	}
-
 	attributes := s.GetAttributes()
 
 	for k, v := range attributes {
-		if _, ok := reservedFieldNames[k]; ok {
-			diags.AddAttributeError(
-				path.Root(k),
-				"Schema Using Reserved Field Name",
-				fmt.Sprintf("%q is a reserved field name", k),
-			)
-		}
-
 		d := validateAttributeFieldName(path.Root(k), k, v)
 
 		diags.Append(d...)

--- a/provider/metaschema/schema_test.go
+++ b/provider/metaschema/schema_test.go
@@ -818,44 +818,6 @@ func TestSchemaValidate(t *testing.T) {
 		"empty-schema": {
 			schema: metaschema.Schema{},
 		},
-		"attribute-using-reserved-field-name": {
-			schema: metaschema.Schema{
-				Attributes: map[string]metaschema.Attribute{
-					"alias": metaschema.StringAttribute{},
-				},
-			},
-			expectedDiags: diag.Diagnostics{
-				diag.NewAttributeErrorDiagnostic(
-					path.Root("alias"),
-					"Schema Using Reserved Field Name",
-					`"alias" is a reserved field name`,
-				),
-			},
-		},
-		"single-nested-attribute-using-nested-reserved-field-name": {
-			schema: metaschema.Schema{
-				Attributes: map[string]metaschema.Attribute{
-					"single_nested_attribute": metaschema.SingleNestedAttribute{
-						Attributes: map[string]metaschema.Attribute{
-							"alias": metaschema.BoolAttribute{},
-						},
-					},
-				},
-			},
-		},
-		"list-nested-attribute-using-nested-reserved-field-name": {
-			schema: metaschema.Schema{
-				Attributes: map[string]metaschema.Attribute{
-					"list_nested_attribute": metaschema.ListNestedAttribute{
-						NestedObject: metaschema.NestedAttributeObject{
-							Attributes: map[string]metaschema.Attribute{
-								"alias": metaschema.Int64Attribute{},
-							},
-						},
-					},
-				},
-			},
-		},
 		"attribute-using-invalid-field-name": {
 			schema: metaschema.Schema{
 				Attributes: map[string]metaschema.Attribute{

--- a/provider/schema/schema_test.go
+++ b/provider/schema/schema_test.go
@@ -7,13 +7,14 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
 func TestSchemaApplyTerraform5AttributePathStep(t *testing.T) {
@@ -991,6 +992,395 @@ func TestSchemaTypeAtTerraformPath(t *testing.T) {
 
 			if diff := cmp.Diff(got, testCase.expected); diff != "" {
 				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestSchemaValidate(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		schema        schema.Schema
+		expectedDiags diag.Diagnostics
+	}{
+		"empty-schema": {
+			schema: schema.Schema{},
+		},
+		"attribute-using-reserved-field-name": {
+			schema: schema.Schema{
+				Attributes: map[string]schema.Attribute{
+					"alias": schema.StringAttribute{},
+				},
+			},
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("alias"),
+					"Schema Using Reserved Field Name",
+					`"alias" is a reserved field name`,
+				),
+			},
+		},
+		"block-using-reserved-field-name": {
+			schema: schema.Schema{
+				Blocks: map[string]schema.Block{
+					"version": schema.ListNestedBlock{},
+				},
+			},
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("version"),
+					"Schema Using Reserved Field Name",
+					`"version" is a reserved field name`,
+				),
+			},
+		},
+		"single-nested-attribute-using-nested-reserved-field-name": {
+			schema: schema.Schema{
+				Attributes: map[string]schema.Attribute{
+					"single_nested_attribute": schema.SingleNestedAttribute{
+						Attributes: map[string]schema.Attribute{
+							"alias": schema.BoolAttribute{},
+						},
+					},
+				},
+			},
+		},
+		"single-nested-block-using-nested-reserved-field-name": {
+			schema: schema.Schema{
+				Blocks: map[string]schema.Block{
+					"single_nested_block": schema.SingleNestedBlock{
+						Attributes: map[string]schema.Attribute{
+							"version": schema.BoolAttribute{},
+						},
+					},
+				},
+			},
+		},
+		"list-nested-attribute-using-nested-reserved-field-name": {
+			schema: schema.Schema{
+				Attributes: map[string]schema.Attribute{
+					"list_nested_attribute": schema.ListNestedAttribute{
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"alias": schema.Int64Attribute{},
+							},
+						},
+					},
+				},
+			},
+		},
+		"list-nested-block-using-nested-reserved-field-name": {
+			schema: schema.Schema{
+				Blocks: map[string]schema.Block{
+					"list_nested_block": schema.ListNestedBlock{
+						NestedObject: schema.NestedBlockObject{
+							Attributes: map[string]schema.Attribute{
+								"version": schema.BoolAttribute{},
+							},
+						},
+					},
+				},
+			},
+		},
+		"attribute-and-blocks-using-reserved-field-names": {
+			schema: schema.Schema{
+				Attributes: map[string]schema.Attribute{
+					"alias": schema.StringAttribute{},
+				},
+				Blocks: map[string]schema.Block{
+					"version": schema.ListNestedBlock{},
+				},
+			},
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("alias"),
+					"Schema Using Reserved Field Name",
+					`"alias" is a reserved field name`,
+				),
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("version"),
+					"Schema Using Reserved Field Name",
+					`"version" is a reserved field name`,
+				),
+			},
+		},
+		"attribute-using-invalid-field-name": {
+			schema: schema.Schema{
+				Attributes: map[string]schema.Attribute{
+					"^": schema.StringAttribute{},
+				},
+			},
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("^"),
+					"Invalid Schema Field Name",
+					`Field name "^" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
+				),
+			},
+		},
+		"block-using-invalid-field-name": {
+			schema: schema.Schema{
+				Blocks: map[string]schema.Block{
+					"^": schema.ListNestedBlock{},
+				},
+			},
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("^"),
+					"Invalid Schema Field Name",
+					`Field name "^" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
+				),
+			},
+		},
+		"single-nested-attribute-using-nested-invalid-field-name": {
+			schema: schema.Schema{
+				Attributes: map[string]schema.Attribute{
+					"single_nested_attribute": schema.SingleNestedAttribute{
+						Attributes: map[string]schema.Attribute{
+							"^": schema.BoolAttribute{},
+						},
+					},
+				},
+			},
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("single_nested_attribute").AtName("^"),
+					"Invalid Schema Field Name",
+					`Field name "^" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
+				),
+			},
+		},
+		"single-nested-block-using-nested-invalid-field-name": {
+			schema: schema.Schema{
+				Blocks: map[string]schema.Block{
+					"single_nested_block": schema.SingleNestedBlock{
+						Attributes: map[string]schema.Attribute{
+							"^": schema.BoolAttribute{},
+						},
+					},
+				},
+			},
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("single_nested_block").AtName("^"),
+					"Invalid Schema Field Name",
+					`Field name "^" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
+				),
+			},
+		},
+		"single-nested-attribute-using-invalid-field-names": {
+			schema: schema.Schema{
+				Attributes: map[string]schema.Attribute{
+					"$": schema.SingleNestedAttribute{
+						Attributes: map[string]schema.Attribute{
+							"^": schema.BoolAttribute{},
+						},
+					},
+				},
+			},
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("$"),
+					"Invalid Schema Field Name",
+					`Field name "$" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
+				),
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("$").AtName("^"),
+					"Invalid Schema Field Name",
+					`Field name "^" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
+				),
+			},
+		},
+		"single-nested-block-using-invalid-field-names": {
+			schema: schema.Schema{
+				Blocks: map[string]schema.Block{
+					"$": schema.SingleNestedBlock{
+						Attributes: map[string]schema.Attribute{
+							"^": schema.BoolAttribute{},
+						},
+					},
+				},
+			},
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("$"),
+					"Invalid Schema Field Name",
+					`Field name "$" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
+				),
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("$").AtName("^"),
+					"Invalid Schema Field Name",
+					`Field name "^" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
+				),
+			},
+		},
+		"single-nested-block-with-nested-block-using-invalid-field-names": {
+			schema: schema.Schema{
+				Blocks: map[string]schema.Block{
+					"$": schema.SingleNestedBlock{
+						Blocks: map[string]schema.Block{
+							"^": schema.SingleNestedBlock{
+								Attributes: map[string]schema.Attribute{
+									"!": schema.BoolAttribute{},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("$"),
+					"Invalid Schema Field Name",
+					`Field name "$" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
+				),
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("$").AtName("^"),
+					"Invalid Schema Field Name",
+					`Field name "^" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
+				),
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("$").AtName("^").AtName("!"),
+					"Invalid Schema Field Name",
+					`Field name "!" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
+				),
+			},
+		},
+		"list-nested-attribute-using-nested-invalid-field-name": {
+			schema: schema.Schema{
+				Attributes: map[string]schema.Attribute{
+					"list_nested_attribute": schema.ListNestedAttribute{
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"^": schema.Int64Attribute{},
+							},
+						},
+					},
+				},
+			},
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("list_nested_attribute").AtName("^"),
+					"Invalid Schema Field Name",
+					`Field name "^" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
+				),
+			},
+		},
+		"list-nested-block-using-nested-invalid-field-name": {
+			schema: schema.Schema{
+				Blocks: map[string]schema.Block{
+					"list_nested_block": schema.ListNestedBlock{
+						NestedObject: schema.NestedBlockObject{
+							Attributes: map[string]schema.Attribute{
+								"^": schema.Int64Attribute{},
+							},
+						},
+					},
+				},
+			},
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("list_nested_block").AtName("^"),
+					"Invalid Schema Field Name",
+					`Field name "^" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
+				),
+			},
+		},
+		"list-nested-attribute-using-invalid-field-names": {
+			schema: schema.Schema{
+				Attributes: map[string]schema.Attribute{
+					"$": schema.ListNestedAttribute{
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"^": schema.Int64Attribute{},
+							},
+						},
+					},
+				},
+			},
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("$"),
+					"Invalid Schema Field Name",
+					`Field name "$" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
+				),
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("$").AtName("^"),
+					"Invalid Schema Field Name",
+					`Field name "^" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
+				),
+			},
+		},
+		"list-nested-block-using-invalid-field-names": {
+			schema: schema.Schema{
+				Blocks: map[string]schema.Block{
+					"$": schema.ListNestedBlock{
+						NestedObject: schema.NestedBlockObject{
+							Attributes: map[string]schema.Attribute{
+								"^": schema.Int64Attribute{},
+							},
+						},
+					},
+				},
+			},
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("$"),
+					"Invalid Schema Field Name",
+					`Field name "$" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
+				),
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("$").AtName("^"),
+					"Invalid Schema Field Name",
+					`Field name "^" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
+				),
+			},
+		},
+		"list-nested-block-with-nested-block-using-invalid-field-names": {
+			schema: schema.Schema{
+				Blocks: map[string]schema.Block{
+					"$": schema.ListNestedBlock{
+						NestedObject: schema.NestedBlockObject{
+							Blocks: map[string]schema.Block{
+								"^": schema.SingleNestedBlock{
+									Attributes: map[string]schema.Attribute{
+										"!": schema.BoolAttribute{},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("$"),
+					"Invalid Schema Field Name",
+					`Field name "$" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
+				),
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("$").AtName("^"),
+					"Invalid Schema Field Name",
+					`Field name "^" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
+				),
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("$").AtName("^").AtName("!"),
+					"Invalid Schema Field Name",
+					`Field name "!" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
+				),
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			diags := testCase.schema.Validate()
+
+			if diff := cmp.Diff(diags, testCase.expectedDiags); diff != "" {
+				t.Errorf("Unexpected diagnostics (+wanted, -got): %s", diff)
 			}
 		})
 	}

--- a/resource/schema/schema.go
+++ b/resource/schema/schema.go
@@ -2,12 +2,15 @@ package schema
 
 import (
 	"context"
+	"fmt"
+	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/path"
-	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
 // Schema must satify the fwschema.Schema interface.
@@ -130,6 +133,130 @@ func (s Schema) TypeAtPath(ctx context.Context, p path.Path) (attr.Type, diag.Di
 // TypeAtTerraformPath returns the framework type at the given tftypes path.
 func (s Schema) TypeAtTerraformPath(ctx context.Context, p *tftypes.AttributePath) (attr.Type, error) {
 	return fwschema.SchemaTypeAtTerraformPath(ctx, s, p)
+}
+
+// Validate verifies that the schema is not using a reserved field name for a top-level attribute.
+func (s Schema) Validate() diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	// Raise error diagnostics when data source configuration uses reserved
+	// field names for root-level attributes.
+	reservedFieldNames := map[string]struct{}{
+		"connection":  {},
+		"count":       {},
+		"depends_on":  {},
+		"lifecycle":   {},
+		"provider":    {},
+		"provisioner": {},
+	}
+
+	attributes := s.GetAttributes()
+
+	for k, v := range attributes {
+		if _, ok := reservedFieldNames[k]; ok {
+			diags.AddAttributeError(
+				path.Root(k),
+				"Schema Using Reserved Field Name",
+				fmt.Sprintf("%q is a reserved field name", k),
+			)
+		}
+
+		d := validateAttributeFieldName(path.Root(k), k, v)
+
+		diags.Append(d...)
+	}
+
+	blocks := s.GetBlocks()
+
+	for k, v := range blocks {
+		if _, ok := reservedFieldNames[k]; ok {
+			diags.AddAttributeError(
+				path.Root(k),
+				"Schema Using Reserved Field Name",
+				fmt.Sprintf("%q is a reserved field name", k),
+			)
+		}
+
+		d := validateBlockFieldName(path.Root(k), k, v)
+
+		diags.Append(d...)
+	}
+
+	return diags
+}
+
+// validFieldNameRegex is used to verify that name used for attributes and blocks
+// comply with the defined regular expression.
+var validFieldNameRegex = regexp.MustCompile("^[a-z0-9_]+$")
+
+// validateAttributeFieldName verifies that the name used for an attribute complies with the regular
+// expression defined in validFieldNameRegex.
+func validateAttributeFieldName(path path.Path, name string, attr fwschema.Attribute) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	if !validFieldNameRegex.MatchString(name) {
+		diags.AddAttributeError(
+			path,
+			"Invalid Schema Field Name",
+			fmt.Sprintf("Field name %q is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.", name),
+		)
+	}
+
+	if na, ok := attr.(fwschema.NestedAttribute); ok {
+		nestedObject := na.GetNestedObject()
+
+		if nestedObject == nil {
+			return diags
+		}
+
+		attributes := nestedObject.GetAttributes()
+
+		for k, v := range attributes {
+			d := validateAttributeFieldName(path.AtName(k), k, v)
+
+			diags.Append(d...)
+		}
+	}
+
+	return diags
+}
+
+// validateBlockFieldName verifies that the name used for a block complies with the regular
+// expression defined in validFieldNameRegex.
+func validateBlockFieldName(path path.Path, name string, b fwschema.Block) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	if !validFieldNameRegex.MatchString(name) {
+		diags.AddAttributeError(
+			path,
+			"Invalid Schema Field Name",
+			fmt.Sprintf("Field name %q is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.", name),
+		)
+	}
+
+	nestedObject := b.GetNestedObject()
+
+	if nestedObject == nil {
+		return diags
+	}
+
+	blocks := nestedObject.GetBlocks()
+
+	for k, v := range blocks {
+		d := validateBlockFieldName(path.AtName(k), k, v)
+
+		diags.Append(d...)
+	}
+
+	attributes := nestedObject.GetAttributes()
+
+	for k, v := range attributes {
+		d := validateAttributeFieldName(path.AtName(k), k, v)
+
+		diags.Append(d...)
+	}
+
+	return diags
 }
 
 // schemaAttributes is a resource to fwschema type conversion function.


### PR DESCRIPTION
Closes: #136

Once all references to `tfsdk.Schema` have been removed we can ammend `fwschema/schema.go`:

```go
type Schema interface {
    /* ... */

    Validate() diag.Diagnostics
}
```