### PR TITLE
Skip blocks while marking computed nils unknown

### DIFF
--- a/internal/fwserver/server_planresourcechange_test.go
+++ b/internal/fwserver/server_planresourcechange_test.go
@@ -115,6 +115,41 @@ func TestMarkComputedNilsAsUnknown(t *testing.T) {
 				Computed: true,
 			},
 		},
+		Blocks: map[string]tfsdk.Block{
+			// nil blocks should remain nil
+			"block-nil-optional-computed": {
+				Attributes: map[string]tfsdk.Attribute{
+					"string-nil": {
+						Type:     types.StringType,
+						Optional: true,
+						Computed: true,
+					},
+					"string-set": {
+						Type:     types.StringType,
+						Optional: true,
+						Computed: true,
+					},
+				},
+				NestingMode: tfsdk.BlockNestingModeSet,
+			},
+			"block-value-optional-computed": {
+				Attributes: map[string]tfsdk.Attribute{
+					// nested computed attributes should be unknown
+					"string-nil": {
+						Type:     types.StringType,
+						Optional: true,
+						Computed: true,
+					},
+					// nested non-nil computed attributes should be left alone
+					"string-set": {
+						Type:     types.StringType,
+						Optional: true,
+						Computed: true,
+					},
+				},
+				NestingMode: tfsdk.BlockNestingModeSet,
+			},
+		},
 	}
 	input := tftypes.NewValue(s.Type().TerraformType(context.Background()), map[string]tftypes.Value{
 		"string-value":                   tftypes.NewValue(tftypes.String, "hello, world"),
@@ -152,6 +187,32 @@ func TestMarkComputedNilsAsUnknown(t *testing.T) {
 			"string-nil": tftypes.NewValue(tftypes.String, nil),
 			"string-set": tftypes.NewValue(tftypes.String, "bar"),
 		}),
+		"block-nil-optional-computed": tftypes.NewValue(tftypes.Set{
+			ElementType: tftypes.Object{
+				AttributeTypes: map[string]tftypes.Type{
+					"string-nil": tftypes.String,
+					"string-set": tftypes.String,
+				},
+			},
+		}, nil),
+		"block-value-optional-computed": tftypes.NewValue(tftypes.Set{
+			ElementType: tftypes.Object{
+				AttributeTypes: map[string]tftypes.Type{
+					"string-nil": tftypes.String,
+					"string-set": tftypes.String,
+				},
+			},
+		}, []tftypes.Value{
+			tftypes.NewValue(tftypes.Object{
+				AttributeTypes: map[string]tftypes.Type{
+					"string-nil": tftypes.String,
+					"string-set": tftypes.String,
+				},
+			}, map[string]tftypes.Value{
+				"string-nil": tftypes.NewValue(tftypes.String, nil),
+				"string-set": tftypes.NewValue(tftypes.String, "bar"),
+			}),
+		}),
 	})
 	expected := tftypes.NewValue(s.Type().TerraformType(context.Background()), map[string]tftypes.Value{
 		"string-value":                   tftypes.NewValue(tftypes.String, "hello, world"),
@@ -188,6 +249,32 @@ func TestMarkComputedNilsAsUnknown(t *testing.T) {
 		}, map[string]tftypes.Value{
 			"string-nil": tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
 			"string-set": tftypes.NewValue(tftypes.String, "bar"),
+		}),
+		"block-nil-optional-computed": tftypes.NewValue(tftypes.Set{
+			ElementType: tftypes.Object{
+				AttributeTypes: map[string]tftypes.Type{
+					"string-nil": tftypes.String,
+					"string-set": tftypes.String,
+				},
+			},
+		}, nil),
+		"block-value-optional-computed": tftypes.NewValue(tftypes.Set{
+			ElementType: tftypes.Object{
+				AttributeTypes: map[string]tftypes.Type{
+					"string-nil": tftypes.String,
+					"string-set": tftypes.String,
+				},
+			},
+		}, []tftypes.Value{
+			tftypes.NewValue(tftypes.Object{
+				AttributeTypes: map[string]tftypes.Type{
+					"string-nil": tftypes.String,
+					"string-set": tftypes.String,
+				},
+			}, map[string]tftypes.Value{
+				"string-nil": tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+				"string-set": tftypes.NewValue(tftypes.String, "bar"),
+			}),
 		}),
 	})
 


### PR DESCRIPTION
Relates #483 
Relates https://github.com/hashicorp/terraform-provider-corner/pull/89
Relates https://github.com/hashicorp/terraform-provider-aws/pull/27857 (acceptance tests pass after this fix)

`MarkComputedNilsAsUnknown` now passes block values through unmodified, rather than throwing an error. 

I extended the single large test object to add block attributes, but I can also split into individual test cases if that'd be helpful. Original issue is reproduced with the updated test case and the fix commented out:

```console
$ go test -count=1 -run "^TestMarkComputedNilsAsUnknown$" ./internal/fwserver/...
--- FAIL: TestMarkComputedNilsAsUnknown (0.00s)
    server_planresourcechange_test.go:283: Unexpected error: AttributeName("block-nil-optional-computed"): couldn't find attribute in resource schema: path leads to block, not an attribute
FAIL
FAIL    github.com/hashicorp/terraform-plugin-framework/internal/fwserver       0.353s
FAIL
```

---
**Edit:** #552 included the change to ignore block type errors, so this PR has been updated to just extend test coverage.