### PR TITLE
internal: Replace tfsdk.Schema, tfsdk.Attribute, and tfsdk.Block usage in unit testing

### DIFF
--- a/internal/fromproto5/applyresourcechange_test.go
+++ b/internal/fromproto5/applyresourcechange_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
 	"github.com/hashicorp/terraform-plugin-framework/internal/privatestate"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 func TestApplyResourceChangeRequest(t *testing.T) {
@@ -37,11 +37,10 @@ func TestApplyResourceChangeRequest(t *testing.T) {
 		t.Fatalf("unexpected error calling tfprotov5.NewDynamicValue(): %s", err)
 	}
 
-	testFwSchema := &tfsdk.Schema{
-		Attributes: map[string]tfsdk.Attribute{
-			"test_attribute": {
+	testFwSchema := schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"test_attribute": schema.StringAttribute{
 				Required: true,
-				Type:     types.StringType,
 			},
 		},
 	}

--- a/internal/fromproto5/config_test.go
+++ b/internal/fromproto5/config_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fromproto5"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
@@ -33,18 +34,18 @@ func TestConfig(t *testing.T) {
 		t.Fatalf("unexpected error calling tfprotov5.NewDynamicValue(): %s", err)
 	}
 
-	testFwSchema := &tfsdk.Schema{
-		Attributes: map[string]tfsdk.Attribute{
-			"test_attribute": {
+	testFwSchema := testschema.Schema{
+		Attributes: map[string]fwschema.Attribute{
+			"test_attribute": testschema.Attribute{
 				Required: true,
 				Type:     types.StringType,
 			},
 		},
 	}
 
-	testFwSchemaInvalid := &tfsdk.Schema{
-		Attributes: map[string]tfsdk.Attribute{
-			"test_attribute": {
+	testFwSchemaInvalid := testschema.Schema{
+		Attributes: map[string]fwschema.Attribute{
+			"test_attribute": testschema.Attribute{
 				Required: true,
 				Type:     types.BoolType,
 			},

--- a/internal/fromproto5/configureprovider_test.go
+++ b/internal/fromproto5/configureprovider_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/internal/fromproto5"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
@@ -34,11 +34,10 @@ func TestConfigureProviderRequest(t *testing.T) {
 		t.Fatalf("unexpected error calling tfprotov5.NewDynamicValue(): %s", err)
 	}
 
-	testFwSchema := &tfsdk.Schema{
-		Attributes: map[string]tfsdk.Attribute{
-			"test_attribute": {
+	testFwSchema := schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"test_attribute": schema.StringAttribute{
 				Required: true,
-				Type:     types.StringType,
 			},
 		},
 	}

--- a/internal/fromproto5/importresourcestate_test.go
+++ b/internal/fromproto5/importresourcestate_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
@@ -19,11 +19,10 @@ import (
 func TestImportResourceStateRequest(t *testing.T) {
 	t.Parallel()
 
-	testFwSchema := &tfsdk.Schema{
-		Attributes: map[string]tfsdk.Attribute{
-			"test_attribute": {
+	testFwSchema := schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"test_attribute": schema.StringAttribute{
 				Required: true,
-				Type:     types.StringType,
 			},
 		},
 	}

--- a/internal/fromproto5/plan_test.go
+++ b/internal/fromproto5/plan_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fromproto5"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
@@ -33,18 +34,18 @@ func TestPlan(t *testing.T) {
 		t.Fatalf("unexpected error calling tfprotov5.NewDynamicValue(): %s", err)
 	}
 
-	testFwSchema := &tfsdk.Schema{
-		Attributes: map[string]tfsdk.Attribute{
-			"test_attribute": {
+	testFwSchema := testschema.Schema{
+		Attributes: map[string]fwschema.Attribute{
+			"test_attribute": testschema.Attribute{
 				Required: true,
 				Type:     types.StringType,
 			},
 		},
 	}
 
-	testFwSchemaInvalid := &tfsdk.Schema{
-		Attributes: map[string]tfsdk.Attribute{
-			"test_attribute": {
+	testFwSchemaInvalid := testschema.Schema{
+		Attributes: map[string]fwschema.Attribute{
+			"test_attribute": testschema.Attribute{
 				Required: true,
 				Type:     types.BoolType,
 			},

--- a/internal/fromproto5/planresourcechange_test.go
+++ b/internal/fromproto5/planresourcechange_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
 	"github.com/hashicorp/terraform-plugin-framework/internal/privatestate"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 func TestPlanResourceChangeRequest(t *testing.T) {
@@ -37,11 +37,10 @@ func TestPlanResourceChangeRequest(t *testing.T) {
 		t.Fatalf("unexpected error calling tfprotov5.NewDynamicValue(): %s", err)
 	}
 
-	testFwSchema := &tfsdk.Schema{
-		Attributes: map[string]tfsdk.Attribute{
-			"test_attribute": {
+	testFwSchema := schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"test_attribute": schema.StringAttribute{
 				Required: true,
-				Type:     types.StringType,
 			},
 		},
 	}

--- a/internal/fromproto5/prepareproviderconfig_test.go
+++ b/internal/fromproto5/prepareproviderconfig_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/internal/fromproto5"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
+	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
@@ -34,11 +34,10 @@ func TestValidateProviderConfigRequest(t *testing.T) {
 		t.Fatalf("unexpected error calling tfprotov5.NewDynamicValue(): %s", err)
 	}
 
-	testFwSchema := &tfsdk.Schema{
-		Attributes: map[string]tfsdk.Attribute{
-			"test_attribute": {
+	testFwSchema := schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"test_attribute": schema.StringAttribute{
 				Required: true,
-				Type:     types.StringType,
 			},
 		},
 	}

--- a/internal/fromproto5/providermeta_test.go
+++ b/internal/fromproto5/providermeta_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fromproto5"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
+	"github.com/hashicorp/terraform-plugin-framework/provider/metaschema"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
@@ -33,20 +33,18 @@ func TestProviderMeta(t *testing.T) {
 		t.Fatalf("unexpected error calling tfprotov5.NewDynamicValue(): %s", err)
 	}
 
-	testFwSchema := &tfsdk.Schema{
-		Attributes: map[string]tfsdk.Attribute{
-			"test_attribute": {
+	testFwSchema := metaschema.Schema{
+		Attributes: map[string]metaschema.Attribute{
+			"test_attribute": metaschema.StringAttribute{
 				Required: true,
-				Type:     types.StringType,
 			},
 		},
 	}
 
-	testFwSchemaInvalid := &tfsdk.Schema{
-		Attributes: map[string]tfsdk.Attribute{
-			"test_attribute": {
+	testFwSchemaInvalid := metaschema.Schema{
+		Attributes: map[string]metaschema.Attribute{
+			"test_attribute": metaschema.BoolAttribute{
 				Required: true,
-				Type:     types.BoolType,
 			},
 		},
 	}

--- a/internal/fromproto5/readresource_test.go
+++ b/internal/fromproto5/readresource_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
 	"github.com/hashicorp/terraform-plugin-framework/internal/privatestate"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 func TestReadResourceRequest(t *testing.T) {
@@ -37,11 +37,10 @@ func TestReadResourceRequest(t *testing.T) {
 		t.Fatalf("unexpected error calling tfprotov5.NewDynamicValue(): %s", err)
 	}
 
-	testFwSchema := &tfsdk.Schema{
-		Attributes: map[string]tfsdk.Attribute{
-			"test_attribute": {
+	testFwSchema := schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"test_attribute": schema.StringAttribute{
 				Required: true,
-				Type:     types.StringType,
 			},
 		},
 	}

--- a/internal/fromproto5/state_test.go
+++ b/internal/fromproto5/state_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fromproto5"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
@@ -33,18 +34,18 @@ func TestState(t *testing.T) {
 		t.Fatalf("unexpected error calling tfprotov5.NewDynamicValue(): %s", err)
 	}
 
-	testFwSchema := &tfsdk.Schema{
-		Attributes: map[string]tfsdk.Attribute{
-			"test_attribute": {
+	testFwSchema := testschema.Schema{
+		Attributes: map[string]fwschema.Attribute{
+			"test_attribute": testschema.Attribute{
 				Required: true,
 				Type:     types.StringType,
 			},
 		},
 	}
 
-	testFwSchemaInvalid := &tfsdk.Schema{
-		Attributes: map[string]tfsdk.Attribute{
-			"test_attribute": {
+	testFwSchemaInvalid := testschema.Schema{
+		Attributes: map[string]fwschema.Attribute{
+			"test_attribute": testschema.Attribute{
 				Required: true,
 				Type:     types.BoolType,
 			},

--- a/internal/fromproto5/upgraderesourcestate_test.go
+++ b/internal/fromproto5/upgraderesourcestate_test.go
@@ -10,19 +10,17 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
-	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
 )
 
 func TestUpgradeResourceStateRequest(t *testing.T) {
 	t.Parallel()
 
-	testFwSchema := &tfsdk.Schema{
-		Attributes: map[string]tfsdk.Attribute{
-			"test_attribute": {
+	testFwSchema := schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"test_attribute": schema.StringAttribute{
 				Required: true,
-				Type:     types.StringType,
 			},
 		},
 	}

--- a/internal/fromproto5/validateresourcetypeconfig_test.go
+++ b/internal/fromproto5/validateresourcetypeconfig_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
@@ -35,11 +35,10 @@ func TestValidateResourceTypeConfigRequest(t *testing.T) {
 		t.Fatalf("unexpected error calling tfprotov5.NewDynamicValue(): %s", err)
 	}
 
-	testFwSchema := &tfsdk.Schema{
-		Attributes: map[string]tfsdk.Attribute{
-			"test_attribute": {
+	testFwSchema := schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"test_attribute": schema.StringAttribute{
 				Required: true,
-				Type:     types.StringType,
 			},
 		},
 	}

--- a/internal/fromproto6/applyresourcechange_test.go
+++ b/internal/fromproto6/applyresourcechange_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
 	"github.com/hashicorp/terraform-plugin-framework/internal/privatestate"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 func TestApplyResourceChangeRequest(t *testing.T) {
@@ -37,11 +37,10 @@ func TestApplyResourceChangeRequest(t *testing.T) {
 		t.Fatalf("unexpected error calling tfprotov6.NewDynamicValue(): %s", err)
 	}
 
-	testFwSchema := &tfsdk.Schema{
-		Attributes: map[string]tfsdk.Attribute{
-			"test_attribute": {
+	testFwSchema := schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"test_attribute": schema.StringAttribute{
 				Required: true,
-				Type:     types.StringType,
 			},
 		},
 	}

--- a/internal/fromproto6/config_test.go
+++ b/internal/fromproto6/config_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fromproto6"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
@@ -33,18 +34,18 @@ func TestConfig(t *testing.T) {
 		t.Fatalf("unexpected error calling tfprotov6.NewDynamicValue(): %s", err)
 	}
 
-	testFwSchema := &tfsdk.Schema{
-		Attributes: map[string]tfsdk.Attribute{
-			"test_attribute": {
+	testFwSchema := testschema.Schema{
+		Attributes: map[string]fwschema.Attribute{
+			"test_attribute": testschema.Attribute{
 				Required: true,
 				Type:     types.StringType,
 			},
 		},
 	}
 
-	testFwSchemaInvalid := &tfsdk.Schema{
-		Attributes: map[string]tfsdk.Attribute{
-			"test_attribute": {
+	testFwSchemaInvalid := testschema.Schema{
+		Attributes: map[string]fwschema.Attribute{
+			"test_attribute": testschema.Attribute{
 				Required: true,
 				Type:     types.BoolType,
 			},

--- a/internal/fromproto6/configureprovider_test.go
+++ b/internal/fromproto6/configureprovider_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/internal/fromproto6"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
@@ -34,11 +34,10 @@ func TestConfigureProviderRequest(t *testing.T) {
 		t.Fatalf("unexpected error calling tfprotov6.NewDynamicValue(): %s", err)
 	}
 
-	testFwSchema := &tfsdk.Schema{
-		Attributes: map[string]tfsdk.Attribute{
-			"test_attribute": {
+	testFwSchema := schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"test_attribute": schema.StringAttribute{
 				Required: true,
-				Type:     types.StringType,
 			},
 		},
 	}

--- a/internal/fromproto6/importresourcestate_test.go
+++ b/internal/fromproto6/importresourcestate_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
@@ -19,11 +19,10 @@ import (
 func TestImportResourceStateRequest(t *testing.T) {
 	t.Parallel()
 
-	testFwSchema := &tfsdk.Schema{
-		Attributes: map[string]tfsdk.Attribute{
-			"test_attribute": {
+	testFwSchema := schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"test_attribute": schema.StringAttribute{
 				Required: true,
-				Type:     types.StringType,
 			},
 		},
 	}

--- a/internal/fromproto6/plan_test.go
+++ b/internal/fromproto6/plan_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fromproto6"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
@@ -33,18 +34,18 @@ func TestPlan(t *testing.T) {
 		t.Fatalf("unexpected error calling tfprotov6.NewDynamicValue(): %s", err)
 	}
 
-	testFwSchema := &tfsdk.Schema{
-		Attributes: map[string]tfsdk.Attribute{
-			"test_attribute": {
+	testFwSchema := testschema.Schema{
+		Attributes: map[string]fwschema.Attribute{
+			"test_attribute": testschema.Attribute{
 				Required: true,
 				Type:     types.StringType,
 			},
 		},
 	}
 
-	testFwSchemaInvalid := &tfsdk.Schema{
-		Attributes: map[string]tfsdk.Attribute{
-			"test_attribute": {
+	testFwSchemaInvalid := testschema.Schema{
+		Attributes: map[string]fwschema.Attribute{
+			"test_attribute": testschema.Attribute{
 				Required: true,
 				Type:     types.BoolType,
 			},

--- a/internal/fromproto6/planresourcechange_test.go
+++ b/internal/fromproto6/planresourcechange_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
 	"github.com/hashicorp/terraform-plugin-framework/internal/privatestate"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 func TestPlanResourceChangeRequest(t *testing.T) {
@@ -37,11 +37,10 @@ func TestPlanResourceChangeRequest(t *testing.T) {
 		t.Fatalf("unexpected error calling tfprotov6.NewDynamicValue(): %s", err)
 	}
 
-	testFwSchema := &tfsdk.Schema{
-		Attributes: map[string]tfsdk.Attribute{
-			"test_attribute": {
+	testFwSchema := schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"test_attribute": schema.StringAttribute{
 				Required: true,
-				Type:     types.StringType,
 			},
 		},
 	}

--- a/internal/fromproto6/providermeta_test.go
+++ b/internal/fromproto6/providermeta_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fromproto6"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
+	"github.com/hashicorp/terraform-plugin-framework/provider/metaschema"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
@@ -33,20 +33,18 @@ func TestProviderMeta(t *testing.T) {
 		t.Fatalf("unexpected error calling tfprotov6.NewDynamicValue(): %s", err)
 	}
 
-	testFwSchema := &tfsdk.Schema{
-		Attributes: map[string]tfsdk.Attribute{
-			"test_attribute": {
+	testFwSchema := metaschema.Schema{
+		Attributes: map[string]metaschema.Attribute{
+			"test_attribute": metaschema.StringAttribute{
 				Required: true,
-				Type:     types.StringType,
 			},
 		},
 	}
 
-	testFwSchemaInvalid := &tfsdk.Schema{
-		Attributes: map[string]tfsdk.Attribute{
-			"test_attribute": {
+	testFwSchemaInvalid := metaschema.Schema{
+		Attributes: map[string]metaschema.Attribute{
+			"test_attribute": metaschema.BoolAttribute{
 				Required: true,
-				Type:     types.BoolType,
 			},
 		},
 	}

--- a/internal/fromproto6/readresource_test.go
+++ b/internal/fromproto6/readresource_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
 	"github.com/hashicorp/terraform-plugin-framework/internal/privatestate"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 func TestReadResourceRequest(t *testing.T) {
@@ -37,11 +37,10 @@ func TestReadResourceRequest(t *testing.T) {
 		t.Fatalf("unexpected error calling tfprotov6.NewDynamicValue(): %s", err)
 	}
 
-	testFwSchema := &tfsdk.Schema{
-		Attributes: map[string]tfsdk.Attribute{
-			"test_attribute": {
+	testFwSchema := schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"test_attribute": schema.StringAttribute{
 				Required: true,
-				Type:     types.StringType,
 			},
 		},
 	}

--- a/internal/fromproto6/state_test.go
+++ b/internal/fromproto6/state_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fromproto6"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
@@ -33,18 +34,18 @@ func TestState(t *testing.T) {
 		t.Fatalf("unexpected error calling tfprotov6.NewDynamicValue(): %s", err)
 	}
 
-	testFwSchema := &tfsdk.Schema{
-		Attributes: map[string]tfsdk.Attribute{
-			"test_attribute": {
+	testFwSchema := testschema.Schema{
+		Attributes: map[string]fwschema.Attribute{
+			"test_attribute": testschema.Attribute{
 				Required: true,
 				Type:     types.StringType,
 			},
 		},
 	}
 
-	testFwSchemaInvalid := &tfsdk.Schema{
-		Attributes: map[string]tfsdk.Attribute{
-			"test_attribute": {
+	testFwSchemaInvalid := testschema.Schema{
+		Attributes: map[string]fwschema.Attribute{
+			"test_attribute": testschema.Attribute{
 				Required: true,
 				Type:     types.BoolType,
 			},

--- a/internal/fromproto6/upgraderesourcestate_test.go
+++ b/internal/fromproto6/upgraderesourcestate_test.go
@@ -10,19 +10,17 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
-	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 )
 
 func TestUpgradeResourceStateRequest(t *testing.T) {
 	t.Parallel()
 
-	testFwSchema := &tfsdk.Schema{
-		Attributes: map[string]tfsdk.Attribute{
-			"test_attribute": {
+	testFwSchema := schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"test_attribute": schema.StringAttribute{
 				Required: true,
-				Type:     types.StringType,
 			},
 		},
 	}

--- a/internal/fromproto6/validateproviderconfig_test.go
+++ b/internal/fromproto6/validateproviderconfig_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/internal/fromproto6"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
+	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
@@ -34,11 +34,10 @@ func TestValidateProviderConfigRequest(t *testing.T) {
 		t.Fatalf("unexpected error calling tfprotov6.NewDynamicValue(): %s", err)
 	}
 
-	testFwSchema := &tfsdk.Schema{
-		Attributes: map[string]tfsdk.Attribute{
-			"test_attribute": {
+	testFwSchema := schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"test_attribute": schema.StringAttribute{
 				Required: true,
-				Type:     types.StringType,
 			},
 		},
 	}

--- a/internal/fromproto6/validateresourceconfig_test.go
+++ b/internal/fromproto6/validateresourceconfig_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
@@ -35,11 +35,10 @@ func TestValidateResourceConfigRequest(t *testing.T) {
 		t.Fatalf("unexpected error calling tfprotov6.NewDynamicValue(): %s", err)
 	}
 
-	testFwSchema := &tfsdk.Schema{
-		Attributes: map[string]tfsdk.Attribute{
-			"test_attribute": {
+	testFwSchema := schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"test_attribute": schema.StringAttribute{
 				Required: true,
-				Type:     types.StringType,
 			},
 		},
 	}

--- a/internal/fromtftypes/attribute_path_test.go
+++ b/internal/fromtftypes/attribute_path_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fromtftypes"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
 	testtypes "github.com/hashicorp/terraform-plugin-framework/internal/testing/types"
 	"github.com/hashicorp/terraform-plugin-framework/path"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
@@ -34,9 +34,9 @@ func TestAttributePath(t *testing.T) {
 		},
 		"AttributeName": {
 			tfType: tftypes.NewAttributePath().WithAttributeName("test"),
-			schema: tfsdk.Schema{
-				Attributes: map[string]tfsdk.Attribute{
-					"test": {
+			schema: testschema.Schema{
+				Attributes: map[string]fwschema.Attribute{
+					"test": testschema.Attribute{
 						Type: types.StringType,
 					},
 				},
@@ -45,9 +45,9 @@ func TestAttributePath(t *testing.T) {
 		},
 		"AttributeName-nonexistent-attribute": {
 			tfType: tftypes.NewAttributePath().WithAttributeName("test"),
-			schema: tfsdk.Schema{
-				Attributes: map[string]tfsdk.Attribute{
-					"not-test": {
+			schema: testschema.Schema{
+				Attributes: map[string]fwschema.Attribute{
+					"not-test": testschema.Attribute{
 						Type: testtypes.StringType{},
 					},
 				},
@@ -66,9 +66,9 @@ func TestAttributePath(t *testing.T) {
 		},
 		"AttributeName-ElementKeyInt": {
 			tfType: tftypes.NewAttributePath().WithAttributeName("test").WithElementKeyInt(1),
-			schema: tfsdk.Schema{
-				Attributes: map[string]tfsdk.Attribute{
-					"test": {
+			schema: testschema.Schema{
+				Attributes: map[string]fwschema.Attribute{
+					"test": testschema.Attribute{
 						Type: types.ListType{
 							ElemType: types.StringType,
 						},
@@ -79,9 +79,9 @@ func TestAttributePath(t *testing.T) {
 		},
 		"AttributeName-ElementKeyValue": {
 			tfType: tftypes.NewAttributePath().WithAttributeName("test").WithElementKeyValue(tftypes.NewValue(tftypes.String, "test-value")),
-			schema: tfsdk.Schema{
-				Attributes: map[string]tfsdk.Attribute{
-					"test": {
+			schema: testschema.Schema{
+				Attributes: map[string]fwschema.Attribute{
+					"test": testschema.Attribute{
 						Type: types.SetType{
 							ElemType: types.StringType,
 						},
@@ -92,9 +92,9 @@ func TestAttributePath(t *testing.T) {
 		},
 		"AttributeName-ElementKeyValue-value-conversion-error": {
 			tfType: tftypes.NewAttributePath().WithAttributeName("test").WithElementKeyValue(tftypes.NewValue(tftypes.String, "test-value")),
-			schema: tfsdk.Schema{
-				Attributes: map[string]tfsdk.Attribute{
-					"test": {
+			schema: testschema.Schema{
+				Attributes: map[string]fwschema.Attribute{
+					"test": testschema.Attribute{
 						Type: types.SetType{
 							ElemType: testtypes.InvalidType{},
 						},
@@ -115,9 +115,9 @@ func TestAttributePath(t *testing.T) {
 		},
 		"ElementKeyInt": {
 			tfType: tftypes.NewAttributePath().WithElementKeyInt(1),
-			schema: tfsdk.Schema{
-				Attributes: map[string]tfsdk.Attribute{
-					"test": {
+			schema: testschema.Schema{
+				Attributes: map[string]fwschema.Attribute{
+					"test": testschema.Attribute{
 						Type: testtypes.StringType{},
 					},
 				},
@@ -136,9 +136,9 @@ func TestAttributePath(t *testing.T) {
 		},
 		"ElementKeyString": {
 			tfType: tftypes.NewAttributePath().WithElementKeyString("test"),
-			schema: tfsdk.Schema{
-				Attributes: map[string]tfsdk.Attribute{
-					"test": {
+			schema: testschema.Schema{
+				Attributes: map[string]fwschema.Attribute{
+					"test": testschema.Attribute{
 						Type: testtypes.StringType{},
 					},
 				},
@@ -157,9 +157,9 @@ func TestAttributePath(t *testing.T) {
 		},
 		"ElementKeyValue": {
 			tfType: tftypes.NewAttributePath().WithElementKeyValue(tftypes.NewValue(tftypes.String, "test-value")),
-			schema: tfsdk.Schema{
-				Attributes: map[string]tfsdk.Attribute{
-					"test": {
+			schema: testschema.Schema{
+				Attributes: map[string]fwschema.Attribute{
+					"test": testschema.Attribute{
 						Type: testtypes.StringType{},
 					},
 				},

--- a/internal/fwschemadata/data_get_at_path_test.go
+++ b/internal/fwschemadata/data_get_at_path_test.go
@@ -12,11 +12,12 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschemadata"
 	intreflect "github.com/hashicorp/terraform-plugin-framework/internal/reflect"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
 	testtypes "github.com/hashicorp/terraform-plugin-framework/internal/testing/types"
 	"github.com/hashicorp/terraform-plugin-framework/path"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -32,9 +33,9 @@ func TestDataGetAtPath(t *testing.T) {
 	}{
 		"invalid-target": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"string": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"string": testschema.Attribute{
 							Optional: true,
 							Type:     testtypes.StringType{},
 						},
@@ -67,9 +68,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"invalid-type": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"bool": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"bool": testschema.Attribute{
 							Optional: true,
 							Type:     types.BoolType,
 						},
@@ -102,9 +103,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"AttrTypeWithValidateError": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"string": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"string": testschema.Attribute{
 							Type:     testtypes.StringTypeWithValidateError{},
 							Required: true,
 						},
@@ -133,9 +134,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"AttrTypeWithValidateWarning": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"string": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"string": testschema.Attribute{
 							Type:     testtypes.StringTypeWithValidateWarning{},
 							Required: true,
 						},
@@ -164,9 +165,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"BoolType-types.Bool-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"bool": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"bool": testschema.Attribute{
 							Optional: true,
 							Type:     types.BoolType,
 						},
@@ -189,9 +190,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"BoolType-types.Bool-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"bool": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"bool": testschema.Attribute{
 							Optional: true,
 							Type:     types.BoolType,
 						},
@@ -214,9 +215,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"BoolType-types.Bool-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"bool": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"bool": testschema.Attribute{
 							Optional: true,
 							Type:     types.BoolType,
 						},
@@ -239,9 +240,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"BoolType-*bool-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"bool": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"bool": testschema.Attribute{
 							Optional: true,
 							Type:     types.BoolType,
 						},
@@ -264,9 +265,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"BoolType-*bool-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"bool": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"bool": testschema.Attribute{
 							Optional: true,
 							Type:     types.BoolType,
 						},
@@ -298,9 +299,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"BoolType-*bool-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"bool": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"bool": testschema.Attribute{
 							Optional: true,
 							Type:     types.BoolType,
 						},
@@ -323,9 +324,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"BoolType-bool-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"bool": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"bool": testschema.Attribute{
 							Optional: true,
 							Type:     types.BoolType,
 						},
@@ -357,9 +358,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"BoolType-bool-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"bool": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"bool": testschema.Attribute{
 							Optional: true,
 							Type:     types.BoolType,
 						},
@@ -391,9 +392,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"BoolType-bool-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"bool": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"bool": testschema.Attribute{
 							Optional: true,
 							Type:     types.BoolType,
 						},
@@ -416,9 +417,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"Float64Type-types.Float64-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"float64": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"float64": testschema.Attribute{
 							Optional: true,
 							Type:     types.Float64Type,
 						},
@@ -441,9 +442,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"Float64Type-types.Float64-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"float64": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"float64": testschema.Attribute{
 							Optional: true,
 							Type:     types.Float64Type,
 						},
@@ -466,9 +467,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"Float64Type-types.Float64-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"float64": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"float64": testschema.Attribute{
 							Optional: true,
 							Type:     types.Float64Type,
 						},
@@ -491,9 +492,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"Float64Type-*float64-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"float64": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"float64": testschema.Attribute{
 							Optional: true,
 							Type:     types.Float64Type,
 						},
@@ -516,9 +517,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"Float64Type-*float64-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"float64": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"float64": testschema.Attribute{
 							Optional: true,
 							Type:     types.Float64Type,
 						},
@@ -550,9 +551,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"Float64Type-*float64-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"float64": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"float64": testschema.Attribute{
 							Optional: true,
 							Type:     types.Float64Type,
 						},
@@ -575,9 +576,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"Float64Type-float64-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"float64": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"float64": testschema.Attribute{
 							Optional: true,
 							Type:     types.Float64Type,
 						},
@@ -609,9 +610,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"Float64Type-float64-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"float64": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"float64": testschema.Attribute{
 							Optional: true,
 							Type:     types.Float64Type,
 						},
@@ -643,9 +644,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"Float64Type-float64-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"float64": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"float64": testschema.Attribute{
 							Optional: true,
 							Type:     types.Float64Type,
 						},
@@ -668,9 +669,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"Int64Type-types.Int64-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"int64": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"int64": testschema.Attribute{
 							Optional: true,
 							Type:     types.Int64Type,
 						},
@@ -693,9 +694,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"Int64Type-types.Int64-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"int64": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"int64": testschema.Attribute{
 							Optional: true,
 							Type:     types.Int64Type,
 						},
@@ -718,9 +719,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"Int64Type-types.Int64-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"int64": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"int64": testschema.Attribute{
 							Optional: true,
 							Type:     types.Int64Type,
 						},
@@ -743,9 +744,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"Int64Type-*int64-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"int64": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"int64": testschema.Attribute{
 							Optional: true,
 							Type:     types.Int64Type,
 						},
@@ -768,9 +769,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"Int64Type-*int64-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"int64": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"int64": testschema.Attribute{
 							Optional: true,
 							Type:     types.Int64Type,
 						},
@@ -802,9 +803,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"Int64Type-*int64-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"int64": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"int64": testschema.Attribute{
 							Optional: true,
 							Type:     types.Int64Type,
 						},
@@ -827,9 +828,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"Int64Type-int64-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"int64": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"int64": testschema.Attribute{
 							Optional: true,
 							Type:     types.Int64Type,
 						},
@@ -861,9 +862,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"Int64Type-int64-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"int64": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"int64": testschema.Attribute{
 							Optional: true,
 							Type:     types.Int64Type,
 						},
@@ -895,9 +896,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"Int64Type-int64-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"int64": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"int64": testschema.Attribute{
 							Optional: true,
 							Type:     types.Int64Type,
 						},
@@ -920,16 +921,18 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"ListBlock-types.List-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"list": {
-							Attributes: map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Blocks: map[string]fwschema.Block{
+						"list": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeList,
+							NestingMode: fwschema.BlockNestingModeList,
 						},
 					},
 				},
@@ -971,16 +974,18 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"ListBlock-types.List-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"list": {
-							Attributes: map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Blocks: map[string]fwschema.Block{
+						"list": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeList,
+							NestingMode: fwschema.BlockNestingModeList,
 						},
 					},
 				},
@@ -1022,16 +1027,18 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"ListBlock-types.List-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"list": {
-							Attributes: map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Blocks: map[string]fwschema.Block{
+						"list": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeList,
+							NestingMode: fwschema.BlockNestingModeList,
 						},
 					},
 				},
@@ -1112,16 +1119,18 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"ListBlock-[]types.Object-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"list": {
-							Attributes: map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Blocks: map[string]fwschema.Block{
+						"list": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeList,
+							NestingMode: fwschema.BlockNestingModeList,
 						},
 					},
 				},
@@ -1157,16 +1166,18 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"ListBlock-[]types.Object-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"list": {
-							Attributes: map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Blocks: map[string]fwschema.Block{
+						"list": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeList,
+							NestingMode: fwschema.BlockNestingModeList,
 						},
 					},
 				},
@@ -1211,16 +1222,18 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"ListBlock-[]types.Object-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"list": {
-							Attributes: map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Blocks: map[string]fwschema.Block{
+						"list": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeList,
+							NestingMode: fwschema.BlockNestingModeList,
 						},
 					},
 				},
@@ -1294,16 +1307,18 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"ListBlock-[]struct-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"list": {
-							Attributes: map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Blocks: map[string]fwschema.Block{
+						"list": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeList,
+							NestingMode: fwschema.BlockNestingModeList,
 						},
 					},
 				},
@@ -1343,16 +1358,18 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"ListBlock-[]struct-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"list": {
-							Attributes: map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Blocks: map[string]fwschema.Block{
+						"list": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeList,
+							NestingMode: fwschema.BlockNestingModeList,
 						},
 					},
 				},
@@ -1401,16 +1418,18 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"ListBlock-[]struct-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"list": {
-							Attributes: map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Blocks: map[string]fwschema.Block{
+						"list": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeList,
+							NestingMode: fwschema.BlockNestingModeList,
 						},
 					},
 				},
@@ -1474,16 +1493,19 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"ListNestedAttributes-types.List-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"list": {
-							Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"list": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeList,
+							Optional:    true,
 						},
 					},
 				},
@@ -1525,16 +1547,19 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"ListNestedAttributes-types.List-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"list": {
-							Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"list": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeList,
+							Optional:    true,
 						},
 					},
 				},
@@ -1576,16 +1601,19 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"ListNestedAttributes-types.List-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"list": {
-							Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"list": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeList,
+							Optional:    true,
 						},
 					},
 				},
@@ -1666,16 +1694,19 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"ListNestedAttributes-[]types.Object-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"list": {
-							Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"list": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeList,
+							Optional:    true,
 						},
 					},
 				},
@@ -1711,16 +1742,19 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"ListNestedAttributes-[]types.Object-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"list": {
-							Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"list": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeList,
+							Optional:    true,
 						},
 					},
 				},
@@ -1765,16 +1799,19 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"ListNestedAttributes-[]types.Object-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"list": {
-							Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"list": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeList,
+							Optional:    true,
 						},
 					},
 				},
@@ -1848,16 +1885,19 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"ListNestedAttributes-[]struct-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"list": {
-							Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"list": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeList,
+							Optional:    true,
 						},
 					},
 				},
@@ -1897,16 +1937,19 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"ListNestedAttributes-[]struct-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"list": {
-							Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"list": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeList,
+							Optional:    true,
 						},
 					},
 				},
@@ -1955,16 +1998,19 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"ListNestedAttributes-[]struct-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"list": {
-							Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"list": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeList,
+							Optional:    true,
 						},
 					},
 				},
@@ -2028,9 +2074,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"ListType-types.List-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"list": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"list": testschema.Attribute{
 							Optional: true,
 							Type: types.ListType{
 								ElemType: types.StringType,
@@ -2062,9 +2108,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"ListType-types.List-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"list": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"list": testschema.Attribute{
 							Optional: true,
 							Type: types.ListType{
 								ElemType: types.StringType,
@@ -2096,9 +2142,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"ListType-types.List-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"list": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"list": testschema.Attribute{
 							Optional: true,
 							Type: types.ListType{
 								ElemType: types.StringType,
@@ -2139,9 +2185,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"ListType-[]types.String-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"list": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"list": testschema.Attribute{
 							Optional: true,
 							Type: types.ListType{
 								ElemType: types.StringType,
@@ -2173,9 +2219,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"ListType-[]types.String-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"list": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"list": testschema.Attribute{
 							Optional: true,
 							Type: types.ListType{
 								ElemType: types.StringType,
@@ -2216,9 +2262,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"ListType-[]types.String-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"list": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"list": testschema.Attribute{
 							Optional: true,
 							Type: types.ListType{
 								ElemType: types.StringType,
@@ -2256,9 +2302,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"ListType-[]string-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"list": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"list": testschema.Attribute{
 							Optional: true,
 							Type: types.ListType{
 								ElemType: types.StringType,
@@ -2290,9 +2336,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"ListType-[]string-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"list": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"list": testschema.Attribute{
 							Optional: true,
 							Type: types.ListType{
 								ElemType: types.StringType,
@@ -2333,9 +2379,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"ListType-[]string-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"list": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"list": testschema.Attribute{
 							Optional: true,
 							Type: types.ListType{
 								ElemType: types.StringType,
@@ -2373,16 +2419,19 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"MapNestedAttributes-types.Map-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"map": {
-							Attributes: tfsdk.MapNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"map": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeMap,
+							Optional:    true,
 						},
 					},
 				},
@@ -2424,16 +2473,19 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"MapNestedAttributes-types.Map-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"map": {
-							Attributes: tfsdk.MapNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"map": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeMap,
+							Optional:    true,
 						},
 					},
 				},
@@ -2475,16 +2527,19 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"MapNestedAttributes-types.Map-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"map": {
-							Attributes: tfsdk.MapNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"map": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeMap,
+							Optional:    true,
 						},
 					},
 				},
@@ -2565,16 +2620,19 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"MapNestedAttributes-map[string]types.Object-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"map": {
-							Attributes: tfsdk.MapNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"map": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeMap,
+							Optional:    true,
 						},
 					},
 				},
@@ -2610,16 +2668,19 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"MapNestedAttributes-map[string]types.Object-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"map": {
-							Attributes: tfsdk.MapNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"map": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeMap,
+							Optional:    true,
 						},
 					},
 				},
@@ -2664,16 +2725,19 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"MapNestedAttributes-map[string]types.Object-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"map": {
-							Attributes: tfsdk.MapNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"map": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeMap,
+							Optional:    true,
 						},
 					},
 				},
@@ -2747,16 +2811,19 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"MapNestedAttributes-map[string]struct-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"map": {
-							Attributes: tfsdk.MapNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"map": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeMap,
+							Optional:    true,
 						},
 					},
 				},
@@ -2796,16 +2863,19 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"MapNestedAttributes-map[string]struct-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"map": {
-							Attributes: tfsdk.MapNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"map": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeMap,
+							Optional:    true,
 						},
 					},
 				},
@@ -2854,16 +2924,19 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"MapNestedAttributes-map[string]struct-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"map": {
-							Attributes: tfsdk.MapNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"map": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeMap,
+							Optional:    true,
 						},
 					},
 				},
@@ -2927,9 +3000,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"MapType-types.Map-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"map": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"map": testschema.Attribute{
 							Optional: true,
 							Type: types.MapType{
 								ElemType: types.StringType,
@@ -2961,9 +3034,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"MapType-types.Map-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"map": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"map": testschema.Attribute{
 							Optional: true,
 							Type: types.MapType{
 								ElemType: types.StringType,
@@ -2995,9 +3068,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"MapType-types.Map-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"map": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"map": testschema.Attribute{
 							Optional: true,
 							Type: types.MapType{
 								ElemType: types.StringType,
@@ -3038,9 +3111,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"MapType-map[string]types.String-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"map": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"map": testschema.Attribute{
 							Optional: true,
 							Type: types.MapType{
 								ElemType: types.StringType,
@@ -3072,9 +3145,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"MapType-map[string]types.String-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"map": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"map": testschema.Attribute{
 							Optional: true,
 							Type: types.MapType{
 								ElemType: types.StringType,
@@ -3115,9 +3188,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"MapType-map[string]types.String-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"map": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"map": testschema.Attribute{
 							Optional: true,
 							Type: types.MapType{
 								ElemType: types.StringType,
@@ -3155,9 +3228,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"MapType-map[string]string-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"map": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"map": testschema.Attribute{
 							Optional: true,
 							Type: types.MapType{
 								ElemType: types.StringType,
@@ -3189,9 +3262,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"MapType-map[string]string-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"map": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"map": testschema.Attribute{
 							Optional: true,
 							Type: types.MapType{
 								ElemType: types.StringType,
@@ -3232,9 +3305,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"MapType-map[string]string-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"map": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"map": testschema.Attribute{
 							Optional: true,
 							Type: types.MapType{
 								ElemType: types.StringType,
@@ -3272,9 +3345,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"ObjectType-types.Object-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"object": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"object": testschema.Attribute{
 							Optional: true,
 							Type: types.ObjectType{
 								AttrTypes: map[string]attr.Type{
@@ -3316,9 +3389,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"ObjectType-types.Object-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"object": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"object": testschema.Attribute{
 							Optional: true,
 							Type: types.ObjectType{
 								AttrTypes: map[string]attr.Type{
@@ -3360,9 +3433,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"ObjectType-types.Object-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"object": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"object": testschema.Attribute{
 							Optional: true,
 							Type: types.ObjectType{
 								AttrTypes: map[string]attr.Type{
@@ -3409,9 +3482,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"ObjectType-*struct-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"object": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"object": testschema.Attribute{
 							Optional: true,
 							Type: types.ObjectType{
 								AttrTypes: map[string]attr.Type{
@@ -3453,9 +3526,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"ObjectType-*struct-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"object": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"object": testschema.Attribute{
 							Optional: true,
 							Type: types.ObjectType{
 								AttrTypes: map[string]attr.Type{
@@ -3506,9 +3579,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"ObjectType-*struct-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"object": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"object": testschema.Attribute{
 							Optional: true,
 							Type: types.ObjectType{
 								AttrTypes: map[string]attr.Type{
@@ -3554,9 +3627,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"ObjectType-struct-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"object": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"object": testschema.Attribute{
 							Optional: true,
 							Type: types.ObjectType{
 								AttrTypes: map[string]attr.Type{
@@ -3609,9 +3682,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"ObjectType-struct-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"object": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"object": testschema.Attribute{
 							Optional: true,
 							Type: types.ObjectType{
 								AttrTypes: map[string]attr.Type{
@@ -3664,9 +3737,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"ObjectType-struct-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"object": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"object": testschema.Attribute{
 							Optional: true,
 							Type: types.ObjectType{
 								AttrTypes: map[string]attr.Type{
@@ -3712,16 +3785,18 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"SetBlock-types.Set-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"set": {
-							Attributes: map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Blocks: map[string]fwschema.Block{
+						"set": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeSet,
+							NestingMode: fwschema.BlockNestingModeSet,
 						},
 					},
 				},
@@ -3763,16 +3838,18 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"SetBlock-types.Set-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"set": {
-							Attributes: map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Blocks: map[string]fwschema.Block{
+						"set": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeSet,
+							NestingMode: fwschema.BlockNestingModeSet,
 						},
 					},
 				},
@@ -3814,16 +3891,18 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"SetBlock-types.Set-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"set": {
-							Attributes: map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Blocks: map[string]fwschema.Block{
+						"set": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeSet,
+							NestingMode: fwschema.BlockNestingModeSet,
 						},
 					},
 				},
@@ -3904,16 +3983,18 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"SetBlock-[]types.Object-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"set": {
-							Attributes: map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Blocks: map[string]fwschema.Block{
+						"set": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeSet,
+							NestingMode: fwschema.BlockNestingModeSet,
 						},
 					},
 				},
@@ -3949,16 +4030,18 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"SetBlock-[]types.Object-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"set": {
-							Attributes: map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Blocks: map[string]fwschema.Block{
+						"set": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeSet,
+							NestingMode: fwschema.BlockNestingModeSet,
 						},
 					},
 				},
@@ -4003,16 +4086,18 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"SetBlock-[]types.Object-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"set": {
-							Attributes: map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Blocks: map[string]fwschema.Block{
+						"set": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeSet,
+							NestingMode: fwschema.BlockNestingModeSet,
 						},
 					},
 				},
@@ -4086,16 +4171,18 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"SetBlock-[]struct-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"set": {
-							Attributes: map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Blocks: map[string]fwschema.Block{
+						"set": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeSet,
+							NestingMode: fwschema.BlockNestingModeSet,
 						},
 					},
 				},
@@ -4135,16 +4222,18 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"SetBlock-[]struct-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"set": {
-							Attributes: map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Blocks: map[string]fwschema.Block{
+						"set": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeSet,
+							NestingMode: fwschema.BlockNestingModeSet,
 						},
 					},
 				},
@@ -4193,16 +4282,18 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"SetBlock-[]struct-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"set": {
-							Attributes: map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Blocks: map[string]fwschema.Block{
+						"set": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeSet,
+							NestingMode: fwschema.BlockNestingModeSet,
 						},
 					},
 				},
@@ -4266,16 +4357,19 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"SetNestedAttributes-types.Set-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"set": {
-							Attributes: tfsdk.SetNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"set": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeSet,
+							Optional:    true,
 						},
 					},
 				},
@@ -4317,16 +4411,19 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"SetNestedAttributes-types.Set-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"set": {
-							Attributes: tfsdk.SetNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"set": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeSet,
+							Optional:    true,
 						},
 					},
 				},
@@ -4368,16 +4465,19 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"SetNestedAttributes-types.Set-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"set": {
-							Attributes: tfsdk.SetNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"set": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeSet,
+							Optional:    true,
 						},
 					},
 				},
@@ -4458,16 +4558,19 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"SetNestedAttributes-[]types.Object-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"set": {
-							Attributes: tfsdk.SetNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"set": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeSet,
+							Optional:    true,
 						},
 					},
 				},
@@ -4503,16 +4606,19 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"SetNestedAttributes-[]types.Object-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"set": {
-							Attributes: tfsdk.SetNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"set": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeSet,
+							Optional:    true,
 						},
 					},
 				},
@@ -4557,16 +4663,19 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"SetNestedAttributes-[]types.Object-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"set": {
-							Attributes: tfsdk.SetNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"set": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeSet,
+							Optional:    true,
 						},
 					},
 				},
@@ -4640,16 +4749,19 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"SetNestedAttributes-[]struct-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"set": {
-							Attributes: tfsdk.SetNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"set": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeSet,
+							Optional:    true,
 						},
 					},
 				},
@@ -4689,16 +4801,19 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"SetNestedAttributes-[]struct-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"set": {
-							Attributes: tfsdk.SetNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"set": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeSet,
+							Optional:    true,
 						},
 					},
 				},
@@ -4747,16 +4862,19 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"SetNestedAttributes-[]struct-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"set": {
-							Attributes: tfsdk.SetNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"set": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeSet,
+							Optional:    true,
 						},
 					},
 				},
@@ -4820,9 +4938,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"SetType-types.Set-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"set": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"set": testschema.Attribute{
 							Optional: true,
 							Type: types.SetType{
 								ElemType: types.StringType,
@@ -4854,9 +4972,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"SetType-types.Set-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"set": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"set": testschema.Attribute{
 							Optional: true,
 							Type: types.SetType{
 								ElemType: types.StringType,
@@ -4888,9 +5006,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"SetType-types.Set-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"set": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"set": testschema.Attribute{
 							Optional: true,
 							Type: types.SetType{
 								ElemType: types.StringType,
@@ -4931,9 +5049,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"SetType-[]types.String-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"set": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"set": testschema.Attribute{
 							Optional: true,
 							Type: types.SetType{
 								ElemType: types.StringType,
@@ -4965,9 +5083,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"SetType-[]types.String-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"set": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"set": testschema.Attribute{
 							Optional: true,
 							Type: types.SetType{
 								ElemType: types.StringType,
@@ -5008,9 +5126,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"SetType-[]types.String-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"set": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"set": testschema.Attribute{
 							Optional: true,
 							Type: types.SetType{
 								ElemType: types.StringType,
@@ -5048,9 +5166,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"SetType-[]string-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"set": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"set": testschema.Attribute{
 							Optional: true,
 							Type: types.SetType{
 								ElemType: types.StringType,
@@ -5082,9 +5200,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"SetType-[]string-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"set": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"set": testschema.Attribute{
 							Optional: true,
 							Type: types.SetType{
 								ElemType: types.StringType,
@@ -5125,9 +5243,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"SetType-[]string-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"set": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"set": testschema.Attribute{
 							Optional: true,
 							Type: types.SetType{
 								ElemType: types.StringType,
@@ -5165,16 +5283,18 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"SingleBlock-types.Object-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"object": {
-							Attributes: map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Blocks: map[string]fwschema.Block{
+						"object": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeSingle,
+							NestingMode: fwschema.BlockNestingModeSingle,
 						},
 					},
 				},
@@ -5210,16 +5330,18 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"SingleBlock-types.Object-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"object": {
-							Attributes: map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Blocks: map[string]fwschema.Block{
+						"object": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeSingle,
+							NestingMode: fwschema.BlockNestingModeSingle,
 						},
 					},
 				},
@@ -5255,16 +5377,18 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"SingleBlock-types.Object-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"object": {
-							Attributes: map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Blocks: map[string]fwschema.Block{
+						"object": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeSingle,
+							NestingMode: fwschema.BlockNestingModeSingle,
 						},
 					},
 				},
@@ -5305,16 +5429,18 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"SingleBlock-*struct-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"object": {
-							Attributes: map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Blocks: map[string]fwschema.Block{
+						"object": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeSingle,
+							NestingMode: fwschema.BlockNestingModeSingle,
 						},
 					},
 				},
@@ -5350,16 +5476,18 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"SingleBlock-*struct-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"object": {
-							Attributes: map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Blocks: map[string]fwschema.Block{
+						"object": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeSingle,
+							NestingMode: fwschema.BlockNestingModeSingle,
 						},
 					},
 				},
@@ -5404,16 +5532,18 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"SingleBlock-*struct-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"object": {
-							Attributes: map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Blocks: map[string]fwschema.Block{
+						"object": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeSingle,
+							NestingMode: fwschema.BlockNestingModeSingle,
 						},
 					},
 				},
@@ -5453,16 +5583,18 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"SingleBlock-struct-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"object": {
-							Attributes: map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Blocks: map[string]fwschema.Block{
+						"object": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeSingle,
+							NestingMode: fwschema.BlockNestingModeSingle,
 						},
 					},
 				},
@@ -5509,16 +5641,18 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"SingleBlock-struct-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"object": {
-							Attributes: map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Blocks: map[string]fwschema.Block{
+						"object": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeSingle,
+							NestingMode: fwschema.BlockNestingModeSingle,
 						},
 					},
 				},
@@ -5565,16 +5699,18 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"SingleBlock-struct-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"object": {
-							Attributes: map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Blocks: map[string]fwschema.Block{
+						"object": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeSingle,
+							NestingMode: fwschema.BlockNestingModeSingle,
 						},
 					},
 				},
@@ -5614,16 +5750,19 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"SingleNestedAttributes-types.Object-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"object": {
-							Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"object": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeSingle,
+							Optional:    true,
 						},
 					},
 				},
@@ -5659,16 +5798,19 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"SingleNestedAttributes-types.Object-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"object": {
-							Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"object": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeSingle,
+							Optional:    true,
 						},
 					},
 				},
@@ -5704,16 +5846,19 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"SingleNestedAttributes-types.Object-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"object": {
-							Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"object": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeSingle,
+							Optional:    true,
 						},
 					},
 				},
@@ -5754,16 +5899,19 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"SingleNestedAttributes-*struct-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"object": {
-							Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"object": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeSingle,
+							Optional:    true,
 						},
 					},
 				},
@@ -5799,16 +5947,19 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"SingleNestedAttributes-*struct-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"object": {
-							Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"object": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeSingle,
+							Optional:    true,
 						},
 					},
 				},
@@ -5853,16 +6004,19 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"SingleNestedAttributes-*struct-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"object": {
-							Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"object": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeSingle,
+							Optional:    true,
 						},
 					},
 				},
@@ -5902,16 +6056,19 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"SingleNestedAttributes-struct-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"object": {
-							Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"object": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeSingle,
+							Optional:    true,
 						},
 					},
 				},
@@ -5958,16 +6115,19 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"SingleNestedAttributes-struct-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"object": {
-							Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"object": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeSingle,
+							Optional:    true,
 						},
 					},
 				},
@@ -6014,16 +6174,19 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"SingleNestedAttributes-struct-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"object": {
-							Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"object": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeSingle,
+							Optional:    true,
 						},
 					},
 				},
@@ -6063,9 +6226,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"StringType-types.string-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"string": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"string": testschema.Attribute{
 							Optional: true,
 							Type:     types.StringType,
 						},
@@ -6088,9 +6251,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"StringType-types.string-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"string": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"string": testschema.Attribute{
 							Optional: true,
 							Type:     types.StringType,
 						},
@@ -6113,9 +6276,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"StringType-types.string-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"string": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"string": testschema.Attribute{
 							Optional: true,
 							Type:     types.StringType,
 						},
@@ -6138,9 +6301,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"StringType-*string-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"string": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"string": testschema.Attribute{
 							Optional: true,
 							Type:     types.StringType,
 						},
@@ -6163,9 +6326,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"StringType-*string-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"string": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"string": testschema.Attribute{
 							Optional: true,
 							Type:     types.StringType,
 						},
@@ -6197,9 +6360,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"StringType-*string-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"string": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"string": testschema.Attribute{
 							Optional: true,
 							Type:     types.StringType,
 						},
@@ -6222,9 +6385,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"StringType-string-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"string": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"string": testschema.Attribute{
 							Optional: true,
 							Type:     types.StringType,
 						},
@@ -6256,9 +6419,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"StringType-string-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"string": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"string": testschema.Attribute{
 							Optional: true,
 							Type:     types.StringType,
 						},
@@ -6290,9 +6453,9 @@ func TestDataGetAtPath(t *testing.T) {
 		},
 		"StringType-string-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"string": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"string": testschema.Attribute{
 							Optional: true,
 							Type:     types.StringType,
 						},

--- a/internal/fwschemadata/data_get_test.go
+++ b/internal/fwschemadata/data_get_test.go
@@ -11,11 +11,12 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschemadata"
 	intreflect "github.com/hashicorp/terraform-plugin-framework/internal/reflect"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
 	testtypes "github.com/hashicorp/terraform-plugin-framework/internal/testing/types"
 	"github.com/hashicorp/terraform-plugin-framework/path"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -30,9 +31,9 @@ func TestDataGet(t *testing.T) {
 	}{
 		"invalid-target": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"string": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"string": testschema.Attribute{
 							Optional: true,
 							Type:     testtypes.StringType{},
 						},
@@ -77,9 +78,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"invalid-type": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"bool": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"bool": testschema.Attribute{
 							Optional: true,
 							Type:     types.BoolType,
 						},
@@ -117,9 +118,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"AttrTypeWithValidateError": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"string": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"string": testschema.Attribute{
 							Type:     testtypes.StringTypeWithValidateError{},
 							Required: true,
 						},
@@ -153,9 +154,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"AttrTypeWithValidateWarning": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"string": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"string": testschema.Attribute{
 							Type:     testtypes.StringTypeWithValidateWarning{},
 							Required: true,
 						},
@@ -189,13 +190,13 @@ func TestDataGet(t *testing.T) {
 		},
 		"multiple-attributes": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"one": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"one": testschema.Attribute{
 							Optional: true,
 							Type:     types.StringType,
 						},
-						"two": {
+						"two": testschema.Attribute{
 							Optional: true,
 							Type:     types.StringType,
 						},
@@ -228,9 +229,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"BoolType-types.Bool-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"bool": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"bool": testschema.Attribute{
 							Optional: true,
 							Type:     types.BoolType,
 						},
@@ -258,9 +259,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"BoolType-types.Bool-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"bool": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"bool": testschema.Attribute{
 							Optional: true,
 							Type:     types.BoolType,
 						},
@@ -288,9 +289,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"BoolType-types.Bool-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"bool": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"bool": testschema.Attribute{
 							Optional: true,
 							Type:     types.BoolType,
 						},
@@ -318,9 +319,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"BoolType-*bool-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"bool": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"bool": testschema.Attribute{
 							Optional: true,
 							Type:     types.BoolType,
 						},
@@ -348,9 +349,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"BoolType-*bool-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"bool": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"bool": testschema.Attribute{
 							Optional: true,
 							Type:     types.BoolType,
 						},
@@ -387,9 +388,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"BoolType-*bool-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"bool": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"bool": testschema.Attribute{
 							Optional: true,
 							Type:     types.BoolType,
 						},
@@ -417,9 +418,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"BoolType-bool-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"bool": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"bool": testschema.Attribute{
 							Optional: true,
 							Type:     types.BoolType,
 						},
@@ -456,9 +457,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"BoolType-bool-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"bool": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"bool": testschema.Attribute{
 							Optional: true,
 							Type:     types.BoolType,
 						},
@@ -495,9 +496,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"BoolType-bool-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"bool": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"bool": testschema.Attribute{
 							Optional: true,
 							Type:     types.BoolType,
 						},
@@ -525,9 +526,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"Float64Type-types.Float64-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"float64": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"float64": testschema.Attribute{
 							Optional: true,
 							Type:     types.Float64Type,
 						},
@@ -555,9 +556,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"Float64Type-types.Float64-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"float64": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"float64": testschema.Attribute{
 							Optional: true,
 							Type:     types.Float64Type,
 						},
@@ -585,9 +586,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"Float64Type-types.Float64-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"float64": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"float64": testschema.Attribute{
 							Optional: true,
 							Type:     types.Float64Type,
 						},
@@ -615,9 +616,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"Float64Type-*float64-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"float64": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"float64": testschema.Attribute{
 							Optional: true,
 							Type:     types.Float64Type,
 						},
@@ -645,9 +646,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"Float64Type-*float64-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"float64": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"float64": testschema.Attribute{
 							Optional: true,
 							Type:     types.Float64Type,
 						},
@@ -684,9 +685,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"Float64Type-*float64-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"float64": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"float64": testschema.Attribute{
 							Optional: true,
 							Type:     types.Float64Type,
 						},
@@ -714,9 +715,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"Float64Type-float64-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"float64": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"float64": testschema.Attribute{
 							Optional: true,
 							Type:     types.Float64Type,
 						},
@@ -753,9 +754,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"Float64Type-float64-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"float64": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"float64": testschema.Attribute{
 							Optional: true,
 							Type:     types.Float64Type,
 						},
@@ -792,9 +793,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"Float64Type-float64-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"float64": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"float64": testschema.Attribute{
 							Optional: true,
 							Type:     types.Float64Type,
 						},
@@ -822,9 +823,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"Int64Type-types.Int64-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"int64": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"int64": testschema.Attribute{
 							Optional: true,
 							Type:     types.Int64Type,
 						},
@@ -852,9 +853,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"Int64Type-types.Int64-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"int64": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"int64": testschema.Attribute{
 							Optional: true,
 							Type:     types.Int64Type,
 						},
@@ -882,9 +883,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"Int64Type-types.Int64-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"int64": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"int64": testschema.Attribute{
 							Optional: true,
 							Type:     types.Int64Type,
 						},
@@ -912,9 +913,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"Int64Type-*int64-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"int64": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"int64": testschema.Attribute{
 							Optional: true,
 							Type:     types.Int64Type,
 						},
@@ -942,9 +943,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"Int64Type-*int64-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"int64": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"int64": testschema.Attribute{
 							Optional: true,
 							Type:     types.Int64Type,
 						},
@@ -981,9 +982,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"Int64Type-*int64-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"int64": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"int64": testschema.Attribute{
 							Optional: true,
 							Type:     types.Int64Type,
 						},
@@ -1011,9 +1012,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"Int64Type-int64-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"int64": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"int64": testschema.Attribute{
 							Optional: true,
 							Type:     types.Int64Type,
 						},
@@ -1050,9 +1051,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"Int64Type-int64-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"int64": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"int64": testschema.Attribute{
 							Optional: true,
 							Type:     types.Int64Type,
 						},
@@ -1089,9 +1090,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"Int64Type-int64-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"int64": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"int64": testschema.Attribute{
 							Optional: true,
 							Type:     types.Int64Type,
 						},
@@ -1119,16 +1120,18 @@ func TestDataGet(t *testing.T) {
 		},
 		"ListBlock-types.List-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"list": {
-							Attributes: map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Blocks: map[string]fwschema.Block{
+						"list": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeList,
+							NestingMode: fwschema.BlockNestingModeList,
 						},
 					},
 				},
@@ -1175,16 +1178,18 @@ func TestDataGet(t *testing.T) {
 		},
 		"ListBlock-types.List-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"list": {
-							Attributes: map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Blocks: map[string]fwschema.Block{
+						"list": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeList,
+							NestingMode: fwschema.BlockNestingModeList,
 						},
 					},
 				},
@@ -1231,16 +1236,18 @@ func TestDataGet(t *testing.T) {
 		},
 		"ListBlock-types.List-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"list": {
-							Attributes: map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Blocks: map[string]fwschema.Block{
+						"list": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeList,
+							NestingMode: fwschema.BlockNestingModeList,
 						},
 					},
 				},
@@ -1326,16 +1333,18 @@ func TestDataGet(t *testing.T) {
 		},
 		"ListBlock-[]types.Object-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"list": {
-							Attributes: map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Blocks: map[string]fwschema.Block{
+						"list": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeList,
+							NestingMode: fwschema.BlockNestingModeList,
 						},
 					},
 				},
@@ -1376,16 +1385,18 @@ func TestDataGet(t *testing.T) {
 		},
 		"ListBlock-[]types.Object-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"list": {
-							Attributes: map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Blocks: map[string]fwschema.Block{
+						"list": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeList,
+							NestingMode: fwschema.BlockNestingModeList,
 						},
 					},
 				},
@@ -1435,16 +1446,18 @@ func TestDataGet(t *testing.T) {
 		},
 		"ListBlock-[]types.Object-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"list": {
-							Attributes: map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Blocks: map[string]fwschema.Block{
+						"list": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeList,
+							NestingMode: fwschema.BlockNestingModeList,
 						},
 					},
 				},
@@ -1523,16 +1536,18 @@ func TestDataGet(t *testing.T) {
 		},
 		"ListBlock-[]struct-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"list": {
-							Attributes: map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Blocks: map[string]fwschema.Block{
+						"list": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeList,
+							NestingMode: fwschema.BlockNestingModeList,
 						},
 					},
 				},
@@ -1577,16 +1592,18 @@ func TestDataGet(t *testing.T) {
 		},
 		"ListBlock-[]struct-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"list": {
-							Attributes: map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Blocks: map[string]fwschema.Block{
+						"list": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeList,
+							NestingMode: fwschema.BlockNestingModeList,
 						},
 					},
 				},
@@ -1640,16 +1657,18 @@ func TestDataGet(t *testing.T) {
 		},
 		"ListBlock-[]struct-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"list": {
-							Attributes: map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Blocks: map[string]fwschema.Block{
+						"list": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeList,
+							NestingMode: fwschema.BlockNestingModeList,
 						},
 					},
 				},
@@ -1720,16 +1739,19 @@ func TestDataGet(t *testing.T) {
 		},
 		"ListNestedAttributes-types.List-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"list": {
-							Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"list": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeList,
+							Optional:    true,
 						},
 					},
 				},
@@ -1776,16 +1798,19 @@ func TestDataGet(t *testing.T) {
 		},
 		"ListNestedAttributes-types.List-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"list": {
-							Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"list": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeList,
+							Optional:    true,
 						},
 					},
 				},
@@ -1832,16 +1857,19 @@ func TestDataGet(t *testing.T) {
 		},
 		"ListNestedAttributes-types.List-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"list": {
-							Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"list": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeList,
+							Optional:    true,
 						},
 					},
 				},
@@ -1927,16 +1955,19 @@ func TestDataGet(t *testing.T) {
 		},
 		"ListNestedAttributes-[]types.Object-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"list": {
-							Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"list": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeList,
+							Optional:    true,
 						},
 					},
 				},
@@ -1977,16 +2008,19 @@ func TestDataGet(t *testing.T) {
 		},
 		"ListNestedAttributes-[]types.Object-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"list": {
-							Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"list": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeList,
+							Optional:    true,
 						},
 					},
 				},
@@ -2036,16 +2070,19 @@ func TestDataGet(t *testing.T) {
 		},
 		"ListNestedAttributes-[]types.Object-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"list": {
-							Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"list": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeList,
+							Optional:    true,
 						},
 					},
 				},
@@ -2124,16 +2161,19 @@ func TestDataGet(t *testing.T) {
 		},
 		"ListNestedAttributes-[]struct-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"list": {
-							Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"list": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeList,
+							Optional:    true,
 						},
 					},
 				},
@@ -2178,16 +2218,19 @@ func TestDataGet(t *testing.T) {
 		},
 		"ListNestedAttributes-[]struct-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"list": {
-							Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"list": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeList,
+							Optional:    true,
 						},
 					},
 				},
@@ -2241,16 +2284,19 @@ func TestDataGet(t *testing.T) {
 		},
 		"ListNestedAttributes-[]struct-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"list": {
-							Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"list": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeList,
+							Optional:    true,
 						},
 					},
 				},
@@ -2321,9 +2367,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"ListType-types.List-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"list": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"list": testschema.Attribute{
 							Optional: true,
 							Type: types.ListType{
 								ElemType: types.StringType,
@@ -2360,9 +2406,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"ListType-types.List-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"list": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"list": testschema.Attribute{
 							Optional: true,
 							Type: types.ListType{
 								ElemType: types.StringType,
@@ -2399,9 +2445,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"ListType-types.List-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"list": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"list": testschema.Attribute{
 							Optional: true,
 							Type: types.ListType{
 								ElemType: types.StringType,
@@ -2447,9 +2493,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"ListType-[]types.String-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"list": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"list": testschema.Attribute{
 							Optional: true,
 							Type: types.ListType{
 								ElemType: types.StringType,
@@ -2486,9 +2532,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"ListType-[]types.String-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"list": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"list": testschema.Attribute{
 							Optional: true,
 							Type: types.ListType{
 								ElemType: types.StringType,
@@ -2534,9 +2580,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"ListType-[]types.String-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"list": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"list": testschema.Attribute{
 							Optional: true,
 							Type: types.ListType{
 								ElemType: types.StringType,
@@ -2579,9 +2625,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"ListType-[]string-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"list": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"list": testschema.Attribute{
 							Optional: true,
 							Type: types.ListType{
 								ElemType: types.StringType,
@@ -2618,9 +2664,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"ListType-[]string-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"list": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"list": testschema.Attribute{
 							Optional: true,
 							Type: types.ListType{
 								ElemType: types.StringType,
@@ -2666,9 +2712,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"ListType-[]string-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"list": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"list": testschema.Attribute{
 							Optional: true,
 							Type: types.ListType{
 								ElemType: types.StringType,
@@ -2711,16 +2757,19 @@ func TestDataGet(t *testing.T) {
 		},
 		"MapNestedAttributes-types.Map-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"map": {
-							Attributes: tfsdk.MapNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"map": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeMap,
+							Optional:    true,
 						},
 					},
 				},
@@ -2767,16 +2816,19 @@ func TestDataGet(t *testing.T) {
 		},
 		"MapNestedAttributes-types.Map-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"map": {
-							Attributes: tfsdk.MapNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"map": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeMap,
+							Optional:    true,
 						},
 					},
 				},
@@ -2823,16 +2875,19 @@ func TestDataGet(t *testing.T) {
 		},
 		"MapNestedAttributes-types.Map-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"map": {
-							Attributes: tfsdk.MapNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"map": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeMap,
+							Optional:    true,
 						},
 					},
 				},
@@ -2918,16 +2973,19 @@ func TestDataGet(t *testing.T) {
 		},
 		"MapNestedAttributes-map[string]types.Object-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"map": {
-							Attributes: tfsdk.MapNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"map": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeMap,
+							Optional:    true,
 						},
 					},
 				},
@@ -2968,16 +3026,19 @@ func TestDataGet(t *testing.T) {
 		},
 		"MapNestedAttributes-map[string]types.Object-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"map": {
-							Attributes: tfsdk.MapNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"map": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeMap,
+							Optional:    true,
 						},
 					},
 				},
@@ -3027,16 +3088,19 @@ func TestDataGet(t *testing.T) {
 		},
 		"MapNestedAttributes-map[string]types.Object-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"map": {
-							Attributes: tfsdk.MapNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"map": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeMap,
+							Optional:    true,
 						},
 					},
 				},
@@ -3115,16 +3179,19 @@ func TestDataGet(t *testing.T) {
 		},
 		"MapNestedAttributes-map[string]struct-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"map": {
-							Attributes: tfsdk.MapNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"map": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeMap,
+							Optional:    true,
 						},
 					},
 				},
@@ -3169,16 +3236,19 @@ func TestDataGet(t *testing.T) {
 		},
 		"MapNestedAttributes-map[string]struct-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"map": {
-							Attributes: tfsdk.MapNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"map": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeMap,
+							Optional:    true,
 						},
 					},
 				},
@@ -3232,16 +3302,19 @@ func TestDataGet(t *testing.T) {
 		},
 		"MapNestedAttributes-map[string]struct-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"map": {
-							Attributes: tfsdk.MapNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"map": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeMap,
+							Optional:    true,
 						},
 					},
 				},
@@ -3312,9 +3385,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"MapType-types.Map-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"map": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"map": testschema.Attribute{
 							Optional: true,
 							Type: types.MapType{
 								ElemType: types.StringType,
@@ -3351,9 +3424,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"MapType-types.Map-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"map": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"map": testschema.Attribute{
 							Optional: true,
 							Type: types.MapType{
 								ElemType: types.StringType,
@@ -3390,9 +3463,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"MapType-types.Map-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"map": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"map": testschema.Attribute{
 							Optional: true,
 							Type: types.MapType{
 								ElemType: types.StringType,
@@ -3438,9 +3511,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"MapType-map[string]types.String-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"map": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"map": testschema.Attribute{
 							Optional: true,
 							Type: types.MapType{
 								ElemType: types.StringType,
@@ -3477,9 +3550,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"MapType-map[string]types.String-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"map": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"map": testschema.Attribute{
 							Optional: true,
 							Type: types.MapType{
 								ElemType: types.StringType,
@@ -3525,9 +3598,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"MapType-map[string]types.String-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"map": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"map": testschema.Attribute{
 							Optional: true,
 							Type: types.MapType{
 								ElemType: types.StringType,
@@ -3570,9 +3643,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"MapType-map[string]string-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"map": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"map": testschema.Attribute{
 							Optional: true,
 							Type: types.MapType{
 								ElemType: types.StringType,
@@ -3609,9 +3682,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"MapType-map[string]string-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"map": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"map": testschema.Attribute{
 							Optional: true,
 							Type: types.MapType{
 								ElemType: types.StringType,
@@ -3657,9 +3730,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"MapType-map[string]string-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"map": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"map": testschema.Attribute{
 							Optional: true,
 							Type: types.MapType{
 								ElemType: types.StringType,
@@ -3702,9 +3775,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"ObjectType-types.Object-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"object": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"object": testschema.Attribute{
 							Optional: true,
 							Type: types.ObjectType{
 								AttrTypes: map[string]attr.Type{
@@ -3751,9 +3824,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"ObjectType-types.Object-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"object": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"object": testschema.Attribute{
 							Optional: true,
 							Type: types.ObjectType{
 								AttrTypes: map[string]attr.Type{
@@ -3800,9 +3873,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"ObjectType-types.Object-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"object": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"object": testschema.Attribute{
 							Optional: true,
 							Type: types.ObjectType{
 								AttrTypes: map[string]attr.Type{
@@ -3854,9 +3927,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"ObjectType-*struct-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"object": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"object": testschema.Attribute{
 							Optional: true,
 							Type: types.ObjectType{
 								AttrTypes: map[string]attr.Type{
@@ -3903,9 +3976,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"ObjectType-*struct-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"object": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"object": testschema.Attribute{
 							Optional: true,
 							Type: types.ObjectType{
 								AttrTypes: map[string]attr.Type{
@@ -3961,9 +4034,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"ObjectType-*struct-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"object": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"object": testschema.Attribute{
 							Optional: true,
 							Type: types.ObjectType{
 								AttrTypes: map[string]attr.Type{
@@ -4016,9 +4089,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"ObjectType-struct-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"object": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"object": testschema.Attribute{
 							Optional: true,
 							Type: types.ObjectType{
 								AttrTypes: map[string]attr.Type{
@@ -4078,9 +4151,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"ObjectType-struct-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"object": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"object": testschema.Attribute{
 							Optional: true,
 							Type: types.ObjectType{
 								AttrTypes: map[string]attr.Type{
@@ -4140,9 +4213,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"ObjectType-struct-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"object": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"object": testschema.Attribute{
 							Optional: true,
 							Type: types.ObjectType{
 								AttrTypes: map[string]attr.Type{
@@ -4195,16 +4268,18 @@ func TestDataGet(t *testing.T) {
 		},
 		"SetBlock-types.Set-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"set": {
-							Attributes: map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Blocks: map[string]fwschema.Block{
+						"set": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeSet,
+							NestingMode: fwschema.BlockNestingModeSet,
 						},
 					},
 				},
@@ -4251,16 +4326,18 @@ func TestDataGet(t *testing.T) {
 		},
 		"SetBlock-types.Set-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"set": {
-							Attributes: map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Blocks: map[string]fwschema.Block{
+						"set": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeSet,
+							NestingMode: fwschema.BlockNestingModeSet,
 						},
 					},
 				},
@@ -4307,16 +4384,18 @@ func TestDataGet(t *testing.T) {
 		},
 		"SetBlock-types.Set-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"set": {
-							Attributes: map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Blocks: map[string]fwschema.Block{
+						"set": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeSet,
+							NestingMode: fwschema.BlockNestingModeSet,
 						},
 					},
 				},
@@ -4402,16 +4481,18 @@ func TestDataGet(t *testing.T) {
 		},
 		"SetBlock-[]types.Object-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"set": {
-							Attributes: map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Blocks: map[string]fwschema.Block{
+						"set": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeSet,
+							NestingMode: fwschema.BlockNestingModeSet,
 						},
 					},
 				},
@@ -4452,16 +4533,18 @@ func TestDataGet(t *testing.T) {
 		},
 		"SetBlock-[]types.Object-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"set": {
-							Attributes: map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Blocks: map[string]fwschema.Block{
+						"set": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeSet,
+							NestingMode: fwschema.BlockNestingModeSet,
 						},
 					},
 				},
@@ -4511,16 +4594,18 @@ func TestDataGet(t *testing.T) {
 		},
 		"SetBlock-[]types.Object-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"set": {
-							Attributes: map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Blocks: map[string]fwschema.Block{
+						"set": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeSet,
+							NestingMode: fwschema.BlockNestingModeSet,
 						},
 					},
 				},
@@ -4599,16 +4684,18 @@ func TestDataGet(t *testing.T) {
 		},
 		"SetBlock-[]struct-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"set": {
-							Attributes: map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Blocks: map[string]fwschema.Block{
+						"set": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeSet,
+							NestingMode: fwschema.BlockNestingModeSet,
 						},
 					},
 				},
@@ -4653,16 +4740,18 @@ func TestDataGet(t *testing.T) {
 		},
 		"SetBlock-[]struct-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"set": {
-							Attributes: map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Blocks: map[string]fwschema.Block{
+						"set": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeSet,
+							NestingMode: fwschema.BlockNestingModeSet,
 						},
 					},
 				},
@@ -4716,16 +4805,18 @@ func TestDataGet(t *testing.T) {
 		},
 		"SetBlock-[]struct-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"set": {
-							Attributes: map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Blocks: map[string]fwschema.Block{
+						"set": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeSet,
+							NestingMode: fwschema.BlockNestingModeSet,
 						},
 					},
 				},
@@ -4796,16 +4887,19 @@ func TestDataGet(t *testing.T) {
 		},
 		"SetNestedAttributes-types.Set-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"set": {
-							Attributes: tfsdk.SetNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"set": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeSet,
+							Optional:    true,
 						},
 					},
 				},
@@ -4852,16 +4946,19 @@ func TestDataGet(t *testing.T) {
 		},
 		"SetNestedAttributes-types.Set-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"set": {
-							Attributes: tfsdk.SetNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"set": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeSet,
+							Optional:    true,
 						},
 					},
 				},
@@ -4908,16 +5005,19 @@ func TestDataGet(t *testing.T) {
 		},
 		"SetNestedAttributes-types.Set-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"set": {
-							Attributes: tfsdk.SetNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"set": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeSet,
+							Optional:    true,
 						},
 					},
 				},
@@ -5003,16 +5103,19 @@ func TestDataGet(t *testing.T) {
 		},
 		"SetNestedAttributes-[]types.Object-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"set": {
-							Attributes: tfsdk.SetNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"set": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeSet,
+							Optional:    true,
 						},
 					},
 				},
@@ -5053,16 +5156,19 @@ func TestDataGet(t *testing.T) {
 		},
 		"SetNestedAttributes-[]types.Object-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"set": {
-							Attributes: tfsdk.SetNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"set": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeSet,
+							Optional:    true,
 						},
 					},
 				},
@@ -5112,16 +5218,19 @@ func TestDataGet(t *testing.T) {
 		},
 		"SetNestedAttributes-[]types.Object-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"set": {
-							Attributes: tfsdk.SetNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"set": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeSet,
+							Optional:    true,
 						},
 					},
 				},
@@ -5200,16 +5309,19 @@ func TestDataGet(t *testing.T) {
 		},
 		"SetNestedAttributes-[]struct-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"set": {
-							Attributes: tfsdk.SetNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"set": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeSet,
+							Optional:    true,
 						},
 					},
 				},
@@ -5254,16 +5366,19 @@ func TestDataGet(t *testing.T) {
 		},
 		"SetNestedAttributes-[]struct-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"set": {
-							Attributes: tfsdk.SetNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"set": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeSet,
+							Optional:    true,
 						},
 					},
 				},
@@ -5317,16 +5432,19 @@ func TestDataGet(t *testing.T) {
 		},
 		"SetNestedAttributes-[]struct-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"set": {
-							Attributes: tfsdk.SetNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"set": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeSet,
+							Optional:    true,
 						},
 					},
 				},
@@ -5397,9 +5515,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"SetType-types.Set-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"set": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"set": testschema.Attribute{
 							Optional: true,
 							Type: types.SetType{
 								ElemType: types.StringType,
@@ -5436,9 +5554,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"SetType-types.Set-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"set": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"set": testschema.Attribute{
 							Optional: true,
 							Type: types.SetType{
 								ElemType: types.StringType,
@@ -5475,9 +5593,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"SetType-types.Set-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"set": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"set": testschema.Attribute{
 							Optional: true,
 							Type: types.SetType{
 								ElemType: types.StringType,
@@ -5523,9 +5641,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"SetType-[]types.String-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"set": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"set": testschema.Attribute{
 							Optional: true,
 							Type: types.SetType{
 								ElemType: types.StringType,
@@ -5562,9 +5680,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"SetType-[]types.String-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"set": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"set": testschema.Attribute{
 							Optional: true,
 							Type: types.SetType{
 								ElemType: types.StringType,
@@ -5610,9 +5728,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"SetType-[]types.String-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"set": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"set": testschema.Attribute{
 							Optional: true,
 							Type: types.SetType{
 								ElemType: types.StringType,
@@ -5655,9 +5773,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"SetType-[]string-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"set": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"set": testschema.Attribute{
 							Optional: true,
 							Type: types.SetType{
 								ElemType: types.StringType,
@@ -5694,9 +5812,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"SetType-[]string-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"set": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"set": testschema.Attribute{
 							Optional: true,
 							Type: types.SetType{
 								ElemType: types.StringType,
@@ -5742,9 +5860,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"SetType-[]string-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"set": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"set": testschema.Attribute{
 							Optional: true,
 							Type: types.SetType{
 								ElemType: types.StringType,
@@ -5787,16 +5905,18 @@ func TestDataGet(t *testing.T) {
 		},
 		"SingleBlock-types.Object-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"object": {
-							Attributes: map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Blocks: map[string]fwschema.Block{
+						"object": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeSingle,
+							NestingMode: fwschema.BlockNestingModeSingle,
 						},
 					},
 				},
@@ -5837,16 +5957,18 @@ func TestDataGet(t *testing.T) {
 		},
 		"SingleBlock-types.Object-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"object": {
-							Attributes: map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Blocks: map[string]fwschema.Block{
+						"object": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeSingle,
+							NestingMode: fwschema.BlockNestingModeSingle,
 						},
 					},
 				},
@@ -5887,16 +6009,18 @@ func TestDataGet(t *testing.T) {
 		},
 		"SingleBlock-types.Object-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"object": {
-							Attributes: map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Blocks: map[string]fwschema.Block{
+						"object": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeSingle,
+							NestingMode: fwschema.BlockNestingModeSingle,
 						},
 					},
 				},
@@ -5942,16 +6066,18 @@ func TestDataGet(t *testing.T) {
 		},
 		"SingleBlock-*struct-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"object": {
-							Attributes: map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Blocks: map[string]fwschema.Block{
+						"object": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeSingle,
+							NestingMode: fwschema.BlockNestingModeSingle,
 						},
 					},
 				},
@@ -5992,16 +6118,18 @@ func TestDataGet(t *testing.T) {
 		},
 		"SingleBlock-*struct-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"object": {
-							Attributes: map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Blocks: map[string]fwschema.Block{
+						"object": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeSingle,
+							NestingMode: fwschema.BlockNestingModeSingle,
 						},
 					},
 				},
@@ -6051,16 +6179,18 @@ func TestDataGet(t *testing.T) {
 		},
 		"SingleBlock-*struct-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"object": {
-							Attributes: map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Blocks: map[string]fwschema.Block{
+						"object": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeSingle,
+							NestingMode: fwschema.BlockNestingModeSingle,
 						},
 					},
 				},
@@ -6107,16 +6237,18 @@ func TestDataGet(t *testing.T) {
 		},
 		"SingleBlock-struct-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"object": {
-							Attributes: map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Blocks: map[string]fwschema.Block{
+						"object": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeSingle,
+							NestingMode: fwschema.BlockNestingModeSingle,
 						},
 					},
 				},
@@ -6170,16 +6302,18 @@ func TestDataGet(t *testing.T) {
 		},
 		"SingleBlock-struct-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"object": {
-							Attributes: map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Blocks: map[string]fwschema.Block{
+						"object": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeSingle,
+							NestingMode: fwschema.BlockNestingModeSingle,
 						},
 					},
 				},
@@ -6233,16 +6367,18 @@ func TestDataGet(t *testing.T) {
 		},
 		"SingleBlock-struct-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"object": {
-							Attributes: map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Blocks: map[string]fwschema.Block{
+						"object": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeSingle,
+							NestingMode: fwschema.BlockNestingModeSingle,
 						},
 					},
 				},
@@ -6289,16 +6425,19 @@ func TestDataGet(t *testing.T) {
 		},
 		"SingleNestedAttributes-types.Object-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"object": {
-							Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"object": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeSingle,
+							Optional:    true,
 						},
 					},
 				},
@@ -6339,16 +6478,19 @@ func TestDataGet(t *testing.T) {
 		},
 		"SingleNestedAttributes-types.Object-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"object": {
-							Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"object": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeSingle,
+							Optional:    true,
 						},
 					},
 				},
@@ -6389,16 +6531,19 @@ func TestDataGet(t *testing.T) {
 		},
 		"SingleNestedAttributes-types.Object-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"object": {
-							Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"object": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeSingle,
+							Optional:    true,
 						},
 					},
 				},
@@ -6444,16 +6589,19 @@ func TestDataGet(t *testing.T) {
 		},
 		"SingleNestedAttributes-*struct-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"object": {
-							Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"object": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeSingle,
+							Optional:    true,
 						},
 					},
 				},
@@ -6494,16 +6642,19 @@ func TestDataGet(t *testing.T) {
 		},
 		"SingleNestedAttributes-*struct-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"object": {
-							Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"object": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeSingle,
+							Optional:    true,
 						},
 					},
 				},
@@ -6553,16 +6704,19 @@ func TestDataGet(t *testing.T) {
 		},
 		"SingleNestedAttributes-*struct-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"object": {
-							Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"object": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeSingle,
+							Optional:    true,
 						},
 					},
 				},
@@ -6609,16 +6763,19 @@ func TestDataGet(t *testing.T) {
 		},
 		"SingleNestedAttributes-struct-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"object": {
-							Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"object": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeSingle,
+							Optional:    true,
 						},
 					},
 				},
@@ -6672,16 +6829,19 @@ func TestDataGet(t *testing.T) {
 		},
 		"SingleNestedAttributes-struct-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"object": {
-							Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"object": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeSingle,
+							Optional:    true,
 						},
 					},
 				},
@@ -6735,16 +6895,19 @@ func TestDataGet(t *testing.T) {
 		},
 		"SingleNestedAttributes-struct-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"object": {
-							Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
-								"nested_string": {
-									Optional: true,
-									Type:     types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"object": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_string": testschema.Attribute{
+										Optional: true,
+										Type:     types.StringType,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeSingle,
+							Optional:    true,
 						},
 					},
 				},
@@ -6791,9 +6954,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"StringType-types.string-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"string": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"string": testschema.Attribute{
 							Optional: true,
 							Type:     types.StringType,
 						},
@@ -6821,9 +6984,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"StringType-types.string-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"string": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"string": testschema.Attribute{
 							Optional: true,
 							Type:     types.StringType,
 						},
@@ -6851,9 +7014,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"StringType-types.string-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"string": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"string": testschema.Attribute{
 							Optional: true,
 							Type:     types.StringType,
 						},
@@ -6881,9 +7044,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"StringType-*string-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"string": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"string": testschema.Attribute{
 							Optional: true,
 							Type:     types.StringType,
 						},
@@ -6911,9 +7074,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"StringType-*string-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"string": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"string": testschema.Attribute{
 							Optional: true,
 							Type:     types.StringType,
 						},
@@ -6950,9 +7113,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"StringType-*string-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"string": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"string": testschema.Attribute{
 							Optional: true,
 							Type:     types.StringType,
 						},
@@ -6980,9 +7143,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"StringType-string-null": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"string": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"string": testschema.Attribute{
 							Optional: true,
 							Type:     types.StringType,
 						},
@@ -7019,9 +7182,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"StringType-string-unknown": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"string": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"string": testschema.Attribute{
 							Optional: true,
 							Type:     types.StringType,
 						},
@@ -7058,9 +7221,9 @@ func TestDataGet(t *testing.T) {
 		},
 		"StringType-string-value": {
 			data: fwschemadata.Data{
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"string": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"string": testschema.Attribute{
 							Optional: true,
 							Type:     types.StringType,
 						},

--- a/internal/fwschemadata/data_path_exists_test.go
+++ b/internal/fwschemadata/data_path_exists_test.go
@@ -7,9 +7,10 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschemadata"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
 	"github.com/hashicorp/terraform-plugin-framework/path"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
@@ -44,9 +45,9 @@ func TestDataPathExists(t *testing.T) {
 				}, map[string]tftypes.Value{
 					"test": tftypes.NewValue(tftypes.String, "testvalue"),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"test": testschema.Attribute{
 							Type:     types.StringType,
 							Required: true,
 						},
@@ -65,9 +66,9 @@ func TestDataPathExists(t *testing.T) {
 				}, map[string]tftypes.Value{
 					"test": tftypes.NewValue(tftypes.String, "testvalue"),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"test": testschema.Attribute{
 							Type:     types.StringType,
 							Required: true,
 						},
@@ -86,9 +87,9 @@ func TestDataPathExists(t *testing.T) {
 				}, map[string]tftypes.Value{
 					"test": tftypes.NewValue(tftypes.String, "testvalue"),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"test": testschema.Attribute{
 							Type:     types.StringType,
 							Required: true,
 						},
@@ -117,9 +118,9 @@ func TestDataPathExists(t *testing.T) {
 						"nested": tftypes.NewValue(tftypes.String, "testvalue"),
 					}),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"test": testschema.Attribute{
 							Type: types.ObjectType{
 								AttrTypes: map[string]attr.Type{
 									"nested": types.StringType,
@@ -152,9 +153,9 @@ func TestDataPathExists(t *testing.T) {
 						"nested": tftypes.NewValue(tftypes.String, "testvalue"),
 					}),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"test": testschema.Attribute{
 							Type: types.ObjectType{
 								AttrTypes: map[string]attr.Type{
 									"nested": types.StringType,
@@ -177,9 +178,9 @@ func TestDataPathExists(t *testing.T) {
 				}, map[string]tftypes.Value{
 					"test": tftypes.NewValue(tftypes.String, "testvalue"),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"test": testschema.Attribute{
 							Type:     types.StringType,
 							Required: true,
 						},
@@ -204,9 +205,9 @@ func TestDataPathExists(t *testing.T) {
 						tftypes.NewValue(tftypes.String, "testvalue"),
 					}),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"test": testschema.Attribute{
 							Type: types.ListType{
 								ElemType: types.StringType,
 							},
@@ -233,9 +234,9 @@ func TestDataPathExists(t *testing.T) {
 						tftypes.NewValue(tftypes.String, "testvalue"),
 					}),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"test": testschema.Attribute{
 							Type: types.ListType{
 								ElemType: types.StringType,
 							},
@@ -256,9 +257,9 @@ func TestDataPathExists(t *testing.T) {
 				}, map[string]tftypes.Value{
 					"test": tftypes.NewValue(tftypes.String, "testvalue"),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"test": testschema.Attribute{
 							Type:     types.StringType,
 							Required: true,
 						},
@@ -283,9 +284,9 @@ func TestDataPathExists(t *testing.T) {
 						"key": tftypes.NewValue(tftypes.String, "testvalue"),
 					}),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"test": testschema.Attribute{
 							Type: types.MapType{
 								ElemType: types.StringType,
 							},
@@ -312,9 +313,9 @@ func TestDataPathExists(t *testing.T) {
 						"key": tftypes.NewValue(tftypes.String, "testvalue"),
 					}),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"test": testschema.Attribute{
 							Type: types.MapType{
 								ElemType: types.StringType,
 							},
@@ -335,9 +336,9 @@ func TestDataPathExists(t *testing.T) {
 				}, map[string]tftypes.Value{
 					"test": tftypes.NewValue(tftypes.String, "testvalue"),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"test": testschema.Attribute{
 							Type:     types.StringType,
 							Required: true,
 						},
@@ -362,9 +363,9 @@ func TestDataPathExists(t *testing.T) {
 						tftypes.NewValue(tftypes.String, "testvalue"),
 					}),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"test": testschema.Attribute{
 							Type: types.SetType{
 								ElemType: types.StringType,
 							},
@@ -391,9 +392,9 @@ func TestDataPathExists(t *testing.T) {
 						tftypes.NewValue(tftypes.String, "testvalue"),
 					}),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"test": testschema.Attribute{
 							Type: types.SetType{
 								ElemType: types.StringType,
 							},
@@ -414,9 +415,9 @@ func TestDataPathExists(t *testing.T) {
 				}, map[string]tftypes.Value{
 					"test": tftypes.NewValue(tftypes.String, "testvalue"),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"test": testschema.Attribute{
 							Type:     types.StringType,
 							Required: true,
 						},

--- a/internal/fwschemadata/data_path_matches_test.go
+++ b/internal/fwschemadata/data_path_matches_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschemadata"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
 	"github.com/hashicorp/terraform-plugin-framework/path"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
@@ -25,9 +25,9 @@ func TestDataPathMatches(t *testing.T) {
 		expectedDiags diag.Diagnostics
 	}{
 		"AttributeNameExact-match": {
-			schema: tfsdk.Schema{
-				Attributes: map[string]tfsdk.Attribute{
-					"test": {
+			schema: testschema.Schema{
+				Attributes: map[string]fwschema.Attribute{
+					"test": testschema.Attribute{
 						Type: types.StringType,
 					},
 				},
@@ -48,9 +48,9 @@ func TestDataPathMatches(t *testing.T) {
 			},
 		},
 		"AttributeNameExact-mismatch": {
-			schema: tfsdk.Schema{
-				Attributes: map[string]tfsdk.Attribute{
-					"test": {
+			schema: testschema.Schema{
+				Attributes: map[string]fwschema.Attribute{
+					"test": testschema.Attribute{
 						Type: types.StringType,
 					},
 				},
@@ -78,14 +78,17 @@ func TestDataPathMatches(t *testing.T) {
 			},
 		},
 		"AttributeNameExact-AttributeNameExact-match": {
-			schema: tfsdk.Schema{
-				Attributes: map[string]tfsdk.Attribute{
-					"test_parent": {
-						Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
-							"test_child": {
-								Type: types.StringType,
+			schema: testschema.Schema{
+				Attributes: map[string]fwschema.Attribute{
+					"test_parent": testschema.NestedAttribute{
+						NestedObject: testschema.NestedAttributeObject{
+							Attributes: map[string]fwschema.Attribute{
+								"test_child": testschema.Attribute{
+									Type: types.StringType,
+								},
 							},
-						}),
+						},
+						NestingMode: fwschema.NestingModeSingle,
 					},
 				},
 			},
@@ -118,14 +121,17 @@ func TestDataPathMatches(t *testing.T) {
 			},
 		},
 		"AttributeNameExact-AttributeNameExact-mismatch": {
-			schema: tfsdk.Schema{
-				Attributes: map[string]tfsdk.Attribute{
-					"test_parent": {
-						Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
-							"test_child": {
-								Type: types.StringType,
+			schema: testschema.Schema{
+				Attributes: map[string]fwschema.Attribute{
+					"test_parent": testschema.NestedAttribute{
+						NestedObject: testschema.NestedAttributeObject{
+							Attributes: map[string]fwschema.Attribute{
+								"test_child": testschema.Attribute{
+									Type: types.StringType,
+								},
 							},
-						}),
+						},
+						NestingMode: fwschema.NestingModeSingle,
 					},
 				},
 			},
@@ -165,14 +171,17 @@ func TestDataPathMatches(t *testing.T) {
 			},
 		},
 		"AttributeNameExact-AttributeNameExact-parent-null": {
-			schema: tfsdk.Schema{
-				Attributes: map[string]tfsdk.Attribute{
-					"test_parent": {
-						Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
-							"test_child": {
-								Type: types.StringType,
+			schema: testschema.Schema{
+				Attributes: map[string]fwschema.Attribute{
+					"test_parent": testschema.NestedAttribute{
+						NestedObject: testschema.NestedAttributeObject{
+							Attributes: map[string]fwschema.Attribute{
+								"test_child": testschema.Attribute{
+									Type: types.StringType,
+								},
 							},
-						}),
+						},
+						NestingMode: fwschema.NestingModeSingle,
 					},
 				},
 			},
@@ -203,14 +212,17 @@ func TestDataPathMatches(t *testing.T) {
 			},
 		},
 		"AttributeNameExact-AttributeNameExact-parent-unknown": {
-			schema: tfsdk.Schema{
-				Attributes: map[string]tfsdk.Attribute{
-					"test_parent": {
-						Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
-							"test_child": {
-								Type: types.StringType,
+			schema: testschema.Schema{
+				Attributes: map[string]fwschema.Attribute{
+					"test_parent": testschema.NestedAttribute{
+						NestedObject: testschema.NestedAttributeObject{
+							Attributes: map[string]fwschema.Attribute{
+								"test_child": testschema.Attribute{
+									Type: types.StringType,
+								},
 							},
-						}),
+						},
+						NestingMode: fwschema.NestingModeSingle,
 					},
 				},
 			},
@@ -241,9 +253,9 @@ func TestDataPathMatches(t *testing.T) {
 			},
 		},
 		"AttributeNameExact-ElementKeyIntAny-match": {
-			schema: tfsdk.Schema{
-				Attributes: map[string]tfsdk.Attribute{
-					"test": {
+			schema: testschema.Schema{
+				Attributes: map[string]fwschema.Attribute{
+					"test": testschema.Attribute{
 						Type: types.ListType{
 							ElemType: types.StringType,
 						},
@@ -279,9 +291,9 @@ func TestDataPathMatches(t *testing.T) {
 			},
 		},
 		"AttributeNameExact-ElementKeyIntAny-mismatch": {
-			schema: tfsdk.Schema{
-				Attributes: map[string]tfsdk.Attribute{
-					"test": {
+			schema: testschema.Schema{
+				Attributes: map[string]fwschema.Attribute{
+					"test": testschema.Attribute{
 						Type: types.SetType{
 							ElemType: types.StringType,
 						},
@@ -322,9 +334,9 @@ func TestDataPathMatches(t *testing.T) {
 			},
 		},
 		"AttributeNameExact-ElementKeyIntAny-parent-null": {
-			schema: tfsdk.Schema{
-				Attributes: map[string]tfsdk.Attribute{
-					"test": {
+			schema: testschema.Schema{
+				Attributes: map[string]fwschema.Attribute{
+					"test": testschema.Attribute{
 						Type: types.ListType{
 							ElemType: types.StringType,
 						},
@@ -354,9 +366,9 @@ func TestDataPathMatches(t *testing.T) {
 			},
 		},
 		"AttributeNameExact-ElementKeyIntAny-parent-unknown": {
-			schema: tfsdk.Schema{
-				Attributes: map[string]tfsdk.Attribute{
-					"test": {
+			schema: testschema.Schema{
+				Attributes: map[string]fwschema.Attribute{
+					"test": testschema.Attribute{
 						Type: types.ListType{
 							ElemType: types.StringType,
 						},
@@ -386,9 +398,9 @@ func TestDataPathMatches(t *testing.T) {
 			},
 		},
 		"AttributeNameExact-ElementKeyIntExact-match": {
-			schema: tfsdk.Schema{
-				Attributes: map[string]tfsdk.Attribute{
-					"test": {
+			schema: testschema.Schema{
+				Attributes: map[string]fwschema.Attribute{
+					"test": testschema.Attribute{
 						Type: types.ListType{
 							ElemType: types.StringType,
 						},
@@ -422,17 +434,20 @@ func TestDataPathMatches(t *testing.T) {
 			},
 		},
 		"AttributeNameExact-ElementKeyIntExact-AttributeNameExact-Parent-AttributeNameExact-match": {
-			schema: tfsdk.Schema{
-				Attributes: map[string]tfsdk.Attribute{
-					"test_parent": {
-						Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
-							"test_child1": {
-								Type: types.StringType,
+			schema: testschema.Schema{
+				Attributes: map[string]fwschema.Attribute{
+					"test_parent": testschema.NestedAttribute{
+						NestedObject: testschema.NestedAttributeObject{
+							Attributes: map[string]fwschema.Attribute{
+								"test_child1": testschema.Attribute{
+									Type: types.StringType,
+								},
+								"test_child2": testschema.Attribute{
+									Type: types.StringType,
+								},
 							},
-							"test_child2": {
-								Type: types.StringType,
-							},
-						}),
+						},
+						NestingMode: fwschema.NestingModeList,
 					},
 				},
 			},
@@ -495,17 +510,20 @@ func TestDataPathMatches(t *testing.T) {
 			},
 		},
 		"AttributeNameExact-ElementKeyIntExact-AttributeNameExact-Parent-AttributeNameExact-parent-null": {
-			schema: tfsdk.Schema{
-				Attributes: map[string]tfsdk.Attribute{
-					"test_parent": {
-						Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
-							"test_child1": {
-								Type: types.StringType,
+			schema: testschema.Schema{
+				Attributes: map[string]fwschema.Attribute{
+					"test_parent": testschema.NestedAttribute{
+						NestedObject: testschema.NestedAttributeObject{
+							Attributes: map[string]fwschema.Attribute{
+								"test_child1": testschema.Attribute{
+									Type: types.StringType,
+								},
+								"test_child2": testschema.Attribute{
+									Type: types.StringType,
+								},
 							},
-							"test_child2": {
-								Type: types.StringType,
-							},
-						}),
+						},
+						NestingMode: fwschema.NestingModeList,
 					},
 				},
 			},
@@ -565,17 +583,20 @@ func TestDataPathMatches(t *testing.T) {
 			},
 		},
 		"AttributeNameExact-ElementKeyIntExact-AttributeNameExact-Parent-AttributeNameExact-parent-unknown": {
-			schema: tfsdk.Schema{
-				Attributes: map[string]tfsdk.Attribute{
-					"test_parent": {
-						Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
-							"test_child1": {
-								Type: types.StringType,
+			schema: testschema.Schema{
+				Attributes: map[string]fwschema.Attribute{
+					"test_parent": testschema.NestedAttribute{
+						NestedObject: testschema.NestedAttributeObject{
+							Attributes: map[string]fwschema.Attribute{
+								"test_child1": testschema.Attribute{
+									Type: types.StringType,
+								},
+								"test_child2": testschema.Attribute{
+									Type: types.StringType,
+								},
 							},
-							"test_child2": {
-								Type: types.StringType,
-							},
-						}),
+						},
+						NestingMode: fwschema.NestingModeList,
 					},
 				},
 			},
@@ -635,9 +656,9 @@ func TestDataPathMatches(t *testing.T) {
 			},
 		},
 		"AttributeNameExact-ElementKeyIntExact-mismatch": {
-			schema: tfsdk.Schema{
-				Attributes: map[string]tfsdk.Attribute{
-					"test": {
+			schema: testschema.Schema{
+				Attributes: map[string]fwschema.Attribute{
+					"test": testschema.Attribute{
 						Type: types.ListType{
 							ElemType: types.StringType,
 						},
@@ -678,9 +699,9 @@ func TestDataPathMatches(t *testing.T) {
 			},
 		},
 		"AttributeNameExact-ElementKeyIntExact-parent-null": {
-			schema: tfsdk.Schema{
-				Attributes: map[string]tfsdk.Attribute{
-					"test": {
+			schema: testschema.Schema{
+				Attributes: map[string]fwschema.Attribute{
+					"test": testschema.Attribute{
 						Type: types.ListType{
 							ElemType: types.StringType,
 						},
@@ -710,9 +731,9 @@ func TestDataPathMatches(t *testing.T) {
 			},
 		},
 		"AttributeNameExact-ElementKeyIntExact-parent-unknown": {
-			schema: tfsdk.Schema{
-				Attributes: map[string]tfsdk.Attribute{
-					"test": {
+			schema: testschema.Schema{
+				Attributes: map[string]fwschema.Attribute{
+					"test": testschema.Attribute{
 						Type: types.ListType{
 							ElemType: types.StringType,
 						},
@@ -742,9 +763,9 @@ func TestDataPathMatches(t *testing.T) {
 			},
 		},
 		"AttributeNameExact-ElementKeyStringAny-match": {
-			schema: tfsdk.Schema{
-				Attributes: map[string]tfsdk.Attribute{
-					"test": {
+			schema: testschema.Schema{
+				Attributes: map[string]fwschema.Attribute{
+					"test": testschema.Attribute{
 						Type: types.MapType{
 							ElemType: types.StringType,
 						},
@@ -779,9 +800,9 @@ func TestDataPathMatches(t *testing.T) {
 			},
 		},
 		"AttributeNameExact-ElementKeyStringAny-mismatch": {
-			schema: tfsdk.Schema{
-				Attributes: map[string]tfsdk.Attribute{
-					"test": {
+			schema: testschema.Schema{
+				Attributes: map[string]fwschema.Attribute{
+					"test": testschema.Attribute{
 						Type: types.ListType{
 							ElemType: types.StringType,
 						},
@@ -822,9 +843,9 @@ func TestDataPathMatches(t *testing.T) {
 			},
 		},
 		"AttributeNameExact-ElementKeyStringAny-parent-null": {
-			schema: tfsdk.Schema{
-				Attributes: map[string]tfsdk.Attribute{
-					"test": {
+			schema: testschema.Schema{
+				Attributes: map[string]fwschema.Attribute{
+					"test": testschema.Attribute{
 						Type: types.MapType{
 							ElemType: types.StringType,
 						},
@@ -854,9 +875,9 @@ func TestDataPathMatches(t *testing.T) {
 			},
 		},
 		"AttributeNameExact-ElementKeyStringAny-parent-unknown": {
-			schema: tfsdk.Schema{
-				Attributes: map[string]tfsdk.Attribute{
-					"test": {
+			schema: testschema.Schema{
+				Attributes: map[string]fwschema.Attribute{
+					"test": testschema.Attribute{
 						Type: types.MapType{
 							ElemType: types.StringType,
 						},
@@ -886,9 +907,9 @@ func TestDataPathMatches(t *testing.T) {
 			},
 		},
 		"AttributeNameExact-ElementKeyStringExact-match": {
-			schema: tfsdk.Schema{
-				Attributes: map[string]tfsdk.Attribute{
-					"test": {
+			schema: testschema.Schema{
+				Attributes: map[string]fwschema.Attribute{
+					"test": testschema.Attribute{
 						Type: types.MapType{
 							ElemType: types.StringType,
 						},
@@ -922,9 +943,9 @@ func TestDataPathMatches(t *testing.T) {
 			},
 		},
 		"AttributeNameExact-ElementKeyStringExact-mismatch": {
-			schema: tfsdk.Schema{
-				Attributes: map[string]tfsdk.Attribute{
-					"test": {
+			schema: testschema.Schema{
+				Attributes: map[string]fwschema.Attribute{
+					"test": testschema.Attribute{
 						Type: types.MapType{
 							ElemType: types.StringType,
 						},
@@ -965,9 +986,9 @@ func TestDataPathMatches(t *testing.T) {
 			},
 		},
 		"AttributeNameExact-ElementKeyStringExact-parent-null": {
-			schema: tfsdk.Schema{
-				Attributes: map[string]tfsdk.Attribute{
-					"test": {
+			schema: testschema.Schema{
+				Attributes: map[string]fwschema.Attribute{
+					"test": testschema.Attribute{
 						Type: types.MapType{
 							ElemType: types.StringType,
 						},
@@ -997,9 +1018,9 @@ func TestDataPathMatches(t *testing.T) {
 			},
 		},
 		"AttributeNameExact-ElementKeyStringExact-parent-unknown": {
-			schema: tfsdk.Schema{
-				Attributes: map[string]tfsdk.Attribute{
-					"test": {
+			schema: testschema.Schema{
+				Attributes: map[string]fwschema.Attribute{
+					"test": testschema.Attribute{
 						Type: types.MapType{
 							ElemType: types.StringType,
 						},
@@ -1029,9 +1050,9 @@ func TestDataPathMatches(t *testing.T) {
 			},
 		},
 		"AttributeNameExact-ElementKeyValueAny-match": {
-			schema: tfsdk.Schema{
-				Attributes: map[string]tfsdk.Attribute{
-					"test": {
+			schema: testschema.Schema{
+				Attributes: map[string]fwschema.Attribute{
+					"test": testschema.Attribute{
 						Type: types.SetType{
 							ElemType: types.StringType,
 						},
@@ -1067,9 +1088,9 @@ func TestDataPathMatches(t *testing.T) {
 			},
 		},
 		"AttributeNameExact-ElementKeyValueAny-mismatch": {
-			schema: tfsdk.Schema{
-				Attributes: map[string]tfsdk.Attribute{
-					"test": {
+			schema: testschema.Schema{
+				Attributes: map[string]fwschema.Attribute{
+					"test": testschema.Attribute{
 						Type: types.ListType{
 							ElemType: types.StringType,
 						},
@@ -1110,9 +1131,9 @@ func TestDataPathMatches(t *testing.T) {
 			},
 		},
 		"AttributeNameExact-ElementKeyValueAny-parent-null": {
-			schema: tfsdk.Schema{
-				Attributes: map[string]tfsdk.Attribute{
-					"test": {
+			schema: testschema.Schema{
+				Attributes: map[string]fwschema.Attribute{
+					"test": testschema.Attribute{
 						Type: types.SetType{
 							ElemType: types.StringType,
 						},
@@ -1142,9 +1163,9 @@ func TestDataPathMatches(t *testing.T) {
 			},
 		},
 		"AttributeNameExact-ElementKeyValueAny-parent-unknown": {
-			schema: tfsdk.Schema{
-				Attributes: map[string]tfsdk.Attribute{
-					"test": {
+			schema: testschema.Schema{
+				Attributes: map[string]fwschema.Attribute{
+					"test": testschema.Attribute{
 						Type: types.SetType{
 							ElemType: types.StringType,
 						},
@@ -1174,9 +1195,9 @@ func TestDataPathMatches(t *testing.T) {
 			},
 		},
 		"AttributeNameExact-ElementKeyValueExact-match": {
-			schema: tfsdk.Schema{
-				Attributes: map[string]tfsdk.Attribute{
-					"test": {
+			schema: testschema.Schema{
+				Attributes: map[string]fwschema.Attribute{
+					"test": testschema.Attribute{
 						Type: types.SetType{
 							ElemType: types.StringType,
 						},
@@ -1210,9 +1231,9 @@ func TestDataPathMatches(t *testing.T) {
 			},
 		},
 		"AttributeNameExact-ElementKeyValueExact-mismatch": {
-			schema: tfsdk.Schema{
-				Attributes: map[string]tfsdk.Attribute{
-					"test": {
+			schema: testschema.Schema{
+				Attributes: map[string]fwschema.Attribute{
+					"test": testschema.Attribute{
 						Type: types.SetType{
 							ElemType: types.StringType,
 						},
@@ -1253,9 +1274,9 @@ func TestDataPathMatches(t *testing.T) {
 			},
 		},
 		"AttributeNameExact-ElementKeyValueExact-parent-null": {
-			schema: tfsdk.Schema{
-				Attributes: map[string]tfsdk.Attribute{
-					"test": {
+			schema: testschema.Schema{
+				Attributes: map[string]fwschema.Attribute{
+					"test": testschema.Attribute{
 						Type: types.SetType{
 							ElemType: types.StringType,
 						},
@@ -1285,9 +1306,9 @@ func TestDataPathMatches(t *testing.T) {
 			},
 		},
 		"AttributeNameExact-ElementKeyValueExact-parent-unknown": {
-			schema: tfsdk.Schema{
-				Attributes: map[string]tfsdk.Attribute{
-					"test": {
+			schema: testschema.Schema{
+				Attributes: map[string]fwschema.Attribute{
+					"test": testschema.Attribute{
 						Type: types.SetType{
 							ElemType: types.StringType,
 						},
@@ -1317,9 +1338,9 @@ func TestDataPathMatches(t *testing.T) {
 			},
 		},
 		"AttributeNameExact-Parent": {
-			schema: tfsdk.Schema{
-				Attributes: map[string]tfsdk.Attribute{
-					"test": {
+			schema: testschema.Schema{
+				Attributes: map[string]fwschema.Attribute{
+					"test": testschema.Attribute{
 						Type: types.StringType,
 					},
 				},
@@ -1347,9 +1368,9 @@ func TestDataPathMatches(t *testing.T) {
 			},
 		},
 		"AttributeNameExact-Parent-Parent": {
-			schema: tfsdk.Schema{
-				Attributes: map[string]tfsdk.Attribute{
-					"test": {
+			schema: testschema.Schema{
+				Attributes: map[string]fwschema.Attribute{
+					"test": testschema.Attribute{
 						Type: types.StringType,
 					},
 				},

--- a/internal/fwschemadata/data_set_at_path_test.go
+++ b/internal/fwschemadata/data_set_at_path_test.go
@@ -7,10 +7,11 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschemadata"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
 	testtypes "github.com/hashicorp/terraform-plugin-framework/internal/testing/types"
 	"github.com/hashicorp/terraform-plugin-framework/path"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
@@ -62,23 +63,26 @@ func TestDataSetAtPath(t *testing.T) {
 					}),
 					"other": tftypes.NewValue(tftypes.String, "should be untouched"),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"disks": {
-							Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
-								"id": {
-									Type:     types.StringType,
-									Required: true,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"disks": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"id": testschema.Attribute{
+										Type:     types.StringType,
+										Required: true,
+									},
+									"delete_with_instance": testschema.Attribute{
+										Type:     types.BoolType,
+										Optional: true,
+									},
 								},
-								"delete_with_instance": {
-									Type:     types.BoolType,
-									Optional: true,
-								},
-							}),
-							Optional: true,
-							Computed: true,
+							},
+							NestingMode: fwschema.NestingModeList,
+							Optional:    true,
+							Computed:    true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.StringType,
 							Required: true,
 						},
@@ -171,23 +175,26 @@ func TestDataSetAtPath(t *testing.T) {
 					}),
 					"other": tftypes.NewValue(tftypes.String, "should be untouched"),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"disks": {
-							Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
-								"id": {
-									Type:     types.StringType,
-									Required: true,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"disks": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"id": testschema.Attribute{
+										Type:     types.StringType,
+										Required: true,
+									},
+									"delete_with_instance": testschema.Attribute{
+										Type:     types.BoolType,
+										Optional: true,
+									},
 								},
-								"delete_with_instance": {
-									Type:     types.BoolType,
-									Optional: true,
-								},
-							}),
-							Optional: true,
-							Computed: true,
+							},
+							NestingMode: fwschema.NestingModeList,
+							Optional:    true,
+							Computed:    true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.StringType,
 							Required: true,
 						},
@@ -269,23 +276,26 @@ func TestDataSetAtPath(t *testing.T) {
 					}, nil),
 					"other": tftypes.NewValue(tftypes.String, "should be untouched"),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"disks": {
-							Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
-								"id": {
-									Type:     types.StringType,
-									Required: true,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"disks": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"id": testschema.Attribute{
+										Type:     types.StringType,
+										Required: true,
+									},
+									"delete_with_instance": testschema.Attribute{
+										Type:     types.BoolType,
+										Optional: true,
+									},
 								},
-								"delete_with_instance": {
-									Type:     types.BoolType,
-									Optional: true,
-								},
-							}),
-							Optional: true,
-							Computed: true,
+							},
+							NestingMode: fwschema.NestingModeList,
+							Optional:    true,
+							Computed:    true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.StringType,
 							Required: true,
 						},
@@ -359,23 +369,26 @@ func TestDataSetAtPath(t *testing.T) {
 					}, nil),
 					"other": tftypes.NewValue(tftypes.String, "should be untouched"),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"disks": {
-							Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
-								"id": {
-									Type:     types.StringType,
-									Required: true,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"disks": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"id": testschema.Attribute{
+										Type:     types.StringType,
+										Required: true,
+									},
+									"delete_with_instance": testschema.Attribute{
+										Type:     types.BoolType,
+										Optional: true,
+									},
 								},
-								"delete_with_instance": {
-									Type:     types.BoolType,
-									Optional: true,
-								},
-							}),
-							Optional: true,
-							Computed: true,
+							},
+							NestingMode: fwschema.NestingModeList,
+							Optional:    true,
+							Computed:    true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.StringType,
 							Required: true,
 						},
@@ -439,15 +452,15 @@ func TestDataSetAtPath(t *testing.T) {
 					}),
 					"other": tftypes.NewValue(tftypes.String, "should be untouched"),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"test": testschema.Attribute{
 							Type: types.MapType{
 								ElemType: types.StringType,
 							},
 							Required: true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.StringType,
 							Required: true,
 						},
@@ -488,15 +501,15 @@ func TestDataSetAtPath(t *testing.T) {
 					}, nil),
 					"other": tftypes.NewValue(tftypes.String, "should be untouched"),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"test": testschema.Attribute{
 							Type: types.MapType{
 								ElemType: types.StringType,
 							},
 							Required: true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.StringType,
 							Required: true,
 						},
@@ -556,23 +569,26 @@ func TestDataSetAtPath(t *testing.T) {
 					}),
 					"other": tftypes.NewValue(tftypes.String, "should be untouched"),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"disks": {
-							Attributes: tfsdk.SetNestedAttributes(map[string]tfsdk.Attribute{
-								"id": {
-									Type:     types.StringType,
-									Required: true,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"disks": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"id": testschema.Attribute{
+										Type:     types.StringType,
+										Required: true,
+									},
+									"delete_with_instance": testschema.Attribute{
+										Type:     types.BoolType,
+										Optional: true,
+									},
 								},
-								"delete_with_instance": {
-									Type:     types.BoolType,
-									Optional: true,
-								},
-							}),
-							Optional: true,
-							Computed: true,
+							},
+							NestingMode: fwschema.NestingModeSet,
+							Optional:    true,
+							Computed:    true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.StringType,
 							Required: true,
 						},
@@ -664,23 +680,26 @@ func TestDataSetAtPath(t *testing.T) {
 					}, nil),
 					"other": tftypes.NewValue(tftypes.String, "should be untouched"),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"disks": {
-							Attributes: tfsdk.SetNestedAttributes(map[string]tfsdk.Attribute{
-								"id": {
-									Type:     types.StringType,
-									Required: true,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"disks": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"id": testschema.Attribute{
+										Type:     types.StringType,
+										Required: true,
+									},
+									"delete_with_instance": testschema.Attribute{
+										Type:     types.BoolType,
+										Optional: true,
+									},
 								},
-								"delete_with_instance": {
-									Type:     types.BoolType,
-									Optional: true,
-								},
-							}),
-							Optional: true,
-							Computed: true,
+							},
+							NestingMode: fwschema.NestingModeSet,
+							Optional:    true,
+							Computed:    true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.StringType,
 							Required: true,
 						},
@@ -749,13 +768,13 @@ func TestDataSetAtPath(t *testing.T) {
 					"test":  tftypes.NewValue(tftypes.Bool, true),
 					"other": tftypes.NewValue(tftypes.String, "should be untouched"),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"test": testschema.Attribute{
 							Type:     types.BoolType,
 							Required: true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.StringType,
 							Required: true,
 						},
@@ -791,15 +810,15 @@ func TestDataSetAtPath(t *testing.T) {
 					}),
 					"other": tftypes.NewValue(tftypes.String, "should be untouched"),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"tags": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"tags": testschema.Attribute{
 							Type: types.ListType{
 								ElemType: types.StringType,
 							},
 							Required: true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.StringType,
 							Required: true,
 						},
@@ -867,23 +886,26 @@ func TestDataSetAtPath(t *testing.T) {
 					}),
 					"other": tftypes.NewValue(tftypes.String, "should be untouched"),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"disks": {
-							Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
-								"id": {
-									Type:     types.StringType,
-									Required: true,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"disks": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"id": testschema.Attribute{
+										Type:     types.StringType,
+										Required: true,
+									},
+									"delete_with_instance": testschema.Attribute{
+										Type:     types.BoolType,
+										Optional: true,
+									},
 								},
-								"delete_with_instance": {
-									Type:     types.BoolType,
-									Optional: true,
-								},
-							}),
-							Optional: true,
-							Computed: true,
+							},
+							NestingMode: fwschema.NestingModeList,
+							Optional:    true,
+							Computed:    true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.StringType,
 							Required: true,
 						},
@@ -959,15 +981,15 @@ func TestDataSetAtPath(t *testing.T) {
 					}),
 					"other": tftypes.NewValue(tftypes.String, "should be untouched"),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"test": testschema.Attribute{
 							Type: types.MapType{
 								ElemType: types.StringType,
 							},
 							Required: true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.StringType,
 							Required: true,
 						},
@@ -1012,15 +1034,15 @@ func TestDataSetAtPath(t *testing.T) {
 					}),
 					"other": tftypes.NewValue(tftypes.String, "should be untouched"),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"test": testschema.Attribute{
 							Type: types.MapType{
 								ElemType: types.StringType,
 							},
 							Required: true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.StringType,
 							Required: true,
 						},
@@ -1057,13 +1079,13 @@ func TestDataSetAtPath(t *testing.T) {
 					"test":  tftypes.NewValue(tftypes.Number, 1),
 					"other": tftypes.NewValue(tftypes.String, "should be untouched"),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"test": testschema.Attribute{
 							Type:     types.NumberType,
 							Required: true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.StringType,
 							Required: true,
 						},
@@ -1106,9 +1128,9 @@ func TestDataSetAtPath(t *testing.T) {
 					}),
 					"other": tftypes.NewValue(tftypes.String, "should be untouched"),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"scratch_disk": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"scratch_disk": testschema.Attribute{
 							Type: types.ObjectType{
 								AttrTypes: map[string]attr.Type{
 									"interface": types.StringType,
@@ -1117,7 +1139,7 @@ func TestDataSetAtPath(t *testing.T) {
 							},
 							Optional: true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.StringType,
 							Required: true,
 						},
@@ -1176,9 +1198,9 @@ func TestDataSetAtPath(t *testing.T) {
 					}),
 					"other": tftypes.NewValue(tftypes.String, "should be untouched"),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"scratch_disk": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"scratch_disk": testschema.Attribute{
 							Type: types.ObjectType{
 								AttrTypes: map[string]attr.Type{
 									"interface": types.StringType,
@@ -1186,7 +1208,7 @@ func TestDataSetAtPath(t *testing.T) {
 							},
 							Optional: true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.StringType,
 							Required: true,
 						},
@@ -1232,15 +1254,15 @@ func TestDataSetAtPath(t *testing.T) {
 					}),
 					"other": tftypes.NewValue(tftypes.String, "should be untouched"),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"tags": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"tags": testschema.Attribute{
 							Type: types.SetType{
 								ElemType: types.StringType,
 							},
 							Required: true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.StringType,
 							Required: true,
 						},
@@ -1308,23 +1330,26 @@ func TestDataSetAtPath(t *testing.T) {
 					}),
 					"other": tftypes.NewValue(tftypes.String, "should be untouched"),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"disks": {
-							Attributes: tfsdk.SetNestedAttributes(map[string]tfsdk.Attribute{
-								"id": {
-									Type:     types.StringType,
-									Required: true,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"disks": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"id": testschema.Attribute{
+										Type:     types.StringType,
+										Required: true,
+									},
+									"delete_with_instance": testschema.Attribute{
+										Type:     types.BoolType,
+										Optional: true,
+									},
 								},
-								"delete_with_instance": {
-									Type:     types.BoolType,
-									Optional: true,
-								},
-							}),
-							Optional: true,
-							Computed: true,
+							},
+							NestingMode: fwschema.NestingModeSet,
+							Optional:    true,
+							Computed:    true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.StringType,
 							Required: true,
 						},
@@ -1410,15 +1435,15 @@ func TestDataSetAtPath(t *testing.T) {
 					}),
 					"other": tftypes.NewValue(tftypes.String, "should be untouched"),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"tags": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"tags": testschema.Attribute{
 							Type: types.SetType{
 								ElemType: types.StringType,
 							},
 							Required: true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.StringType,
 							Required: true,
 						},
@@ -1456,13 +1481,13 @@ func TestDataSetAtPath(t *testing.T) {
 					"test":  tftypes.NewValue(tftypes.String, "originalvalue"),
 					"other": tftypes.NewValue(tftypes.String, "should be untouched"),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"test": testschema.Attribute{
 							Type:     types.StringType,
 							Required: true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.StringType,
 							Required: true,
 						},
@@ -1488,9 +1513,9 @@ func TestDataSetAtPath(t *testing.T) {
 						"test": tftypes.Bool,
 					},
 				}, nil),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"test": testschema.Attribute{
 							Type:     types.BoolType,
 							Required: true,
 						},
@@ -1520,13 +1545,13 @@ func TestDataSetAtPath(t *testing.T) {
 						"other": tftypes.String,
 					},
 				}, nil),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"test": testschema.Attribute{
 							Type:     types.BoolType,
 							Required: true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.StringType,
 							Required: true,
 						},
@@ -1555,15 +1580,15 @@ func TestDataSetAtPath(t *testing.T) {
 						"other": tftypes.String,
 					},
 				}, nil),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"tags": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"tags": testschema.Attribute{
 							Type: types.ListType{
 								ElemType: types.StringType,
 							},
 							Required: true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.StringType,
 							Required: true,
 						},
@@ -1597,9 +1622,9 @@ func TestDataSetAtPath(t *testing.T) {
 						"other": tftypes.String,
 					},
 				}, nil),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"test": testschema.Attribute{
 							Type: testtypes.ListTypeWithValidateWarning{
 								ListType: types.ListType{
 									ElemType: types.StringType,
@@ -1608,7 +1633,7 @@ func TestDataSetAtPath(t *testing.T) {
 							Optional: true,
 							Computed: true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.StringType,
 							Required: true,
 						},
@@ -1651,23 +1676,26 @@ func TestDataSetAtPath(t *testing.T) {
 						"other": tftypes.String,
 					},
 				}, nil),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"disks": {
-							Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
-								"id": {
-									Type:     types.StringType,
-									Required: true,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"disks": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"id": testschema.Attribute{
+										Type:     types.StringType,
+										Required: true,
+									},
+									"delete_with_instance": testschema.Attribute{
+										Type:     types.BoolType,
+										Optional: true,
+									},
 								},
-								"delete_with_instance": {
-									Type:     types.BoolType,
-									Optional: true,
-								},
-							}),
-							Optional: true,
-							Computed: true,
+							},
+							NestingMode: fwschema.NestingModeList,
+							Optional:    true,
+							Computed:    true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.StringType,
 							Required: true,
 						},
@@ -1731,23 +1759,26 @@ func TestDataSetAtPath(t *testing.T) {
 						"other": tftypes.String,
 					},
 				}, nil),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"disks": {
-							Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
-								"id": {
-									Type:     types.StringType,
-									Required: true,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"disks": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"id": testschema.Attribute{
+										Type:     types.StringType,
+										Required: true,
+									},
+									"delete_with_instance": testschema.Attribute{
+										Type:     types.BoolType,
+										Optional: true,
+									},
 								},
-								"delete_with_instance": {
-									Type:     types.BoolType,
-									Optional: true,
-								},
-							}),
-							Optional: true,
-							Computed: true,
+							},
+							NestingMode: fwschema.NestingModeList,
+							Optional:    true,
+							Computed:    true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.StringType,
 							Required: true,
 						},
@@ -1789,23 +1820,26 @@ func TestDataSetAtPath(t *testing.T) {
 				TerraformValue: tftypes.NewValue(tftypes.Object{
 					AttributeTypes: map[string]tftypes.Type{},
 				}, nil),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"disks": {
-							Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
-								"id": {
-									Type:     testtypes.StringTypeWithValidateWarning{},
-									Required: true,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"disks": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"id": testschema.Attribute{
+										Type:     testtypes.StringTypeWithValidateWarning{},
+										Required: true,
+									},
+									"delete_with_instance": testschema.Attribute{
+										Type:     types.BoolType,
+										Optional: true,
+									},
 								},
-								"delete_with_instance": {
-									Type:     types.BoolType,
-									Optional: true,
-								},
-							}),
-							Optional: true,
-							Computed: true,
+							},
+							NestingMode: fwschema.NestingModeList,
+							Optional:    true,
+							Computed:    true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.StringType,
 							Required: true,
 						},
@@ -1867,15 +1901,15 @@ func TestDataSetAtPath(t *testing.T) {
 						"other": tftypes.String,
 					},
 				}, nil),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"test": testschema.Attribute{
 							Type: types.MapType{
 								ElemType: types.StringType,
 							},
 							Required: true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.StringType,
 							Required: true,
 						},
@@ -1912,9 +1946,9 @@ func TestDataSetAtPath(t *testing.T) {
 						"other": tftypes.String,
 					},
 				}, nil),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"test": testschema.Attribute{
 							Type: testtypes.MapTypeWithValidateWarning{
 								MapType: types.MapType{
 									ElemType: types.StringType,
@@ -1922,7 +1956,7 @@ func TestDataSetAtPath(t *testing.T) {
 							},
 							Required: true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.StringType,
 							Required: true,
 						},
@@ -1960,15 +1994,15 @@ func TestDataSetAtPath(t *testing.T) {
 						"other": tftypes.String,
 					},
 				}, nil),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"test": testschema.Attribute{
 							Type: types.MapType{
 								ElemType: types.StringType,
 							},
 							Required: true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.StringType,
 							Required: true,
 						},
@@ -2003,15 +2037,15 @@ func TestDataSetAtPath(t *testing.T) {
 						"other": tftypes.String,
 					},
 				}, nil),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"test": testschema.Attribute{
 							Type: types.MapType{
 								ElemType: testtypes.StringTypeWithValidateWarning{},
 							},
 							Required: true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.StringType,
 							Required: true,
 						},
@@ -2047,13 +2081,13 @@ func TestDataSetAtPath(t *testing.T) {
 						"other": tftypes.String,
 					},
 				}, nil),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"test": testschema.Attribute{
 							Type:     types.NumberType,
 							Required: true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.StringType,
 							Required: true,
 						},
@@ -2084,9 +2118,9 @@ func TestDataSetAtPath(t *testing.T) {
 						"other": tftypes.String,
 					},
 				}, nil),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"scratch_disk": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"scratch_disk": testschema.Attribute{
 							Type: types.ObjectType{
 								AttrTypes: map[string]attr.Type{
 									"interface": types.StringType,
@@ -2094,7 +2128,7 @@ func TestDataSetAtPath(t *testing.T) {
 							},
 							Optional: true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.StringType,
 							Required: true,
 						},
@@ -2135,15 +2169,15 @@ func TestDataSetAtPath(t *testing.T) {
 						"other": tftypes.String,
 					},
 				}, nil),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"tags": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"tags": testschema.Attribute{
 							Type: types.SetType{
 								ElemType: types.StringType,
 							},
 							Required: true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.StringType,
 							Required: true,
 						},
@@ -2182,23 +2216,26 @@ func TestDataSetAtPath(t *testing.T) {
 						"other": tftypes.String,
 					},
 				}, nil),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"disks": {
-							Attributes: tfsdk.SetNestedAttributes(map[string]tfsdk.Attribute{
-								"id": {
-									Type:     types.StringType,
-									Required: true,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"disks": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"id": testschema.Attribute{
+										Type:     types.StringType,
+										Required: true,
+									},
+									"delete_with_instance": testschema.Attribute{
+										Type:     types.BoolType,
+										Optional: true,
+									},
 								},
-								"delete_with_instance": {
-									Type:     types.BoolType,
-									Optional: true,
-								},
-							}),
-							Optional: true,
-							Computed: true,
+							},
+							NestingMode: fwschema.NestingModeSet,
+							Optional:    true,
+							Computed:    true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.StringType,
 							Required: true,
 						},
@@ -2266,9 +2303,9 @@ func TestDataSetAtPath(t *testing.T) {
 						"other": tftypes.String,
 					},
 				}, nil),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"test": testschema.Attribute{
 							Type: testtypes.SetTypeWithValidateWarning{
 								SetType: types.SetType{
 									ElemType: types.StringType,
@@ -2277,7 +2314,7 @@ func TestDataSetAtPath(t *testing.T) {
 							Optional: true,
 							Computed: true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.StringType,
 							Required: true,
 						},
@@ -2320,23 +2357,26 @@ func TestDataSetAtPath(t *testing.T) {
 						"other": tftypes.String,
 					},
 				}, nil),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"disks": {
-							Attributes: tfsdk.SetNestedAttributes(map[string]tfsdk.Attribute{
-								"id": {
-									Type:     testtypes.StringTypeWithValidateWarning{},
-									Required: true,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"disks": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"id": testschema.Attribute{
+										Type:     testtypes.StringTypeWithValidateWarning{},
+										Required: true,
+									},
+									"delete_with_instance": testschema.Attribute{
+										Type:     types.BoolType,
+										Optional: true,
+									},
 								},
-								"delete_with_instance": {
-									Type:     types.BoolType,
-									Optional: true,
-								},
-							}),
-							Optional: true,
-							Computed: true,
+							},
+							NestingMode: fwschema.NestingModeSet,
+							Optional:    true,
+							Computed:    true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.StringType,
 							Required: true,
 						},
@@ -2414,13 +2454,13 @@ func TestDataSetAtPath(t *testing.T) {
 						"other": tftypes.String,
 					},
 				}, nil),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"test": testschema.Attribute{
 							Type:     types.StringType,
 							Required: true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.StringType,
 							Required: true,
 						},
@@ -2448,9 +2488,9 @@ func TestDataSetAtPath(t *testing.T) {
 				}, map[string]tftypes.Value{
 					"name": tftypes.NewValue(tftypes.String, "originalname"),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"name": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"name": testschema.Attribute{
 							Type:     testtypes.StringTypeWithValidateError{},
 							Required: true,
 						},
@@ -2477,9 +2517,9 @@ func TestDataSetAtPath(t *testing.T) {
 				}, map[string]tftypes.Value{
 					"name": tftypes.NewValue(tftypes.String, "originalname"),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"name": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"name": testschema.Attribute{
 							Type:     testtypes.StringTypeWithValidateWarning{},
 							Required: true,
 						},

--- a/internal/fwschemadata/data_set_test.go
+++ b/internal/fwschemadata/data_set_test.go
@@ -6,10 +6,11 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschemadata"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
 	testtypes "github.com/hashicorp/terraform-plugin-framework/internal/testing/types"
 	"github.com/hashicorp/terraform-plugin-framework/path"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
@@ -34,9 +35,9 @@ func TestDataSet(t *testing.T) {
 				}, map[string]tftypes.Value{
 					"name": tftypes.NewValue(tftypes.String, "oldvalue"),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"name": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"name": testschema.Attribute{
 							Type:     types.StringType,
 							Required: true,
 						},
@@ -59,9 +60,9 @@ func TestDataSet(t *testing.T) {
 		"overwrite": {
 			data: fwschemadata.Data{
 				TerraformValue: tftypes.Value{},
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"name": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"name": testschema.Attribute{
 							Type:     types.StringType,
 							Required: true,
 						},
@@ -84,17 +85,17 @@ func TestDataSet(t *testing.T) {
 		"multiple-attributes": {
 			data: fwschemadata.Data{
 				TerraformValue: tftypes.Value{},
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"one": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"one": testschema.Attribute{
 							Type:     types.StringType,
 							Required: true,
 						},
-						"two": {
+						"two": testschema.Attribute{
 							Type:     types.StringType,
 							Required: true,
 						},
-						"three": {
+						"three": testschema.Attribute{
 							Type:     types.StringType,
 							Required: true,
 						},
@@ -125,9 +126,9 @@ func TestDataSet(t *testing.T) {
 		"AttrTypeWithValidateError": {
 			data: fwschemadata.Data{
 				TerraformValue: tftypes.Value{},
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"name": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"name": testschema.Attribute{
 							Type:     testtypes.StringTypeWithValidateError{},
 							Required: true,
 						},
@@ -145,9 +146,9 @@ func TestDataSet(t *testing.T) {
 		"AttrTypeWithValidateWarning": {
 			data: fwschemadata.Data{
 				TerraformValue: tftypes.Value{},
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"name": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"name": testschema.Attribute{
 							Type:     testtypes.StringTypeWithValidateWarning{},
 							Required: true,
 						},

--- a/internal/fwschemadata/data_value_test.go
+++ b/internal/fwschemadata/data_value_test.go
@@ -7,10 +7,11 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschemadata"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
 	testtypes "github.com/hashicorp/terraform-plugin-framework/internal/testing/types"
 	"github.com/hashicorp/terraform-plugin-framework/path"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
@@ -34,13 +35,13 @@ func TestDataValueAtPath(t *testing.T) {
 						"other": tftypes.Bool,
 					},
 				}, nil),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"test": testschema.Attribute{
 							Type:     types.StringType,
 							Required: true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.BoolType,
 							Optional: true,
 						},
@@ -59,9 +60,9 @@ func TestDataValueAtPath(t *testing.T) {
 				}, map[string]tftypes.Value{
 					"test": tftypes.NewValue(tftypes.String, "value"),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"test": testschema.Attribute{
 							Type:     types.StringType,
 							Required: true,
 						},
@@ -94,15 +95,15 @@ func TestDataValueAtPath(t *testing.T) {
 					}, nil),
 					"other": tftypes.NewValue(tftypes.Bool, nil),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"test": testschema.Attribute{
 							Type: types.ListType{
 								ElemType: types.StringType,
 							},
 							Required: true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.BoolType,
 							Optional: true,
 						},
@@ -130,15 +131,15 @@ func TestDataValueAtPath(t *testing.T) {
 					}),
 					"other": tftypes.NewValue(tftypes.Bool, nil),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"test": testschema.Attribute{
 							Type: types.ListType{
 								ElemType: types.StringType,
 							},
 							Required: true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.BoolType,
 							Optional: true,
 						},
@@ -171,18 +172,21 @@ func TestDataValueAtPath(t *testing.T) {
 					}, nil),
 					"other": tftypes.NewValue(tftypes.Bool, nil),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test": {
-							Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
-								"sub_test": {
-									Type:     types.StringType,
-									Required: true,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"test": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"sub_test": testschema.Attribute{
+										Type:     types.StringType,
+										Required: true,
+									},
 								},
-							}),
-							Required: true,
+							},
+							NestingMode: fwschema.NestingModeList,
+							Required:    true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.BoolType,
 							Optional: true,
 						},
@@ -223,23 +227,29 @@ func TestDataValueAtPath(t *testing.T) {
 					}, nil),
 					"other": tftypes.NewValue(tftypes.Bool, nil),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test": {
-							Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
-								"sub_test": {
-									Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
-										"value": {
-											Type:     types.StringType,
-											Optional: true,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"test": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"sub_test": testschema.NestedAttribute{
+										NestedObject: testschema.NestedAttributeObject{
+											Attributes: map[string]fwschema.Attribute{
+												"value": testschema.Attribute{
+													Type:     types.StringType,
+													Optional: true,
+												},
+											},
 										},
-									}),
-									Optional: true,
+										NestingMode: fwschema.NestingModeSingle,
+										Optional:    true,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeList,
+							Optional:    true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.BoolType,
 							Optional: true,
 						},
@@ -282,18 +292,21 @@ func TestDataValueAtPath(t *testing.T) {
 					}),
 					"other": tftypes.NewValue(tftypes.Bool, nil),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test": {
-							Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
-								"sub_test": {
-									Type:     types.StringType,
-									Required: true,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"test": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"sub_test": testschema.Attribute{
+										Type:     types.StringType,
+										Required: true,
+									},
 								},
-							}),
-							Required: true,
+							},
+							NestingMode: fwschema.NestingModeList,
+							Required:    true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.BoolType,
 							Optional: true,
 						},
@@ -340,31 +353,35 @@ func TestDataValueAtPath(t *testing.T) {
 						},
 					}, nil),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"other_attr": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"other_attr": testschema.Attribute{
 							Type:     types.BoolType,
 							Optional: true,
 						},
 					},
-					Blocks: map[string]tfsdk.Block{
-						"other_block": {
-							Attributes: map[string]tfsdk.Attribute{
-								"sub_test": {
-									Type:     types.BoolType,
-									Optional: true,
+					Blocks: map[string]fwschema.Block{
+						"other_block": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"sub_test": testschema.Attribute{
+										Type:     types.BoolType,
+										Optional: true,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeList,
+							NestingMode: fwschema.BlockNestingModeList,
 						},
-						"test": {
-							Attributes: map[string]tfsdk.Attribute{
-								"sub_test": {
-									Type:     types.StringType,
-									Required: true,
+						"test": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"sub_test": testschema.Attribute{
+										Type:     types.StringType,
+										Optional: true,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeList,
+							NestingMode: fwschema.BlockNestingModeList,
 						},
 					},
 				},
@@ -417,31 +434,35 @@ func TestDataValueAtPath(t *testing.T) {
 						}),
 					}),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"other_attr": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"other_attr": testschema.Attribute{
 							Type:     types.BoolType,
 							Optional: true,
 						},
 					},
-					Blocks: map[string]tfsdk.Block{
-						"other_block": {
-							Attributes: map[string]tfsdk.Attribute{
-								"sub_test": {
-									Type:     types.BoolType,
-									Optional: true,
+					Blocks: map[string]fwschema.Block{
+						"other_block": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"sub_test": testschema.Attribute{
+										Type:     types.BoolType,
+										Optional: true,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeList,
+							NestingMode: fwschema.BlockNestingModeList,
 						},
-						"test": {
-							Attributes: map[string]tfsdk.Attribute{
-								"sub_test": {
-									Type:     types.StringType,
-									Required: true,
+						"test": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"sub_test": testschema.Attribute{
+										Type:     types.StringType,
+										Optional: true,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeList,
+							NestingMode: fwschema.BlockNestingModeList,
 						},
 					},
 				},
@@ -464,15 +485,15 @@ func TestDataValueAtPath(t *testing.T) {
 					}, nil),
 					"other": tftypes.NewValue(tftypes.Bool, nil),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"test": testschema.Attribute{
 							Type: types.MapType{
 								ElemType: types.StringType,
 							},
 							Required: true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.BoolType,
 							Optional: true,
 						},
@@ -500,15 +521,15 @@ func TestDataValueAtPath(t *testing.T) {
 					}),
 					"other": tftypes.NewValue(tftypes.Bool, nil),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"test": testschema.Attribute{
 							Type: types.MapType{
 								ElemType: types.StringType,
 							},
 							Required: true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.BoolType,
 							Optional: true,
 						},
@@ -535,15 +556,15 @@ func TestDataValueAtPath(t *testing.T) {
 					}),
 					"other": tftypes.NewValue(tftypes.Bool, nil),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"test": testschema.Attribute{
 							Type: types.MapType{
 								ElemType: types.StringType,
 							},
 							Required: true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.BoolType,
 							Optional: true,
 						},
@@ -576,18 +597,21 @@ func TestDataValueAtPath(t *testing.T) {
 					}, nil),
 					"other": tftypes.NewValue(tftypes.Bool, nil),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test": {
-							Attributes: tfsdk.MapNestedAttributes(map[string]tfsdk.Attribute{
-								"sub_test": {
-									Type:     types.StringType,
-									Required: true,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"test": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"sub_test": testschema.Attribute{
+										Type:     types.StringType,
+										Required: true,
+									},
 								},
-							}),
-							Required: true,
+							},
+							NestingMode: fwschema.NestingModeMap,
+							Required:    true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.BoolType,
 							Optional: true,
 						},
@@ -628,18 +652,21 @@ func TestDataValueAtPath(t *testing.T) {
 					}),
 					"other": tftypes.NewValue(tftypes.Bool, nil),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test": {
-							Attributes: tfsdk.MapNestedAttributes(map[string]tfsdk.Attribute{
-								"sub_test": {
-									Type:     types.StringType,
-									Required: true,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"test": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"sub_test": testschema.Attribute{
+										Type:     types.StringType,
+										Required: true,
+									},
 								},
-							}),
-							Required: true,
+							},
+							NestingMode: fwschema.NestingModeMap,
+							Required:    true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.BoolType,
 							Optional: true,
 						},
@@ -670,9 +697,9 @@ func TestDataValueAtPath(t *testing.T) {
 					}),
 					"other": tftypes.NewValue(tftypes.Bool, nil),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"test": testschema.Attribute{
 							Type: types.ObjectType{
 								AttrTypes: map[string]attr.Type{
 									"sub_test": types.StringType,
@@ -680,7 +707,7 @@ func TestDataValueAtPath(t *testing.T) {
 							},
 							Required: true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.BoolType,
 							Optional: true,
 						},
@@ -705,15 +732,15 @@ func TestDataValueAtPath(t *testing.T) {
 					}, nil),
 					"other": tftypes.NewValue(tftypes.Bool, nil),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"test": testschema.Attribute{
 							Type: types.SetType{
 								ElemType: types.StringType,
 							},
 							Required: true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.BoolType,
 							Optional: true,
 						},
@@ -741,15 +768,15 @@ func TestDataValueAtPath(t *testing.T) {
 					}),
 					"other": tftypes.NewValue(tftypes.Bool, nil),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"test": testschema.Attribute{
 							Type: types.SetType{
 								ElemType: types.StringType,
 							},
 							Required: true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.BoolType,
 							Optional: true,
 						},
@@ -782,18 +809,21 @@ func TestDataValueAtPath(t *testing.T) {
 					}, nil),
 					"other": tftypes.NewValue(tftypes.Bool, nil),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test": {
-							Attributes: tfsdk.SetNestedAttributes(map[string]tfsdk.Attribute{
-								"sub_test": {
-									Type:     types.StringType,
-									Required: true,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"test": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"sub_test": testschema.Attribute{
+										Type:     types.StringType,
+										Required: true,
+									},
 								},
-							}),
-							Required: true,
+							},
+							NestingMode: fwschema.NestingModeSet,
+							Required:    true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.BoolType,
 							Optional: true,
 						},
@@ -841,18 +871,21 @@ func TestDataValueAtPath(t *testing.T) {
 					}),
 					"other": tftypes.NewValue(tftypes.Bool, nil),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test": {
-							Attributes: tfsdk.SetNestedAttributes(map[string]tfsdk.Attribute{
-								"sub_test": {
-									Type:     types.StringType,
-									Required: true,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"test": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"sub_test": testschema.Attribute{
+										Type:     types.StringType,
+										Required: true,
+									},
 								},
-							}),
-							Required: true,
+							},
+							NestingMode: fwschema.NestingModeSet,
+							Required:    true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.BoolType,
 							Optional: true,
 						},
@@ -906,31 +939,35 @@ func TestDataValueAtPath(t *testing.T) {
 						},
 					}, nil),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"other_attr": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"other_attr": testschema.Attribute{
 							Type:     types.BoolType,
 							Optional: true,
 						},
 					},
-					Blocks: map[string]tfsdk.Block{
-						"other_block": {
-							Attributes: map[string]tfsdk.Attribute{
-								"sub_test": {
-									Type:     types.BoolType,
-									Optional: true,
+					Blocks: map[string]fwschema.Block{
+						"other_block": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"sub_test": testschema.Attribute{
+										Type:     types.BoolType,
+										Optional: true,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeSet,
+							NestingMode: fwschema.BlockNestingModeSet,
 						},
-						"test": {
-							Attributes: map[string]tfsdk.Attribute{
-								"sub_test": {
-									Type:     types.StringType,
-									Required: true,
+						"test": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"sub_test": testschema.Attribute{
+										Type:     types.StringType,
+										Optional: true,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeSet,
+							NestingMode: fwschema.BlockNestingModeSet,
 						},
 					},
 				},
@@ -990,31 +1027,35 @@ func TestDataValueAtPath(t *testing.T) {
 						}),
 					}),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"other_attr": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"other_attr": testschema.Attribute{
 							Type:     types.BoolType,
 							Optional: true,
 						},
 					},
-					Blocks: map[string]tfsdk.Block{
-						"other_block": {
-							Attributes: map[string]tfsdk.Attribute{
-								"sub_test": {
-									Type:     types.BoolType,
-									Optional: true,
+					Blocks: map[string]fwschema.Block{
+						"other_block": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"sub_test": testschema.Attribute{
+										Type:     types.BoolType,
+										Optional: true,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeSet,
+							NestingMode: fwschema.BlockNestingModeSet,
 						},
-						"test": {
-							Attributes: map[string]tfsdk.Attribute{
-								"sub_test": {
-									Type:     types.StringType,
-									Required: true,
+						"test": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"sub_test": testschema.Attribute{
+										Type:     types.StringType,
+										Optional: true,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeSet,
+							NestingMode: fwschema.BlockNestingModeSet,
 						},
 					},
 				},
@@ -1058,31 +1099,35 @@ func TestDataValueAtPath(t *testing.T) {
 						},
 					}, nil),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"other_attr": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"other_attr": testschema.Attribute{
 							Type:     types.BoolType,
 							Optional: true,
 						},
 					},
-					Blocks: map[string]tfsdk.Block{
-						"other_block": {
-							Attributes: map[string]tfsdk.Attribute{
-								"sub_test": {
-									Type:     types.BoolType,
-									Optional: true,
+					Blocks: map[string]fwschema.Block{
+						"other_block": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"sub_test": testschema.Attribute{
+										Type:     types.BoolType,
+										Optional: true,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeSingle,
+							NestingMode: fwschema.BlockNestingModeSingle,
 						},
-						"test": {
-							Attributes: map[string]tfsdk.Attribute{
-								"sub_test": {
-									Type:     types.Float64Type,
-									Optional: true,
+						"test": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"sub_test": testschema.Attribute{
+										Type:     types.Float64Type,
+										Optional: true,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeSingle,
+							NestingMode: fwschema.BlockNestingModeSingle,
 						},
 					},
 				},
@@ -1119,31 +1164,35 @@ func TestDataValueAtPath(t *testing.T) {
 						},
 					}, nil),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"other_attr": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"other_attr": testschema.Attribute{
 							Type:     types.BoolType,
 							Optional: true,
 						},
 					},
-					Blocks: map[string]tfsdk.Block{
-						"other_block": {
-							Attributes: map[string]tfsdk.Attribute{
-								"sub_test": {
-									Type:     types.BoolType,
-									Optional: true,
+					Blocks: map[string]fwschema.Block{
+						"other_block": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"sub_test": testschema.Attribute{
+										Type:     types.BoolType,
+										Optional: true,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeSingle,
+							NestingMode: fwschema.BlockNestingModeSingle,
 						},
-						"test": {
-							Attributes: map[string]tfsdk.Attribute{
-								"sub_test": {
-									Type:     types.Int64Type,
-									Optional: true,
+						"test": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"sub_test": testschema.Attribute{
+										Type:     types.Int64Type,
+										Optional: true,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeSingle,
+							NestingMode: fwschema.BlockNestingModeSingle,
 						},
 					},
 				},
@@ -1188,35 +1237,39 @@ func TestDataValueAtPath(t *testing.T) {
 						},
 					}, nil),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"other_attr": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"other_attr": testschema.Attribute{
 							Type:     types.BoolType,
 							Optional: true,
 						},
 					},
-					Blocks: map[string]tfsdk.Block{
-						"other_block": {
-							Attributes: map[string]tfsdk.Attribute{
-								"sub_test": {
-									Type: types.SetType{
-										ElemType: types.BoolType,
+					Blocks: map[string]fwschema.Block{
+						"other_block": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"sub_test": testschema.Attribute{
+										Type: types.SetType{
+											ElemType: types.BoolType,
+										},
+										Optional: true,
 									},
-									Optional: true,
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeSingle,
+							NestingMode: fwschema.BlockNestingModeSingle,
 						},
-						"test": {
-							Attributes: map[string]tfsdk.Attribute{
-								"sub_test": {
-									Type: types.SetType{
-										ElemType: types.StringType,
+						"test": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"sub_test": testschema.Attribute{
+										Type: types.SetType{
+											ElemType: types.StringType,
+										},
+										Optional: true,
 									},
-									Optional: true,
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeSingle,
+							NestingMode: fwschema.BlockNestingModeSingle,
 						},
 					},
 				},
@@ -1253,31 +1306,35 @@ func TestDataValueAtPath(t *testing.T) {
 						},
 					}, nil),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"other_attr": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"other_attr": testschema.Attribute{
 							Type:     types.BoolType,
 							Optional: true,
 						},
 					},
-					Blocks: map[string]tfsdk.Block{
-						"other_block": {
-							Attributes: map[string]tfsdk.Attribute{
-								"sub_test": {
-									Type:     types.BoolType,
-									Optional: true,
+					Blocks: map[string]fwschema.Block{
+						"other_block": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"sub_test": testschema.Attribute{
+										Type:     types.BoolType,
+										Optional: true,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeSingle,
+							NestingMode: fwschema.BlockNestingModeSingle,
 						},
-						"test": {
-							Attributes: map[string]tfsdk.Attribute{
-								"sub_test": {
-									Type:     types.StringType,
-									Optional: true,
+						"test": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"sub_test": testschema.Attribute{
+										Type:     types.StringType,
+										Optional: true,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeSingle,
+							NestingMode: fwschema.BlockNestingModeSingle,
 						},
 					},
 				},
@@ -1318,31 +1375,35 @@ func TestDataValueAtPath(t *testing.T) {
 						"sub_test": tftypes.NewValue(tftypes.String, "value"),
 					}),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"other_attr": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"other_attr": testschema.Attribute{
 							Type:     types.BoolType,
 							Optional: true,
 						},
 					},
-					Blocks: map[string]tfsdk.Block{
-						"other_block": {
-							Attributes: map[string]tfsdk.Attribute{
-								"sub_test": {
-									Type:     types.BoolType,
-									Optional: true,
+					Blocks: map[string]fwschema.Block{
+						"other_block": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"sub_test": testschema.Attribute{
+										Type:     types.BoolType,
+										Optional: true,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeSingle,
+							NestingMode: fwschema.BlockNestingModeSingle,
 						},
-						"test": {
-							Attributes: map[string]tfsdk.Attribute{
-								"sub_test": {
-									Type:     types.StringType,
-									Optional: true,
+						"test": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"sub_test": testschema.Attribute{
+										Type:     types.StringType,
+										Optional: true,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeSingle,
+							NestingMode: fwschema.BlockNestingModeSingle,
 						},
 					},
 				},
@@ -1369,18 +1430,21 @@ func TestDataValueAtPath(t *testing.T) {
 					}, nil),
 					"other": tftypes.NewValue(tftypes.Bool, nil),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test": {
-							Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
-								"sub_test": {
-									Type:     types.Float64Type,
-									Optional: true,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"test": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"sub_test": testschema.Attribute{
+										Type:     types.Float64Type,
+										Optional: true,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeSingle,
+							Optional:    true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.BoolType,
 							Optional: true,
 						},
@@ -1409,18 +1473,21 @@ func TestDataValueAtPath(t *testing.T) {
 					}, nil),
 					"other": tftypes.NewValue(tftypes.Bool, nil),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test": {
-							Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
-								"sub_test": {
-									Type:     types.Int64Type,
-									Optional: true,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"test": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"sub_test": testschema.Attribute{
+										Type:     types.Int64Type,
+										Optional: true,
+									},
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeSingle,
+							Optional:    true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.BoolType,
 							Optional: true,
 						},
@@ -1453,20 +1520,23 @@ func TestDataValueAtPath(t *testing.T) {
 					}, nil),
 					"other": tftypes.NewValue(tftypes.Bool, nil),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test": {
-							Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
-								"sub_test": {
-									Type: types.SetType{
-										ElemType: types.StringType,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"test": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"sub_test": testschema.Attribute{
+										Type: types.SetType{
+											ElemType: types.StringType,
+										},
+										Optional: true,
 									},
-									Optional: true,
 								},
-							}),
-							Optional: true,
+							},
+							NestingMode: fwschema.NestingModeSingle,
+							Optional:    true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.BoolType,
 							Optional: true,
 						},
@@ -1495,18 +1565,21 @@ func TestDataValueAtPath(t *testing.T) {
 					}, nil),
 					"other": tftypes.NewValue(tftypes.Bool, nil),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test": {
-							Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
-								"sub_test": {
-									Type:     types.StringType,
-									Required: true,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"test": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"sub_test": testschema.Attribute{
+										Type:     types.StringType,
+										Required: true,
+									},
 								},
-							}),
-							Required: true,
+							},
+							NestingMode: fwschema.NestingModeSingle,
+							Required:    true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.BoolType,
 							Optional: true,
 						},
@@ -1537,18 +1610,21 @@ func TestDataValueAtPath(t *testing.T) {
 					}),
 					"other": tftypes.NewValue(tftypes.Bool, nil),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test": {
-							Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
-								"sub_test": {
-									Type:     types.StringType,
-									Required: true,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"test": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"sub_test": testschema.Attribute{
+										Type:     types.StringType,
+										Required: true,
+									},
 								},
-							}),
-							Required: true,
+							},
+							NestingMode: fwschema.NestingModeSingle,
+							Required:    true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.BoolType,
 							Optional: true,
 						},
@@ -1569,13 +1645,13 @@ func TestDataValueAtPath(t *testing.T) {
 					"test":  tftypes.NewValue(tftypes.String, nil),
 					"other": tftypes.NewValue(tftypes.Bool, nil),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"test": testschema.Attribute{
 							Type:     types.StringType,
 							Required: true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.StringType,
 							Required: true,
 						},
@@ -1596,13 +1672,13 @@ func TestDataValueAtPath(t *testing.T) {
 					"test":  tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
 					"other": tftypes.NewValue(tftypes.Bool, nil),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"test": testschema.Attribute{
 							Type:     types.StringType,
 							Required: true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.BoolType,
 							Optional: true,
 						},
@@ -1623,13 +1699,13 @@ func TestDataValueAtPath(t *testing.T) {
 					"test":  tftypes.NewValue(tftypes.String, "value"),
 					"other": tftypes.NewValue(tftypes.Bool, nil),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"test": testschema.Attribute{
 							Type:     types.StringType,
 							Required: true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.BoolType,
 							Optional: true,
 						},
@@ -1650,13 +1726,13 @@ func TestDataValueAtPath(t *testing.T) {
 					"test":  tftypes.NewValue(tftypes.String, "value"),
 					"other": tftypes.NewValue(tftypes.Bool, nil),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"test": testschema.Attribute{
 							Type:     testtypes.StringTypeWithValidateError{},
 							Required: true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.BoolType,
 							Optional: true,
 						},
@@ -1678,13 +1754,13 @@ func TestDataValueAtPath(t *testing.T) {
 					"test":  tftypes.NewValue(tftypes.String, "value"),
 					"other": tftypes.NewValue(tftypes.Bool, nil),
 				}),
-				Schema: tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test": {
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"test": testschema.Attribute{
 							Type:     testtypes.StringTypeWithValidateWarning{},
 							Required: true,
 						},
-						"other": {
+						"other": testschema.Attribute{
 							Type:     types.BoolType,
 							Optional: true,
 						},

--- a/internal/fwserver/attribute_validation_test.go
+++ b/internal/fwserver/attribute_validation_test.go
@@ -29,73 +29,6 @@ func TestAttributeValidate(t *testing.T) {
 		req  tfsdk.ValidateAttributeRequest
 		resp tfsdk.ValidateAttributeResponse
 	}{
-		"no-attributes-or-type": {
-			req: tfsdk.ValidateAttributeRequest{
-				AttributePath: path.Root("test"),
-				Config: tfsdk.Config{
-					Raw: tftypes.NewValue(tftypes.Object{
-						AttributeTypes: map[string]tftypes.Type{
-							"test": tftypes.String,
-						},
-					}, map[string]tftypes.Value{
-						"test": tftypes.NewValue(tftypes.String, "testvalue"),
-					}),
-					Schema: tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test": {
-								Required: true,
-							},
-						},
-					},
-				},
-			},
-			resp: tfsdk.ValidateAttributeResponse{
-				Diagnostics: diag.Diagnostics{
-					diag.NewAttributeErrorDiagnostic(
-						path.Root("test"),
-						"Invalid Attribute Definition",
-						"Attribute must define either Attributes or Type. This is always a problem with the provider and should be reported to the provider developer.",
-					),
-				},
-			},
-		},
-		"both-attributes-and-type": {
-			req: tfsdk.ValidateAttributeRequest{
-				AttributePath: path.Root("test"),
-				Config: tfsdk.Config{
-					Raw: tftypes.NewValue(tftypes.Object{
-						AttributeTypes: map[string]tftypes.Type{
-							"test": tftypes.String,
-						},
-					}, map[string]tftypes.Value{
-						"test": tftypes.NewValue(tftypes.String, "testvalue"),
-					}),
-					Schema: tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test": {
-								Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
-									"testing": {
-										Type:     types.StringType,
-										Optional: true,
-									},
-								}),
-								Type:     types.StringType,
-								Required: true,
-							},
-						},
-					},
-				},
-			},
-			resp: tfsdk.ValidateAttributeResponse{
-				Diagnostics: diag.Diagnostics{
-					diag.NewAttributeErrorDiagnostic(
-						path.Root("test"),
-						"Invalid Attribute Definition",
-						"Attribute cannot define both Attributes and Type. This is always a problem with the provider and should be reported to the provider developer.",
-					),
-				},
-			},
-		},
 		"missing-required-optional-and-computed": {
 			req: tfsdk.ValidateAttributeRequest{
 				AttributePath: path.Root("test"),
@@ -107,9 +40,9 @@ func TestAttributeValidate(t *testing.T) {
 					}, map[string]tftypes.Value{
 						"test": tftypes.NewValue(tftypes.String, "testvalue"),
 					}),
-					Schema: tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test": {
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.Attribute{
 								Type: types.StringType,
 							},
 						},
@@ -137,9 +70,9 @@ func TestAttributeValidate(t *testing.T) {
 					}, map[string]tftypes.Value{
 						"test": tftypes.NewValue(tftypes.String, "testvalue"),
 					}),
-					Schema: tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test": {
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.Attribute{
 								Type:     types.ListType{ElemType: types.StringType},
 								Required: true,
 							},
@@ -169,9 +102,9 @@ func TestAttributeValidate(t *testing.T) {
 					}, map[string]tftypes.Value{
 						"test": tftypes.NewValue(tftypes.String, nil),
 					}),
-					Schema: tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test": {
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.Attribute{
 								Computed: true,
 								Type:     types.StringType,
 							},
@@ -192,9 +125,9 @@ func TestAttributeValidate(t *testing.T) {
 					}, map[string]tftypes.Value{
 						"test": tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
 					}),
-					Schema: tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test": {
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.Attribute{
 								Computed: true,
 								Type:     types.StringType,
 							},
@@ -224,9 +157,9 @@ func TestAttributeValidate(t *testing.T) {
 					}, map[string]tftypes.Value{
 						"test": tftypes.NewValue(tftypes.String, "testvalue"),
 					}),
-					Schema: tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test": {
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.Attribute{
 								Computed: true,
 								Type:     types.StringType,
 							},
@@ -256,9 +189,9 @@ func TestAttributeValidate(t *testing.T) {
 					}, map[string]tftypes.Value{
 						"test": tftypes.NewValue(tftypes.String, nil),
 					}),
-					Schema: tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test": {
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.Attribute{
 								Computed: true,
 								Optional: true,
 								Type:     types.StringType,
@@ -280,9 +213,9 @@ func TestAttributeValidate(t *testing.T) {
 					}, map[string]tftypes.Value{
 						"test": tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
 					}),
-					Schema: tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test": {
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.Attribute{
 								Computed: true,
 								Optional: true,
 								Type:     types.StringType,
@@ -304,9 +237,9 @@ func TestAttributeValidate(t *testing.T) {
 					}, map[string]tftypes.Value{
 						"test": tftypes.NewValue(tftypes.String, "testvalue"),
 					}),
-					Schema: tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test": {
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.Attribute{
 								Computed: true,
 								Optional: true,
 								Type:     types.StringType,
@@ -328,9 +261,9 @@ func TestAttributeValidate(t *testing.T) {
 					}, map[string]tftypes.Value{
 						"test": tftypes.NewValue(tftypes.String, nil),
 					}),
-					Schema: tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test": {
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.Attribute{
 								Required: true,
 								Type:     types.StringType,
 							},
@@ -360,9 +293,9 @@ func TestAttributeValidate(t *testing.T) {
 					}, map[string]tftypes.Value{
 						"test": tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
 					}),
-					Schema: tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test": {
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.Attribute{
 								Required: true,
 								Type:     types.StringType,
 							},
@@ -383,9 +316,9 @@ func TestAttributeValidate(t *testing.T) {
 					}, map[string]tftypes.Value{
 						"test": tftypes.NewValue(tftypes.String, "testvalue"),
 					}),
-					Schema: tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test": {
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.Attribute{
 								Required: true,
 								Type:     types.StringType,
 							},
@@ -406,9 +339,9 @@ func TestAttributeValidate(t *testing.T) {
 					}, map[string]tftypes.Value{
 						"test": tftypes.NewValue(tftypes.String, "testvalue"),
 					}),
-					Schema: tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test": {
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.Attribute{
 								Type:     types.StringType,
 								Required: true,
 							},
@@ -429,9 +362,9 @@ func TestAttributeValidate(t *testing.T) {
 					}, map[string]tftypes.Value{
 						"test": tftypes.NewValue(tftypes.String, "testvalue"),
 					}),
-					Schema: tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test": {
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.Attribute{
 								Type:               types.StringType,
 								Optional:           true,
 								DeprecationMessage: "Use something else instead.",
@@ -461,9 +394,9 @@ func TestAttributeValidate(t *testing.T) {
 					}, map[string]tftypes.Value{
 						"test": tftypes.NewValue(tftypes.String, nil),
 					}),
-					Schema: tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test": {
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.Attribute{
 								Type:               types.StringType,
 								Optional:           true,
 								DeprecationMessage: "Use something else instead.",
@@ -485,9 +418,9 @@ func TestAttributeValidate(t *testing.T) {
 					}, map[string]tftypes.Value{
 						"test": tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
 					}),
-					Schema: tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test": {
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.Attribute{
 								Type:               types.StringType,
 								Optional:           true,
 								DeprecationMessage: "Use something else instead.",
@@ -509,14 +442,21 @@ func TestAttributeValidate(t *testing.T) {
 					}, map[string]tftypes.Value{
 						"test": tftypes.NewValue(tftypes.String, "testvalue"),
 					}),
-					Schema: tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test": {
-								Type:     types.StringType,
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.AttributeWithStringValidators{
 								Required: true,
-								Validators: []tfsdk.AttributeValidator{
-									testWarningAttributeValidator{},
-									testWarningAttributeValidator{},
+								Validators: []validator.String{
+									testvalidator.String{
+										ValidateStringMethod: func(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+											resp.Diagnostics.Append(testWarningDiagnostic1)
+										},
+									},
+									testvalidator.String{
+										ValidateStringMethod: func(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+											resp.Diagnostics.Append(testWarningDiagnostic2)
+										},
+									},
 								},
 							},
 						},
@@ -541,14 +481,21 @@ func TestAttributeValidate(t *testing.T) {
 					}, map[string]tftypes.Value{
 						"test": tftypes.NewValue(tftypes.String, "testvalue"),
 					}),
-					Schema: tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test": {
-								Type:     types.StringType,
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.AttributeWithStringValidators{
 								Required: true,
-								Validators: []tfsdk.AttributeValidator{
-									testErrorAttributeValidator{},
-									testErrorAttributeValidator{},
+								Validators: []validator.String{
+									testvalidator.String{
+										ValidateStringMethod: func(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+											resp.Diagnostics.Append(testErrorDiagnostic1)
+										},
+									},
+									testvalidator.String{
+										ValidateStringMethod: func(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+											resp.Diagnostics.Append(testErrorDiagnostic2)
+										},
+									},
 								},
 							},
 						},
@@ -573,9 +520,9 @@ func TestAttributeValidate(t *testing.T) {
 					}, map[string]tftypes.Value{
 						"test": tftypes.NewValue(tftypes.String, "testvalue"),
 					}),
-					Schema: tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test": {
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.Attribute{
 								Type:     testtypes.StringTypeWithValidateError{},
 								Required: true,
 							},
@@ -600,9 +547,9 @@ func TestAttributeValidate(t *testing.T) {
 					}, map[string]tftypes.Value{
 						"test": tftypes.NewValue(tftypes.String, "testvalue"),
 					}),
-					Schema: tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test": {
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.Attribute{
 								Type:     testtypes.StringTypeWithValidateWarning{},
 								Required: true,
 							},
@@ -656,16 +603,19 @@ func TestAttributeValidate(t *testing.T) {
 							),
 						},
 					),
-					Schema: tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test": {
-								Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
-									"nested_attr": {
-										Type:     types.StringType,
-										Required: true,
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.NestedAttribute{
+								NestedObject: testschema.NestedAttributeObject{
+									Attributes: map[string]fwschema.Attribute{
+										"nested_attr": testschema.Attribute{
+											Type:     types.StringType,
+											Required: true,
+										},
 									},
-								}),
-								Required: true,
+								},
+								NestingMode: fwschema.NestingModeList,
+								Required:    true,
 							},
 						},
 					},
@@ -713,16 +663,26 @@ func TestAttributeValidate(t *testing.T) {
 							),
 						},
 					),
-					Schema: tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test": {
-								Attributes: testtypes.ListNestedAttributesCustomType{
-									NestedAttributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
-										"nested_attr": {
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.NestedAttribute{
+								NestedObject: testschema.NestedAttributeObject{
+									Attributes: map[string]fwschema.Attribute{
+										"nested_attr": testschema.Attribute{
 											Type:     types.StringType,
 											Required: true,
 										},
-									}),
+									},
+								},
+								NestingMode: fwschema.NestingModeList,
+								Type: testtypes.ListNestedAttributesCustomTypeType{
+									ListType: types.ListType{
+										ElemType: types.ObjectType{
+											AttrTypes: map[string]attr.Type{
+												"nested_attr": types.StringType,
+											},
+										},
+									},
 								},
 								Required: true,
 							},
@@ -772,19 +732,25 @@ func TestAttributeValidate(t *testing.T) {
 							),
 						},
 					),
-					Schema: tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test": {
-								Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
-									"nested_attr": {
-										Type:     types.StringType,
-										Required: true,
-										Validators: []tfsdk.AttributeValidator{
-											testErrorAttributeValidator{},
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.NestedAttribute{
+								NestedObject: testschema.NestedAttributeObject{
+									Attributes: map[string]fwschema.Attribute{
+										"nested_attr": testschema.AttributeWithStringValidators{
+											Required: true,
+											Validators: []validator.String{
+												testvalidator.String{
+													ValidateStringMethod: func(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+														resp.Diagnostics.Append(testErrorDiagnostic1)
+													},
+												},
+											},
 										},
 									},
-								}),
-								Required: true,
+								},
+								NestingMode: fwschema.NestingModeList,
+								Required:    true,
 							},
 						},
 					},
@@ -836,19 +802,32 @@ func TestAttributeValidate(t *testing.T) {
 							),
 						},
 					),
-					Schema: tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test": {
-								Attributes: testtypes.ListNestedAttributesCustomType{
-									NestedAttributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
-										"nested_attr": {
-											Type:     types.StringType,
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.NestedAttribute{
+								NestedObject: testschema.NestedAttributeObject{
+									Attributes: map[string]fwschema.Attribute{
+										"nested_attr": testschema.AttributeWithStringValidators{
 											Required: true,
-											Validators: []tfsdk.AttributeValidator{
-												testErrorAttributeValidator{},
+											Validators: []validator.String{
+												testvalidator.String{
+													ValidateStringMethod: func(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+														resp.Diagnostics.Append(testErrorDiagnostic1)
+													},
+												},
 											},
 										},
-									}),
+									},
+								},
+								NestingMode: fwschema.NestingModeList,
+								Type: testtypes.ListNestedAttributesCustomTypeType{
+									ListType: types.ListType{
+										ElemType: types.ObjectType{
+											AttrTypes: map[string]attr.Type{
+												"nested_attr": types.StringType,
+											},
+										},
+									},
 								},
 								Required: true,
 							},
@@ -902,16 +881,19 @@ func TestAttributeValidate(t *testing.T) {
 							),
 						},
 					),
-					Schema: tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test": {
-								Attributes: tfsdk.MapNestedAttributes(map[string]tfsdk.Attribute{
-									"nested_attr": {
-										Type:     types.StringType,
-										Required: true,
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.NestedAttribute{
+								NestedObject: testschema.NestedAttributeObject{
+									Attributes: map[string]fwschema.Attribute{
+										"nested_attr": testschema.Attribute{
+											Type:     types.StringType,
+											Required: true,
+										},
 									},
-								}),
-								Required: true,
+								},
+								NestingMode: fwschema.NestingModeMap,
+								Required:    true,
 							},
 						},
 					},
@@ -959,16 +941,26 @@ func TestAttributeValidate(t *testing.T) {
 							),
 						},
 					),
-					Schema: tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test": {
-								Attributes: testtypes.MapNestedAttributesCustomType{
-									NestedAttributes: tfsdk.MapNestedAttributes(map[string]tfsdk.Attribute{
-										"nested_attr": {
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.NestedAttribute{
+								NestedObject: testschema.NestedAttributeObject{
+									Attributes: map[string]fwschema.Attribute{
+										"nested_attr": testschema.Attribute{
 											Type:     types.StringType,
 											Required: true,
 										},
-									}),
+									},
+								},
+								NestingMode: fwschema.NestingModeMap,
+								Type: testtypes.MapNestedAttributesCustomTypeType{
+									MapType: types.MapType{
+										ElemType: types.ObjectType{
+											AttrTypes: map[string]attr.Type{
+												"nested_attr": types.StringType,
+											},
+										},
+									},
 								},
 								Required: true,
 							},
@@ -1018,19 +1010,25 @@ func TestAttributeValidate(t *testing.T) {
 							),
 						},
 					),
-					Schema: tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test": {
-								Attributes: tfsdk.MapNestedAttributes(map[string]tfsdk.Attribute{
-									"nested_attr": {
-										Type:     types.StringType,
-										Required: true,
-										Validators: []tfsdk.AttributeValidator{
-											testErrorAttributeValidator{},
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.NestedAttribute{
+								NestedObject: testschema.NestedAttributeObject{
+									Attributes: map[string]fwschema.Attribute{
+										"nested_attr": testschema.AttributeWithStringValidators{
+											Required: true,
+											Validators: []validator.String{
+												testvalidator.String{
+													ValidateStringMethod: func(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+														resp.Diagnostics.Append(testErrorDiagnostic1)
+													},
+												},
+											},
 										},
 									},
-								}),
-								Required: true,
+								},
+								NestingMode: fwschema.NestingModeMap,
+								Required:    true,
 							},
 						},
 					},
@@ -1082,19 +1080,32 @@ func TestAttributeValidate(t *testing.T) {
 							),
 						},
 					),
-					Schema: tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test": {
-								Attributes: testtypes.MapNestedAttributesCustomType{
-									NestedAttributes: tfsdk.MapNestedAttributes(map[string]tfsdk.Attribute{
-										"nested_attr": {
-											Type:     types.StringType,
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.NestedAttribute{
+								NestedObject: testschema.NestedAttributeObject{
+									Attributes: map[string]fwschema.Attribute{
+										"nested_attr": testschema.AttributeWithStringValidators{
 											Required: true,
-											Validators: []tfsdk.AttributeValidator{
-												testErrorAttributeValidator{},
+											Validators: []validator.String{
+												testvalidator.String{
+													ValidateStringMethod: func(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+														resp.Diagnostics.Append(testErrorDiagnostic1)
+													},
+												},
 											},
 										},
-									}),
+									},
+								},
+								NestingMode: fwschema.NestingModeMap,
+								Type: testtypes.MapNestedAttributesCustomTypeType{
+									MapType: types.MapType{
+										ElemType: types.ObjectType{
+											AttrTypes: map[string]attr.Type{
+												"nested_attr": types.StringType,
+											},
+										},
+									},
 								},
 								Required: true,
 							},
@@ -1148,16 +1159,19 @@ func TestAttributeValidate(t *testing.T) {
 							),
 						},
 					),
-					Schema: tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test": {
-								Attributes: tfsdk.SetNestedAttributes(map[string]tfsdk.Attribute{
-									"nested_attr": {
-										Type:     types.StringType,
-										Required: true,
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.NestedAttribute{
+								NestedObject: testschema.NestedAttributeObject{
+									Attributes: map[string]fwschema.Attribute{
+										"nested_attr": testschema.Attribute{
+											Type:     types.StringType,
+											Required: true,
+										},
 									},
-								}),
-								Required: true,
+								},
+								NestingMode: fwschema.NestingModeSet,
+								Required:    true,
 							},
 						},
 					},
@@ -1205,16 +1219,26 @@ func TestAttributeValidate(t *testing.T) {
 							),
 						},
 					),
-					Schema: tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test": {
-								Attributes: testtypes.SetNestedAttributesCustomType{
-									NestedAttributes: tfsdk.SetNestedAttributes(map[string]tfsdk.Attribute{
-										"nested_attr": {
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.NestedAttribute{
+								NestedObject: testschema.NestedAttributeObject{
+									Attributes: map[string]fwschema.Attribute{
+										"nested_attr": testschema.Attribute{
 											Type:     types.StringType,
 											Required: true,
 										},
-									}),
+									},
+								},
+								NestingMode: fwschema.NestingModeSet,
+								Type: testtypes.SetNestedAttributesCustomTypeType{
+									SetType: types.SetType{
+										ElemType: types.ObjectType{
+											AttrTypes: map[string]attr.Type{
+												"nested_attr": types.StringType,
+											},
+										},
+									},
 								},
 								Required: true,
 							},
@@ -1264,19 +1288,25 @@ func TestAttributeValidate(t *testing.T) {
 							),
 						},
 					),
-					Schema: tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test": {
-								Attributes: tfsdk.SetNestedAttributes(map[string]tfsdk.Attribute{
-									"nested_attr": {
-										Type:     types.StringType,
-										Required: true,
-										Validators: []tfsdk.AttributeValidator{
-											testErrorAttributeValidator{},
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.NestedAttribute{
+								NestedObject: testschema.NestedAttributeObject{
+									Attributes: map[string]fwschema.Attribute{
+										"nested_attr": testschema.AttributeWithStringValidators{
+											Required: true,
+											Validators: []validator.String{
+												testvalidator.String{
+													ValidateStringMethod: func(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+														resp.Diagnostics.Append(testErrorDiagnostic1)
+													},
+												},
+											},
 										},
 									},
-								}),
-								Required: true,
+								},
+								NestingMode: fwschema.NestingModeSet,
+								Required:    true,
 							},
 						},
 					},
@@ -1328,19 +1358,32 @@ func TestAttributeValidate(t *testing.T) {
 							),
 						},
 					),
-					Schema: tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test": {
-								Attributes: testtypes.SetNestedAttributesCustomType{
-									NestedAttributes: tfsdk.SetNestedAttributes(map[string]tfsdk.Attribute{
-										"nested_attr": {
-											Type:     types.StringType,
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.NestedAttribute{
+								NestedObject: testschema.NestedAttributeObject{
+									Attributes: map[string]fwschema.Attribute{
+										"nested_attr": testschema.AttributeWithStringValidators{
 											Required: true,
-											Validators: []tfsdk.AttributeValidator{
-												testErrorAttributeValidator{},
+											Validators: []validator.String{
+												testvalidator.String{
+													ValidateStringMethod: func(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+														resp.Diagnostics.Append(testErrorDiagnostic1)
+													},
+												},
 											},
 										},
-									}),
+									},
+								},
+								NestingMode: fwschema.NestingModeSet,
+								Type: testtypes.SetNestedAttributesCustomTypeType{
+									SetType: types.SetType{
+										ElemType: types.ObjectType{
+											AttrTypes: map[string]attr.Type{
+												"nested_attr": types.StringType,
+											},
+										},
+									},
 								},
 								Required: true,
 							},
@@ -1381,16 +1424,19 @@ func TestAttributeValidate(t *testing.T) {
 							),
 						},
 					),
-					Schema: tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test": {
-								Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
-									"nested_attr": {
-										Type:     types.StringType,
-										Required: true,
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.NestedAttribute{
+								NestedObject: testschema.NestedAttributeObject{
+									Attributes: map[string]fwschema.Attribute{
+										"nested_attr": testschema.Attribute{
+											Type:     types.StringType,
+											Required: true,
+										},
 									},
-								}),
-								Required: true,
+								},
+								NestingMode: fwschema.NestingModeSingle,
+								Required:    true,
 							},
 						},
 					},
@@ -1425,18 +1471,26 @@ func TestAttributeValidate(t *testing.T) {
 							),
 						},
 					),
-					Schema: tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test": {
-								Attributes: testtypes.SingleNestedAttributesCustomType{
-									NestedAttributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
-										"nested_attr": {
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.NestedAttribute{
+								NestedObject: testschema.NestedAttributeObject{
+									Attributes: map[string]fwschema.Attribute{
+										"nested_attr": testschema.Attribute{
 											Type:     types.StringType,
 											Required: true,
 										},
-									}),
+									},
 								},
-								Required: true,
+								NestingMode: fwschema.NestingModeSingle,
+								Required:    true,
+								Type: testtypes.SingleNestedAttributesCustomTypeType{
+									ObjectType: types.ObjectType{
+										AttrTypes: map[string]attr.Type{
+											"nested_attr": types.StringType,
+										},
+									},
+								},
 							},
 						},
 					},
@@ -1470,19 +1524,25 @@ func TestAttributeValidate(t *testing.T) {
 							),
 						},
 					),
-					Schema: tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test": {
-								Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
-									"nested_attr": {
-										Type:     types.StringType,
-										Required: true,
-										Validators: []tfsdk.AttributeValidator{
-											testErrorAttributeValidator{},
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.NestedAttribute{
+								NestedObject: testschema.NestedAttributeObject{
+									Attributes: map[string]fwschema.Attribute{
+										"nested_attr": testschema.AttributeWithStringValidators{
+											Required: true,
+											Validators: []validator.String{
+												testvalidator.String{
+													ValidateStringMethod: func(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+														resp.Diagnostics.Append(testErrorDiagnostic1)
+													},
+												},
+											},
 										},
 									},
-								}),
-								Required: true,
+								},
+								NestingMode: fwschema.NestingModeSingle,
+								Required:    true,
 							},
 						},
 					},
@@ -1520,21 +1580,32 @@ func TestAttributeValidate(t *testing.T) {
 							),
 						},
 					),
-					Schema: tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test": {
-								Attributes: testtypes.SingleNestedAttributesCustomType{
-									NestedAttributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
-										"nested_attr": {
-											Type:     types.StringType,
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.NestedAttribute{
+								NestedObject: testschema.NestedAttributeObject{
+									Attributes: map[string]fwschema.Attribute{
+										"nested_attr": testschema.AttributeWithStringValidators{
 											Required: true,
-											Validators: []tfsdk.AttributeValidator{
-												testErrorAttributeValidator{},
+											Validators: []validator.String{
+												testvalidator.String{
+													ValidateStringMethod: func(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+														resp.Diagnostics.Append(testErrorDiagnostic1)
+													},
+												},
 											},
 										},
-									}),
+									},
 								},
-								Required: true,
+								NestingMode: fwschema.NestingModeSingle,
+								Required:    true,
+								Type: testtypes.SingleNestedAttributesCustomTypeType{
+									ObjectType: types.ObjectType{
+										AttrTypes: map[string]attr.Type{
+											"nested_attr": types.StringType,
+										},
+									},
+								},
 							},
 						},
 					},
@@ -3787,43 +3858,3 @@ var (
 		"This is a warning.",
 	)
 )
-
-type testErrorAttributeValidator struct {
-	tfsdk.AttributeValidator
-}
-
-func (v testErrorAttributeValidator) Description(ctx context.Context) string {
-	return "validation that always returns an error"
-}
-
-func (v testErrorAttributeValidator) MarkdownDescription(ctx context.Context) string {
-	return v.Description(ctx)
-}
-
-func (v testErrorAttributeValidator) Validate(ctx context.Context, req tfsdk.ValidateAttributeRequest, resp *tfsdk.ValidateAttributeResponse) {
-	if len(resp.Diagnostics) == 0 {
-		resp.Diagnostics.Append(testErrorDiagnostic1)
-	} else {
-		resp.Diagnostics.Append(testErrorDiagnostic2)
-	}
-}
-
-type testWarningAttributeValidator struct {
-	tfsdk.AttributeValidator
-}
-
-func (v testWarningAttributeValidator) Description(ctx context.Context) string {
-	return "validation that always returns a warning"
-}
-
-func (v testWarningAttributeValidator) MarkdownDescription(ctx context.Context) string {
-	return v.Description(ctx)
-}
-
-func (v testWarningAttributeValidator) Validate(ctx context.Context, req tfsdk.ValidateAttributeRequest, resp *tfsdk.ValidateAttributeResponse) {
-	if len(resp.Diagnostics) == 0 {
-		resp.Diagnostics.Append(testWarningDiagnostic1)
-	} else {
-		resp.Diagnostics.Append(testWarningDiagnostic2)
-	}
-}

--- a/internal/fwserver/block_validation_test.go
+++ b/internal/fwserver/block_validation_test.go
@@ -67,17 +67,19 @@ func TestBlockValidate(t *testing.T) {
 							),
 						},
 					),
-					Schema: tfsdk.Schema{
-						Blocks: map[string]tfsdk.Block{
-							"test": {
-								Attributes: map[string]tfsdk.Attribute{
-									"nested_attr": {
-										Type:     types.StringType,
-										Required: true,
+					Schema: testschema.Schema{
+						Blocks: map[string]fwschema.Block{
+							"test": testschema.Block{
+								NestedObject: testschema.NestedBlockObject{
+									Attributes: map[string]fwschema.Attribute{
+										"nested_attr": testschema.Attribute{
+											Type:     types.StringType,
+											Required: true,
+										},
 									},
 								},
 								DeprecationMessage: "Use something else instead.",
-								NestingMode:        tfsdk.BlockNestingModeList,
+								NestingMode:        fwschema.BlockNestingModeList,
 							},
 						},
 					},
@@ -122,17 +124,19 @@ func TestBlockValidate(t *testing.T) {
 							),
 						},
 					),
-					Schema: tfsdk.Schema{
-						Blocks: map[string]tfsdk.Block{
-							"test": {
-								Attributes: map[string]tfsdk.Attribute{
-									"nested_attr": {
-										Type:     types.StringType,
-										Required: true,
+					Schema: testschema.Schema{
+						Blocks: map[string]fwschema.Block{
+							"test": testschema.Block{
+								NestedObject: testschema.NestedBlockObject{
+									Attributes: map[string]fwschema.Attribute{
+										"nested_attr": testschema.Attribute{
+											Type:     types.StringType,
+											Required: true,
+										},
 									},
 								},
 								DeprecationMessage: "Use something else instead.",
-								NestingMode:        tfsdk.BlockNestingModeList,
+								NestingMode:        fwschema.BlockNestingModeList,
 							},
 						},
 					},
@@ -169,17 +173,19 @@ func TestBlockValidate(t *testing.T) {
 							),
 						},
 					),
-					Schema: tfsdk.Schema{
-						Blocks: map[string]tfsdk.Block{
-							"test": {
-								Attributes: map[string]tfsdk.Attribute{
-									"nested_attr": {
-										Type:     types.StringType,
-										Required: true,
+					Schema: testschema.Schema{
+						Blocks: map[string]fwschema.Block{
+							"test": testschema.Block{
+								NestedObject: testschema.NestedBlockObject{
+									Attributes: map[string]fwschema.Attribute{
+										"nested_attr": testschema.Attribute{
+											Type:     types.StringType,
+											Required: true,
+										},
 									},
 								},
 								DeprecationMessage: "Use something else instead.",
-								NestingMode:        tfsdk.BlockNestingModeList,
+								NestingMode:        fwschema.BlockNestingModeList,
 							},
 						},
 					},
@@ -227,19 +233,26 @@ func TestBlockValidate(t *testing.T) {
 							),
 						},
 					),
-					Schema: tfsdk.Schema{
-						Blocks: map[string]tfsdk.Block{
-							"test": {
-								Attributes: map[string]tfsdk.Attribute{
-									"nested_attr": {
+					Schema: testschema.Schema{
+						Blocks: map[string]fwschema.Block{
+							"test": testschema.BlockWithListValidators{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_attr": testschema.Attribute{
 										Type:     types.StringType,
 										Required: true,
 									},
 								},
-								NestingMode: tfsdk.BlockNestingModeList,
-								Validators: []tfsdk.AttributeValidator{
-									testWarningAttributeValidator{},
-									testWarningAttributeValidator{},
+								Validators: []validator.List{
+									testvalidator.List{
+										ValidateListMethod: func(ctx context.Context, req validator.ListRequest, resp *validator.ListResponse) {
+											resp.Diagnostics.Append(testWarningDiagnostic1)
+										},
+									},
+									testvalidator.List{
+										ValidateListMethod: func(ctx context.Context, req validator.ListRequest, resp *validator.ListResponse) {
+											resp.Diagnostics.Append(testWarningDiagnostic2)
+										},
+									},
 								},
 							},
 						},
@@ -293,19 +306,26 @@ func TestBlockValidate(t *testing.T) {
 							),
 						},
 					),
-					Schema: tfsdk.Schema{
-						Blocks: map[string]tfsdk.Block{
-							"test": {
-								Attributes: map[string]tfsdk.Attribute{
-									"nested_attr": {
+					Schema: testschema.Schema{
+						Blocks: map[string]fwschema.Block{
+							"test": testschema.BlockWithListValidators{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_attr": testschema.Attribute{
 										Type:     types.StringType,
 										Required: true,
 									},
 								},
-								NestingMode: tfsdk.BlockNestingModeList,
-								Validators: []tfsdk.AttributeValidator{
-									testErrorAttributeValidator{},
-									testErrorAttributeValidator{},
+								Validators: []validator.List{
+									testvalidator.List{
+										ValidateListMethod: func(ctx context.Context, req validator.ListRequest, resp *validator.ListResponse) {
+											resp.Diagnostics.Append(testErrorDiagnostic1)
+										},
+									},
+									testvalidator.List{
+										ValidateListMethod: func(ctx context.Context, req validator.ListRequest, resp *validator.ListResponse) {
+											resp.Diagnostics.Append(testErrorDiagnostic2)
+										},
+									},
 								},
 							},
 						},
@@ -359,20 +379,29 @@ func TestBlockValidate(t *testing.T) {
 							),
 						},
 					),
-					Schema: tfsdk.Schema{
-						Blocks: map[string]tfsdk.Block{
-							"test": {
-								Attributes: map[string]tfsdk.Attribute{
-									"nested_attr": {
-										Type:     types.StringType,
-										Required: true,
-										Validators: []tfsdk.AttributeValidator{
-											testWarningAttributeValidator{},
-											testWarningAttributeValidator{},
+					Schema: testschema.Schema{
+						Blocks: map[string]fwschema.Block{
+							"test": testschema.Block{
+								NestedObject: testschema.NestedBlockObject{
+									Attributes: map[string]fwschema.Attribute{
+										"nested_attr": testschema.AttributeWithStringValidators{
+											Required: true,
+											Validators: []validator.String{
+												testvalidator.String{
+													ValidateStringMethod: func(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+														resp.Diagnostics.Append(testWarningDiagnostic1)
+													},
+												},
+												testvalidator.String{
+													ValidateStringMethod: func(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+														resp.Diagnostics.Append(testWarningDiagnostic2)
+													},
+												},
+											},
 										},
 									},
 								},
-								NestingMode: tfsdk.BlockNestingModeList,
+								NestingMode: fwschema.BlockNestingModeList,
 							},
 						},
 					},
@@ -425,20 +454,29 @@ func TestBlockValidate(t *testing.T) {
 							),
 						},
 					),
-					Schema: tfsdk.Schema{
-						Blocks: map[string]tfsdk.Block{
-							"test": {
-								Attributes: map[string]tfsdk.Attribute{
-									"nested_attr": {
-										Type:     types.StringType,
-										Required: true,
-										Validators: []tfsdk.AttributeValidator{
-											testErrorAttributeValidator{},
-											testErrorAttributeValidator{},
+					Schema: testschema.Schema{
+						Blocks: map[string]fwschema.Block{
+							"test": testschema.Block{
+								NestedObject: testschema.NestedBlockObject{
+									Attributes: map[string]fwschema.Attribute{
+										"nested_attr": testschema.AttributeWithStringValidators{
+											Required: true,
+											Validators: []validator.String{
+												testvalidator.String{
+													ValidateStringMethod: func(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+														resp.Diagnostics.Append(testErrorDiagnostic1)
+													},
+												},
+												testvalidator.String{
+													ValidateStringMethod: func(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+														resp.Diagnostics.Append(testErrorDiagnostic2)
+													},
+												},
+											},
 										},
 									},
 								},
-								NestingMode: tfsdk.BlockNestingModeList,
+								NestingMode: fwschema.BlockNestingModeList,
 							},
 						},
 					},
@@ -491,16 +529,18 @@ func TestBlockValidate(t *testing.T) {
 							),
 						},
 					),
-					Schema: tfsdk.Schema{
-						Blocks: map[string]tfsdk.Block{
-							"test": {
-								Attributes: map[string]tfsdk.Attribute{
-									"nested_attr": {
-										Type:     testtypes.StringTypeWithValidateError{},
-										Required: true,
+					Schema: testschema.Schema{
+						Blocks: map[string]fwschema.Block{
+							"test": testschema.Block{
+								NestedObject: testschema.NestedBlockObject{
+									Attributes: map[string]fwschema.Attribute{
+										"nested_attr": testschema.Attribute{
+											Type:     testtypes.StringTypeWithValidateError{},
+											Required: true,
+										},
 									},
 								},
-								NestingMode: tfsdk.BlockNestingModeList,
+								NestingMode: fwschema.BlockNestingModeList,
 							},
 						},
 					},
@@ -552,16 +592,18 @@ func TestBlockValidate(t *testing.T) {
 							),
 						},
 					),
-					Schema: tfsdk.Schema{
-						Blocks: map[string]tfsdk.Block{
-							"test": {
-								Attributes: map[string]tfsdk.Attribute{
-									"nested_attr": {
-										Type:     testtypes.StringTypeWithValidateWarning{},
-										Required: true,
+					Schema: testschema.Schema{
+						Blocks: map[string]fwschema.Block{
+							"test": testschema.Block{
+								NestedObject: testschema.NestedBlockObject{
+									Attributes: map[string]fwschema.Attribute{
+										"nested_attr": testschema.Attribute{
+											Type:     testtypes.StringTypeWithValidateWarning{},
+											Required: true,
+										},
 									},
 								},
-								NestingMode: tfsdk.BlockNestingModeList,
+								NestingMode: fwschema.BlockNestingModeList,
 							},
 						},
 					},
@@ -613,16 +655,18 @@ func TestBlockValidate(t *testing.T) {
 							),
 						},
 					),
-					Schema: tfsdk.Schema{
-						Blocks: map[string]tfsdk.Block{
-							"test": {
-								Attributes: map[string]tfsdk.Attribute{
-									"nested_attr": {
-										Type:     types.StringType,
-										Required: true,
+					Schema: testschema.Schema{
+						Blocks: map[string]fwschema.Block{
+							"test": testschema.Block{
+								NestedObject: testschema.NestedBlockObject{
+									Attributes: map[string]fwschema.Attribute{
+										"nested_attr": testschema.Attribute{
+											Type:     types.StringType,
+											Required: true,
+										},
 									},
 								},
-								NestingMode: tfsdk.BlockNestingModeList,
+								NestingMode: fwschema.BlockNestingModeList,
 							},
 						},
 					},
@@ -670,19 +714,24 @@ func TestBlockValidate(t *testing.T) {
 							),
 						},
 					),
-					Schema: tfsdk.Schema{
-						Blocks: map[string]tfsdk.Block{
-							"test": {
-								Attributes: map[string]tfsdk.Attribute{
-									"nested_attr": {
-										Type:     types.StringType,
-										Required: true,
-										Validators: []tfsdk.AttributeValidator{
-											testErrorAttributeValidator{},
+					Schema: testschema.Schema{
+						Blocks: map[string]fwschema.Block{
+							"test": testschema.Block{
+								NestedObject: testschema.NestedBlockObject{
+									Attributes: map[string]fwschema.Attribute{
+										"nested_attr": testschema.AttributeWithStringValidators{
+											Required: true,
+											Validators: []validator.String{
+												testvalidator.String{
+													ValidateStringMethod: func(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+														resp.Diagnostics.Append(testErrorDiagnostic1)
+													},
+												},
+											},
 										},
 									},
 								},
-								NestingMode: tfsdk.BlockNestingModeList,
+								NestingMode: fwschema.BlockNestingModeList,
 							},
 						},
 					},
@@ -691,732 +740,6 @@ func TestBlockValidate(t *testing.T) {
 			resp: tfsdk.ValidateAttributeResponse{
 				Diagnostics: diag.Diagnostics{
 					testErrorDiagnostic1,
-				},
-			},
-		},
-		"list-maxitems-validation-known-invalid": {
-			req: tfsdk.ValidateAttributeRequest{
-				AttributePath: path.Root("test"),
-				Config: tfsdk.Config{
-					Raw: tftypes.NewValue(
-						tftypes.Object{
-							AttributeTypes: map[string]tftypes.Type{
-								"test": tftypes.List{
-									ElementType: tftypes.Object{
-										AttributeTypes: map[string]tftypes.Type{
-											"nested_attr": tftypes.String,
-										},
-									},
-								},
-							},
-						},
-						map[string]tftypes.Value{
-							"test": tftypes.NewValue(
-								tftypes.List{
-									ElementType: tftypes.Object{
-										AttributeTypes: map[string]tftypes.Type{
-											"nested_attr": tftypes.String,
-										},
-									},
-								},
-								[]tftypes.Value{
-									tftypes.NewValue(
-										tftypes.Object{
-											AttributeTypes: map[string]tftypes.Type{
-												"nested_attr": tftypes.String,
-											},
-										},
-										map[string]tftypes.Value{
-											"nested_attr": tftypes.NewValue(tftypes.String, "testvalue1"),
-										},
-									),
-									tftypes.NewValue(
-										tftypes.Object{
-											AttributeTypes: map[string]tftypes.Type{
-												"nested_attr": tftypes.String,
-											},
-										},
-										map[string]tftypes.Value{
-											"nested_attr": tftypes.NewValue(tftypes.String, "testvalue2"),
-										},
-									),
-								},
-							),
-						},
-					),
-					Schema: tfsdk.Schema{
-						Blocks: map[string]tfsdk.Block{
-							"test": {
-								Attributes: map[string]tfsdk.Attribute{
-									"nested_attr": {
-										Type:     types.StringType,
-										Optional: true,
-									},
-								},
-								MaxItems:    1,
-								NestingMode: tfsdk.BlockNestingModeList,
-							},
-						},
-					},
-				},
-			},
-			resp: tfsdk.ValidateAttributeResponse{
-				Diagnostics: diag.Diagnostics{
-					diag.NewAttributeErrorDiagnostic(
-						path.Root("test"),
-						"Extra Block Configuration",
-						"The configuration should declare a maximum of 1 block, however 2 blocks were configured.",
-					),
-				},
-			},
-		},
-		"list-maxitems-validation-known-valid": {
-			req: tfsdk.ValidateAttributeRequest{
-				AttributePath: path.Root("test"),
-				Config: tfsdk.Config{
-					Raw: tftypes.NewValue(
-						tftypes.Object{
-							AttributeTypes: map[string]tftypes.Type{
-								"test": tftypes.List{
-									ElementType: tftypes.Object{
-										AttributeTypes: map[string]tftypes.Type{
-											"nested_attr": tftypes.String,
-										},
-									},
-								},
-							},
-						},
-						map[string]tftypes.Value{
-							"test": tftypes.NewValue(
-								tftypes.List{
-									ElementType: tftypes.Object{
-										AttributeTypes: map[string]tftypes.Type{
-											"nested_attr": tftypes.String,
-										},
-									},
-								},
-								[]tftypes.Value{
-									tftypes.NewValue(
-										tftypes.Object{
-											AttributeTypes: map[string]tftypes.Type{
-												"nested_attr": tftypes.String,
-											},
-										},
-										map[string]tftypes.Value{
-											"nested_attr": tftypes.NewValue(tftypes.String, "testvalue1"),
-										},
-									),
-								},
-							),
-						},
-					),
-					Schema: tfsdk.Schema{
-						Blocks: map[string]tfsdk.Block{
-							"test": {
-								Attributes: map[string]tfsdk.Attribute{
-									"nested_attr": {
-										Type:     types.StringType,
-										Optional: true,
-									},
-								},
-								MaxItems:    1,
-								NestingMode: tfsdk.BlockNestingModeList,
-							},
-						},
-					},
-				},
-			},
-			resp: tfsdk.ValidateAttributeResponse{},
-		},
-		"list-maxitems-validation-null": {
-			req: tfsdk.ValidateAttributeRequest{
-				AttributePath: path.Root("test"),
-				Config: tfsdk.Config{
-					Raw: tftypes.NewValue(
-						tftypes.Object{
-							AttributeTypes: map[string]tftypes.Type{
-								"test": tftypes.List{
-									ElementType: tftypes.Object{
-										AttributeTypes: map[string]tftypes.Type{
-											"nested_attr": tftypes.String,
-										},
-									},
-								},
-							},
-						},
-						map[string]tftypes.Value{
-							"test": tftypes.NewValue(
-								tftypes.List{
-									ElementType: tftypes.Object{
-										AttributeTypes: map[string]tftypes.Type{
-											"nested_attr": tftypes.String,
-										},
-									},
-								},
-								nil,
-							),
-						},
-					),
-					Schema: tfsdk.Schema{
-						Blocks: map[string]tfsdk.Block{
-							"test": {
-								Attributes: map[string]tfsdk.Attribute{
-									"nested_attr": {
-										Type:     types.StringType,
-										Optional: true,
-									},
-								},
-								MaxItems:    1,
-								NestingMode: tfsdk.BlockNestingModeList,
-							},
-						},
-					},
-				},
-			},
-			resp: tfsdk.ValidateAttributeResponse{},
-		},
-		"list-maxitems-validation-null-values": {
-			req: tfsdk.ValidateAttributeRequest{
-				AttributePath: path.Root("test"),
-				Config: tfsdk.Config{
-					Raw: tftypes.NewValue(
-						tftypes.Object{
-							AttributeTypes: map[string]tftypes.Type{
-								"test": tftypes.List{
-									ElementType: tftypes.Object{
-										AttributeTypes: map[string]tftypes.Type{
-											"nested_attr": tftypes.String,
-										},
-									},
-								},
-							},
-						},
-						map[string]tftypes.Value{
-							"test": tftypes.NewValue(
-								tftypes.List{
-									ElementType: tftypes.Object{
-										AttributeTypes: map[string]tftypes.Type{
-											"nested_attr": tftypes.String,
-										},
-									},
-								},
-								[]tftypes.Value{
-									tftypes.NewValue(
-										tftypes.Object{
-											AttributeTypes: map[string]tftypes.Type{
-												"nested_attr": tftypes.String,
-											},
-										},
-										nil,
-									),
-									tftypes.NewValue(
-										tftypes.Object{
-											AttributeTypes: map[string]tftypes.Type{
-												"nested_attr": tftypes.String,
-											},
-										},
-										nil,
-									),
-								},
-							),
-						},
-					),
-					Schema: tfsdk.Schema{
-						Blocks: map[string]tfsdk.Block{
-							"test": {
-								Attributes: map[string]tfsdk.Attribute{
-									"nested_attr": {
-										Type:     types.StringType,
-										Optional: true,
-									},
-								},
-								MaxItems:    1,
-								NestingMode: tfsdk.BlockNestingModeList,
-							},
-						},
-					},
-				},
-			},
-			resp: tfsdk.ValidateAttributeResponse{
-				Diagnostics: diag.Diagnostics{
-					diag.NewAttributeErrorDiagnostic(
-						path.Root("test"),
-						"Extra Block Configuration",
-						"The configuration should declare a maximum of 1 block, however 2 blocks were configured.",
-					),
-				},
-			},
-		},
-		"list-maxitems-validation-unknown": {
-			req: tfsdk.ValidateAttributeRequest{
-				AttributePath: path.Root("test"),
-				Config: tfsdk.Config{
-					Raw: tftypes.NewValue(
-						tftypes.Object{
-							AttributeTypes: map[string]tftypes.Type{
-								"test": tftypes.List{
-									ElementType: tftypes.Object{
-										AttributeTypes: map[string]tftypes.Type{
-											"nested_attr": tftypes.String,
-										},
-									},
-								},
-							},
-						},
-						map[string]tftypes.Value{
-							"test": tftypes.NewValue(
-								tftypes.List{
-									ElementType: tftypes.Object{
-										AttributeTypes: map[string]tftypes.Type{
-											"nested_attr": tftypes.String,
-										},
-									},
-								},
-								tftypes.UnknownValue,
-							),
-						},
-					),
-					Schema: tfsdk.Schema{
-						Blocks: map[string]tfsdk.Block{
-							"test": {
-								Attributes: map[string]tfsdk.Attribute{
-									"nested_attr": {
-										Type:     types.StringType,
-										Optional: true,
-									},
-								},
-								MaxItems:    1,
-								NestingMode: tfsdk.BlockNestingModeList,
-							},
-						},
-					},
-				},
-			},
-			resp: tfsdk.ValidateAttributeResponse{},
-		},
-		"list-maxitems-validation-unknown-values": {
-			req: tfsdk.ValidateAttributeRequest{
-				AttributePath: path.Root("test"),
-				Config: tfsdk.Config{
-					Raw: tftypes.NewValue(
-						tftypes.Object{
-							AttributeTypes: map[string]tftypes.Type{
-								"test": tftypes.List{
-									ElementType: tftypes.Object{
-										AttributeTypes: map[string]tftypes.Type{
-											"nested_attr": tftypes.String,
-										},
-									},
-								},
-							},
-						},
-						map[string]tftypes.Value{
-							"test": tftypes.NewValue(
-								tftypes.List{
-									ElementType: tftypes.Object{
-										AttributeTypes: map[string]tftypes.Type{
-											"nested_attr": tftypes.String,
-										},
-									},
-								},
-								[]tftypes.Value{
-									tftypes.NewValue(
-										tftypes.Object{
-											AttributeTypes: map[string]tftypes.Type{
-												"nested_attr": tftypes.String,
-											},
-										},
-										tftypes.UnknownValue,
-									),
-									tftypes.NewValue(
-										tftypes.Object{
-											AttributeTypes: map[string]tftypes.Type{
-												"nested_attr": tftypes.String,
-											},
-										},
-										tftypes.UnknownValue,
-									),
-								},
-							),
-						},
-					),
-					Schema: tfsdk.Schema{
-						Blocks: map[string]tfsdk.Block{
-							"test": {
-								Attributes: map[string]tfsdk.Attribute{
-									"nested_attr": {
-										Type:     types.StringType,
-										Optional: true,
-									},
-								},
-								MaxItems:    1,
-								NestingMode: tfsdk.BlockNestingModeList,
-							},
-						},
-					},
-				},
-			},
-			resp: tfsdk.ValidateAttributeResponse{
-				Diagnostics: diag.Diagnostics{
-					diag.NewAttributeErrorDiagnostic(
-						path.Root("test"),
-						"Extra Block Configuration",
-						"The configuration should declare a maximum of 1 block, however 2 blocks were configured.",
-					),
-				},
-			},
-		},
-		"list-minitems-validation-known-invalid": {
-			req: tfsdk.ValidateAttributeRequest{
-				AttributePath: path.Root("test"),
-				Config: tfsdk.Config{
-					Raw: tftypes.NewValue(
-						tftypes.Object{
-							AttributeTypes: map[string]tftypes.Type{
-								"test": tftypes.List{
-									ElementType: tftypes.Object{
-										AttributeTypes: map[string]tftypes.Type{
-											"nested_attr": tftypes.String,
-										},
-									},
-								},
-							},
-						},
-						map[string]tftypes.Value{
-							"test": tftypes.NewValue(
-								tftypes.List{
-									ElementType: tftypes.Object{
-										AttributeTypes: map[string]tftypes.Type{
-											"nested_attr": tftypes.String,
-										},
-									},
-								},
-								[]tftypes.Value{
-									tftypes.NewValue(
-										tftypes.Object{
-											AttributeTypes: map[string]tftypes.Type{
-												"nested_attr": tftypes.String,
-											},
-										},
-										map[string]tftypes.Value{
-											"nested_attr": tftypes.NewValue(tftypes.String, "testvalue1"),
-										},
-									),
-								},
-							),
-						},
-					),
-					Schema: tfsdk.Schema{
-						Blocks: map[string]tfsdk.Block{
-							"test": {
-								Attributes: map[string]tfsdk.Attribute{
-									"nested_attr": {
-										Type:     types.StringType,
-										Optional: true,
-									},
-								},
-								MinItems:    2,
-								NestingMode: tfsdk.BlockNestingModeList,
-							},
-						},
-					},
-				},
-			},
-			resp: tfsdk.ValidateAttributeResponse{
-				Diagnostics: diag.Diagnostics{
-					diag.NewAttributeErrorDiagnostic(
-						path.Root("test"),
-						"Missing Block Configuration",
-						"The configuration should declare a minimum of 2 blocks, however 1 block was configured.",
-					),
-				},
-			},
-		},
-		"list-minitems-validation-known-valid": {
-			req: tfsdk.ValidateAttributeRequest{
-				AttributePath: path.Root("test"),
-				Config: tfsdk.Config{
-					Raw: tftypes.NewValue(
-						tftypes.Object{
-							AttributeTypes: map[string]tftypes.Type{
-								"test": tftypes.List{
-									ElementType: tftypes.Object{
-										AttributeTypes: map[string]tftypes.Type{
-											"nested_attr": tftypes.String,
-										},
-									},
-								},
-							},
-						},
-						map[string]tftypes.Value{
-							"test": tftypes.NewValue(
-								tftypes.List{
-									ElementType: tftypes.Object{
-										AttributeTypes: map[string]tftypes.Type{
-											"nested_attr": tftypes.String,
-										},
-									},
-								},
-								[]tftypes.Value{
-									tftypes.NewValue(
-										tftypes.Object{
-											AttributeTypes: map[string]tftypes.Type{
-												"nested_attr": tftypes.String,
-											},
-										},
-										map[string]tftypes.Value{
-											"nested_attr": tftypes.NewValue(tftypes.String, "testvalue1"),
-										},
-									),
-								},
-							),
-						},
-					),
-					Schema: tfsdk.Schema{
-						Blocks: map[string]tfsdk.Block{
-							"test": {
-								Attributes: map[string]tfsdk.Attribute{
-									"nested_attr": {
-										Type:     types.StringType,
-										Optional: true,
-									},
-								},
-								MinItems:    1,
-								NestingMode: tfsdk.BlockNestingModeList,
-							},
-						},
-					},
-				},
-			},
-			resp: tfsdk.ValidateAttributeResponse{},
-		},
-		"list-minitems-validation-null": {
-			req: tfsdk.ValidateAttributeRequest{
-				AttributePath: path.Root("test"),
-				Config: tfsdk.Config{
-					Raw: tftypes.NewValue(
-						tftypes.Object{
-							AttributeTypes: map[string]tftypes.Type{
-								"test": tftypes.List{
-									ElementType: tftypes.Object{
-										AttributeTypes: map[string]tftypes.Type{
-											"nested_attr": tftypes.String,
-										},
-									},
-								},
-							},
-						},
-						map[string]tftypes.Value{
-							"test": tftypes.NewValue(
-								tftypes.List{
-									ElementType: tftypes.Object{
-										AttributeTypes: map[string]tftypes.Type{
-											"nested_attr": tftypes.String,
-										},
-									},
-								},
-								nil,
-							),
-						},
-					),
-					Schema: tfsdk.Schema{
-						Blocks: map[string]tfsdk.Block{
-							"test": {
-								Attributes: map[string]tfsdk.Attribute{
-									"nested_attr": {
-										Type:     types.StringType,
-										Optional: true,
-									},
-								},
-								MinItems:    1,
-								NestingMode: tfsdk.BlockNestingModeList,
-							},
-						},
-					},
-				},
-			},
-			resp: tfsdk.ValidateAttributeResponse{
-				Diagnostics: diag.Diagnostics{
-					diag.NewAttributeErrorDiagnostic(
-						path.Root("test"),
-						"Missing Block Configuration",
-						"The configuration should declare a minimum of 1 block, however 0 blocks were configured.",
-					),
-				},
-			},
-		},
-		"list-minitems-validation-null-values": {
-			req: tfsdk.ValidateAttributeRequest{
-				AttributePath: path.Root("test"),
-				Config: tfsdk.Config{
-					Raw: tftypes.NewValue(
-						tftypes.Object{
-							AttributeTypes: map[string]tftypes.Type{
-								"test": tftypes.List{
-									ElementType: tftypes.Object{
-										AttributeTypes: map[string]tftypes.Type{
-											"nested_attr": tftypes.String,
-										},
-									},
-								},
-							},
-						},
-						map[string]tftypes.Value{
-							"test": tftypes.NewValue(
-								tftypes.List{
-									ElementType: tftypes.Object{
-										AttributeTypes: map[string]tftypes.Type{
-											"nested_attr": tftypes.String,
-										},
-									},
-								},
-								[]tftypes.Value{
-									tftypes.NewValue(
-										tftypes.Object{
-											AttributeTypes: map[string]tftypes.Type{
-												"nested_attr": tftypes.String,
-											},
-										},
-										nil,
-									),
-								},
-							),
-						},
-					),
-					Schema: tfsdk.Schema{
-						Blocks: map[string]tfsdk.Block{
-							"test": {
-								Attributes: map[string]tfsdk.Attribute{
-									"nested_attr": {
-										Type:     types.StringType,
-										Optional: true,
-									},
-								},
-								MinItems:    2,
-								NestingMode: tfsdk.BlockNestingModeList,
-							},
-						},
-					},
-				},
-			},
-			resp: tfsdk.ValidateAttributeResponse{
-				Diagnostics: diag.Diagnostics{
-					diag.NewAttributeErrorDiagnostic(
-						path.Root("test"),
-						"Missing Block Configuration",
-						"The configuration should declare a minimum of 2 blocks, however 1 block was configured.",
-					),
-				},
-			},
-		},
-		"list-minitems-validation-unknown": {
-			req: tfsdk.ValidateAttributeRequest{
-				AttributePath: path.Root("test"),
-				Config: tfsdk.Config{
-					Raw: tftypes.NewValue(
-						tftypes.Object{
-							AttributeTypes: map[string]tftypes.Type{
-								"test": tftypes.List{
-									ElementType: tftypes.Object{
-										AttributeTypes: map[string]tftypes.Type{
-											"nested_attr": tftypes.String,
-										},
-									},
-								},
-							},
-						},
-						map[string]tftypes.Value{
-							"test": tftypes.NewValue(
-								tftypes.List{
-									ElementType: tftypes.Object{
-										AttributeTypes: map[string]tftypes.Type{
-											"nested_attr": tftypes.String,
-										},
-									},
-								},
-								tftypes.UnknownValue,
-							),
-						},
-					),
-					Schema: tfsdk.Schema{
-						Blocks: map[string]tfsdk.Block{
-							"test": {
-								Attributes: map[string]tfsdk.Attribute{
-									"nested_attr": {
-										Type:     types.StringType,
-										Optional: true,
-									},
-								},
-								MinItems:    1,
-								NestingMode: tfsdk.BlockNestingModeList,
-							},
-						},
-					},
-				},
-			},
-			resp: tfsdk.ValidateAttributeResponse{},
-		},
-		"list-minitems-validation-unknown-values": {
-			req: tfsdk.ValidateAttributeRequest{
-				AttributePath: path.Root("test"),
-				Config: tfsdk.Config{
-					Raw: tftypes.NewValue(
-						tftypes.Object{
-							AttributeTypes: map[string]tftypes.Type{
-								"test": tftypes.List{
-									ElementType: tftypes.Object{
-										AttributeTypes: map[string]tftypes.Type{
-											"nested_attr": tftypes.String,
-										},
-									},
-								},
-							},
-						},
-						map[string]tftypes.Value{
-							"test": tftypes.NewValue(
-								tftypes.List{
-									ElementType: tftypes.Object{
-										AttributeTypes: map[string]tftypes.Type{
-											"nested_attr": tftypes.String,
-										},
-									},
-								},
-								[]tftypes.Value{
-									tftypes.NewValue(
-										tftypes.Object{
-											AttributeTypes: map[string]tftypes.Type{
-												"nested_attr": tftypes.String,
-											},
-										},
-										tftypes.UnknownValue,
-									),
-								},
-							),
-						},
-					),
-					Schema: tfsdk.Schema{
-						Blocks: map[string]tfsdk.Block{
-							"test": {
-								Attributes: map[string]tfsdk.Attribute{
-									"nested_attr": {
-										Type:     types.StringType,
-										Optional: true,
-									},
-								},
-								MinItems:    2,
-								NestingMode: tfsdk.BlockNestingModeList,
-							},
-						},
-					},
-				},
-			},
-			resp: tfsdk.ValidateAttributeResponse{
-				Diagnostics: diag.Diagnostics{
-					diag.NewAttributeErrorDiagnostic(
-						path.Root("test"),
-						"Missing Block Configuration",
-						"The configuration should declare a minimum of 2 blocks, however 1 block was configured.",
-					),
 				},
 			},
 		},
@@ -1460,16 +783,18 @@ func TestBlockValidate(t *testing.T) {
 							),
 						},
 					),
-					Schema: tfsdk.Schema{
-						Blocks: map[string]tfsdk.Block{
-							"test": {
-								Attributes: map[string]tfsdk.Attribute{
-									"nested_attr": {
-										Type:     types.StringType,
-										Required: true,
+					Schema: testschema.Schema{
+						Blocks: map[string]fwschema.Block{
+							"test": testschema.Block{
+								NestedObject: testschema.NestedBlockObject{
+									Attributes: map[string]fwschema.Attribute{
+										"nested_attr": testschema.Attribute{
+											Type:     types.StringType,
+											Required: true,
+										},
 									},
 								},
-								NestingMode: tfsdk.BlockNestingModeSet,
+								NestingMode: fwschema.BlockNestingModeSet,
 							},
 						},
 					},
@@ -1517,19 +842,24 @@ func TestBlockValidate(t *testing.T) {
 							),
 						},
 					),
-					Schema: tfsdk.Schema{
-						Blocks: map[string]tfsdk.Block{
-							"test": {
-								Attributes: map[string]tfsdk.Attribute{
-									"nested_attr": {
-										Type:     types.StringType,
-										Required: true,
-										Validators: []tfsdk.AttributeValidator{
-											testErrorAttributeValidator{},
+					Schema: testschema.Schema{
+						Blocks: map[string]fwschema.Block{
+							"test": testschema.Block{
+								NestedObject: testschema.NestedBlockObject{
+									Attributes: map[string]fwschema.Attribute{
+										"nested_attr": testschema.AttributeWithStringValidators{
+											Required: true,
+											Validators: []validator.String{
+												testvalidator.String{
+													ValidateStringMethod: func(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+														resp.Diagnostics.Append(testErrorDiagnostic1)
+													},
+												},
+											},
 										},
 									},
 								},
-								NestingMode: tfsdk.BlockNestingModeSet,
+								NestingMode: fwschema.BlockNestingModeSet,
 							},
 						},
 					},
@@ -1538,735 +868,6 @@ func TestBlockValidate(t *testing.T) {
 			resp: tfsdk.ValidateAttributeResponse{
 				Diagnostics: diag.Diagnostics{
 					testErrorDiagnostic1,
-				},
-			},
-		},
-		"set-maxitems-validation-known-invalid": {
-			req: tfsdk.ValidateAttributeRequest{
-				AttributePath: path.Root("test"),
-				Config: tfsdk.Config{
-					Raw: tftypes.NewValue(
-						tftypes.Object{
-							AttributeTypes: map[string]tftypes.Type{
-								"test": tftypes.Set{
-									ElementType: tftypes.Object{
-										AttributeTypes: map[string]tftypes.Type{
-											"nested_attr": tftypes.String,
-										},
-									},
-								},
-							},
-						},
-						map[string]tftypes.Value{
-							"test": tftypes.NewValue(
-								tftypes.Set{
-									ElementType: tftypes.Object{
-										AttributeTypes: map[string]tftypes.Type{
-											"nested_attr": tftypes.String,
-										},
-									},
-								},
-								[]tftypes.Value{
-									tftypes.NewValue(
-										tftypes.Object{
-											AttributeTypes: map[string]tftypes.Type{
-												"nested_attr": tftypes.String,
-											},
-										},
-										map[string]tftypes.Value{
-											"nested_attr": tftypes.NewValue(tftypes.String, "testvalue1"),
-										},
-									),
-									tftypes.NewValue(
-										tftypes.Object{
-											AttributeTypes: map[string]tftypes.Type{
-												"nested_attr": tftypes.String,
-											},
-										},
-										map[string]tftypes.Value{
-											"nested_attr": tftypes.NewValue(tftypes.String, "testvalue2"),
-										},
-									),
-								},
-							),
-						},
-					),
-					Schema: tfsdk.Schema{
-						Blocks: map[string]tfsdk.Block{
-							"test": {
-								Attributes: map[string]tfsdk.Attribute{
-									"nested_attr": {
-										Type:     types.StringType,
-										Optional: true,
-									},
-								},
-								MaxItems:    1,
-								NestingMode: tfsdk.BlockNestingModeSet,
-							},
-						},
-					},
-				},
-			},
-			resp: tfsdk.ValidateAttributeResponse{
-				Diagnostics: diag.Diagnostics{
-					diag.NewAttributeErrorDiagnostic(
-						path.Root("test"),
-						"Extra Block Configuration",
-						"The configuration should declare a maximum of 1 block, however 2 blocks were configured.",
-					),
-				},
-			},
-		},
-		"set-maxitems-validation-known-valid": {
-			req: tfsdk.ValidateAttributeRequest{
-				AttributePath: path.Root("test"),
-				Config: tfsdk.Config{
-					Raw: tftypes.NewValue(
-						tftypes.Object{
-							AttributeTypes: map[string]tftypes.Type{
-								"test": tftypes.Set{
-									ElementType: tftypes.Object{
-										AttributeTypes: map[string]tftypes.Type{
-											"nested_attr": tftypes.String,
-										},
-									},
-								},
-							},
-						},
-						map[string]tftypes.Value{
-							"test": tftypes.NewValue(
-								tftypes.Set{
-									ElementType: tftypes.Object{
-										AttributeTypes: map[string]tftypes.Type{
-											"nested_attr": tftypes.String,
-										},
-									},
-								},
-								[]tftypes.Value{
-									tftypes.NewValue(
-										tftypes.Object{
-											AttributeTypes: map[string]tftypes.Type{
-												"nested_attr": tftypes.String,
-											},
-										},
-										map[string]tftypes.Value{
-											"nested_attr": tftypes.NewValue(tftypes.String, "testvalue1"),
-										},
-									),
-								},
-							),
-						},
-					),
-					Schema: tfsdk.Schema{
-						Blocks: map[string]tfsdk.Block{
-							"test": {
-								Attributes: map[string]tfsdk.Attribute{
-									"nested_attr": {
-										Type:     types.StringType,
-										Optional: true,
-									},
-								},
-								MaxItems:    1,
-								NestingMode: tfsdk.BlockNestingModeSet,
-							},
-						},
-					},
-				},
-			},
-			resp: tfsdk.ValidateAttributeResponse{},
-		},
-		"set-maxitems-validation-null": {
-			req: tfsdk.ValidateAttributeRequest{
-				AttributePath: path.Root("test"),
-				Config: tfsdk.Config{
-					Raw: tftypes.NewValue(
-						tftypes.Object{
-							AttributeTypes: map[string]tftypes.Type{
-								"test": tftypes.Set{
-									ElementType: tftypes.Object{
-										AttributeTypes: map[string]tftypes.Type{
-											"nested_attr": tftypes.String,
-										},
-									},
-								},
-							},
-						},
-						map[string]tftypes.Value{
-							"test": tftypes.NewValue(
-								tftypes.Set{
-									ElementType: tftypes.Object{
-										AttributeTypes: map[string]tftypes.Type{
-											"nested_attr": tftypes.String,
-										},
-									},
-								},
-								nil,
-							),
-						},
-					),
-					Schema: tfsdk.Schema{
-						Blocks: map[string]tfsdk.Block{
-							"test": {
-								Attributes: map[string]tfsdk.Attribute{
-									"nested_attr": {
-										Type:     types.StringType,
-										Optional: true,
-									},
-								},
-								MaxItems:    1,
-								NestingMode: tfsdk.BlockNestingModeSet,
-							},
-						},
-					},
-				},
-			},
-			resp: tfsdk.ValidateAttributeResponse{},
-		},
-		"set-maxitems-validation-null-values": {
-			req: tfsdk.ValidateAttributeRequest{
-				AttributePath: path.Root("test"),
-				Config: tfsdk.Config{
-					Raw: tftypes.NewValue(
-						tftypes.Object{
-							AttributeTypes: map[string]tftypes.Type{
-								"test": tftypes.Set{
-									ElementType: tftypes.Object{
-										AttributeTypes: map[string]tftypes.Type{
-											"nested_attr": tftypes.String,
-										},
-									},
-								},
-							},
-						},
-						map[string]tftypes.Value{
-							"test": tftypes.NewValue(
-								tftypes.Set{
-									ElementType: tftypes.Object{
-										AttributeTypes: map[string]tftypes.Type{
-											"nested_attr": tftypes.String,
-										},
-									},
-								},
-								[]tftypes.Value{
-									tftypes.NewValue(
-										tftypes.Object{
-											AttributeTypes: map[string]tftypes.Type{
-												"nested_attr": tftypes.String,
-											},
-										},
-										nil,
-									),
-									// Must not be a duplicate value.
-									tftypes.NewValue(
-										tftypes.Object{
-											AttributeTypes: map[string]tftypes.Type{
-												"nested_attr": tftypes.String,
-											},
-										},
-										map[string]tftypes.Value{
-											"nested_attr": tftypes.NewValue(tftypes.String, "testvalue"),
-										},
-									),
-								},
-							),
-						},
-					),
-					Schema: tfsdk.Schema{
-						Blocks: map[string]tfsdk.Block{
-							"test": {
-								Attributes: map[string]tfsdk.Attribute{
-									"nested_attr": {
-										Type:     types.StringType,
-										Optional: true,
-									},
-								},
-								MaxItems:    1,
-								NestingMode: tfsdk.BlockNestingModeSet,
-							},
-						},
-					},
-				},
-			},
-			resp: tfsdk.ValidateAttributeResponse{
-				Diagnostics: diag.Diagnostics{
-					diag.NewAttributeErrorDiagnostic(
-						path.Root("test"),
-						"Extra Block Configuration",
-						"The configuration should declare a maximum of 1 block, however 2 blocks were configured.",
-					),
-				},
-			},
-		},
-		"set-maxitems-validation-unknown": {
-			req: tfsdk.ValidateAttributeRequest{
-				AttributePath: path.Root("test"),
-				Config: tfsdk.Config{
-					Raw: tftypes.NewValue(
-						tftypes.Object{
-							AttributeTypes: map[string]tftypes.Type{
-								"test": tftypes.Set{
-									ElementType: tftypes.Object{
-										AttributeTypes: map[string]tftypes.Type{
-											"nested_attr": tftypes.String,
-										},
-									},
-								},
-							},
-						},
-						map[string]tftypes.Value{
-							"test": tftypes.NewValue(
-								tftypes.Set{
-									ElementType: tftypes.Object{
-										AttributeTypes: map[string]tftypes.Type{
-											"nested_attr": tftypes.String,
-										},
-									},
-								},
-								tftypes.UnknownValue,
-							),
-						},
-					),
-					Schema: tfsdk.Schema{
-						Blocks: map[string]tfsdk.Block{
-							"test": {
-								Attributes: map[string]tfsdk.Attribute{
-									"nested_attr": {
-										Type:     types.StringType,
-										Optional: true,
-									},
-								},
-								MaxItems:    1,
-								NestingMode: tfsdk.BlockNestingModeSet,
-							},
-						},
-					},
-				},
-			},
-			resp: tfsdk.ValidateAttributeResponse{},
-		},
-		"set-maxitems-validation-unknown-values": {
-			req: tfsdk.ValidateAttributeRequest{
-				AttributePath: path.Root("test"),
-				Config: tfsdk.Config{
-					Raw: tftypes.NewValue(
-						tftypes.Object{
-							AttributeTypes: map[string]tftypes.Type{
-								"test": tftypes.Set{
-									ElementType: tftypes.Object{
-										AttributeTypes: map[string]tftypes.Type{
-											"nested_attr": tftypes.String,
-										},
-									},
-								},
-							},
-						},
-						map[string]tftypes.Value{
-							"test": tftypes.NewValue(
-								tftypes.Set{
-									ElementType: tftypes.Object{
-										AttributeTypes: map[string]tftypes.Type{
-											"nested_attr": tftypes.String,
-										},
-									},
-								},
-								[]tftypes.Value{
-									tftypes.NewValue(
-										tftypes.Object{
-											AttributeTypes: map[string]tftypes.Type{
-												"nested_attr": tftypes.String,
-											},
-										},
-										tftypes.UnknownValue,
-									),
-									tftypes.NewValue(
-										tftypes.Object{
-											AttributeTypes: map[string]tftypes.Type{
-												"nested_attr": tftypes.String,
-											},
-										},
-										tftypes.UnknownValue,
-									),
-								},
-							),
-						},
-					),
-					Schema: tfsdk.Schema{
-						Blocks: map[string]tfsdk.Block{
-							"test": {
-								Attributes: map[string]tfsdk.Attribute{
-									"nested_attr": {
-										Type:     types.StringType,
-										Optional: true,
-									},
-								},
-								MaxItems:    1,
-								NestingMode: tfsdk.BlockNestingModeSet,
-							},
-						},
-					},
-				},
-			},
-			resp: tfsdk.ValidateAttributeResponse{
-				Diagnostics: diag.Diagnostics{
-					diag.NewAttributeErrorDiagnostic(
-						path.Root("test"),
-						"Extra Block Configuration",
-						"The configuration should declare a maximum of 1 block, however 2 blocks were configured.",
-					),
-				},
-			},
-		},
-		"set-minitems-validation-known-invalid": {
-			req: tfsdk.ValidateAttributeRequest{
-				AttributePath: path.Root("test"),
-				Config: tfsdk.Config{
-					Raw: tftypes.NewValue(
-						tftypes.Object{
-							AttributeTypes: map[string]tftypes.Type{
-								"test": tftypes.Set{
-									ElementType: tftypes.Object{
-										AttributeTypes: map[string]tftypes.Type{
-											"nested_attr": tftypes.String,
-										},
-									},
-								},
-							},
-						},
-						map[string]tftypes.Value{
-							"test": tftypes.NewValue(
-								tftypes.Set{
-									ElementType: tftypes.Object{
-										AttributeTypes: map[string]tftypes.Type{
-											"nested_attr": tftypes.String,
-										},
-									},
-								},
-								[]tftypes.Value{
-									tftypes.NewValue(
-										tftypes.Object{
-											AttributeTypes: map[string]tftypes.Type{
-												"nested_attr": tftypes.String,
-											},
-										},
-										map[string]tftypes.Value{
-											"nested_attr": tftypes.NewValue(tftypes.String, "testvalue1"),
-										},
-									),
-								},
-							),
-						},
-					),
-					Schema: tfsdk.Schema{
-						Blocks: map[string]tfsdk.Block{
-							"test": {
-								Attributes: map[string]tfsdk.Attribute{
-									"nested_attr": {
-										Type:     types.StringType,
-										Optional: true,
-									},
-								},
-								MinItems:    2,
-								NestingMode: tfsdk.BlockNestingModeSet,
-							},
-						},
-					},
-				},
-			},
-			resp: tfsdk.ValidateAttributeResponse{
-				Diagnostics: diag.Diagnostics{
-					diag.NewAttributeErrorDiagnostic(
-						path.Root("test"),
-						"Missing Block Configuration",
-						"The configuration should declare a minimum of 2 blocks, however 1 block was configured.",
-					),
-				},
-			},
-		},
-		"set-minitems-validation-known-valid": {
-			req: tfsdk.ValidateAttributeRequest{
-				AttributePath: path.Root("test"),
-				Config: tfsdk.Config{
-					Raw: tftypes.NewValue(
-						tftypes.Object{
-							AttributeTypes: map[string]tftypes.Type{
-								"test": tftypes.Set{
-									ElementType: tftypes.Object{
-										AttributeTypes: map[string]tftypes.Type{
-											"nested_attr": tftypes.String,
-										},
-									},
-								},
-							},
-						},
-						map[string]tftypes.Value{
-							"test": tftypes.NewValue(
-								tftypes.Set{
-									ElementType: tftypes.Object{
-										AttributeTypes: map[string]tftypes.Type{
-											"nested_attr": tftypes.String,
-										},
-									},
-								},
-								[]tftypes.Value{
-									tftypes.NewValue(
-										tftypes.Object{
-											AttributeTypes: map[string]tftypes.Type{
-												"nested_attr": tftypes.String,
-											},
-										},
-										map[string]tftypes.Value{
-											"nested_attr": tftypes.NewValue(tftypes.String, "testvalue1"),
-										},
-									),
-								},
-							),
-						},
-					),
-					Schema: tfsdk.Schema{
-						Blocks: map[string]tfsdk.Block{
-							"test": {
-								Attributes: map[string]tfsdk.Attribute{
-									"nested_attr": {
-										Type:     types.StringType,
-										Optional: true,
-									},
-								},
-								MinItems:    1,
-								NestingMode: tfsdk.BlockNestingModeSet,
-							},
-						},
-					},
-				},
-			},
-			resp: tfsdk.ValidateAttributeResponse{},
-		},
-		"set-minitems-validation-null": {
-			req: tfsdk.ValidateAttributeRequest{
-				AttributePath: path.Root("test"),
-				Config: tfsdk.Config{
-					Raw: tftypes.NewValue(
-						tftypes.Object{
-							AttributeTypes: map[string]tftypes.Type{
-								"test": tftypes.Set{
-									ElementType: tftypes.Object{
-										AttributeTypes: map[string]tftypes.Type{
-											"nested_attr": tftypes.String,
-										},
-									},
-								},
-							},
-						},
-						map[string]tftypes.Value{
-							"test": tftypes.NewValue(
-								tftypes.Set{
-									ElementType: tftypes.Object{
-										AttributeTypes: map[string]tftypes.Type{
-											"nested_attr": tftypes.String,
-										},
-									},
-								},
-								nil,
-							),
-						},
-					),
-					Schema: tfsdk.Schema{
-						Blocks: map[string]tfsdk.Block{
-							"test": {
-								Attributes: map[string]tfsdk.Attribute{
-									"nested_attr": {
-										Type:     types.StringType,
-										Optional: true,
-									},
-								},
-								MinItems:    1,
-								NestingMode: tfsdk.BlockNestingModeSet,
-							},
-						},
-					},
-				},
-			},
-			resp: tfsdk.ValidateAttributeResponse{
-				Diagnostics: diag.Diagnostics{
-					diag.NewAttributeErrorDiagnostic(
-						path.Root("test"),
-						"Missing Block Configuration",
-						"The configuration should declare a minimum of 1 block, however 0 blocks were configured.",
-					),
-				},
-			},
-		},
-		"set-minitems-validation-null-values": {
-			req: tfsdk.ValidateAttributeRequest{
-				AttributePath: path.Root("test"),
-				Config: tfsdk.Config{
-					Raw: tftypes.NewValue(
-						tftypes.Object{
-							AttributeTypes: map[string]tftypes.Type{
-								"test": tftypes.Set{
-									ElementType: tftypes.Object{
-										AttributeTypes: map[string]tftypes.Type{
-											"nested_attr": tftypes.String,
-										},
-									},
-								},
-							},
-						},
-						map[string]tftypes.Value{
-							"test": tftypes.NewValue(
-								tftypes.Set{
-									ElementType: tftypes.Object{
-										AttributeTypes: map[string]tftypes.Type{
-											"nested_attr": tftypes.String,
-										},
-									},
-								},
-								[]tftypes.Value{
-									tftypes.NewValue(
-										tftypes.Object{
-											AttributeTypes: map[string]tftypes.Type{
-												"nested_attr": tftypes.String,
-											},
-										},
-										nil,
-									),
-								},
-							),
-						},
-					),
-					Schema: tfsdk.Schema{
-						Blocks: map[string]tfsdk.Block{
-							"test": {
-								Attributes: map[string]tfsdk.Attribute{
-									"nested_attr": {
-										Type:     types.StringType,
-										Optional: true,
-									},
-								},
-								MinItems:    2,
-								NestingMode: tfsdk.BlockNestingModeSet,
-							},
-						},
-					},
-				},
-			},
-			resp: tfsdk.ValidateAttributeResponse{
-				Diagnostics: diag.Diagnostics{
-					diag.NewAttributeErrorDiagnostic(
-						path.Root("test"),
-						"Missing Block Configuration",
-						"The configuration should declare a minimum of 2 blocks, however 1 block was configured.",
-					),
-				},
-			},
-		},
-		"set-minitems-validation-unknown": {
-			req: tfsdk.ValidateAttributeRequest{
-				AttributePath: path.Root("test"),
-				Config: tfsdk.Config{
-					Raw: tftypes.NewValue(
-						tftypes.Object{
-							AttributeTypes: map[string]tftypes.Type{
-								"test": tftypes.Set{
-									ElementType: tftypes.Object{
-										AttributeTypes: map[string]tftypes.Type{
-											"nested_attr": tftypes.String,
-										},
-									},
-								},
-							},
-						},
-						map[string]tftypes.Value{
-							"test": tftypes.NewValue(
-								tftypes.Set{
-									ElementType: tftypes.Object{
-										AttributeTypes: map[string]tftypes.Type{
-											"nested_attr": tftypes.String,
-										},
-									},
-								},
-								tftypes.UnknownValue,
-							),
-						},
-					),
-					Schema: tfsdk.Schema{
-						Blocks: map[string]tfsdk.Block{
-							"test": {
-								Attributes: map[string]tfsdk.Attribute{
-									"nested_attr": {
-										Type:     types.StringType,
-										Optional: true,
-									},
-								},
-								MinItems:    1,
-								NestingMode: tfsdk.BlockNestingModeSet,
-							},
-						},
-					},
-				},
-			},
-			resp: tfsdk.ValidateAttributeResponse{},
-		},
-		"set-minitems-validation-unknown-values": {
-			req: tfsdk.ValidateAttributeRequest{
-				AttributePath: path.Root("test"),
-				Config: tfsdk.Config{
-					Raw: tftypes.NewValue(
-						tftypes.Object{
-							AttributeTypes: map[string]tftypes.Type{
-								"test": tftypes.Set{
-									ElementType: tftypes.Object{
-										AttributeTypes: map[string]tftypes.Type{
-											"nested_attr": tftypes.String,
-										},
-									},
-								},
-							},
-						},
-						map[string]tftypes.Value{
-							"test": tftypes.NewValue(
-								tftypes.Set{
-									ElementType: tftypes.Object{
-										AttributeTypes: map[string]tftypes.Type{
-											"nested_attr": tftypes.String,
-										},
-									},
-								},
-								[]tftypes.Value{
-									tftypes.NewValue(
-										tftypes.Object{
-											AttributeTypes: map[string]tftypes.Type{
-												"nested_attr": tftypes.String,
-											},
-										},
-										tftypes.UnknownValue,
-									),
-								},
-							),
-						},
-					),
-					Schema: tfsdk.Schema{
-						Blocks: map[string]tfsdk.Block{
-							"test": {
-								Attributes: map[string]tfsdk.Attribute{
-									"nested_attr": {
-										Type:     types.StringType,
-										Optional: true,
-									},
-								},
-								MinItems:    2,
-								NestingMode: tfsdk.BlockNestingModeSet,
-							},
-						},
-					},
-				},
-			},
-			resp: tfsdk.ValidateAttributeResponse{
-				Diagnostics: diag.Diagnostics{
-					diag.NewAttributeErrorDiagnostic(
-						path.Root("test"),
-						"Missing Block Configuration",
-						"The configuration should declare a minimum of 2 blocks, however 1 block was configured.",
-					),
 				},
 			},
 		},
@@ -2297,16 +898,18 @@ func TestBlockValidate(t *testing.T) {
 							),
 						},
 					),
-					Schema: tfsdk.Schema{
-						Blocks: map[string]tfsdk.Block{
-							"test": {
-								Attributes: map[string]tfsdk.Attribute{
-									"nested_attr": {
-										Type:     types.StringType,
-										Required: true,
+					Schema: testschema.Schema{
+						Blocks: map[string]fwschema.Block{
+							"test": testschema.Block{
+								NestedObject: testschema.NestedBlockObject{
+									Attributes: map[string]fwschema.Attribute{
+										"nested_attr": testschema.Attribute{
+											Type:     types.StringType,
+											Required: true,
+										},
 									},
 								},
-								NestingMode: tfsdk.BlockNestingModeSingle,
+								NestingMode: fwschema.BlockNestingModeSingle,
 							},
 						},
 					},
@@ -2341,19 +944,24 @@ func TestBlockValidate(t *testing.T) {
 							),
 						},
 					),
-					Schema: tfsdk.Schema{
-						Blocks: map[string]tfsdk.Block{
-							"test": {
-								Attributes: map[string]tfsdk.Attribute{
-									"nested_attr": {
-										Type:     types.StringType,
-										Required: true,
-										Validators: []tfsdk.AttributeValidator{
-											testErrorAttributeValidator{},
+					Schema: testschema.Schema{
+						Blocks: map[string]fwschema.Block{
+							"test": testschema.Block{
+								NestedObject: testschema.NestedBlockObject{
+									Attributes: map[string]fwschema.Attribute{
+										"nested_attr": testschema.AttributeWithStringValidators{
+											Required: true,
+											Validators: []validator.String{
+												testvalidator.String{
+													ValidateStringMethod: func(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+														resp.Diagnostics.Append(testErrorDiagnostic1)
+													},
+												},
+											},
 										},
 									},
 								},
-								NestingMode: tfsdk.BlockNestingModeSingle,
+								NestingMode: fwschema.BlockNestingModeSingle,
 							},
 						},
 					},
@@ -2364,276 +972,6 @@ func TestBlockValidate(t *testing.T) {
 					testErrorDiagnostic1,
 				},
 			},
-		},
-		"single-maxitems-validation-known-valid": {
-			req: tfsdk.ValidateAttributeRequest{
-				AttributePath: path.Root("test"),
-				Config: tfsdk.Config{
-					Raw: tftypes.NewValue(
-						tftypes.Object{
-							AttributeTypes: map[string]tftypes.Type{
-								"test": tftypes.Object{
-									AttributeTypes: map[string]tftypes.Type{
-										"nested_attr": tftypes.String,
-									},
-								},
-							},
-						},
-						map[string]tftypes.Value{
-							"test": tftypes.NewValue(
-								tftypes.Object{
-									AttributeTypes: map[string]tftypes.Type{
-										"nested_attr": tftypes.String,
-									},
-								},
-								map[string]tftypes.Value{
-									"nested_attr": tftypes.NewValue(tftypes.String, "testvalue1"),
-								},
-							),
-						},
-					),
-					Schema: tfsdk.Schema{
-						Blocks: map[string]tfsdk.Block{
-							"test": {
-								Attributes: map[string]tfsdk.Attribute{
-									"nested_attr": {
-										Type:     types.StringType,
-										Optional: true,
-									},
-								},
-								MaxItems:    1,
-								NestingMode: tfsdk.BlockNestingModeSingle,
-							},
-						},
-					},
-				},
-			},
-			resp: tfsdk.ValidateAttributeResponse{},
-		},
-		"single-maxitems-validation-null": {
-			req: tfsdk.ValidateAttributeRequest{
-				AttributePath: path.Root("test"),
-				Config: tfsdk.Config{
-					Raw: tftypes.NewValue(
-						tftypes.Object{
-							AttributeTypes: map[string]tftypes.Type{
-								"test": tftypes.Object{
-									AttributeTypes: map[string]tftypes.Type{
-										"nested_attr": tftypes.String,
-									},
-								},
-							},
-						},
-						map[string]tftypes.Value{
-							"test": tftypes.NewValue(
-								tftypes.Object{
-									AttributeTypes: map[string]tftypes.Type{
-										"nested_attr": tftypes.String,
-									},
-								},
-								nil,
-							),
-						},
-					),
-					Schema: tfsdk.Schema{
-						Blocks: map[string]tfsdk.Block{
-							"test": {
-								Attributes: map[string]tfsdk.Attribute{
-									"nested_attr": {
-										Type:     types.StringType,
-										Optional: true,
-									},
-								},
-								MaxItems:    1,
-								NestingMode: tfsdk.BlockNestingModeSingle,
-							},
-						},
-					},
-				},
-			},
-			resp: tfsdk.ValidateAttributeResponse{},
-		},
-		"single-maxitems-validation-unknown": {
-			req: tfsdk.ValidateAttributeRequest{
-				AttributePath: path.Root("test"),
-				Config: tfsdk.Config{
-					Raw: tftypes.NewValue(
-						tftypes.Object{
-							AttributeTypes: map[string]tftypes.Type{
-								"test": tftypes.Object{
-									AttributeTypes: map[string]tftypes.Type{
-										"nested_attr": tftypes.String,
-									},
-								},
-							},
-						},
-						map[string]tftypes.Value{
-							"test": tftypes.NewValue(
-								tftypes.Object{
-									AttributeTypes: map[string]tftypes.Type{
-										"nested_attr": tftypes.String,
-									},
-								},
-								tftypes.UnknownValue,
-							),
-						},
-					),
-					Schema: tfsdk.Schema{
-						Blocks: map[string]tfsdk.Block{
-							"test": {
-								Attributes: map[string]tfsdk.Attribute{
-									"nested_attr": {
-										Type:     types.StringType,
-										Optional: true,
-									},
-								},
-								MaxItems:    1,
-								NestingMode: tfsdk.BlockNestingModeSingle,
-							},
-						},
-					},
-				},
-			},
-			resp: tfsdk.ValidateAttributeResponse{},
-		},
-		"single-minitems-validation-known-valid": {
-			req: tfsdk.ValidateAttributeRequest{
-				AttributePath: path.Root("test"),
-				Config: tfsdk.Config{
-					Raw: tftypes.NewValue(
-						tftypes.Object{
-							AttributeTypes: map[string]tftypes.Type{
-								"test": tftypes.Object{
-									AttributeTypes: map[string]tftypes.Type{
-										"nested_attr": tftypes.String,
-									},
-								},
-							},
-						},
-						map[string]tftypes.Value{
-							"test": tftypes.NewValue(
-								tftypes.Object{
-									AttributeTypes: map[string]tftypes.Type{
-										"nested_attr": tftypes.String,
-									},
-								},
-								map[string]tftypes.Value{
-									"nested_attr": tftypes.NewValue(tftypes.String, "testvalue1"),
-								},
-							),
-						},
-					),
-					Schema: tfsdk.Schema{
-						Blocks: map[string]tfsdk.Block{
-							"test": {
-								Attributes: map[string]tfsdk.Attribute{
-									"nested_attr": {
-										Type:     types.StringType,
-										Optional: true,
-									},
-								},
-								MinItems:    1,
-								NestingMode: tfsdk.BlockNestingModeSingle,
-							},
-						},
-					},
-				},
-			},
-			resp: tfsdk.ValidateAttributeResponse{},
-		},
-		"single-minitems-validation-null": {
-			req: tfsdk.ValidateAttributeRequest{
-				AttributePath: path.Root("test"),
-				Config: tfsdk.Config{
-					Raw: tftypes.NewValue(
-						tftypes.Object{
-							AttributeTypes: map[string]tftypes.Type{
-								"test": tftypes.Object{
-									AttributeTypes: map[string]tftypes.Type{
-										"nested_attr": tftypes.String,
-									},
-								},
-							},
-						},
-						map[string]tftypes.Value{
-							"test": tftypes.NewValue(
-								tftypes.Object{
-									AttributeTypes: map[string]tftypes.Type{
-										"nested_attr": tftypes.String,
-									},
-								},
-								nil,
-							),
-						},
-					),
-					Schema: tfsdk.Schema{
-						Blocks: map[string]tfsdk.Block{
-							"test": {
-								Attributes: map[string]tfsdk.Attribute{
-									"nested_attr": {
-										Type:     types.StringType,
-										Optional: true,
-									},
-								},
-								MinItems:    1,
-								NestingMode: tfsdk.BlockNestingModeSingle,
-							},
-						},
-					},
-				},
-			},
-			resp: tfsdk.ValidateAttributeResponse{
-				Diagnostics: diag.Diagnostics{
-					diag.NewAttributeErrorDiagnostic(
-						path.Root("test"),
-						"Missing Block Configuration",
-						"The configuration should declare a minimum of 1 block, however 0 blocks were configured.",
-					),
-				},
-			},
-		},
-		"single-minitems-validation-unknown": {
-			req: tfsdk.ValidateAttributeRequest{
-				AttributePath: path.Root("test"),
-				Config: tfsdk.Config{
-					Raw: tftypes.NewValue(
-						tftypes.Object{
-							AttributeTypes: map[string]tftypes.Type{
-								"test": tftypes.Object{
-									AttributeTypes: map[string]tftypes.Type{
-										"nested_attr": tftypes.String,
-									},
-								},
-							},
-						},
-						map[string]tftypes.Value{
-							"test": tftypes.NewValue(
-								tftypes.Object{
-									AttributeTypes: map[string]tftypes.Type{
-										"nested_attr": tftypes.String,
-									},
-								},
-								tftypes.UnknownValue,
-							),
-						},
-					),
-					Schema: tfsdk.Schema{
-						Blocks: map[string]tfsdk.Block{
-							"test": {
-								Attributes: map[string]tfsdk.Attribute{
-									"nested_attr": {
-										Type:     types.StringType,
-										Optional: true,
-									},
-								},
-								MinItems:    1,
-								NestingMode: tfsdk.BlockNestingModeSingle,
-							},
-						},
-					},
-				},
-			},
-			resp: tfsdk.ValidateAttributeResponse{},
 		},
 	}
 

--- a/internal/fwserver/schema_validation_test.go
+++ b/internal/fwserver/schema_validation_test.go
@@ -6,6 +6,10 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
@@ -30,13 +34,13 @@ func TestSchemaValidate(t *testing.T) {
 						"attr1": tftypes.NewValue(tftypes.String, "attr1value"),
 						"attr2": tftypes.NewValue(tftypes.String, "attr2value"),
 					}),
-					Schema: tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"attr1": {
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"attr1": testschema.Attribute{
 								Type:     types.StringType,
 								Required: true,
 							},
-							"attr2": {
+							"attr2": testschema.Attribute{
 								Type:     types.StringType,
 								Required: true,
 							},
@@ -58,13 +62,13 @@ func TestSchemaValidate(t *testing.T) {
 						"attr1": tftypes.NewValue(tftypes.String, "attr1value"),
 						"attr2": tftypes.NewValue(tftypes.String, "attr2value"),
 					}),
-					Schema: tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"attr1": {
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"attr1": testschema.Attribute{
 								Type:     types.StringType,
 								Required: true,
 							},
-							"attr2": {
+							"attr2": testschema.Attribute{
 								Type:     types.StringType,
 								Required: true,
 							},
@@ -94,21 +98,22 @@ func TestSchemaValidate(t *testing.T) {
 						"attr1": tftypes.NewValue(tftypes.String, "attr1value"),
 						"attr2": tftypes.NewValue(tftypes.String, "attr2value"),
 					}),
-					Schema: tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"attr1": {
-								Type:     types.StringType,
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"attr1": testschema.AttributeWithStringValidators{
 								Required: true,
-								Validators: []tfsdk.AttributeValidator{
-									testWarningAttributeValidator{},
+								Validators: []validator.String{
+									testvalidator.String{
+										ValidateStringMethod: func(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+											resp.Diagnostics.Append(testWarningDiagnostic1)
+											resp.Diagnostics.Append(testWarningDiagnostic2)
+										},
+									},
 								},
 							},
-							"attr2": {
-								Type:     types.StringType,
+							"attr2": testschema.Attribute{
 								Required: true,
-								Validators: []tfsdk.AttributeValidator{
-									testWarningAttributeValidator{},
-								},
+								Type:     types.StringType,
 							},
 						},
 					},
@@ -133,21 +138,22 @@ func TestSchemaValidate(t *testing.T) {
 						"attr1": tftypes.NewValue(tftypes.String, "attr1value"),
 						"attr2": tftypes.NewValue(tftypes.String, "attr2value"),
 					}),
-					Schema: tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"attr1": {
-								Type:     types.StringType,
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"attr1": testschema.AttributeWithStringValidators{
 								Required: true,
-								Validators: []tfsdk.AttributeValidator{
-									testErrorAttributeValidator{},
+								Validators: []validator.String{
+									testvalidator.String{
+										ValidateStringMethod: func(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+											resp.Diagnostics.Append(testErrorDiagnostic1)
+											resp.Diagnostics.Append(testErrorDiagnostic2)
+										},
+									},
 								},
 							},
-							"attr2": {
-								Type:     types.StringType,
+							"attr2": testschema.Attribute{
 								Required: true,
-								Validators: []tfsdk.AttributeValidator{
-									testErrorAttributeValidator{},
-								},
+								Type:     types.StringType,
 							},
 						},
 					},

--- a/internal/fwserver/server_applyresourcechange_test.go
+++ b/internal/fwserver/server_applyresourcechange_test.go
@@ -13,7 +13,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
 	"github.com/hashicorp/terraform-plugin-framework/internal/privatestate"
 	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testprovider"
+	"github.com/hashicorp/terraform-plugin-framework/provider/metaschema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -28,15 +30,13 @@ func TestServerApplyResourceChange(t *testing.T) {
 		},
 	}
 
-	testSchema := tfsdk.Schema{
-		Attributes: map[string]tfsdk.Attribute{
-			"test_computed": {
+	testSchema := schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"test_computed": schema.StringAttribute{
 				Computed: true,
-				Type:     types.StringType,
 			},
-			"test_required": {
+			"test_required": schema.StringAttribute{
 				Required: true,
-				Type:     types.StringType,
 			},
 		},
 	}
@@ -66,11 +66,10 @@ func TestServerApplyResourceChange(t *testing.T) {
 		"test_provider_meta_attribute": tftypes.NewValue(tftypes.String, "test-provider-meta-value"),
 	})
 
-	testProviderMetaSchema := tfsdk.Schema{
-		Attributes: map[string]tfsdk.Attribute{
-			"test_provider_meta_attribute": {
+	testProviderMetaSchema := metaschema.Schema{
+		Attributes: map[string]metaschema.Attribute{
+			"test_provider_meta_attribute": metaschema.StringAttribute{
 				Optional: true,
-				Type:     types.StringType,
 			},
 		},
 	}

--- a/internal/fwserver/server_createresource_test.go
+++ b/internal/fwserver/server_createresource_test.go
@@ -12,7 +12,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
 	"github.com/hashicorp/terraform-plugin-framework/internal/privatestate"
 	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testprovider"
+	"github.com/hashicorp/terraform-plugin-framework/provider/metaschema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -27,15 +29,13 @@ func TestServerCreateResource(t *testing.T) {
 		},
 	}
 
-	testSchema := tfsdk.Schema{
-		Attributes: map[string]tfsdk.Attribute{
-			"test_computed": {
+	testSchema := schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"test_computed": schema.StringAttribute{
 				Computed: true,
-				Type:     types.StringType,
 			},
-			"test_required": {
+			"test_required": schema.StringAttribute{
 				Required: true,
-				Type:     types.StringType,
 			},
 		},
 	}
@@ -60,11 +60,10 @@ func TestServerCreateResource(t *testing.T) {
 		"test_provider_meta_attribute": tftypes.NewValue(tftypes.String, "test-provider-meta-value"),
 	})
 
-	testProviderMetaSchema := tfsdk.Schema{
-		Attributes: map[string]tfsdk.Attribute{
-			"test_provider_meta_attribute": {
+	testProviderMetaSchema := metaschema.Schema{
+		Attributes: map[string]metaschema.Attribute{
+			"test_provider_meta_attribute": metaschema.StringAttribute{
 				Optional: true,
-				Type:     types.StringType,
 			},
 		},
 	}

--- a/internal/fwserver/server_deleteresource_test.go
+++ b/internal/fwserver/server_deleteresource_test.go
@@ -13,7 +13,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
 	"github.com/hashicorp/terraform-plugin-framework/internal/privatestate"
 	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testprovider"
+	"github.com/hashicorp/terraform-plugin-framework/provider/metaschema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -28,15 +30,13 @@ func TestServerDeleteResource(t *testing.T) {
 		},
 	}
 
-	testSchema := tfsdk.Schema{
-		Attributes: map[string]tfsdk.Attribute{
-			"test_computed": {
+	testSchema := schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"test_computed": schema.StringAttribute{
 				Computed: true,
-				Type:     types.StringType,
 			},
-			"test_required": {
+			"test_required": schema.StringAttribute{
 				Required: true,
-				Type:     types.StringType,
 			},
 		},
 	}
@@ -61,11 +61,10 @@ func TestServerDeleteResource(t *testing.T) {
 		"test_provider_meta_attribute": tftypes.NewValue(tftypes.String, "test-provider-meta-value"),
 	})
 
-	testProviderMetaSchema := tfsdk.Schema{
-		Attributes: map[string]tfsdk.Attribute{
-			"test_provider_meta_attribute": {
+	testProviderMetaSchema := metaschema.Schema{
+		Attributes: map[string]metaschema.Attribute{
+			"test_provider_meta_attribute": metaschema.StringAttribute{
 				Optional: true,
-				Type:     types.StringType,
 			},
 		},
 	}

--- a/internal/fwserver/server_importresourcestate_test.go
+++ b/internal/fwserver/server_importresourcestate_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testprovider"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 func TestServerImportResourceState(t *testing.T) {
@@ -41,19 +41,16 @@ func TestServerImportResourceState(t *testing.T) {
 		"required": tftypes.NewValue(tftypes.String, nil),
 	})
 
-	testSchema := tfsdk.Schema{
-		Attributes: map[string]tfsdk.Attribute{
-			"id": {
+	testSchema := schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
 				Computed: true,
-				Type:     types.StringType,
 			},
-			"optional": {
+			"optional": schema.StringAttribute{
 				Optional: true,
-				Type:     types.StringType,
 			},
-			"required": {
+			"required": schema.StringAttribute{
 				Required: true,
-				Type:     types.StringType,
 			},
 		},
 	}

--- a/internal/fwserver/server_readresource_test.go
+++ b/internal/fwserver/server_readresource_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/internal/privatestate"
 	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testprovider"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -38,15 +39,13 @@ func TestServerReadResource(t *testing.T) {
 		"test_required": tftypes.NewValue(tftypes.String, "test-currentstate-value"),
 	})
 
-	testSchema := tfsdk.Schema{
-		Attributes: map[string]tfsdk.Attribute{
-			"test_computed": {
+	testSchema := schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"test_computed": schema.StringAttribute{
 				Computed: true,
-				Type:     types.StringType,
 			},
-			"test_required": {
+			"test_required": schema.StringAttribute{
 				Required: true,
-				Type:     types.StringType,
 			},
 		},
 	}

--- a/internal/fwserver/server_updateresource_test.go
+++ b/internal/fwserver/server_updateresource_test.go
@@ -13,7 +13,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
 	"github.com/hashicorp/terraform-plugin-framework/internal/privatestate"
 	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testprovider"
+	"github.com/hashicorp/terraform-plugin-framework/provider/metaschema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -28,15 +30,13 @@ func TestServerUpdateResource(t *testing.T) {
 		},
 	}
 
-	testSchema := tfsdk.Schema{
-		Attributes: map[string]tfsdk.Attribute{
-			"test_computed": {
+	testSchema := schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"test_computed": schema.StringAttribute{
 				Computed: true,
-				Type:     types.StringType,
 			},
-			"test_required": {
+			"test_required": schema.StringAttribute{
 				Required: true,
-				Type:     types.StringType,
 			},
 		},
 	}
@@ -56,11 +56,10 @@ func TestServerUpdateResource(t *testing.T) {
 		"test_provider_meta_attribute": tftypes.NewValue(tftypes.String, "test-provider-meta-value"),
 	})
 
-	testProviderMetaSchema := tfsdk.Schema{
-		Attributes: map[string]tfsdk.Attribute{
-			"test_provider_meta_attribute": {
+	testProviderMetaSchema := metaschema.Schema{
+		Attributes: map[string]metaschema.Attribute{
+			"test_provider_meta_attribute": metaschema.StringAttribute{
 				Optional: true,
-				Type:     types.StringType,
 			},
 		},
 	}

--- a/internal/testing/planmodifiers/planmodifiers.go
+++ b/internal/testing/planmodifiers/planmodifiers.go
@@ -3,6 +3,7 @@ package planmodifiers
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -43,14 +44,9 @@ func (t TestErrorDiagModifier) MarkdownDescription(ctx context.Context) string {
 
 type TestAttrPlanValueModifierOne struct{}
 
-func (t TestAttrPlanValueModifierOne) Modify(ctx context.Context, req tfsdk.ModifyAttributePlanRequest, resp *tfsdk.ModifyAttributePlanResponse) {
-	attrVal, ok := req.AttributePlan.(types.String)
-	if !ok {
-		return
-	}
-
-	if attrVal.ValueString() == "TESTATTRONE" {
-		resp.AttributePlan = types.StringValue("TESTATTRTWO")
+func (t TestAttrPlanValueModifierOne) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	if req.PlanValue.ValueString() == "TESTATTRONE" {
+		resp.PlanValue = types.StringValue("TESTATTRTWO")
 	}
 }
 
@@ -126,7 +122,20 @@ func (m TestRequiresReplaceFalseModifier) MarkdownDescription(ctx context.Contex
 
 type TestAttrPlanPrivateModifierGet struct{}
 
-func (t TestAttrPlanPrivateModifierGet) Modify(ctx context.Context, req tfsdk.ModifyAttributePlanRequest, resp *tfsdk.ModifyAttributePlanResponse) {
+func (t TestAttrPlanPrivateModifierGet) PlanModifyList(ctx context.Context, req planmodifier.ListRequest, resp *planmodifier.ListResponse) {
+	expected := `{"pKeyOne": {"k0": "zero", "k1": 1}}`
+
+	key := "providerKeyOne"
+	got, diags := req.Private.GetKey(ctx, key)
+
+	resp.Diagnostics.Append(diags...)
+
+	if string(got) != expected {
+		resp.Diagnostics.AddError("unexpected req.Private.Provider value: %s", string(got))
+	}
+}
+
+func (t TestAttrPlanPrivateModifierGet) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
 	expected := `{"pKeyOne": {"k0": "zero", "k1": 1}}`
 
 	key := "providerKeyOne"
@@ -149,7 +158,31 @@ func (t TestAttrPlanPrivateModifierGet) MarkdownDescription(ctx context.Context)
 
 type TestAttrPlanPrivateModifierSet struct{}
 
-func (t TestAttrPlanPrivateModifierSet) Modify(ctx context.Context, req tfsdk.ModifyAttributePlanRequest, resp *tfsdk.ModifyAttributePlanResponse) {
+func (t TestAttrPlanPrivateModifierSet) PlanModifyList(ctx context.Context, req planmodifier.ListRequest, resp *planmodifier.ListResponse) {
+	diags := resp.Private.SetKey(ctx, "providerKeyOne", []byte(`{"pKeyOne": {"k0": "zero", "k1": 1}}`))
+
+	resp.Diagnostics.Append(diags...)
+}
+
+func (t TestAttrPlanPrivateModifierSet) PlanModifyMap(ctx context.Context, req planmodifier.MapRequest, resp *planmodifier.MapResponse) {
+	diags := resp.Private.SetKey(ctx, "providerKeyOne", []byte(`{"pKeyOne": {"k0": "zero", "k1": 1}}`))
+
+	resp.Diagnostics.Append(diags...)
+}
+
+func (t TestAttrPlanPrivateModifierSet) PlanModifyObject(ctx context.Context, req planmodifier.ObjectRequest, resp *planmodifier.ObjectResponse) {
+	diags := resp.Private.SetKey(ctx, "providerKeyOne", []byte(`{"pKeyOne": {"k0": "zero", "k1": 1}}`))
+
+	resp.Diagnostics.Append(diags...)
+}
+
+func (t TestAttrPlanPrivateModifierSet) PlanModifySet(ctx context.Context, req planmodifier.SetRequest, resp *planmodifier.SetResponse) {
+	diags := resp.Private.SetKey(ctx, "providerKeyOne", []byte(`{"pKeyOne": {"k0": "zero", "k1": 1}}`))
+
+	resp.Diagnostics.Append(diags...)
+}
+
+func (t TestAttrPlanPrivateModifierSet) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
 	diags := resp.Private.SetKey(ctx, "providerKeyOne", []byte(`{"pKeyOne": {"k0": "zero", "k1": 1}}`))
 
 	resp.Diagnostics.Append(diags...)

--- a/internal/testing/testschema/attribute.go
+++ b/internal/testing/testschema/attribute.go
@@ -1,0 +1,76 @@
+package testschema
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+var _ fwschema.Attribute = Attribute{}
+
+type Attribute struct {
+	Computed            bool
+	DeprecationMessage  string
+	Description         string
+	MarkdownDescription string
+	Optional            bool
+	Required            bool
+	Sensitive           bool
+	Type                attr.Type
+}
+
+// ApplyTerraform5AttributePathStep satisfies the fwschema.Attribute interface.
+func (a Attribute) ApplyTerraform5AttributePathStep(step tftypes.AttributePathStep) (any, error) {
+	return a.GetType().ApplyTerraform5AttributePathStep(step)
+}
+
+// Equal satisfies the fwschema.Attribute interface.
+func (a Attribute) Equal(o fwschema.Attribute) bool {
+	_, ok := o.(Attribute)
+
+	if !ok {
+		return false
+	}
+
+	return fwschema.AttributesEqual(a, o)
+}
+
+// GetDeprecationMessage satisfies the fwschema.Attribute interface.
+func (a Attribute) GetDeprecationMessage() string {
+	return a.DeprecationMessage
+}
+
+// GetDescription satisfies the fwschema.Attribute interface.
+func (a Attribute) GetDescription() string {
+	return a.Description
+}
+
+// GetMarkdownDescription satisfies the fwschema.Attribute interface.
+func (a Attribute) GetMarkdownDescription() string {
+	return a.MarkdownDescription
+}
+
+// GetType satisfies the fwschema.Attribute interface.
+func (a Attribute) GetType() attr.Type {
+	return a.Type
+}
+
+// IsComputed satisfies the fwschema.Attribute interface.
+func (a Attribute) IsComputed() bool {
+	return a.Computed
+}
+
+// IsOptional satisfies the fwschema.Attribute interface.
+func (a Attribute) IsOptional() bool {
+	return a.Optional
+}
+
+// IsRequired satisfies the fwschema.Attribute interface.
+func (a Attribute) IsRequired() bool {
+	return a.Required
+}
+
+// IsSensitive satisfies the fwschema.Attribute interface.
+func (a Attribute) IsSensitive() bool {
+	return a.Sensitive
+}

--- a/internal/testing/testschema/block.go
+++ b/internal/testing/testschema/block.go
@@ -1,0 +1,89 @@
+package testschema
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+var _ fwschema.Block = Block{}
+
+type Block struct {
+	DeprecationMessage  string
+	Description         string
+	MarkdownDescription string
+	MaxItems            int64
+	MinItems            int64
+	NestedObject        fwschema.NestedBlockObject
+	NestingMode         fwschema.BlockNestingMode
+}
+
+// ApplyTerraform5AttributePathStep satisfies the fwschema.Block interface.
+func (b Block) ApplyTerraform5AttributePathStep(step tftypes.AttributePathStep) (any, error) {
+	return b.Type().ApplyTerraform5AttributePathStep(step)
+}
+
+// Equal satisfies the fwschema.Block interface.
+func (b Block) Equal(o fwschema.Block) bool {
+	_, ok := o.(Block)
+
+	if !ok {
+		return false
+	}
+
+	return fwschema.BlocksEqual(b, o)
+}
+
+// GetDeprecationMessage satisfies the fwschema.Block interface.
+func (b Block) GetDeprecationMessage() string {
+	return b.DeprecationMessage
+}
+
+// GetDescription satisfies the fwschema.Block interface.
+func (b Block) GetDescription() string {
+	return b.Description
+}
+
+// GetMarkdownDescription satisfies the fwschema.Block interface.
+func (b Block) GetMarkdownDescription() string {
+	return b.MarkdownDescription
+}
+
+// GetMaxItems satisfies the fwschema.Block interface.
+func (b Block) GetMaxItems() int64 {
+	return b.MaxItems
+}
+
+// GetMinItems satisfies the fwschema.Block interface.
+func (b Block) GetMinItems() int64 {
+	return b.MinItems
+}
+
+// GetNestedObject satisfies the fwschema.Block interface.
+func (b Block) GetNestedObject() fwschema.NestedBlockObject {
+	return b.NestedObject
+}
+
+// GetNestingMode satisfies the fwschema.Block interface.
+func (b Block) GetNestingMode() fwschema.BlockNestingMode {
+	return b.NestingMode
+}
+
+// Type satisfies the fwschema.Block interface.
+func (b Block) Type() attr.Type {
+	switch b.GetNestingMode() {
+	case fwschema.BlockNestingModeList:
+		return types.ListType{
+			ElemType: b.GetNestedObject().Type(),
+		}
+	case fwschema.BlockNestingModeSet:
+		return types.SetType{
+			ElemType: b.GetNestedObject().Type(),
+		}
+	case fwschema.BlockNestingModeSingle:
+		return b.GetNestedObject().Type()
+	default:
+		return nil
+	}
+}

--- a/internal/testing/testschema/nested_attribute.go
+++ b/internal/testing/testschema/nested_attribute.go
@@ -1,0 +1,110 @@
+package testschema
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+var _ fwschema.NestedAttribute = NestedAttribute{}
+
+type NestedAttribute struct {
+	Computed            bool
+	DeprecationMessage  string
+	Description         string
+	MarkdownDescription string
+	NestedObject        fwschema.NestedAttributeObject
+	NestingMode         fwschema.NestingMode
+	Optional            bool
+	Required            bool
+	Sensitive           bool
+	Type                attr.Type
+}
+
+// ApplyTerraform5AttributePathStep satisfies the fwschema.Attribute interface.
+func (a NestedAttribute) ApplyTerraform5AttributePathStep(step tftypes.AttributePathStep) (any, error) {
+	return a.GetType().ApplyTerraform5AttributePathStep(step)
+}
+
+// Equal satisfies the fwschema.Attribute interface.
+func (a NestedAttribute) Equal(o fwschema.Attribute) bool {
+	_, ok := o.(NestedAttribute)
+
+	if !ok {
+		return false
+	}
+
+	return fwschema.AttributesEqual(a, o)
+}
+
+// GetDeprecationMessage satisfies the fwschema.Attribute interface.
+func (a NestedAttribute) GetDeprecationMessage() string {
+	return a.DeprecationMessage
+}
+
+// GetDescription satisfies the fwschema.Attribute interface.
+func (a NestedAttribute) GetDescription() string {
+	return a.Description
+}
+
+// GetMarkdownDescription satisfies the fwschema.Attribute interface.
+func (a NestedAttribute) GetMarkdownDescription() string {
+	return a.MarkdownDescription
+}
+
+// GetNestedObject satisfies the fwschema.NestedAttribute interface.
+func (a NestedAttribute) GetNestedObject() fwschema.NestedAttributeObject {
+	return a.NestedObject
+}
+
+// GetNestingMode satisfies the fwschema.NestedAttribute interface.
+func (a NestedAttribute) GetNestingMode() fwschema.NestingMode {
+	return a.NestingMode
+}
+
+// GetType satisfies the fwschema.Attribute interface.
+func (a NestedAttribute) GetType() attr.Type {
+	if a.Type != nil {
+		return a.Type
+	}
+
+	switch a.GetNestingMode() {
+	case fwschema.NestingModeList:
+		return types.ListType{
+			ElemType: a.GetNestedObject().Type(),
+		}
+	case fwschema.NestingModeMap:
+		return types.MapType{
+			ElemType: a.GetNestedObject().Type(),
+		}
+	case fwschema.NestingModeSet:
+		return types.SetType{
+			ElemType: a.GetNestedObject().Type(),
+		}
+	case fwschema.NestingModeSingle:
+		return a.GetNestedObject().Type()
+	default:
+		return nil
+	}
+}
+
+// IsComputed satisfies the fwschema.Attribute interface.
+func (a NestedAttribute) IsComputed() bool {
+	return a.Computed
+}
+
+// IsOptional satisfies the fwschema.Attribute interface.
+func (a NestedAttribute) IsOptional() bool {
+	return a.Optional
+}
+
+// IsRequired satisfies the fwschema.Attribute interface.
+func (a NestedAttribute) IsRequired() bool {
+	return a.Required
+}
+
+// IsSensitive satisfies the fwschema.Attribute interface.
+func (a NestedAttribute) IsSensitive() bool {
+	return a.Sensitive
+}

--- a/internal/testing/testschema/nested_attribute_with_list_plan_modifiers.go
+++ b/internal/testing/testschema/nested_attribute_with_list_plan_modifiers.go
@@ -1,0 +1,105 @@
+package testschema
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema/fwxschema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+var (
+	_ fwschema.NestedAttribute                 = NestedAttributeWithListPlanModifiers{}
+	_ fwxschema.AttributeWithListPlanModifiers = NestedAttributeWithListPlanModifiers{}
+)
+
+type NestedAttributeWithListPlanModifiers struct {
+	Computed            bool
+	DeprecationMessage  string
+	Description         string
+	MarkdownDescription string
+	NestedObject        fwschema.NestedAttributeObject
+	Optional            bool
+	PlanModifiers       []planmodifier.List
+	Required            bool
+	Sensitive           bool
+	Type                attr.Type
+}
+
+// ApplyTerraform5AttributePathStep satisfies the fwschema.Attribute interface.
+func (a NestedAttributeWithListPlanModifiers) ApplyTerraform5AttributePathStep(step tftypes.AttributePathStep) (any, error) {
+	return a.GetType().ApplyTerraform5AttributePathStep(step)
+}
+
+// Equal satisfies the fwschema.Attribute interface.
+func (a NestedAttributeWithListPlanModifiers) Equal(o fwschema.Attribute) bool {
+	_, ok := o.(NestedAttributeWithListPlanModifiers)
+
+	if !ok {
+		return false
+	}
+
+	return fwschema.AttributesEqual(a, o)
+}
+
+// GetDeprecationMessage satisfies the fwschema.Attribute interface.
+func (a NestedAttributeWithListPlanModifiers) GetDeprecationMessage() string {
+	return a.DeprecationMessage
+}
+
+// GetDescription satisfies the fwschema.Attribute interface.
+func (a NestedAttributeWithListPlanModifiers) GetDescription() string {
+	return a.Description
+}
+
+// GetMarkdownDescription satisfies the fwschema.Attribute interface.
+func (a NestedAttributeWithListPlanModifiers) GetMarkdownDescription() string {
+	return a.MarkdownDescription
+}
+
+// GetNestedObject satisfies the fwschema.NestedAttribute interface.
+func (a NestedAttributeWithListPlanModifiers) GetNestedObject() fwschema.NestedAttributeObject {
+	return a.NestedObject
+}
+
+// GetNestingMode satisfies the fwschema.NestedAttribute interface.
+func (a NestedAttributeWithListPlanModifiers) GetNestingMode() fwschema.NestingMode {
+	return fwschema.NestingModeList
+}
+
+// GetType satisfies the fwschema.Attribute interface.
+func (a NestedAttributeWithListPlanModifiers) GetType() attr.Type {
+	if a.Type != nil {
+		return a.Type
+	}
+
+	return types.ListType{
+		ElemType: a.GetNestedObject().Type(),
+	}
+}
+
+// IsComputed satisfies the fwschema.Attribute interface.
+func (a NestedAttributeWithListPlanModifiers) IsComputed() bool {
+	return a.Computed
+}
+
+// IsOptional satisfies the fwschema.Attribute interface.
+func (a NestedAttributeWithListPlanModifiers) IsOptional() bool {
+	return a.Optional
+}
+
+// IsRequired satisfies the fwschema.Attribute interface.
+func (a NestedAttributeWithListPlanModifiers) IsRequired() bool {
+	return a.Required
+}
+
+// IsSensitive satisfies the fwschema.Attribute interface.
+func (a NestedAttributeWithListPlanModifiers) IsSensitive() bool {
+	return a.Sensitive
+}
+
+// ListPlanModifiers satisfies the fwxschema.AttributeWithListPlanModifiers interface.
+func (a NestedAttributeWithListPlanModifiers) ListPlanModifiers() []planmodifier.List {
+	return a.PlanModifiers
+}

--- a/internal/testing/testschema/nested_attribute_with_map_plan_modifiers.go
+++ b/internal/testing/testschema/nested_attribute_with_map_plan_modifiers.go
@@ -1,0 +1,105 @@
+package testschema
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema/fwxschema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+var (
+	_ fwschema.NestedAttribute                = NestedAttributeWithMapPlanModifiers{}
+	_ fwxschema.AttributeWithMapPlanModifiers = NestedAttributeWithMapPlanModifiers{}
+)
+
+type NestedAttributeWithMapPlanModifiers struct {
+	Computed            bool
+	DeprecationMessage  string
+	Description         string
+	MarkdownDescription string
+	NestedObject        fwschema.NestedAttributeObject
+	Optional            bool
+	PlanModifiers       []planmodifier.Map
+	Required            bool
+	Sensitive           bool
+	Type                attr.Type
+}
+
+// ApplyTerraform5AttributePathStep satisfies the fwschema.Attribute interface.
+func (a NestedAttributeWithMapPlanModifiers) ApplyTerraform5AttributePathStep(step tftypes.AttributePathStep) (any, error) {
+	return a.GetType().ApplyTerraform5AttributePathStep(step)
+}
+
+// Equal satisfies the fwschema.Attribute interface.
+func (a NestedAttributeWithMapPlanModifiers) Equal(o fwschema.Attribute) bool {
+	_, ok := o.(NestedAttributeWithMapPlanModifiers)
+
+	if !ok {
+		return false
+	}
+
+	return fwschema.AttributesEqual(a, o)
+}
+
+// GetDeprecationMessage satisfies the fwschema.Attribute interface.
+func (a NestedAttributeWithMapPlanModifiers) GetDeprecationMessage() string {
+	return a.DeprecationMessage
+}
+
+// GetDescription satisfies the fwschema.Attribute interface.
+func (a NestedAttributeWithMapPlanModifiers) GetDescription() string {
+	return a.Description
+}
+
+// GetMarkdownDescription satisfies the fwschema.Attribute interface.
+func (a NestedAttributeWithMapPlanModifiers) GetMarkdownDescription() string {
+	return a.MarkdownDescription
+}
+
+// GetNestedObject satisfies the fwschema.NestedAttribute interface.
+func (a NestedAttributeWithMapPlanModifiers) GetNestedObject() fwschema.NestedAttributeObject {
+	return a.NestedObject
+}
+
+// GetNestingMode satisfies the fwschema.NestedAttribute interface.
+func (a NestedAttributeWithMapPlanModifiers) GetNestingMode() fwschema.NestingMode {
+	return fwschema.NestingModeMap
+}
+
+// GetType satisfies the fwschema.Attribute interface.
+func (a NestedAttributeWithMapPlanModifiers) GetType() attr.Type {
+	if a.Type != nil {
+		return a.Type
+	}
+
+	return types.MapType{
+		ElemType: a.GetNestedObject().Type(),
+	}
+}
+
+// IsComputed satisfies the fwschema.Attribute interface.
+func (a NestedAttributeWithMapPlanModifiers) IsComputed() bool {
+	return a.Computed
+}
+
+// IsOptional satisfies the fwschema.Attribute interface.
+func (a NestedAttributeWithMapPlanModifiers) IsOptional() bool {
+	return a.Optional
+}
+
+// IsRequired satisfies the fwschema.Attribute interface.
+func (a NestedAttributeWithMapPlanModifiers) IsRequired() bool {
+	return a.Required
+}
+
+// IsSensitive satisfies the fwschema.Attribute interface.
+func (a NestedAttributeWithMapPlanModifiers) IsSensitive() bool {
+	return a.Sensitive
+}
+
+// MapPlanModifiers satisfies the fwxschema.AttributeWithMapPlanModifiers interface.
+func (a NestedAttributeWithMapPlanModifiers) MapPlanModifiers() []planmodifier.Map {
+	return a.PlanModifiers
+}

--- a/internal/testing/testschema/nested_attribute_with_object_plan_modifiers.go
+++ b/internal/testing/testschema/nested_attribute_with_object_plan_modifiers.go
@@ -1,0 +1,102 @@
+package testschema
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema/fwxschema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+var (
+	_ fwschema.NestedAttribute                   = NestedAttributeWithObjectPlanModifiers{}
+	_ fwxschema.AttributeWithObjectPlanModifiers = NestedAttributeWithObjectPlanModifiers{}
+)
+
+type NestedAttributeWithObjectPlanModifiers struct {
+	Computed            bool
+	DeprecationMessage  string
+	Description         string
+	MarkdownDescription string
+	NestedObject        fwschema.NestedAttributeObject
+	Optional            bool
+	PlanModifiers       []planmodifier.Object
+	Required            bool
+	Sensitive           bool
+	Type                attr.Type
+}
+
+// ApplyTerraform5AttributePathStep satisfies the fwschema.Attribute interface.
+func (a NestedAttributeWithObjectPlanModifiers) ApplyTerraform5AttributePathStep(step tftypes.AttributePathStep) (any, error) {
+	return a.GetType().ApplyTerraform5AttributePathStep(step)
+}
+
+// Equal satisfies the fwschema.Attribute interface.
+func (a NestedAttributeWithObjectPlanModifiers) Equal(o fwschema.Attribute) bool {
+	_, ok := o.(NestedAttributeWithObjectPlanModifiers)
+
+	if !ok {
+		return false
+	}
+
+	return fwschema.AttributesEqual(a, o)
+}
+
+// GetDeprecationMessage satisfies the fwschema.Attribute interface.
+func (a NestedAttributeWithObjectPlanModifiers) GetDeprecationMessage() string {
+	return a.DeprecationMessage
+}
+
+// GetDescription satisfies the fwschema.Attribute interface.
+func (a NestedAttributeWithObjectPlanModifiers) GetDescription() string {
+	return a.Description
+}
+
+// GetMarkdownDescription satisfies the fwschema.Attribute interface.
+func (a NestedAttributeWithObjectPlanModifiers) GetMarkdownDescription() string {
+	return a.MarkdownDescription
+}
+
+// GetNestedObject satisfies the fwschema.NestedAttribute interface.
+func (a NestedAttributeWithObjectPlanModifiers) GetNestedObject() fwschema.NestedAttributeObject {
+	return a.NestedObject
+}
+
+// GetNestingMode satisfies the fwschema.NestedAttribute interface.
+func (a NestedAttributeWithObjectPlanModifiers) GetNestingMode() fwschema.NestingMode {
+	return fwschema.NestingModeSingle
+}
+
+// GetType satisfies the fwschema.Attribute interface.
+func (a NestedAttributeWithObjectPlanModifiers) GetType() attr.Type {
+	if a.Type != nil {
+		return a.Type
+	}
+
+	return a.GetNestedObject().Type()
+}
+
+// IsComputed satisfies the fwschema.Attribute interface.
+func (a NestedAttributeWithObjectPlanModifiers) IsComputed() bool {
+	return a.Computed
+}
+
+// IsOptional satisfies the fwschema.Attribute interface.
+func (a NestedAttributeWithObjectPlanModifiers) IsOptional() bool {
+	return a.Optional
+}
+
+// IsRequired satisfies the fwschema.Attribute interface.
+func (a NestedAttributeWithObjectPlanModifiers) IsRequired() bool {
+	return a.Required
+}
+
+// IsSensitive satisfies the fwschema.Attribute interface.
+func (a NestedAttributeWithObjectPlanModifiers) IsSensitive() bool {
+	return a.Sensitive
+}
+
+// ObjectPlanModifiers satisfies the fwxschema.AttributeWithObjectPlanModifiers interface.
+func (a NestedAttributeWithObjectPlanModifiers) ObjectPlanModifiers() []planmodifier.Object {
+	return a.PlanModifiers
+}

--- a/internal/testing/testschema/nested_attribute_with_set_plan_modifiers.go
+++ b/internal/testing/testschema/nested_attribute_with_set_plan_modifiers.go
@@ -1,0 +1,105 @@
+package testschema
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema/fwxschema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+var (
+	_ fwschema.NestedAttribute                = NestedAttributeWithSetPlanModifiers{}
+	_ fwxschema.AttributeWithSetPlanModifiers = NestedAttributeWithSetPlanModifiers{}
+)
+
+type NestedAttributeWithSetPlanModifiers struct {
+	Computed            bool
+	DeprecationMessage  string
+	Description         string
+	MarkdownDescription string
+	NestedObject        fwschema.NestedAttributeObject
+	Optional            bool
+	PlanModifiers       []planmodifier.Set
+	Required            bool
+	Sensitive           bool
+	Type                attr.Type
+}
+
+// ApplyTerraform5AttributePathStep satisfies the fwschema.Attribute interface.
+func (a NestedAttributeWithSetPlanModifiers) ApplyTerraform5AttributePathStep(step tftypes.AttributePathStep) (any, error) {
+	return a.GetType().ApplyTerraform5AttributePathStep(step)
+}
+
+// Equal satisfies the fwschema.Attribute interface.
+func (a NestedAttributeWithSetPlanModifiers) Equal(o fwschema.Attribute) bool {
+	_, ok := o.(NestedAttributeWithSetPlanModifiers)
+
+	if !ok {
+		return false
+	}
+
+	return fwschema.AttributesEqual(a, o)
+}
+
+// GetDeprecationMessage satisfies the fwschema.Attribute interface.
+func (a NestedAttributeWithSetPlanModifiers) GetDeprecationMessage() string {
+	return a.DeprecationMessage
+}
+
+// GetDescription satisfies the fwschema.Attribute interface.
+func (a NestedAttributeWithSetPlanModifiers) GetDescription() string {
+	return a.Description
+}
+
+// GetMarkdownDescription satisfies the fwschema.Attribute interface.
+func (a NestedAttributeWithSetPlanModifiers) GetMarkdownDescription() string {
+	return a.MarkdownDescription
+}
+
+// GetNestedObject satisfies the fwschema.NestedAttribute interface.
+func (a NestedAttributeWithSetPlanModifiers) GetNestedObject() fwschema.NestedAttributeObject {
+	return a.NestedObject
+}
+
+// GetNestingMode satisfies the fwschema.NestedAttribute interface.
+func (a NestedAttributeWithSetPlanModifiers) GetNestingMode() fwschema.NestingMode {
+	return fwschema.NestingModeSet
+}
+
+// GetType satisfies the fwschema.Attribute interface.
+func (a NestedAttributeWithSetPlanModifiers) GetType() attr.Type {
+	if a.Type != nil {
+		return a.Type
+	}
+
+	return types.SetType{
+		ElemType: a.GetNestedObject().Type(),
+	}
+}
+
+// IsComputed satisfies the fwschema.Attribute interface.
+func (a NestedAttributeWithSetPlanModifiers) IsComputed() bool {
+	return a.Computed
+}
+
+// IsOptional satisfies the fwschema.Attribute interface.
+func (a NestedAttributeWithSetPlanModifiers) IsOptional() bool {
+	return a.Optional
+}
+
+// IsRequired satisfies the fwschema.Attribute interface.
+func (a NestedAttributeWithSetPlanModifiers) IsRequired() bool {
+	return a.Required
+}
+
+// IsSensitive satisfies the fwschema.Attribute interface.
+func (a NestedAttributeWithSetPlanModifiers) IsSensitive() bool {
+	return a.Sensitive
+}
+
+// SetPlanModifiers satisfies the fwxschema.AttributeWithSetPlanModifiers interface.
+func (a NestedAttributeWithSetPlanModifiers) SetPlanModifiers() []planmodifier.Set {
+	return a.PlanModifiers
+}

--- a/internal/toproto5/applyresourcechange_test.go
+++ b/internal/toproto5/applyresourcechange_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
 	"github.com/hashicorp/terraform-plugin-framework/internal/privatestate"
 	"github.com/hashicorp/terraform-plugin-framework/internal/toproto5"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 func TestApplyResourceChangeResponse(t *testing.T) {
@@ -37,11 +37,10 @@ func TestApplyResourceChangeResponse(t *testing.T) {
 
 	testState := &tfsdk.State{
 		Raw: testProto5Value,
-		Schema: tfsdk.Schema{
-			Attributes: map[string]tfsdk.Attribute{
-				"test_attribute": {
+		Schema: schema.Schema{
+			Attributes: map[string]schema.Attribute{
+				"test_attribute": schema.StringAttribute{
 					Required: true,
-					Type:     types.StringType,
 				},
 			},
 		},
@@ -49,11 +48,10 @@ func TestApplyResourceChangeResponse(t *testing.T) {
 
 	testStateInvalid := &tfsdk.State{
 		Raw: testProto5Value,
-		Schema: tfsdk.Schema{
-			Attributes: map[string]tfsdk.Attribute{
-				"test_attribute": {
+		Schema: schema.Schema{
+			Attributes: map[string]schema.Attribute{
+				"test_attribute": schema.BoolAttribute{
 					Required: true,
-					Type:     types.BoolType,
 				},
 			},
 		},

--- a/internal/toproto5/block_test.go
+++ b/internal/toproto5/block_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/toproto5"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
@@ -27,11 +27,13 @@ func TestBlock(t *testing.T) {
 	tests := map[string]testCase{
 		"nestingmode-invalid": {
 			name: "test",
-			block: tfsdk.Block{
-				Attributes: map[string]tfsdk.Attribute{
-					"sub_test": {
-						Type:     types.StringType,
-						Optional: true,
+			block: testschema.Block{
+				NestedObject: testschema.NestedBlockObject{
+					Attributes: map[string]fwschema.Attribute{
+						"sub_test": testschema.Attribute{
+							Type:     types.StringType,
+							Optional: true,
+						},
 					},
 				},
 			},
@@ -40,14 +42,16 @@ func TestBlock(t *testing.T) {
 		},
 		"nestingmode-list-attributes": {
 			name: "test",
-			block: tfsdk.Block{
-				Attributes: map[string]tfsdk.Attribute{
-					"sub_test": {
-						Type:     types.StringType,
-						Optional: true,
+			block: testschema.Block{
+				NestedObject: testschema.NestedBlockObject{
+					Attributes: map[string]fwschema.Attribute{
+						"sub_test": testschema.Attribute{
+							Type:     types.StringType,
+							Optional: true,
+						},
 					},
 				},
-				NestingMode: tfsdk.BlockNestingModeList,
+				NestingMode: fwschema.BlockNestingModeList,
 			},
 			path: tftypes.NewAttributePath(),
 			expected: &tfprotov5.SchemaNestedBlock{
@@ -66,25 +70,29 @@ func TestBlock(t *testing.T) {
 		},
 		"nestingmode-list-attributes-and-blocks": {
 			name: "test",
-			block: tfsdk.Block{
-				Attributes: map[string]tfsdk.Attribute{
-					"sub_attr": {
-						Type:     types.StringType,
-						Optional: true,
-					},
-				},
-				Blocks: map[string]tfsdk.Block{
-					"sub_block": {
-						Attributes: map[string]tfsdk.Attribute{
-							"sub_block_attr": {
-								Type:     types.StringType,
-								Optional: true,
-							},
+			block: testschema.Block{
+				NestedObject: testschema.NestedBlockObject{
+					Attributes: map[string]fwschema.Attribute{
+						"sub_attr": testschema.Attribute{
+							Type:     types.StringType,
+							Optional: true,
 						},
-						NestingMode: tfsdk.BlockNestingModeList,
+					},
+					Blocks: map[string]fwschema.Block{
+						"sub_block": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"sub_block_attr": testschema.Attribute{
+										Type:     types.StringType,
+										Optional: true,
+									},
+								},
+							},
+							NestingMode: fwschema.BlockNestingModeList,
+						},
 					},
 				},
-				NestingMode: tfsdk.BlockNestingModeList,
+				NestingMode: fwschema.BlockNestingModeList,
 			},
 			path: tftypes.NewAttributePath(),
 			expected: &tfprotov5.SchemaNestedBlock{
@@ -118,19 +126,23 @@ func TestBlock(t *testing.T) {
 		},
 		"nestingmode-list-blocks": {
 			name: "test",
-			block: tfsdk.Block{
-				Blocks: map[string]tfsdk.Block{
-					"sub_block": {
-						Attributes: map[string]tfsdk.Attribute{
-							"sub_block_attr": {
-								Type:     types.StringType,
-								Optional: true,
+			block: testschema.Block{
+				NestedObject: testschema.NestedBlockObject{
+					Blocks: map[string]fwschema.Block{
+						"sub_block": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"sub_block_attr": testschema.Attribute{
+										Type:     types.StringType,
+										Optional: true,
+									},
+								},
 							},
+							NestingMode: fwschema.BlockNestingModeList,
 						},
-						NestingMode: tfsdk.BlockNestingModeList,
 					},
 				},
-				NestingMode: tfsdk.BlockNestingModeList,
+				NestingMode: fwschema.BlockNestingModeList,
 			},
 			path: tftypes.NewAttributePath(),
 			expected: &tfprotov5.SchemaNestedBlock{
@@ -157,14 +169,16 @@ func TestBlock(t *testing.T) {
 		},
 		"nestingmode-set-attributes": {
 			name: "test",
-			block: tfsdk.Block{
-				Attributes: map[string]tfsdk.Attribute{
-					"sub_test": {
-						Type:     types.StringType,
-						Optional: true,
+			block: testschema.Block{
+				NestedObject: testschema.NestedBlockObject{
+					Attributes: map[string]fwschema.Attribute{
+						"sub_test": testschema.Attribute{
+							Type:     types.StringType,
+							Optional: true,
+						},
 					},
 				},
-				NestingMode: tfsdk.BlockNestingModeSet,
+				NestingMode: fwschema.BlockNestingModeSet,
 			},
 			path: tftypes.NewAttributePath(),
 			expected: &tfprotov5.SchemaNestedBlock{
@@ -183,25 +197,29 @@ func TestBlock(t *testing.T) {
 		},
 		"nestingmode-set-attributes-and-blocks": {
 			name: "test",
-			block: tfsdk.Block{
-				Attributes: map[string]tfsdk.Attribute{
-					"sub_attr": {
-						Type:     types.StringType,
-						Optional: true,
-					},
-				},
-				Blocks: map[string]tfsdk.Block{
-					"sub_block": {
-						Attributes: map[string]tfsdk.Attribute{
-							"sub_block_attr": {
-								Type:     types.StringType,
-								Optional: true,
-							},
+			block: testschema.Block{
+				NestedObject: testschema.NestedBlockObject{
+					Attributes: map[string]fwschema.Attribute{
+						"sub_attr": testschema.Attribute{
+							Type:     types.StringType,
+							Optional: true,
 						},
-						NestingMode: tfsdk.BlockNestingModeSet,
+					},
+					Blocks: map[string]fwschema.Block{
+						"sub_block": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"sub_block_attr": testschema.Attribute{
+										Type:     types.StringType,
+										Optional: true,
+									},
+								},
+							},
+							NestingMode: fwschema.BlockNestingModeSet,
+						},
 					},
 				},
-				NestingMode: tfsdk.BlockNestingModeSet,
+				NestingMode: fwschema.BlockNestingModeSet,
 			},
 			path: tftypes.NewAttributePath(),
 			expected: &tfprotov5.SchemaNestedBlock{
@@ -235,19 +253,23 @@ func TestBlock(t *testing.T) {
 		},
 		"nestingmode-set-blocks": {
 			name: "test",
-			block: tfsdk.Block{
-				Blocks: map[string]tfsdk.Block{
-					"sub_block": {
-						Attributes: map[string]tfsdk.Attribute{
-							"sub_block_attr": {
-								Type:     types.StringType,
-								Optional: true,
+			block: testschema.Block{
+				NestedObject: testschema.NestedBlockObject{
+					Blocks: map[string]fwschema.Block{
+						"sub_block": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"sub_block_attr": testschema.Attribute{
+										Type:     types.StringType,
+										Optional: true,
+									},
+								},
 							},
+							NestingMode: fwschema.BlockNestingModeSet,
 						},
-						NestingMode: tfsdk.BlockNestingModeSet,
 					},
 				},
-				NestingMode: tfsdk.BlockNestingModeSet,
+				NestingMode: fwschema.BlockNestingModeSet,
 			},
 			path: tftypes.NewAttributePath(),
 			expected: &tfprotov5.SchemaNestedBlock{
@@ -274,14 +296,16 @@ func TestBlock(t *testing.T) {
 		},
 		"nestingmode-single-attributes": {
 			name: "test",
-			block: tfsdk.Block{
-				Attributes: map[string]tfsdk.Attribute{
-					"sub_test": {
-						Type:     types.StringType,
-						Optional: true,
+			block: testschema.Block{
+				NestedObject: testschema.NestedBlockObject{
+					Attributes: map[string]fwschema.Attribute{
+						"sub_test": testschema.Attribute{
+							Type:     types.StringType,
+							Optional: true,
+						},
 					},
 				},
-				NestingMode: tfsdk.BlockNestingModeSingle,
+				NestingMode: fwschema.BlockNestingModeSingle,
 			},
 			path: tftypes.NewAttributePath(),
 			expected: &tfprotov5.SchemaNestedBlock{
@@ -300,25 +324,29 @@ func TestBlock(t *testing.T) {
 		},
 		"nestingmode-single-attributes-and-blocks": {
 			name: "test",
-			block: tfsdk.Block{
-				Attributes: map[string]tfsdk.Attribute{
-					"sub_attr": {
-						Type:     types.StringType,
-						Optional: true,
-					},
-				},
-				Blocks: map[string]tfsdk.Block{
-					"sub_block": {
-						Attributes: map[string]tfsdk.Attribute{
-							"sub_block_attr": {
-								Type:     types.StringType,
-								Optional: true,
-							},
+			block: testschema.Block{
+				NestedObject: testschema.NestedBlockObject{
+					Attributes: map[string]fwschema.Attribute{
+						"sub_attr": testschema.Attribute{
+							Type:     types.StringType,
+							Optional: true,
 						},
-						NestingMode: tfsdk.BlockNestingModeSingle,
+					},
+					Blocks: map[string]fwschema.Block{
+						"sub_block": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"sub_block_attr": testschema.Attribute{
+										Type:     types.StringType,
+										Optional: true,
+									},
+								},
+							},
+							NestingMode: fwschema.BlockNestingModeSingle,
+						},
 					},
 				},
-				NestingMode: tfsdk.BlockNestingModeSingle,
+				NestingMode: fwschema.BlockNestingModeSingle,
 			},
 			path: tftypes.NewAttributePath(),
 			expected: &tfprotov5.SchemaNestedBlock{
@@ -352,19 +380,23 @@ func TestBlock(t *testing.T) {
 		},
 		"nestingmode-single-blocks": {
 			name: "test",
-			block: tfsdk.Block{
-				Blocks: map[string]tfsdk.Block{
-					"sub_block": {
-						Attributes: map[string]tfsdk.Attribute{
-							"sub_block_attr": {
-								Type:     types.StringType,
-								Optional: true,
+			block: testschema.Block{
+				NestedObject: testschema.NestedBlockObject{
+					Blocks: map[string]fwschema.Block{
+						"sub_block": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"sub_block_attr": testschema.Attribute{
+										Type:     types.StringType,
+										Optional: true,
+									},
+								},
 							},
+							NestingMode: fwschema.BlockNestingModeSingle,
 						},
-						NestingMode: tfsdk.BlockNestingModeSingle,
 					},
 				},
-				NestingMode: tfsdk.BlockNestingModeSingle,
+				NestingMode: fwschema.BlockNestingModeSingle,
 			},
 			path: tftypes.NewAttributePath(),
 			expected: &tfprotov5.SchemaNestedBlock{
@@ -391,15 +423,17 @@ func TestBlock(t *testing.T) {
 		},
 		"deprecationmessage": {
 			name: "test",
-			block: tfsdk.Block{
-				Attributes: map[string]tfsdk.Attribute{
-					"sub_test": {
-						Type:     types.StringType,
-						Optional: true,
+			block: testschema.Block{
+				NestedObject: testschema.NestedBlockObject{
+					Attributes: map[string]fwschema.Attribute{
+						"sub_test": testschema.Attribute{
+							Type:     types.StringType,
+							Optional: true,
+						},
 					},
 				},
 				DeprecationMessage: "deprecated, use something else instead",
-				NestingMode:        tfsdk.BlockNestingModeList,
+				NestingMode:        fwschema.BlockNestingModeList,
 			},
 			path: tftypes.NewAttributePath(),
 			expected: &tfprotov5.SchemaNestedBlock{
@@ -419,15 +453,17 @@ func TestBlock(t *testing.T) {
 		},
 		"description": {
 			name: "test",
-			block: tfsdk.Block{
-				Attributes: map[string]tfsdk.Attribute{
-					"sub_test": {
-						Type:     types.StringType,
-						Optional: true,
+			block: testschema.Block{
+				NestedObject: testschema.NestedBlockObject{
+					Attributes: map[string]fwschema.Attribute{
+						"sub_test": testschema.Attribute{
+							Type:     types.StringType,
+							Optional: true,
+						},
 					},
 				},
 				Description: "test description",
-				NestingMode: tfsdk.BlockNestingModeList,
+				NestingMode: fwschema.BlockNestingModeList,
 			},
 			path: tftypes.NewAttributePath(),
 			expected: &tfprotov5.SchemaNestedBlock{
@@ -448,16 +484,18 @@ func TestBlock(t *testing.T) {
 		},
 		"description-and-markdowndescription": {
 			name: "test",
-			block: tfsdk.Block{
-				Attributes: map[string]tfsdk.Attribute{
-					"sub_test": {
-						Type:     types.StringType,
-						Optional: true,
+			block: testschema.Block{
+				NestedObject: testschema.NestedBlockObject{
+					Attributes: map[string]fwschema.Attribute{
+						"sub_test": testschema.Attribute{
+							Type:     types.StringType,
+							Optional: true,
+						},
 					},
 				},
 				Description:         "test plain description",
 				MarkdownDescription: "test markdown description",
-				NestingMode:         tfsdk.BlockNestingModeList,
+				NestingMode:         fwschema.BlockNestingModeList,
 			},
 			path: tftypes.NewAttributePath(),
 			expected: &tfprotov5.SchemaNestedBlock{
@@ -478,15 +516,17 @@ func TestBlock(t *testing.T) {
 		},
 		"markdowndescription": {
 			name: "test",
-			block: tfsdk.Block{
-				Attributes: map[string]tfsdk.Attribute{
-					"sub_test": {
-						Type:     types.StringType,
-						Optional: true,
+			block: testschema.Block{
+				NestedObject: testschema.NestedBlockObject{
+					Attributes: map[string]fwschema.Attribute{
+						"sub_test": testschema.Attribute{
+							Type:     types.StringType,
+							Optional: true,
+						},
 					},
 				},
 				MarkdownDescription: "test description",
-				NestingMode:         tfsdk.BlockNestingModeList,
+				NestingMode:         fwschema.BlockNestingModeList,
 			},
 			path: tftypes.NewAttributePath(),
 			expected: &tfprotov5.SchemaNestedBlock{
@@ -507,15 +547,17 @@ func TestBlock(t *testing.T) {
 		},
 		"maxitems": {
 			name: "test",
-			block: tfsdk.Block{
-				Attributes: map[string]tfsdk.Attribute{
-					"sub_test": {
-						Type:     types.StringType,
-						Optional: true,
+			block: testschema.Block{
+				NestedObject: testschema.NestedBlockObject{
+					Attributes: map[string]fwschema.Attribute{
+						"sub_test": testschema.Attribute{
+							Type:     types.StringType,
+							Optional: true,
+						},
 					},
 				},
 				MaxItems:    10,
-				NestingMode: tfsdk.BlockNestingModeList,
+				NestingMode: fwschema.BlockNestingModeList,
 			},
 			path: tftypes.NewAttributePath(),
 			expected: &tfprotov5.SchemaNestedBlock{
@@ -535,15 +577,17 @@ func TestBlock(t *testing.T) {
 		},
 		"minitems": {
 			name: "test",
-			block: tfsdk.Block{
-				Attributes: map[string]tfsdk.Attribute{
-					"sub_test": {
-						Type:     types.StringType,
-						Optional: true,
+			block: testschema.Block{
+				NestedObject: testschema.NestedBlockObject{
+					Attributes: map[string]fwschema.Attribute{
+						"sub_test": testschema.Attribute{
+							Type:     types.StringType,
+							Optional: true,
+						},
 					},
 				},
 				MinItems:    10,
-				NestingMode: tfsdk.BlockNestingModeList,
+				NestingMode: fwschema.BlockNestingModeList,
 			},
 			path: tftypes.NewAttributePath(),
 			expected: &tfprotov5.SchemaNestedBlock{

--- a/internal/toproto5/config_test.go
+++ b/internal/toproto5/config_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/toproto5"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -34,9 +36,9 @@ func TestConfig(t *testing.T) {
 
 	testConfig := &tfsdk.Config{
 		Raw: testProto5Value,
-		Schema: tfsdk.Schema{
-			Attributes: map[string]tfsdk.Attribute{
-				"test_attribute": {
+		Schema: testschema.Schema{
+			Attributes: map[string]fwschema.Attribute{
+				"test_attribute": testschema.Attribute{
 					Required: true,
 					Type:     types.StringType,
 				},
@@ -46,9 +48,9 @@ func TestConfig(t *testing.T) {
 
 	testConfigInvalid := &tfsdk.Config{
 		Raw: testProto5Value,
-		Schema: tfsdk.Schema{
-			Attributes: map[string]tfsdk.Attribute{
-				"test_attribute": {
+		Schema: testschema.Schema{
+			Attributes: map[string]fwschema.Attribute{
+				"test_attribute": testschema.Attribute{
 					Required: true,
 					Type:     types.BoolType,
 				},

--- a/internal/toproto5/getproviderschema_test.go
+++ b/internal/toproto5/getproviderschema_test.go
@@ -6,10 +6,13 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	datasourceschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
 	"github.com/hashicorp/terraform-plugin-framework/internal/toproto5"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/provider/metaschema"
+	providerschema "github.com/hashicorp/terraform-plugin-framework/provider/schema"
+	resourceschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
@@ -33,19 +36,17 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"data-source-multiple-data-sources": {
 			input: &fwserver.GetProviderSchemaResponse{
 				DataSourceSchemas: map[string]fwschema.Schema{
-					"test_data_source_1": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_data_source_1": datasourceschema.Schema{
+						Attributes: map[string]datasourceschema.Attribute{
+							"test_attribute": datasourceschema.BoolAttribute{
 								Computed: true,
-								Type:     types.BoolType,
 							},
 						},
 					},
-					"test_data_source_2": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_data_source_2": datasourceschema.Schema{
+						Attributes: map[string]datasourceschema.Attribute{
+							"test_attribute": datasourceschema.BoolAttribute{
 								Computed: true,
-								Type:     types.BoolType,
 							},
 						},
 					},
@@ -82,11 +83,10 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"data-source-attribute-computed": {
 			input: &fwserver.GetProviderSchemaResponse{
 				DataSourceSchemas: map[string]fwschema.Schema{
-					"test_data_source": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_data_source": datasourceschema.Schema{
+						Attributes: map[string]datasourceschema.Attribute{
+							"test_attribute": datasourceschema.BoolAttribute{
 								Computed: true,
-								Type:     types.BoolType,
 							},
 						},
 					},
@@ -112,12 +112,11 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"data-source-attribute-deprecated": {
 			input: &fwserver.GetProviderSchemaResponse{
 				DataSourceSchemas: map[string]fwschema.Schema{
-					"test_data_source": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_data_source": datasourceschema.Schema{
+						Attributes: map[string]datasourceschema.Attribute{
+							"test_attribute": datasourceschema.BoolAttribute{
 								DeprecationMessage: "deprecated",
 								Optional:           true,
-								Type:               types.BoolType,
 							},
 						},
 					},
@@ -144,11 +143,10 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"data-source-attribute-optional": {
 			input: &fwserver.GetProviderSchemaResponse{
 				DataSourceSchemas: map[string]fwschema.Schema{
-					"test_data_source": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_data_source": datasourceschema.Schema{
+						Attributes: map[string]datasourceschema.Attribute{
+							"test_attribute": datasourceschema.BoolAttribute{
 								Optional: true,
-								Type:     types.BoolType,
 							},
 						},
 					},
@@ -174,12 +172,11 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"data-source-attribute-optional-computed": {
 			input: &fwserver.GetProviderSchemaResponse{
 				DataSourceSchemas: map[string]fwschema.Schema{
-					"test_data_source": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_data_source": datasourceschema.Schema{
+						Attributes: map[string]datasourceschema.Attribute{
+							"test_attribute": datasourceschema.BoolAttribute{
 								Computed: true,
 								Optional: true,
-								Type:     types.BoolType,
 							},
 						},
 					},
@@ -206,11 +203,10 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"data-source-attribute-required": {
 			input: &fwserver.GetProviderSchemaResponse{
 				DataSourceSchemas: map[string]fwschema.Schema{
-					"test_data_source": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_data_source": datasourceschema.Schema{
+						Attributes: map[string]datasourceschema.Attribute{
+							"test_attribute": datasourceschema.BoolAttribute{
 								Required: true,
-								Type:     types.BoolType,
 							},
 						},
 					},
@@ -236,12 +232,11 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"data-source-attribute-sensitive": {
 			input: &fwserver.GetProviderSchemaResponse{
 				DataSourceSchemas: map[string]fwschema.Schema{
-					"test_data_source": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_data_source": datasourceschema.Schema{
+						Attributes: map[string]datasourceschema.Attribute{
+							"test_attribute": datasourceschema.BoolAttribute{
 								Computed:  true,
 								Sensitive: true,
-								Type:      types.BoolType,
 							},
 						},
 					},
@@ -268,11 +263,10 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"data-source-attribute-type-bool": {
 			input: &fwserver.GetProviderSchemaResponse{
 				DataSourceSchemas: map[string]fwschema.Schema{
-					"test_data_source": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_data_source": datasourceschema.Schema{
+						Attributes: map[string]datasourceschema.Attribute{
+							"test_attribute": datasourceschema.BoolAttribute{
 								Required: true,
-								Type:     types.BoolType,
 							},
 						},
 					},
@@ -298,11 +292,10 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"data-source-attribute-type-float64": {
 			input: &fwserver.GetProviderSchemaResponse{
 				DataSourceSchemas: map[string]fwschema.Schema{
-					"test_data_source": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_data_source": datasourceschema.Schema{
+						Attributes: map[string]datasourceschema.Attribute{
+							"test_attribute": datasourceschema.Float64Attribute{
 								Required: true,
-								Type:     types.Float64Type,
 							},
 						},
 					},
@@ -328,11 +321,10 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"data-source-attribute-type-int64": {
 			input: &fwserver.GetProviderSchemaResponse{
 				DataSourceSchemas: map[string]fwschema.Schema{
-					"test_data_source": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_data_source": datasourceschema.Schema{
+						Attributes: map[string]datasourceschema.Attribute{
+							"test_attribute": datasourceschema.Int64Attribute{
 								Required: true,
-								Type:     types.Int64Type,
 							},
 						},
 					},
@@ -358,14 +350,12 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"data-source-attribute-type-list-list-string": {
 			input: &fwserver.GetProviderSchemaResponse{
 				DataSourceSchemas: map[string]fwschema.Schema{
-					"test_data_source": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_data_source": datasourceschema.Schema{
+						Attributes: map[string]datasourceschema.Attribute{
+							"test_attribute": datasourceschema.ListAttribute{
 								Required: true,
-								Type: types.ListType{
-									ElemType: types.ListType{
-										ElemType: types.StringType,
-									},
+								ElementType: types.ListType{
+									ElemType: types.StringType,
 								},
 							},
 						},
@@ -396,15 +386,16 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"data-source-attribute-type-list-nested-attributes": {
 			input: &fwserver.GetProviderSchemaResponse{
 				DataSourceSchemas: map[string]fwschema.Schema{
-					"test_data_source": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
-								Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
-									"test_nested_attribute": {
-										Type:     types.StringType,
-										Required: true,
+					"test_data_source": datasourceschema.Schema{
+						Attributes: map[string]datasourceschema.Attribute{
+							"test_attribute": datasourceschema.ListNestedAttribute{
+								NestedObject: datasourceschema.NestedAttributeObject{
+									Attributes: map[string]datasourceschema.Attribute{
+										"test_nested_attribute": datasourceschema.StringAttribute{
+											Required: true,
+										},
 									},
-								}),
+								},
 								Required: true,
 							},
 						},
@@ -428,15 +419,13 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"data-source-attribute-type-list-object": {
 			input: &fwserver.GetProviderSchemaResponse{
 				DataSourceSchemas: map[string]fwschema.Schema{
-					"test_data_source": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_data_source": datasourceschema.Schema{
+						Attributes: map[string]datasourceschema.Attribute{
+							"test_attribute": datasourceschema.ListAttribute{
 								Required: true,
-								Type: types.ListType{
-									ElemType: types.ObjectType{
-										AttrTypes: map[string]attr.Type{
-											"test_object_attribute": types.StringType,
-										},
+								ElementType: types.ObjectType{
+									AttrTypes: map[string]attr.Type{
+										"test_object_attribute": types.StringType,
 									},
 								},
 							},
@@ -470,13 +459,11 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"data-source-attribute-type-list-string": {
 			input: &fwserver.GetProviderSchemaResponse{
 				DataSourceSchemas: map[string]fwschema.Schema{
-					"test_data_source": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
-								Required: true,
-								Type: types.ListType{
-									ElemType: types.StringType,
-								},
+					"test_data_source": datasourceschema.Schema{
+						Attributes: map[string]datasourceschema.Attribute{
+							"test_attribute": datasourceschema.ListAttribute{
+								Required:    true,
+								ElementType: types.StringType,
 							},
 						},
 					},
@@ -504,15 +491,16 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"data-source-attribute-type-map-nested-attributes": {
 			input: &fwserver.GetProviderSchemaResponse{
 				DataSourceSchemas: map[string]fwschema.Schema{
-					"test_data_source": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
-								Attributes: tfsdk.MapNestedAttributes(map[string]tfsdk.Attribute{
-									"test_nested_attribute": {
-										Type:     types.StringType,
-										Required: true,
+					"test_data_source": datasourceschema.Schema{
+						Attributes: map[string]datasourceschema.Attribute{
+							"test_attribute": datasourceschema.MapNestedAttribute{
+								NestedObject: datasourceschema.NestedAttributeObject{
+									Attributes: map[string]datasourceschema.Attribute{
+										"test_nested_attribute": datasourceschema.StringAttribute{
+											Required: true,
+										},
 									},
-								}),
+								},
 								Required: true,
 							},
 						},
@@ -536,13 +524,11 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"data-source-attribute-type-map-string": {
 			input: &fwserver.GetProviderSchemaResponse{
 				DataSourceSchemas: map[string]fwschema.Schema{
-					"test_data_source": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
-								Required: true,
-								Type: types.MapType{
-									ElemType: types.StringType,
-								},
+					"test_data_source": datasourceschema.Schema{
+						Attributes: map[string]datasourceschema.Attribute{
+							"test_attribute": datasourceschema.MapAttribute{
+								Required:    true,
+								ElementType: types.StringType,
 							},
 						},
 					},
@@ -570,11 +556,10 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"data-source-attribute-type-number": {
 			input: &fwserver.GetProviderSchemaResponse{
 				DataSourceSchemas: map[string]fwschema.Schema{
-					"test_data_source": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_data_source": datasourceschema.Schema{
+						Attributes: map[string]datasourceschema.Attribute{
+							"test_attribute": datasourceschema.NumberAttribute{
 								Required: true,
-								Type:     types.NumberType,
 							},
 						},
 					},
@@ -600,14 +585,12 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"data-source-attribute-type-object": {
 			input: &fwserver.GetProviderSchemaResponse{
 				DataSourceSchemas: map[string]fwschema.Schema{
-					"test_data_source": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_data_source": datasourceschema.Schema{
+						Attributes: map[string]datasourceschema.Attribute{
+							"test_attribute": datasourceschema.ObjectAttribute{
 								Required: true,
-								Type: types.ObjectType{
-									AttrTypes: map[string]attr.Type{
-										"test_object_attribute": types.StringType,
-									},
+								AttributeTypes: map[string]attr.Type{
+									"test_object_attribute": types.StringType,
 								},
 							},
 						},
@@ -638,15 +621,16 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"data-source-attribute-type-set-nested-attributes": {
 			input: &fwserver.GetProviderSchemaResponse{
 				DataSourceSchemas: map[string]fwschema.Schema{
-					"test_data_source": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
-								Attributes: tfsdk.SetNestedAttributes(map[string]tfsdk.Attribute{
-									"test_nested_attribute": {
-										Type:     types.StringType,
-										Required: true,
+					"test_data_source": datasourceschema.Schema{
+						Attributes: map[string]datasourceschema.Attribute{
+							"test_attribute": datasourceschema.SetNestedAttribute{
+								NestedObject: datasourceschema.NestedAttributeObject{
+									Attributes: map[string]datasourceschema.Attribute{
+										"test_nested_attribute": datasourceschema.StringAttribute{
+											Required: true,
+										},
 									},
-								}),
+								},
 								Required: true,
 							},
 						},
@@ -670,15 +654,13 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"data-source-attribute-type-set-object": {
 			input: &fwserver.GetProviderSchemaResponse{
 				DataSourceSchemas: map[string]fwschema.Schema{
-					"test_data_source": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_data_source": datasourceschema.Schema{
+						Attributes: map[string]datasourceschema.Attribute{
+							"test_attribute": datasourceschema.SetAttribute{
 								Required: true,
-								Type: types.SetType{
-									ElemType: types.ObjectType{
-										AttrTypes: map[string]attr.Type{
-											"test_object_attribute": types.StringType,
-										},
+								ElementType: types.ObjectType{
+									AttrTypes: map[string]attr.Type{
+										"test_object_attribute": types.StringType,
 									},
 								},
 							},
@@ -712,14 +694,12 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"data-source-attribute-type-set-set-string": {
 			input: &fwserver.GetProviderSchemaResponse{
 				DataSourceSchemas: map[string]fwschema.Schema{
-					"test_data_source": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_data_source": datasourceschema.Schema{
+						Attributes: map[string]datasourceschema.Attribute{
+							"test_attribute": datasourceschema.SetAttribute{
 								Required: true,
-								Type: types.SetType{
-									ElemType: types.SetType{
-										ElemType: types.StringType,
-									},
+								ElementType: types.SetType{
+									ElemType: types.StringType,
 								},
 							},
 						},
@@ -750,13 +730,11 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"data-source-attribute-type-set-string": {
 			input: &fwserver.GetProviderSchemaResponse{
 				DataSourceSchemas: map[string]fwschema.Schema{
-					"test_data_source": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
-								Required: true,
-								Type: types.SetType{
-									ElemType: types.StringType,
-								},
+					"test_data_source": datasourceschema.Schema{
+						Attributes: map[string]datasourceschema.Attribute{
+							"test_attribute": datasourceschema.SetAttribute{
+								Required:    true,
+								ElementType: types.StringType,
 							},
 						},
 					},
@@ -784,15 +762,14 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"data-source-attribute-type-single-nested-attributes": {
 			input: &fwserver.GetProviderSchemaResponse{
 				DataSourceSchemas: map[string]fwschema.Schema{
-					"test_data_source": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
-								Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
-									"test_nested_attribute": {
-										Type:     types.StringType,
+					"test_data_source": datasourceschema.Schema{
+						Attributes: map[string]datasourceschema.Attribute{
+							"test_attribute": datasourceschema.SingleNestedAttribute{
+								Attributes: map[string]datasourceschema.Attribute{
+									"test_nested_attribute": datasourceschema.StringAttribute{
 										Required: true,
 									},
-								}),
+								},
 								Required: true,
 							},
 						},
@@ -816,11 +793,10 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"data-source-attribute-type-string": {
 			input: &fwserver.GetProviderSchemaResponse{
 				DataSourceSchemas: map[string]fwschema.Schema{
-					"test_data_source": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_data_source": datasourceschema.Schema{
+						Attributes: map[string]datasourceschema.Attribute{
+							"test_attribute": datasourceschema.StringAttribute{
 								Required: true,
-								Type:     types.StringType,
 							},
 						},
 					},
@@ -846,16 +822,16 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"data-source-block-list": {
 			input: &fwserver.GetProviderSchemaResponse{
 				DataSourceSchemas: map[string]fwschema.Schema{
-					"test_data_source": &tfsdk.Schema{
-						Blocks: map[string]tfsdk.Block{
-							"test_block": {
-								Attributes: map[string]tfsdk.Attribute{
-									"test_attribute": {
-										Type:     types.StringType,
-										Required: true,
+					"test_data_source": datasourceschema.Schema{
+						Blocks: map[string]datasourceschema.Block{
+							"test_block": datasourceschema.ListNestedBlock{
+								NestedObject: datasourceschema.NestedBlockObject{
+									Attributes: map[string]datasourceschema.Attribute{
+										"test_attribute": datasourceschema.StringAttribute{
+											Required: true,
+										},
 									},
 								},
-								NestingMode: tfsdk.BlockNestingModeList,
 							},
 						},
 					},
@@ -889,16 +865,16 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"data-source-block-set": {
 			input: &fwserver.GetProviderSchemaResponse{
 				DataSourceSchemas: map[string]fwschema.Schema{
-					"test_data_source": &tfsdk.Schema{
-						Blocks: map[string]tfsdk.Block{
-							"test_block": {
-								Attributes: map[string]tfsdk.Attribute{
-									"test_attribute": {
-										Type:     types.StringType,
-										Required: true,
+					"test_data_source": datasourceschema.Schema{
+						Blocks: map[string]datasourceschema.Block{
+							"test_block": datasourceschema.SetNestedBlock{
+								NestedObject: datasourceschema.NestedBlockObject{
+									Attributes: map[string]datasourceschema.Attribute{
+										"test_attribute": datasourceschema.StringAttribute{
+											Required: true,
+										},
 									},
 								},
-								NestingMode: tfsdk.BlockNestingModeSet,
 							},
 						},
 					},
@@ -932,16 +908,14 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"data-source-block-single": {
 			input: &fwserver.GetProviderSchemaResponse{
 				DataSourceSchemas: map[string]fwschema.Schema{
-					"test_data_source": &tfsdk.Schema{
-						Blocks: map[string]tfsdk.Block{
-							"test_block": {
-								Attributes: map[string]tfsdk.Attribute{
-									"test_attribute": {
-										Type:     types.StringType,
+					"test_data_source": datasourceschema.Schema{
+						Blocks: map[string]datasourceschema.Block{
+							"test_block": datasourceschema.SingleNestedBlock{
+								Attributes: map[string]datasourceschema.Attribute{
+									"test_attribute": datasourceschema.StringAttribute{
 										Required: true,
 									},
 								},
-								NestingMode: tfsdk.BlockNestingModeSingle,
 							},
 						},
 					},
@@ -972,59 +946,13 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				ResourceSchemas: map[string]*tfprotov5.Schema{},
 			},
 		},
-		"data-source-version": {
-			input: &fwserver.GetProviderSchemaResponse{
-				DataSourceSchemas: map[string]fwschema.Schema{
-					"test_data_source": &tfsdk.Schema{
-						Version: 123,
-					},
-				},
-			},
-			expected: &tfprotov5.GetProviderSchemaResponse{
-				DataSourceSchemas: map[string]*tfprotov5.Schema{
-					"test_data_source": {
-						Block:   &tfprotov5.SchemaBlock{},
-						Version: 123,
-					},
-				},
-				ResourceSchemas: map[string]*tfprotov5.Schema{},
-			},
-		},
-		"provider-attribute-computed": {
-			input: &fwserver.GetProviderSchemaResponse{
-				Provider: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
-							Computed: true,
-							Type:     types.BoolType,
-						},
-					},
-				},
-			},
-			expected: &tfprotov5.GetProviderSchemaResponse{
-				DataSourceSchemas: map[string]*tfprotov5.Schema{},
-				Provider: &tfprotov5.Schema{
-					Block: &tfprotov5.SchemaBlock{
-						Attributes: []*tfprotov5.SchemaAttribute{
-							{
-								Computed: true,
-								Name:     "test_attribute",
-								Type:     tftypes.Bool,
-							},
-						},
-					},
-				},
-				ResourceSchemas: map[string]*tfprotov5.Schema{},
-			},
-		},
 		"provider-attribute-deprecated": {
 			input: &fwserver.GetProviderSchemaResponse{
-				Provider: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
+				Provider: providerschema.Schema{
+					Attributes: map[string]providerschema.Attribute{
+						"test_attribute": providerschema.BoolAttribute{
 							DeprecationMessage: "deprecated",
 							Optional:           true,
-							Type:               types.BoolType,
 						},
 					},
 				},
@@ -1048,11 +976,10 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-attribute-optional": {
 			input: &fwserver.GetProviderSchemaResponse{
-				Provider: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
+				Provider: providerschema.Schema{
+					Attributes: map[string]providerschema.Attribute{
+						"test_attribute": providerschema.BoolAttribute{
 							Optional: true,
-							Type:     types.BoolType,
 						},
 					},
 				},
@@ -1063,35 +990,6 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 					Block: &tfprotov5.SchemaBlock{
 						Attributes: []*tfprotov5.SchemaAttribute{
 							{
-								Name:     "test_attribute",
-								Optional: true,
-								Type:     tftypes.Bool,
-							},
-						},
-					},
-				},
-				ResourceSchemas: map[string]*tfprotov5.Schema{},
-			},
-		},
-		"provider-attribute-optional-computed": {
-			input: &fwserver.GetProviderSchemaResponse{
-				Provider: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
-							Computed: true,
-							Optional: true,
-							Type:     types.BoolType,
-						},
-					},
-				},
-			},
-			expected: &tfprotov5.GetProviderSchemaResponse{
-				DataSourceSchemas: map[string]*tfprotov5.Schema{},
-				Provider: &tfprotov5.Schema{
-					Block: &tfprotov5.SchemaBlock{
-						Attributes: []*tfprotov5.SchemaAttribute{
-							{
-								Computed: true,
 								Name:     "test_attribute",
 								Optional: true,
 								Type:     tftypes.Bool,
@@ -1104,11 +1002,10 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-attribute-required": {
 			input: &fwserver.GetProviderSchemaResponse{
-				Provider: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
+				Provider: providerschema.Schema{
+					Attributes: map[string]providerschema.Attribute{
+						"test_attribute": providerschema.BoolAttribute{
 							Required: true,
-							Type:     types.BoolType,
 						},
 					},
 				},
@@ -1131,12 +1028,11 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-attribute-sensitive": {
 			input: &fwserver.GetProviderSchemaResponse{
-				Provider: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
-							Computed:  true,
+				Provider: providerschema.Schema{
+					Attributes: map[string]providerschema.Attribute{
+						"test_attribute": providerschema.BoolAttribute{
+							Optional:  true,
 							Sensitive: true,
-							Type:      types.BoolType,
 						},
 					},
 				},
@@ -1147,8 +1043,8 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 					Block: &tfprotov5.SchemaBlock{
 						Attributes: []*tfprotov5.SchemaAttribute{
 							{
-								Computed:  true,
 								Name:      "test_attribute",
+								Optional:  true,
 								Sensitive: true,
 								Type:      tftypes.Bool,
 							},
@@ -1160,11 +1056,10 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-attribute-type-bool": {
 			input: &fwserver.GetProviderSchemaResponse{
-				Provider: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
+				Provider: providerschema.Schema{
+					Attributes: map[string]providerschema.Attribute{
+						"test_attribute": providerschema.BoolAttribute{
 							Required: true,
-							Type:     types.BoolType,
 						},
 					},
 				},
@@ -1187,11 +1082,10 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-attribute-type-float64": {
 			input: &fwserver.GetProviderSchemaResponse{
-				Provider: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
+				Provider: providerschema.Schema{
+					Attributes: map[string]providerschema.Attribute{
+						"test_attribute": providerschema.Float64Attribute{
 							Required: true,
-							Type:     types.Float64Type,
 						},
 					},
 				},
@@ -1214,11 +1108,10 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-attribute-type-int64": {
 			input: &fwserver.GetProviderSchemaResponse{
-				Provider: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
+				Provider: providerschema.Schema{
+					Attributes: map[string]providerschema.Attribute{
+						"test_attribute": providerschema.Int64Attribute{
 							Required: true,
-							Type:     types.Int64Type,
 						},
 					},
 				},
@@ -1241,14 +1134,12 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-attribute-type-list-list-string": {
 			input: &fwserver.GetProviderSchemaResponse{
-				Provider: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
+				Provider: providerschema.Schema{
+					Attributes: map[string]providerschema.Attribute{
+						"test_attribute": providerschema.ListAttribute{
 							Required: true,
-							Type: types.ListType{
-								ElemType: types.ListType{
-									ElemType: types.StringType,
-								},
+							ElementType: types.ListType{
+								ElemType: types.StringType,
 							},
 						},
 					},
@@ -1276,15 +1167,16 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-attribute-type-list-nested-attributes": {
 			input: &fwserver.GetProviderSchemaResponse{
-				Provider: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
-							Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
-								"test_nested_attribute": {
-									Type:     types.StringType,
-									Required: true,
+				Provider: providerschema.Schema{
+					Attributes: map[string]providerschema.Attribute{
+						"test_attribute": providerschema.ListNestedAttribute{
+							NestedObject: providerschema.NestedAttributeObject{
+								Attributes: map[string]providerschema.Attribute{
+									"test_nested_attribute": providerschema.StringAttribute{
+										Required: true,
+									},
 								},
-							}),
+							},
 							Required: true,
 						},
 					},
@@ -1304,15 +1196,13 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-attribute-type-list-object": {
 			input: &fwserver.GetProviderSchemaResponse{
-				Provider: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
+				Provider: providerschema.Schema{
+					Attributes: map[string]providerschema.Attribute{
+						"test_attribute": providerschema.ListAttribute{
 							Required: true,
-							Type: types.ListType{
-								ElemType: types.ObjectType{
-									AttrTypes: map[string]attr.Type{
-										"test_object_attribute": types.StringType,
-									},
+							ElementType: types.ObjectType{
+								AttrTypes: map[string]attr.Type{
+									"test_object_attribute": types.StringType,
 								},
 							},
 						},
@@ -1343,13 +1233,11 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-attribute-type-list-string": {
 			input: &fwserver.GetProviderSchemaResponse{
-				Provider: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
-							Required: true,
-							Type: types.ListType{
-								ElemType: types.StringType,
-							},
+				Provider: providerschema.Schema{
+					Attributes: map[string]providerschema.Attribute{
+						"test_attribute": providerschema.ListAttribute{
+							Required:    true,
+							ElementType: types.StringType,
 						},
 					},
 				},
@@ -1374,15 +1262,16 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-attribute-type-map-nested-attributes": {
 			input: &fwserver.GetProviderSchemaResponse{
-				Provider: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
-							Attributes: tfsdk.MapNestedAttributes(map[string]tfsdk.Attribute{
-								"test_nested_attribute": {
-									Type:     types.StringType,
-									Required: true,
+				Provider: providerschema.Schema{
+					Attributes: map[string]providerschema.Attribute{
+						"test_attribute": providerschema.MapNestedAttribute{
+							NestedObject: providerschema.NestedAttributeObject{
+								Attributes: map[string]providerschema.Attribute{
+									"test_nested_attribute": providerschema.StringAttribute{
+										Required: true,
+									},
 								},
-							}),
+							},
 							Required: true,
 						},
 					},
@@ -1402,13 +1291,11 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-attribute-type-map-string": {
 			input: &fwserver.GetProviderSchemaResponse{
-				Provider: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
-							Required: true,
-							Type: types.MapType{
-								ElemType: types.StringType,
-							},
+				Provider: providerschema.Schema{
+					Attributes: map[string]providerschema.Attribute{
+						"test_attribute": providerschema.MapAttribute{
+							Required:    true,
+							ElementType: types.StringType,
 						},
 					},
 				},
@@ -1433,11 +1320,10 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-attribute-type-number": {
 			input: &fwserver.GetProviderSchemaResponse{
-				Provider: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
+				Provider: providerschema.Schema{
+					Attributes: map[string]providerschema.Attribute{
+						"test_attribute": providerschema.NumberAttribute{
 							Required: true,
-							Type:     types.NumberType,
 						},
 					},
 				},
@@ -1460,14 +1346,12 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-attribute-type-object": {
 			input: &fwserver.GetProviderSchemaResponse{
-				Provider: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
+				Provider: providerschema.Schema{
+					Attributes: map[string]providerschema.Attribute{
+						"test_attribute": providerschema.ObjectAttribute{
 							Required: true,
-							Type: types.ObjectType{
-								AttrTypes: map[string]attr.Type{
-									"test_object_attribute": types.StringType,
-								},
+							AttributeTypes: map[string]attr.Type{
+								"test_object_attribute": types.StringType,
 							},
 						},
 					},
@@ -1495,15 +1379,16 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-attribute-type-set-nested-attributes": {
 			input: &fwserver.GetProviderSchemaResponse{
-				Provider: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
-							Attributes: tfsdk.SetNestedAttributes(map[string]tfsdk.Attribute{
-								"test_nested_attribute": {
-									Type:     types.StringType,
-									Required: true,
+				Provider: providerschema.Schema{
+					Attributes: map[string]providerschema.Attribute{
+						"test_attribute": providerschema.SetNestedAttribute{
+							NestedObject: providerschema.NestedAttributeObject{
+								Attributes: map[string]providerschema.Attribute{
+									"test_nested_attribute": providerschema.StringAttribute{
+										Required: true,
+									},
 								},
-							}),
+							},
 							Required: true,
 						},
 					},
@@ -1523,15 +1408,13 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-attribute-type-set-object": {
 			input: &fwserver.GetProviderSchemaResponse{
-				Provider: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
+				Provider: providerschema.Schema{
+					Attributes: map[string]providerschema.Attribute{
+						"test_attribute": providerschema.SetAttribute{
 							Required: true,
-							Type: types.SetType{
-								ElemType: types.ObjectType{
-									AttrTypes: map[string]attr.Type{
-										"test_object_attribute": types.StringType,
-									},
+							ElementType: types.ObjectType{
+								AttrTypes: map[string]attr.Type{
+									"test_object_attribute": types.StringType,
 								},
 							},
 						},
@@ -1562,14 +1445,12 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-attribute-type-set-set-string": {
 			input: &fwserver.GetProviderSchemaResponse{
-				Provider: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
+				Provider: providerschema.Schema{
+					Attributes: map[string]providerschema.Attribute{
+						"test_attribute": providerschema.SetAttribute{
 							Required: true,
-							Type: types.SetType{
-								ElemType: types.SetType{
-									ElemType: types.StringType,
-								},
+							ElementType: types.SetType{
+								ElemType: types.StringType,
 							},
 						},
 					},
@@ -1597,13 +1478,11 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-attribute-type-set-string": {
 			input: &fwserver.GetProviderSchemaResponse{
-				Provider: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
-							Required: true,
-							Type: types.SetType{
-								ElemType: types.StringType,
-							},
+				Provider: providerschema.Schema{
+					Attributes: map[string]providerschema.Attribute{
+						"test_attribute": providerschema.SetAttribute{
+							Required:    true,
+							ElementType: types.StringType,
 						},
 					},
 				},
@@ -1628,15 +1507,14 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-attribute-type-single-nested-attributes": {
 			input: &fwserver.GetProviderSchemaResponse{
-				Provider: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
-							Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
-								"test_nested_attribute": {
-									Type:     types.StringType,
+				Provider: providerschema.Schema{
+					Attributes: map[string]providerschema.Attribute{
+						"test_attribute": providerschema.SingleNestedAttribute{
+							Attributes: map[string]providerschema.Attribute{
+								"test_nested_attribute": providerschema.StringAttribute{
 									Required: true,
 								},
-							}),
+							},
 							Required: true,
 						},
 					},
@@ -1656,11 +1534,10 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-attribute-type-string": {
 			input: &fwserver.GetProviderSchemaResponse{
-				Provider: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
+				Provider: providerschema.Schema{
+					Attributes: map[string]providerschema.Attribute{
+						"test_attribute": providerschema.StringAttribute{
 							Required: true,
-							Type:     types.StringType,
 						},
 					},
 				},
@@ -1683,16 +1560,16 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-block-list": {
 			input: &fwserver.GetProviderSchemaResponse{
-				Provider: &tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"test_block": {
-							Attributes: map[string]tfsdk.Attribute{
-								"test_attribute": {
-									Type:     types.StringType,
-									Required: true,
+				Provider: providerschema.Schema{
+					Blocks: map[string]providerschema.Block{
+						"test_block": providerschema.ListNestedBlock{
+							NestedObject: providerschema.NestedBlockObject{
+								Attributes: map[string]providerschema.Attribute{
+									"test_attribute": providerschema.StringAttribute{
+										Required: true,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeList,
 						},
 					},
 				},
@@ -1723,16 +1600,16 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-block-set": {
 			input: &fwserver.GetProviderSchemaResponse{
-				Provider: &tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"test_block": {
-							Attributes: map[string]tfsdk.Attribute{
-								"test_attribute": {
-									Type:     types.StringType,
-									Required: true,
+				Provider: providerschema.Schema{
+					Blocks: map[string]providerschema.Block{
+						"test_block": providerschema.SetNestedBlock{
+							NestedObject: providerschema.NestedBlockObject{
+								Attributes: map[string]providerschema.Attribute{
+									"test_attribute": providerschema.StringAttribute{
+										Required: true,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeSet,
 						},
 					},
 				},
@@ -1763,16 +1640,14 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-block-single": {
 			input: &fwserver.GetProviderSchemaResponse{
-				Provider: &tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"test_block": {
-							Attributes: map[string]tfsdk.Attribute{
-								"test_attribute": {
-									Type:     types.StringType,
+				Provider: providerschema.Schema{
+					Blocks: map[string]providerschema.Block{
+						"test_block": providerschema.SingleNestedBlock{
+							Attributes: map[string]providerschema.Attribute{
+								"test_attribute": providerschema.StringAttribute{
 									Required: true,
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeSingle,
 						},
 					},
 				},
@@ -1801,84 +1676,12 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				ResourceSchemas: map[string]*tfprotov5.Schema{},
 			},
 		},
-		"provider-version": {
-			input: &fwserver.GetProviderSchemaResponse{
-				Provider: &tfsdk.Schema{
-					Version: 123,
-				},
-			},
-			expected: &tfprotov5.GetProviderSchemaResponse{
-				DataSourceSchemas: map[string]*tfprotov5.Schema{},
-				Provider: &tfprotov5.Schema{
-					Block:   &tfprotov5.SchemaBlock{},
-					Version: 123,
-				},
-				ResourceSchemas: map[string]*tfprotov5.Schema{},
-			},
-		},
-		"provider-meta-attribute-computed": {
-			input: &fwserver.GetProviderSchemaResponse{
-				ProviderMeta: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
-							Computed: true,
-							Type:     types.BoolType,
-						},
-					},
-				},
-			},
-			expected: &tfprotov5.GetProviderSchemaResponse{
-				DataSourceSchemas: map[string]*tfprotov5.Schema{},
-				ProviderMeta: &tfprotov5.Schema{
-					Block: &tfprotov5.SchemaBlock{
-						Attributes: []*tfprotov5.SchemaAttribute{
-							{
-								Computed: true,
-								Name:     "test_attribute",
-								Type:     tftypes.Bool,
-							},
-						},
-					},
-				},
-				ResourceSchemas: map[string]*tfprotov5.Schema{},
-			},
-		},
-		"provider-meta-attribute-deprecated": {
-			input: &fwserver.GetProviderSchemaResponse{
-				ProviderMeta: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
-							DeprecationMessage: "deprecated",
-							Optional:           true,
-							Type:               types.BoolType,
-						},
-					},
-				},
-			},
-			expected: &tfprotov5.GetProviderSchemaResponse{
-				DataSourceSchemas: map[string]*tfprotov5.Schema{},
-				ProviderMeta: &tfprotov5.Schema{
-					Block: &tfprotov5.SchemaBlock{
-						Attributes: []*tfprotov5.SchemaAttribute{
-							{
-								Deprecated: true,
-								Name:       "test_attribute",
-								Optional:   true,
-								Type:       tftypes.Bool,
-							},
-						},
-					},
-				},
-				ResourceSchemas: map[string]*tfprotov5.Schema{},
-			},
-		},
 		"provider-meta-attribute-optional": {
 			input: &fwserver.GetProviderSchemaResponse{
-				ProviderMeta: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
+				ProviderMeta: metaschema.Schema{
+					Attributes: map[string]metaschema.Attribute{
+						"test_attribute": metaschema.BoolAttribute{
 							Optional: true,
-							Type:     types.BoolType,
 						},
 					},
 				},
@@ -1889,35 +1692,6 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 					Block: &tfprotov5.SchemaBlock{
 						Attributes: []*tfprotov5.SchemaAttribute{
 							{
-								Name:     "test_attribute",
-								Optional: true,
-								Type:     tftypes.Bool,
-							},
-						},
-					},
-				},
-				ResourceSchemas: map[string]*tfprotov5.Schema{},
-			},
-		},
-		"provider-meta-attribute-optional-computed": {
-			input: &fwserver.GetProviderSchemaResponse{
-				ProviderMeta: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
-							Computed: true,
-							Optional: true,
-							Type:     types.BoolType,
-						},
-					},
-				},
-			},
-			expected: &tfprotov5.GetProviderSchemaResponse{
-				DataSourceSchemas: map[string]*tfprotov5.Schema{},
-				ProviderMeta: &tfprotov5.Schema{
-					Block: &tfprotov5.SchemaBlock{
-						Attributes: []*tfprotov5.SchemaAttribute{
-							{
-								Computed: true,
 								Name:     "test_attribute",
 								Optional: true,
 								Type:     tftypes.Bool,
@@ -1930,11 +1704,10 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-meta-attribute-required": {
 			input: &fwserver.GetProviderSchemaResponse{
-				ProviderMeta: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
+				ProviderMeta: metaschema.Schema{
+					Attributes: map[string]metaschema.Attribute{
+						"test_attribute": metaschema.BoolAttribute{
 							Required: true,
-							Type:     types.BoolType,
 						},
 					},
 				},
@@ -1955,42 +1728,12 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				ResourceSchemas: map[string]*tfprotov5.Schema{},
 			},
 		},
-		"provider-meta-attribute-sensitive": {
-			input: &fwserver.GetProviderSchemaResponse{
-				ProviderMeta: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
-							Computed:  true,
-							Sensitive: true,
-							Type:      types.BoolType,
-						},
-					},
-				},
-			},
-			expected: &tfprotov5.GetProviderSchemaResponse{
-				DataSourceSchemas: map[string]*tfprotov5.Schema{},
-				ProviderMeta: &tfprotov5.Schema{
-					Block: &tfprotov5.SchemaBlock{
-						Attributes: []*tfprotov5.SchemaAttribute{
-							{
-								Computed:  true,
-								Name:      "test_attribute",
-								Sensitive: true,
-								Type:      tftypes.Bool,
-							},
-						},
-					},
-				},
-				ResourceSchemas: map[string]*tfprotov5.Schema{},
-			},
-		},
 		"provider-meta-attribute-type-bool": {
 			input: &fwserver.GetProviderSchemaResponse{
-				ProviderMeta: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
+				ProviderMeta: metaschema.Schema{
+					Attributes: map[string]metaschema.Attribute{
+						"test_attribute": metaschema.BoolAttribute{
 							Required: true,
-							Type:     types.BoolType,
 						},
 					},
 				},
@@ -2013,11 +1756,10 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-meta-attribute-type-float64": {
 			input: &fwserver.GetProviderSchemaResponse{
-				ProviderMeta: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
+				ProviderMeta: metaschema.Schema{
+					Attributes: map[string]metaschema.Attribute{
+						"test_attribute": metaschema.Float64Attribute{
 							Required: true,
-							Type:     types.Float64Type,
 						},
 					},
 				},
@@ -2040,11 +1782,10 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-meta-attribute-type-int64": {
 			input: &fwserver.GetProviderSchemaResponse{
-				ProviderMeta: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
+				ProviderMeta: metaschema.Schema{
+					Attributes: map[string]metaschema.Attribute{
+						"test_attribute": metaschema.Int64Attribute{
 							Required: true,
-							Type:     types.Int64Type,
 						},
 					},
 				},
@@ -2067,14 +1808,12 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-meta-attribute-type-list-list-string": {
 			input: &fwserver.GetProviderSchemaResponse{
-				ProviderMeta: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
+				ProviderMeta: metaschema.Schema{
+					Attributes: map[string]metaschema.Attribute{
+						"test_attribute": metaschema.ListAttribute{
 							Required: true,
-							Type: types.ListType{
-								ElemType: types.ListType{
-									ElemType: types.StringType,
-								},
+							ElementType: types.ListType{
+								ElemType: types.StringType,
 							},
 						},
 					},
@@ -2102,15 +1841,16 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-meta-attribute-type-list-nested-attributes": {
 			input: &fwserver.GetProviderSchemaResponse{
-				ProviderMeta: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
-							Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
-								"test_nested_attribute": {
-									Type:     types.StringType,
-									Required: true,
+				ProviderMeta: metaschema.Schema{
+					Attributes: map[string]metaschema.Attribute{
+						"test_attribute": metaschema.ListNestedAttribute{
+							NestedObject: metaschema.NestedAttributeObject{
+								Attributes: map[string]metaschema.Attribute{
+									"test_nested_attribute": metaschema.StringAttribute{
+										Required: true,
+									},
 								},
-							}),
+							},
 							Required: true,
 						},
 					},
@@ -2130,15 +1870,13 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-meta-attribute-type-list-object": {
 			input: &fwserver.GetProviderSchemaResponse{
-				ProviderMeta: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
+				ProviderMeta: metaschema.Schema{
+					Attributes: map[string]metaschema.Attribute{
+						"test_attribute": metaschema.ListAttribute{
 							Required: true,
-							Type: types.ListType{
-								ElemType: types.ObjectType{
-									AttrTypes: map[string]attr.Type{
-										"test_nested_attribute": types.StringType,
-									},
+							ElementType: types.ObjectType{
+								AttrTypes: map[string]attr.Type{
+									"test_nested_attribute": types.StringType,
 								},
 							},
 						},
@@ -2169,13 +1907,11 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-meta-attribute-type-list-string": {
 			input: &fwserver.GetProviderSchemaResponse{
-				ProviderMeta: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
-							Required: true,
-							Type: types.ListType{
-								ElemType: types.StringType,
-							},
+				ProviderMeta: metaschema.Schema{
+					Attributes: map[string]metaschema.Attribute{
+						"test_attribute": metaschema.ListAttribute{
+							Required:    true,
+							ElementType: types.StringType,
 						},
 					},
 				},
@@ -2200,15 +1936,16 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-meta-attribute-type-map-nested-attributes": {
 			input: &fwserver.GetProviderSchemaResponse{
-				ProviderMeta: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
-							Attributes: tfsdk.MapNestedAttributes(map[string]tfsdk.Attribute{
-								"test_nested_attribute": {
-									Type:     types.StringType,
-									Required: true,
+				ProviderMeta: metaschema.Schema{
+					Attributes: map[string]metaschema.Attribute{
+						"test_attribute": metaschema.MapNestedAttribute{
+							NestedObject: metaschema.NestedAttributeObject{
+								Attributes: map[string]metaschema.Attribute{
+									"test_nested_attribute": metaschema.StringAttribute{
+										Required: true,
+									},
 								},
-							}),
+							},
 							Required: true,
 						},
 					},
@@ -2228,13 +1965,11 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-meta-attribute-type-map-string": {
 			input: &fwserver.GetProviderSchemaResponse{
-				ProviderMeta: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
-							Required: true,
-							Type: types.MapType{
-								ElemType: types.StringType,
-							},
+				ProviderMeta: metaschema.Schema{
+					Attributes: map[string]metaschema.Attribute{
+						"test_attribute": metaschema.MapAttribute{
+							Required:    true,
+							ElementType: types.StringType,
 						},
 					},
 				},
@@ -2259,11 +1994,10 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-meta-attribute-type-number": {
 			input: &fwserver.GetProviderSchemaResponse{
-				ProviderMeta: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
+				ProviderMeta: metaschema.Schema{
+					Attributes: map[string]metaschema.Attribute{
+						"test_attribute": metaschema.NumberAttribute{
 							Required: true,
-							Type:     types.NumberType,
 						},
 					},
 				},
@@ -2286,14 +2020,12 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-meta-attribute-type-object": {
 			input: &fwserver.GetProviderSchemaResponse{
-				ProviderMeta: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
+				ProviderMeta: metaschema.Schema{
+					Attributes: map[string]metaschema.Attribute{
+						"test_attribute": metaschema.ObjectAttribute{
 							Required: true,
-							Type: types.ObjectType{
-								AttrTypes: map[string]attr.Type{
-									"test_object_attribute": types.StringType,
-								},
+							AttributeTypes: map[string]attr.Type{
+								"test_object_attribute": types.StringType,
 							},
 						},
 					},
@@ -2321,15 +2053,16 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-meta-attribute-type-set-nested-attributes": {
 			input: &fwserver.GetProviderSchemaResponse{
-				ProviderMeta: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
-							Attributes: tfsdk.SetNestedAttributes(map[string]tfsdk.Attribute{
-								"test_nested_attribute": {
-									Type:     types.StringType,
-									Required: true,
+				ProviderMeta: metaschema.Schema{
+					Attributes: map[string]metaschema.Attribute{
+						"test_attribute": metaschema.SetNestedAttribute{
+							NestedObject: metaschema.NestedAttributeObject{
+								Attributes: map[string]metaschema.Attribute{
+									"test_nested_attribute": metaschema.StringAttribute{
+										Required: true,
+									},
 								},
-							}),
+							},
 							Required: true,
 						},
 					},
@@ -2349,15 +2082,13 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-meta-attribute-type-set-object": {
 			input: &fwserver.GetProviderSchemaResponse{
-				ProviderMeta: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
+				ProviderMeta: metaschema.Schema{
+					Attributes: map[string]metaschema.Attribute{
+						"test_attribute": metaschema.SetAttribute{
 							Required: true,
-							Type: types.SetType{
-								ElemType: types.ObjectType{
-									AttrTypes: map[string]attr.Type{
-										"test_object_attribute": types.StringType,
-									},
+							ElementType: types.ObjectType{
+								AttrTypes: map[string]attr.Type{
+									"test_object_attribute": types.StringType,
 								},
 							},
 						},
@@ -2388,14 +2119,12 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-meta-attribute-type-set-set-string": {
 			input: &fwserver.GetProviderSchemaResponse{
-				ProviderMeta: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
+				ProviderMeta: metaschema.Schema{
+					Attributes: map[string]metaschema.Attribute{
+						"test_attribute": metaschema.SetAttribute{
 							Required: true,
-							Type: types.SetType{
-								ElemType: types.SetType{
-									ElemType: types.StringType,
-								},
+							ElementType: types.SetType{
+								ElemType: types.StringType,
 							},
 						},
 					},
@@ -2423,13 +2152,11 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-meta-attribute-type-set-string": {
 			input: &fwserver.GetProviderSchemaResponse{
-				ProviderMeta: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
-							Required: true,
-							Type: types.SetType{
-								ElemType: types.StringType,
-							},
+				ProviderMeta: metaschema.Schema{
+					Attributes: map[string]metaschema.Attribute{
+						"test_attribute": metaschema.SetAttribute{
+							Required:    true,
+							ElementType: types.StringType,
 						},
 					},
 				},
@@ -2454,15 +2181,14 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-meta-attribute-type-single-nested-attributes": {
 			input: &fwserver.GetProviderSchemaResponse{
-				ProviderMeta: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
-							Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
-								"test_nested_attribute": {
-									Type:     types.StringType,
+				ProviderMeta: metaschema.Schema{
+					Attributes: map[string]metaschema.Attribute{
+						"test_attribute": metaschema.SingleNestedAttribute{
+							Attributes: map[string]metaschema.Attribute{
+								"test_nested_attribute": metaschema.StringAttribute{
 									Required: true,
 								},
-							}),
+							},
 							Required: true,
 						},
 					},
@@ -2482,11 +2208,10 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-meta-attribute-type-string": {
 			input: &fwserver.GetProviderSchemaResponse{
-				ProviderMeta: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
+				ProviderMeta: metaschema.Schema{
+					Attributes: map[string]metaschema.Attribute{
+						"test_attribute": metaschema.StringAttribute{
 							Required: true,
-							Type:     types.StringType,
 						},
 					},
 				},
@@ -2507,157 +2232,20 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				ResourceSchemas: map[string]*tfprotov5.Schema{},
 			},
 		},
-		"provider-meta-block-list": {
-			input: &fwserver.GetProviderSchemaResponse{
-				ProviderMeta: &tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"test_block": {
-							Attributes: map[string]tfsdk.Attribute{
-								"test_attribute": {
-									Type:     types.StringType,
-									Required: true,
-								},
-							},
-							NestingMode: tfsdk.BlockNestingModeList,
-						},
-					},
-				},
-			},
-			expected: &tfprotov5.GetProviderSchemaResponse{
-				DataSourceSchemas: map[string]*tfprotov5.Schema{},
-				ProviderMeta: &tfprotov5.Schema{
-					Block: &tfprotov5.SchemaBlock{
-						BlockTypes: []*tfprotov5.SchemaNestedBlock{
-							{
-								Block: &tfprotov5.SchemaBlock{
-									Attributes: []*tfprotov5.SchemaAttribute{
-										{
-											Name:     "test_attribute",
-											Type:     tftypes.String,
-											Required: true,
-										},
-									},
-								},
-								Nesting:  tfprotov5.SchemaNestedBlockNestingModeList,
-								TypeName: "test_block",
-							},
-						},
-					},
-				},
-				ResourceSchemas: map[string]*tfprotov5.Schema{},
-			},
-		},
-		"provider-meta-block-set": {
-			input: &fwserver.GetProviderSchemaResponse{
-				ProviderMeta: &tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"test_block": {
-							Attributes: map[string]tfsdk.Attribute{
-								"test_attribute": {
-									Type:     types.StringType,
-									Required: true,
-								},
-							},
-							NestingMode: tfsdk.BlockNestingModeSet,
-						},
-					},
-				},
-			},
-			expected: &tfprotov5.GetProviderSchemaResponse{
-				DataSourceSchemas: map[string]*tfprotov5.Schema{},
-				ProviderMeta: &tfprotov5.Schema{
-					Block: &tfprotov5.SchemaBlock{
-						BlockTypes: []*tfprotov5.SchemaNestedBlock{
-							{
-								Block: &tfprotov5.SchemaBlock{
-									Attributes: []*tfprotov5.SchemaAttribute{
-										{
-											Name:     "test_attribute",
-											Type:     tftypes.String,
-											Required: true,
-										},
-									},
-								},
-								Nesting:  tfprotov5.SchemaNestedBlockNestingModeSet,
-								TypeName: "test_block",
-							},
-						},
-					},
-				},
-				ResourceSchemas: map[string]*tfprotov5.Schema{},
-			},
-		},
-		"provider-meta-block-single": {
-			input: &fwserver.GetProviderSchemaResponse{
-				ProviderMeta: &tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"test_block": {
-							Attributes: map[string]tfsdk.Attribute{
-								"test_attribute": {
-									Type:     types.StringType,
-									Required: true,
-								},
-							},
-							NestingMode: tfsdk.BlockNestingModeSingle,
-						},
-					},
-				},
-			},
-			expected: &tfprotov5.GetProviderSchemaResponse{
-				DataSourceSchemas: map[string]*tfprotov5.Schema{},
-				ProviderMeta: &tfprotov5.Schema{
-					Block: &tfprotov5.SchemaBlock{
-						BlockTypes: []*tfprotov5.SchemaNestedBlock{
-							{
-								Block: &tfprotov5.SchemaBlock{
-									Attributes: []*tfprotov5.SchemaAttribute{
-										{
-											Name:     "test_attribute",
-											Type:     tftypes.String,
-											Required: true,
-										},
-									},
-								},
-								Nesting:  tfprotov5.SchemaNestedBlockNestingModeSingle,
-								TypeName: "test_block",
-							},
-						},
-					},
-				},
-				ResourceSchemas: map[string]*tfprotov5.Schema{},
-			},
-		},
-		"provider-meta-version": {
-			input: &fwserver.GetProviderSchemaResponse{
-				ProviderMeta: &tfsdk.Schema{
-					Version: 123,
-				},
-			},
-			expected: &tfprotov5.GetProviderSchemaResponse{
-				DataSourceSchemas: map[string]*tfprotov5.Schema{},
-				ProviderMeta: &tfprotov5.Schema{
-					Block:   &tfprotov5.SchemaBlock{},
-					Version: 123,
-				},
-				ResourceSchemas: map[string]*tfprotov5.Schema{},
-			},
-		},
 		"resource-multiple-resources": {
 			input: &fwserver.GetProviderSchemaResponse{
 				ResourceSchemas: map[string]fwschema.Schema{
-					"test_resource_1": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_resource_1": resourceschema.Schema{
+						Attributes: map[string]resourceschema.Attribute{
+							"test_attribute": resourceschema.BoolAttribute{
 								Computed: true,
-								Type:     types.BoolType,
 							},
 						},
 					},
-					"test_resource_2": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_resource_2": resourceschema.Schema{
+						Attributes: map[string]resourceschema.Attribute{
+							"test_attribute": resourceschema.BoolAttribute{
 								Computed: true,
-								Type:     types.BoolType,
 							},
 						},
 					},
@@ -2694,11 +2282,10 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"resource-attribute-computed": {
 			input: &fwserver.GetProviderSchemaResponse{
 				ResourceSchemas: map[string]fwschema.Schema{
-					"test_resource": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_resource": resourceschema.Schema{
+						Attributes: map[string]resourceschema.Attribute{
+							"test_attribute": resourceschema.BoolAttribute{
 								Computed: true,
-								Type:     types.BoolType,
 							},
 						},
 					},
@@ -2724,12 +2311,11 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"resource-attribute-deprecated": {
 			input: &fwserver.GetProviderSchemaResponse{
 				ResourceSchemas: map[string]fwschema.Schema{
-					"test_resource": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_resource": resourceschema.Schema{
+						Attributes: map[string]resourceschema.Attribute{
+							"test_attribute": resourceschema.BoolAttribute{
 								DeprecationMessage: "deprecated",
 								Optional:           true,
-								Type:               types.BoolType,
 							},
 						},
 					},
@@ -2756,11 +2342,10 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"resource-attribute-optional": {
 			input: &fwserver.GetProviderSchemaResponse{
 				ResourceSchemas: map[string]fwschema.Schema{
-					"test_resource": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_resource": resourceschema.Schema{
+						Attributes: map[string]resourceschema.Attribute{
+							"test_attribute": resourceschema.BoolAttribute{
 								Optional: true,
-								Type:     types.BoolType,
 							},
 						},
 					},
@@ -2786,12 +2371,11 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"resource-attribute-optional-computed": {
 			input: &fwserver.GetProviderSchemaResponse{
 				ResourceSchemas: map[string]fwschema.Schema{
-					"test_resource": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_resource": resourceschema.Schema{
+						Attributes: map[string]resourceschema.Attribute{
+							"test_attribute": resourceschema.BoolAttribute{
 								Computed: true,
 								Optional: true,
-								Type:     types.BoolType,
 							},
 						},
 					},
@@ -2818,11 +2402,10 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"resource-attribute-required": {
 			input: &fwserver.GetProviderSchemaResponse{
 				ResourceSchemas: map[string]fwschema.Schema{
-					"test_resource": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_resource": resourceschema.Schema{
+						Attributes: map[string]resourceschema.Attribute{
+							"test_attribute": resourceschema.BoolAttribute{
 								Required: true,
-								Type:     types.BoolType,
 							},
 						},
 					},
@@ -2848,12 +2431,11 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"resource-attribute-sensitive": {
 			input: &fwserver.GetProviderSchemaResponse{
 				ResourceSchemas: map[string]fwschema.Schema{
-					"test_resource": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_resource": resourceschema.Schema{
+						Attributes: map[string]resourceschema.Attribute{
+							"test_attribute": resourceschema.BoolAttribute{
 								Computed:  true,
 								Sensitive: true,
-								Type:      types.BoolType,
 							},
 						},
 					},
@@ -2880,11 +2462,10 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"resource-attribute-type-bool": {
 			input: &fwserver.GetProviderSchemaResponse{
 				ResourceSchemas: map[string]fwschema.Schema{
-					"test_resource": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_resource": resourceschema.Schema{
+						Attributes: map[string]resourceschema.Attribute{
+							"test_attribute": resourceschema.BoolAttribute{
 								Required: true,
-								Type:     types.BoolType,
 							},
 						},
 					},
@@ -2910,11 +2491,10 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"resource-attribute-type-float64": {
 			input: &fwserver.GetProviderSchemaResponse{
 				ResourceSchemas: map[string]fwschema.Schema{
-					"test_resource": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_resource": resourceschema.Schema{
+						Attributes: map[string]resourceschema.Attribute{
+							"test_attribute": resourceschema.Float64Attribute{
 								Required: true,
-								Type:     types.Float64Type,
 							},
 						},
 					},
@@ -2940,11 +2520,10 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"resource-attribute-type-int64": {
 			input: &fwserver.GetProviderSchemaResponse{
 				ResourceSchemas: map[string]fwschema.Schema{
-					"test_resource": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_resource": resourceschema.Schema{
+						Attributes: map[string]resourceschema.Attribute{
+							"test_attribute": resourceschema.Int64Attribute{
 								Required: true,
-								Type:     types.Int64Type,
 							},
 						},
 					},
@@ -2970,14 +2549,12 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"resource-attribute-type-list-list-string": {
 			input: &fwserver.GetProviderSchemaResponse{
 				ResourceSchemas: map[string]fwschema.Schema{
-					"test_resource": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_resource": resourceschema.Schema{
+						Attributes: map[string]resourceschema.Attribute{
+							"test_attribute": resourceschema.ListAttribute{
 								Required: true,
-								Type: types.ListType{
-									ElemType: types.ListType{
-										ElemType: types.StringType,
-									},
+								ElementType: types.ListType{
+									ElemType: types.StringType,
 								},
 							},
 						},
@@ -3008,15 +2585,16 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"resource-attribute-type-list-nested-attributes": {
 			input: &fwserver.GetProviderSchemaResponse{
 				ResourceSchemas: map[string]fwschema.Schema{
-					"test_resource": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
-								Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
-									"test_nested_attribute": {
-										Type:     types.StringType,
-										Required: true,
+					"test_resource": resourceschema.Schema{
+						Attributes: map[string]resourceschema.Attribute{
+							"test_attribute": resourceschema.ListNestedAttribute{
+								NestedObject: resourceschema.NestedAttributeObject{
+									Attributes: map[string]resourceschema.Attribute{
+										"test_nested_attribute": resourceschema.StringAttribute{
+											Required: true,
+										},
 									},
-								}),
+								},
 								Required: true,
 							},
 						},
@@ -3040,15 +2618,13 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"resource-attribute-type-list-object": {
 			input: &fwserver.GetProviderSchemaResponse{
 				ResourceSchemas: map[string]fwschema.Schema{
-					"test_resource": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_resource": resourceschema.Schema{
+						Attributes: map[string]resourceschema.Attribute{
+							"test_attribute": resourceschema.ListAttribute{
 								Required: true,
-								Type: types.ListType{
-									ElemType: types.ObjectType{
-										AttrTypes: map[string]attr.Type{
-											"test_object_attribute": types.StringType,
-										},
+								ElementType: types.ObjectType{
+									AttrTypes: map[string]attr.Type{
+										"test_object_attribute": types.StringType,
 									},
 								},
 							},
@@ -3082,13 +2658,11 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"resource-attribute-type-list-string": {
 			input: &fwserver.GetProviderSchemaResponse{
 				ResourceSchemas: map[string]fwschema.Schema{
-					"test_resource": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
-								Required: true,
-								Type: types.ListType{
-									ElemType: types.StringType,
-								},
+					"test_resource": resourceschema.Schema{
+						Attributes: map[string]resourceschema.Attribute{
+							"test_attribute": resourceschema.ListAttribute{
+								Required:    true,
+								ElementType: types.StringType,
 							},
 						},
 					},
@@ -3116,15 +2690,16 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"resource-attribute-type-map-nested-attributes": {
 			input: &fwserver.GetProviderSchemaResponse{
 				ResourceSchemas: map[string]fwschema.Schema{
-					"test_resource": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
-								Attributes: tfsdk.MapNestedAttributes(map[string]tfsdk.Attribute{
-									"test_nested_attribute": {
-										Type:     types.StringType,
-										Required: true,
+					"test_resource": resourceschema.Schema{
+						Attributes: map[string]resourceschema.Attribute{
+							"test_attribute": resourceschema.MapNestedAttribute{
+								NestedObject: resourceschema.NestedAttributeObject{
+									Attributes: map[string]resourceschema.Attribute{
+										"test_nested_attribute": resourceschema.StringAttribute{
+											Required: true,
+										},
 									},
-								}),
+								},
 								Required: true,
 							},
 						},
@@ -3148,13 +2723,11 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"resource-attribute-type-map-string": {
 			input: &fwserver.GetProviderSchemaResponse{
 				ResourceSchemas: map[string]fwschema.Schema{
-					"test_resource": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
-								Required: true,
-								Type: types.MapType{
-									ElemType: types.StringType,
-								},
+					"test_resource": resourceschema.Schema{
+						Attributes: map[string]resourceschema.Attribute{
+							"test_attribute": resourceschema.MapAttribute{
+								Required:    true,
+								ElementType: types.StringType,
 							},
 						},
 					},
@@ -3182,11 +2755,10 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"resource-attribute-type-number": {
 			input: &fwserver.GetProviderSchemaResponse{
 				ResourceSchemas: map[string]fwschema.Schema{
-					"test_resource": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_resource": resourceschema.Schema{
+						Attributes: map[string]resourceschema.Attribute{
+							"test_attribute": resourceschema.NumberAttribute{
 								Required: true,
-								Type:     types.NumberType,
 							},
 						},
 					},
@@ -3212,14 +2784,12 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"resource-attribute-type-object": {
 			input: &fwserver.GetProviderSchemaResponse{
 				ResourceSchemas: map[string]fwschema.Schema{
-					"test_resource": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_resource": resourceschema.Schema{
+						Attributes: map[string]resourceschema.Attribute{
+							"test_attribute": resourceschema.ObjectAttribute{
 								Required: true,
-								Type: types.ObjectType{
-									AttrTypes: map[string]attr.Type{
-										"test_object_attribute": types.StringType,
-									},
+								AttributeTypes: map[string]attr.Type{
+									"test_object_attribute": types.StringType,
 								},
 							},
 						},
@@ -3250,15 +2820,16 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"resource-attribute-type-set-nested-attributes": {
 			input: &fwserver.GetProviderSchemaResponse{
 				ResourceSchemas: map[string]fwschema.Schema{
-					"test_resource": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
-								Attributes: tfsdk.SetNestedAttributes(map[string]tfsdk.Attribute{
-									"test_nested_attribute": {
-										Type:     types.StringType,
-										Required: true,
+					"test_resource": resourceschema.Schema{
+						Attributes: map[string]resourceschema.Attribute{
+							"test_attribute": resourceschema.SetNestedAttribute{
+								NestedObject: resourceschema.NestedAttributeObject{
+									Attributes: map[string]resourceschema.Attribute{
+										"test_nested_attribute": resourceschema.StringAttribute{
+											Required: true,
+										},
 									},
-								}),
+								},
 								Required: true,
 							},
 						},
@@ -3282,15 +2853,13 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"resource-attribute-type-set-object": {
 			input: &fwserver.GetProviderSchemaResponse{
 				ResourceSchemas: map[string]fwschema.Schema{
-					"test_resource": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_resource": resourceschema.Schema{
+						Attributes: map[string]resourceschema.Attribute{
+							"test_attribute": resourceschema.SetAttribute{
 								Required: true,
-								Type: types.SetType{
-									ElemType: types.ObjectType{
-										AttrTypes: map[string]attr.Type{
-											"test_object_attribute": types.StringType,
-										},
+								ElementType: types.ObjectType{
+									AttrTypes: map[string]attr.Type{
+										"test_object_attribute": types.StringType,
 									},
 								},
 							},
@@ -3324,14 +2893,12 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"resource-attribute-type-set-set-string": {
 			input: &fwserver.GetProviderSchemaResponse{
 				ResourceSchemas: map[string]fwschema.Schema{
-					"test_resource": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_resource": resourceschema.Schema{
+						Attributes: map[string]resourceschema.Attribute{
+							"test_attribute": resourceschema.SetAttribute{
 								Required: true,
-								Type: types.SetType{
-									ElemType: types.SetType{
-										ElemType: types.StringType,
-									},
+								ElementType: types.SetType{
+									ElemType: types.StringType,
 								},
 							},
 						},
@@ -3362,13 +2929,11 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"resource-attribute-type-set-string": {
 			input: &fwserver.GetProviderSchemaResponse{
 				ResourceSchemas: map[string]fwschema.Schema{
-					"test_resource": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
-								Required: true,
-								Type: types.SetType{
-									ElemType: types.StringType,
-								},
+					"test_resource": resourceschema.Schema{
+						Attributes: map[string]resourceschema.Attribute{
+							"test_attribute": resourceschema.SetAttribute{
+								Required:    true,
+								ElementType: types.StringType,
 							},
 						},
 					},
@@ -3396,15 +2961,14 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"resource-attribute-type-single-nested-attributes": {
 			input: &fwserver.GetProviderSchemaResponse{
 				ResourceSchemas: map[string]fwschema.Schema{
-					"test_resource": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
-								Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
-									"test_nested_attribute": {
-										Type:     types.StringType,
+					"test_resource": resourceschema.Schema{
+						Attributes: map[string]resourceschema.Attribute{
+							"test_attribute": resourceschema.SingleNestedAttribute{
+								Attributes: map[string]resourceschema.Attribute{
+									"test_nested_attribute": resourceschema.StringAttribute{
 										Required: true,
 									},
-								}),
+								},
 								Required: true,
 							},
 						},
@@ -3428,11 +2992,10 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"resource-attribute-type-string": {
 			input: &fwserver.GetProviderSchemaResponse{
 				ResourceSchemas: map[string]fwschema.Schema{
-					"test_resource": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_resource": resourceschema.Schema{
+						Attributes: map[string]resourceschema.Attribute{
+							"test_attribute": resourceschema.StringAttribute{
 								Required: true,
-								Type:     types.StringType,
 							},
 						},
 					},
@@ -3458,16 +3021,16 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"resource-block-list": {
 			input: &fwserver.GetProviderSchemaResponse{
 				ResourceSchemas: map[string]fwschema.Schema{
-					"test_resource": &tfsdk.Schema{
-						Blocks: map[string]tfsdk.Block{
-							"test_block": {
-								Attributes: map[string]tfsdk.Attribute{
-									"test_attribute": {
-										Type:     types.StringType,
-										Required: true,
+					"test_resource": resourceschema.Schema{
+						Blocks: map[string]resourceschema.Block{
+							"test_block": resourceschema.ListNestedBlock{
+								NestedObject: resourceschema.NestedBlockObject{
+									Attributes: map[string]resourceschema.Attribute{
+										"test_attribute": resourceschema.StringAttribute{
+											Required: true,
+										},
 									},
 								},
-								NestingMode: tfsdk.BlockNestingModeList,
 							},
 						},
 					},
@@ -3501,16 +3064,16 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"resource-block-set": {
 			input: &fwserver.GetProviderSchemaResponse{
 				ResourceSchemas: map[string]fwschema.Schema{
-					"test_resource": &tfsdk.Schema{
-						Blocks: map[string]tfsdk.Block{
-							"test_block": {
-								Attributes: map[string]tfsdk.Attribute{
-									"test_attribute": {
-										Type:     types.StringType,
-										Required: true,
+					"test_resource": resourceschema.Schema{
+						Blocks: map[string]resourceschema.Block{
+							"test_block": resourceschema.SetNestedBlock{
+								NestedObject: resourceschema.NestedBlockObject{
+									Attributes: map[string]resourceschema.Attribute{
+										"test_attribute": resourceschema.StringAttribute{
+											Required: true,
+										},
 									},
 								},
-								NestingMode: tfsdk.BlockNestingModeSet,
 							},
 						},
 					},
@@ -3544,16 +3107,14 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"resource-block-single": {
 			input: &fwserver.GetProviderSchemaResponse{
 				ResourceSchemas: map[string]fwschema.Schema{
-					"test_resource": &tfsdk.Schema{
-						Blocks: map[string]tfsdk.Block{
-							"test_block": {
-								Attributes: map[string]tfsdk.Attribute{
-									"test_attribute": {
-										Type:     types.StringType,
+					"test_resource": resourceschema.Schema{
+						Blocks: map[string]resourceschema.Block{
+							"test_block": resourceschema.SingleNestedBlock{
+								Attributes: map[string]resourceschema.Attribute{
+									"test_attribute": resourceschema.StringAttribute{
 										Required: true,
 									},
 								},
-								NestingMode: tfsdk.BlockNestingModeSingle,
 							},
 						},
 					},
@@ -3587,7 +3148,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"resource-version": {
 			input: &fwserver.GetProviderSchemaResponse{
 				ResourceSchemas: map[string]fwschema.Schema{
-					"test_resource": &tfsdk.Schema{
+					"test_resource": resourceschema.Schema{
 						Version: 123,
 					},
 				},

--- a/internal/toproto5/importedresource_test.go
+++ b/internal/toproto5/importedresource_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
 	"github.com/hashicorp/terraform-plugin-framework/internal/privatestate"
 	"github.com/hashicorp/terraform-plugin-framework/internal/toproto5"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 func TestImportResourceStateResponse(t *testing.T) {
@@ -49,11 +49,10 @@ func TestImportResourceStateResponse(t *testing.T) {
 
 	testState := tfsdk.State{
 		Raw: testProto5Value,
-		Schema: tfsdk.Schema{
-			Attributes: map[string]tfsdk.Attribute{
-				"test_attribute": {
+		Schema: schema.Schema{
+			Attributes: map[string]schema.Attribute{
+				"test_attribute": schema.StringAttribute{
 					Required: true,
-					Type:     types.StringType,
 				},
 			},
 		},
@@ -61,11 +60,10 @@ func TestImportResourceStateResponse(t *testing.T) {
 
 	testStateInvalid := tfsdk.State{
 		Raw: testProto5Value,
-		Schema: tfsdk.Schema{
-			Attributes: map[string]tfsdk.Attribute{
-				"test_attribute": {
+		Schema: schema.Schema{
+			Attributes: map[string]schema.Attribute{
+				"test_attribute": schema.BoolAttribute{
 					Required: true,
-					Type:     types.BoolType,
 				},
 			},
 		},
@@ -73,8 +71,8 @@ func TestImportResourceStateResponse(t *testing.T) {
 
 	testEmptyState := tfsdk.State{
 		Raw: testProto5Value,
-		Schema: tfsdk.Schema{
-			Attributes: map[string]tfsdk.Attribute{},
+		Schema: schema.Schema{
+			Attributes: map[string]schema.Attribute{},
 		},
 	}
 

--- a/internal/toproto5/planresourcechange_test.go
+++ b/internal/toproto5/planresourcechange_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/internal/privatestate"
 	"github.com/hashicorp/terraform-plugin-framework/internal/toproto5"
 	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 func TestPlanResourceChangeResponse(t *testing.T) {
@@ -38,11 +38,10 @@ func TestPlanResourceChangeResponse(t *testing.T) {
 
 	testState := &tfsdk.State{
 		Raw: testProto5Value,
-		Schema: tfsdk.Schema{
-			Attributes: map[string]tfsdk.Attribute{
-				"test_attribute": {
+		Schema: schema.Schema{
+			Attributes: map[string]schema.Attribute{
+				"test_attribute": schema.StringAttribute{
 					Required: true,
-					Type:     types.StringType,
 				},
 			},
 		},
@@ -50,11 +49,10 @@ func TestPlanResourceChangeResponse(t *testing.T) {
 
 	testStateInvalid := &tfsdk.State{
 		Raw: testProto5Value,
-		Schema: tfsdk.Schema{
-			Attributes: map[string]tfsdk.Attribute{
-				"test_attribute": {
+		Schema: schema.Schema{
+			Attributes: map[string]schema.Attribute{
+				"test_attribute": schema.BoolAttribute{
 					Required: true,
-					Type:     types.BoolType,
 				},
 			},
 		},

--- a/internal/toproto5/prepareproviderconfig_test.go
+++ b/internal/toproto5/prepareproviderconfig_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
 	"github.com/hashicorp/terraform-plugin-framework/internal/toproto5"
+	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
@@ -35,11 +35,10 @@ func TestPrepareProviderConfigResponse(t *testing.T) {
 
 	testConfig := &tfsdk.Config{
 		Raw: testProto5Value,
-		Schema: tfsdk.Schema{
-			Attributes: map[string]tfsdk.Attribute{
-				"test_attribute": {
+		Schema: schema.Schema{
+			Attributes: map[string]schema.Attribute{
+				"test_attribute": schema.StringAttribute{
 					Required: true,
-					Type:     types.StringType,
 				},
 			},
 		},
@@ -47,11 +46,10 @@ func TestPrepareProviderConfigResponse(t *testing.T) {
 
 	testConfigInvalid := &tfsdk.Config{
 		Raw: testProto5Value,
-		Schema: tfsdk.Schema{
-			Attributes: map[string]tfsdk.Attribute{
-				"test_attribute": {
+		Schema: schema.Schema{
+			Attributes: map[string]schema.Attribute{
+				"test_attribute": schema.BoolAttribute{
 					Required: true,
-					Type:     types.BoolType,
 				},
 			},
 		},

--- a/internal/toproto5/readdatasource_test.go
+++ b/internal/toproto5/readdatasource_test.go
@@ -5,11 +5,11 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
 	"github.com/hashicorp/terraform-plugin-framework/internal/toproto5"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
@@ -35,11 +35,10 @@ func TestReadDataSourceResponse(t *testing.T) {
 
 	testState := &tfsdk.State{
 		Raw: testProto5Value,
-		Schema: tfsdk.Schema{
-			Attributes: map[string]tfsdk.Attribute{
-				"test_attribute": {
+		Schema: schema.Schema{
+			Attributes: map[string]schema.Attribute{
+				"test_attribute": schema.StringAttribute{
 					Required: true,
-					Type:     types.StringType,
 				},
 			},
 		},
@@ -47,11 +46,10 @@ func TestReadDataSourceResponse(t *testing.T) {
 
 	testStateInvalid := &tfsdk.State{
 		Raw: testProto5Value,
-		Schema: tfsdk.Schema{
-			Attributes: map[string]tfsdk.Attribute{
-				"test_attribute": {
+		Schema: schema.Schema{
+			Attributes: map[string]schema.Attribute{
+				"test_attribute": schema.BoolAttribute{
 					Required: true,
-					Type:     types.BoolType,
 				},
 			},
 		},

--- a/internal/toproto5/readresource_test.go
+++ b/internal/toproto5/readresource_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
 	"github.com/hashicorp/terraform-plugin-framework/internal/privatestate"
 	"github.com/hashicorp/terraform-plugin-framework/internal/toproto5"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 func TestReadResourceResponse(t *testing.T) {
@@ -45,11 +45,10 @@ func TestReadResourceResponse(t *testing.T) {
 
 	testState := &tfsdk.State{
 		Raw: testProto5Value,
-		Schema: tfsdk.Schema{
-			Attributes: map[string]tfsdk.Attribute{
-				"test_attribute": {
+		Schema: schema.Schema{
+			Attributes: map[string]schema.Attribute{
+				"test_attribute": schema.StringAttribute{
 					Required: true,
-					Type:     types.StringType,
 				},
 			},
 		},
@@ -57,11 +56,10 @@ func TestReadResourceResponse(t *testing.T) {
 
 	testStateInvalid := &tfsdk.State{
 		Raw: testProto5Value,
-		Schema: tfsdk.Schema{
-			Attributes: map[string]tfsdk.Attribute{
-				"test_attribute": {
+		Schema: schema.Schema{
+			Attributes: map[string]schema.Attribute{
+				"test_attribute": schema.BoolAttribute{
 					Required: true,
-					Type:     types.BoolType,
 				},
 			},
 		},

--- a/internal/toproto5/schema_attribute_test.go
+++ b/internal/toproto5/schema_attribute_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/toproto5"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
@@ -28,7 +28,7 @@ func TestSchemaAttribute(t *testing.T) {
 	tests := map[string]testCase{
 		"deprecated": {
 			name: "string",
-			attr: tfsdk.Attribute{
+			attr: testschema.Attribute{
 				Type:               types.StringType,
 				Optional:           true,
 				DeprecationMessage: "deprecated, use new_string instead",
@@ -43,7 +43,7 @@ func TestSchemaAttribute(t *testing.T) {
 		},
 		"description-plain": {
 			name: "string",
-			attr: tfsdk.Attribute{
+			attr: testschema.Attribute{
 				Type:        types.StringType,
 				Optional:    true,
 				Description: "A string attribute",
@@ -59,7 +59,7 @@ func TestSchemaAttribute(t *testing.T) {
 		},
 		"description-markdown": {
 			name: "string",
-			attr: tfsdk.Attribute{
+			attr: testschema.Attribute{
 				Type:                types.StringType,
 				Optional:            true,
 				MarkdownDescription: "A string attribute",
@@ -75,7 +75,7 @@ func TestSchemaAttribute(t *testing.T) {
 		},
 		"description-both": {
 			name: "string",
-			attr: tfsdk.Attribute{
+			attr: testschema.Attribute{
 				Type:                types.StringType,
 				Optional:            true,
 				Description:         "A string attribute",
@@ -92,7 +92,7 @@ func TestSchemaAttribute(t *testing.T) {
 		},
 		"attr-string": {
 			name: "string",
-			attr: tfsdk.Attribute{
+			attr: testschema.Attribute{
 				Type:     types.StringType,
 				Optional: true,
 			},
@@ -105,7 +105,7 @@ func TestSchemaAttribute(t *testing.T) {
 		},
 		"attr-bool": {
 			name: "bool",
-			attr: tfsdk.Attribute{
+			attr: testschema.Attribute{
 				Type:     types.BoolType,
 				Optional: true,
 			},
@@ -118,7 +118,7 @@ func TestSchemaAttribute(t *testing.T) {
 		},
 		"attr-number": {
 			name: "number",
-			attr: tfsdk.Attribute{
+			attr: testschema.Attribute{
 				Type:     types.NumberType,
 				Optional: true,
 			},
@@ -131,7 +131,7 @@ func TestSchemaAttribute(t *testing.T) {
 		},
 		"attr-list": {
 			name: "list",
-			attr: tfsdk.Attribute{
+			attr: testschema.Attribute{
 				Type:     types.ListType{ElemType: types.NumberType},
 				Optional: true,
 			},
@@ -144,7 +144,7 @@ func TestSchemaAttribute(t *testing.T) {
 		},
 		"attr-map": {
 			name: "map",
-			attr: tfsdk.Attribute{
+			attr: testschema.Attribute{
 				Type:     types.MapType{ElemType: types.StringType},
 				Optional: true,
 			},
@@ -157,7 +157,7 @@ func TestSchemaAttribute(t *testing.T) {
 		},
 		"attr-object": {
 			name: "object",
-			attr: tfsdk.Attribute{
+			attr: testschema.Attribute{
 				Type: types.ObjectType{AttrTypes: map[string]attr.Type{
 					"foo": types.StringType,
 					"bar": types.NumberType,
@@ -178,7 +178,7 @@ func TestSchemaAttribute(t *testing.T) {
 		},
 		"attr-set": {
 			name: "set",
-			attr: tfsdk.Attribute{
+			attr: testschema.Attribute{
 				Type:     types.SetType{ElemType: types.NumberType},
 				Optional: true,
 			},
@@ -192,7 +192,7 @@ func TestSchemaAttribute(t *testing.T) {
 		// TODO: add tuple attribute when we support it
 		"required": {
 			name: "string",
-			attr: tfsdk.Attribute{
+			attr: testschema.Attribute{
 				Type:     types.StringType,
 				Required: true,
 			},
@@ -205,7 +205,7 @@ func TestSchemaAttribute(t *testing.T) {
 		},
 		"optional": {
 			name: "string",
-			attr: tfsdk.Attribute{
+			attr: testschema.Attribute{
 				Type:     types.StringType,
 				Optional: true,
 			},
@@ -218,7 +218,7 @@ func TestSchemaAttribute(t *testing.T) {
 		},
 		"computed": {
 			name: "string",
-			attr: tfsdk.Attribute{
+			attr: testschema.Attribute{
 				Type:     types.StringType,
 				Computed: true,
 			},
@@ -231,7 +231,7 @@ func TestSchemaAttribute(t *testing.T) {
 		},
 		"optional-computed": {
 			name: "string",
-			attr: tfsdk.Attribute{
+			attr: testschema.Attribute{
 				Type:     types.StringType,
 				Computed: true,
 				Optional: true,
@@ -246,7 +246,7 @@ func TestSchemaAttribute(t *testing.T) {
 		},
 		"sensitive": {
 			name: "string",
-			attr: tfsdk.Attribute{
+			attr: testschema.Attribute{
 				Type:      types.StringType,
 				Optional:  true,
 				Sensitive: true,
@@ -261,96 +261,103 @@ func TestSchemaAttribute(t *testing.T) {
 		},
 		"nested-attr-single": {
 			name: "single_nested",
-			attr: tfsdk.Attribute{
-				Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
-					"string": {
-						Type:     types.StringType,
-						Optional: true,
+			attr: testschema.NestedAttribute{
+				NestedObject: testschema.NestedAttributeObject{
+					Attributes: map[string]fwschema.Attribute{
+						"string": testschema.Attribute{
+							Type:     types.StringType,
+							Optional: true,
+						},
+						"computed": testschema.Attribute{
+							Type:      types.NumberType,
+							Computed:  true,
+							Sensitive: true,
+						},
 					},
-					"computed": {
-						Type:      types.NumberType,
-						Computed:  true,
-						Sensitive: true,
-					},
-				}),
-				Optional: true,
+				},
+				NestingMode: fwschema.NestingModeSingle,
+				Optional:    true,
 			},
 			path:        tftypes.NewAttributePath(),
 			expectedErr: "protocol version 5 cannot have Attributes set",
 		},
 		"nested-attr-list": {
 			name: "list_nested",
-			attr: tfsdk.Attribute{
-				Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
-					"string": {
-						Type:     types.StringType,
-						Optional: true,
+			attr: testschema.NestedAttribute{
+				NestedObject: testschema.NestedAttributeObject{
+					Attributes: map[string]fwschema.Attribute{
+						"string": testschema.Attribute{
+							Type:     types.StringType,
+							Optional: true,
+						},
+						"computed": testschema.Attribute{
+							Type:      types.NumberType,
+							Computed:  true,
+							Sensitive: true,
+						},
 					},
-					"computed": {
-						Type:      types.NumberType,
-						Computed:  true,
-						Sensitive: true,
+				},
+				NestingMode: fwschema.NestingModeList,
+				Optional:    true,
+			},
+			path:        tftypes.NewAttributePath(),
+			expectedErr: "protocol version 5 cannot have Attributes set",
+		},
+		"nested-attr-map": {
+			name: "map_nested",
+			attr: testschema.NestedAttribute{
+				NestedObject: testschema.NestedAttributeObject{
+					Attributes: map[string]fwschema.Attribute{
+						"string": testschema.Attribute{
+							Type:     types.StringType,
+							Optional: true,
+						},
+						"computed": testschema.Attribute{
+							Type:      types.NumberType,
+							Computed:  true,
+							Sensitive: true,
+						},
 					},
-				}),
-				Optional: true,
+				},
+				NestingMode: fwschema.NestingModeMap,
+				Optional:    true,
 			},
 			path:        tftypes.NewAttributePath(),
 			expectedErr: "protocol version 5 cannot have Attributes set",
 		},
 		"nested-attr-set": {
 			name: "set_nested",
-			attr: tfsdk.Attribute{
-				Attributes: tfsdk.SetNestedAttributes(map[string]tfsdk.Attribute{
-					"string": {
-						Type:     types.StringType,
-						Optional: true,
+			attr: testschema.NestedAttribute{
+				NestedObject: testschema.NestedAttributeObject{
+					Attributes: map[string]fwschema.Attribute{
+						"string": testschema.Attribute{
+							Type:     types.StringType,
+							Optional: true,
+						},
+						"computed": testschema.Attribute{
+							Type:      types.NumberType,
+							Computed:  true,
+							Sensitive: true,
+						},
 					},
-					"computed": {
-						Type:      types.NumberType,
-						Computed:  true,
-						Sensitive: true,
-					},
-				}),
-				Optional: true,
-			},
-			path:        tftypes.NewAttributePath(),
-			expectedErr: "protocol version 5 cannot have Attributes set",
-		},
-		"attr-and-nested-attr-set": {
-			name: "whoops",
-			attr: tfsdk.Attribute{
-				Type: types.StringType,
-				Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
-					"testing": {
-						Type:     types.StringType,
-						Optional: true,
-					},
-				}),
-				Optional: true,
+				},
+				NestingMode: fwschema.NestingModeSet,
+				Optional:    true,
 			},
 			path:        tftypes.NewAttributePath(),
 			expectedErr: "protocol version 5 cannot have Attributes set",
 		},
 		"attr-and-nested-attr-unset": {
 			name: "whoops",
-			attr: tfsdk.Attribute{
+			attr: testschema.Attribute{
 				Optional: true,
 			},
 			path:        tftypes.NewAttributePath(),
 			expectedErr: "must have Type set",
 		},
-		"attr-and-nested-attr-empty": {
-			name: "whoops",
-			attr: tfsdk.Attribute{
-				Optional:   true,
-				Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{}),
-			},
-			path:        tftypes.NewAttributePath(),
-			expectedErr: "protocol version 5 cannot have Attributes set",
-		},
 		"missing-required-optional-and-computed": {
 			name: "whoops",
-			attr: tfsdk.Attribute{
+			attr: testschema.Attribute{
 				Type: types.StringType,
 			},
 			path:        tftypes.NewAttributePath(),

--- a/internal/toproto5/state_test.go
+++ b/internal/toproto5/state_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/toproto5"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -34,9 +36,9 @@ func TestState(t *testing.T) {
 
 	testState := &tfsdk.State{
 		Raw: testProto5Value,
-		Schema: tfsdk.Schema{
-			Attributes: map[string]tfsdk.Attribute{
-				"test_attribute": {
+		Schema: testschema.Schema{
+			Attributes: map[string]fwschema.Attribute{
+				"test_attribute": testschema.Attribute{
 					Required: true,
 					Type:     types.StringType,
 				},
@@ -46,9 +48,9 @@ func TestState(t *testing.T) {
 
 	testStateInvalid := &tfsdk.State{
 		Raw: testProto5Value,
-		Schema: tfsdk.Schema{
-			Attributes: map[string]tfsdk.Attribute{
-				"test_attribute": {
+		Schema: testschema.Schema{
+			Attributes: map[string]fwschema.Attribute{
+				"test_attribute": testschema.Attribute{
 					Required: true,
 					Type:     types.BoolType,
 				},

--- a/internal/toproto5/upgraderesourcestate_test.go
+++ b/internal/toproto5/upgraderesourcestate_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
 	"github.com/hashicorp/terraform-plugin-framework/internal/toproto5"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
@@ -35,11 +35,10 @@ func TestUpgradeResourceStateResponse(t *testing.T) {
 
 	testState := &tfsdk.State{
 		Raw: testProto5Value,
-		Schema: tfsdk.Schema{
-			Attributes: map[string]tfsdk.Attribute{
-				"test_attribute": {
+		Schema: schema.Schema{
+			Attributes: map[string]schema.Attribute{
+				"test_attribute": schema.StringAttribute{
 					Required: true,
-					Type:     types.StringType,
 				},
 			},
 		},
@@ -47,11 +46,10 @@ func TestUpgradeResourceStateResponse(t *testing.T) {
 
 	testStateInvalid := &tfsdk.State{
 		Raw: testProto5Value,
-		Schema: tfsdk.Schema{
-			Attributes: map[string]tfsdk.Attribute{
-				"test_attribute": {
+		Schema: schema.Schema{
+			Attributes: map[string]schema.Attribute{
+				"test_attribute": schema.BoolAttribute{
 					Required: true,
-					Type:     types.BoolType,
 				},
 			},
 		},

--- a/internal/toproto6/applyresourcechange_test.go
+++ b/internal/toproto6/applyresourcechange_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
 	"github.com/hashicorp/terraform-plugin-framework/internal/privatestate"
 	"github.com/hashicorp/terraform-plugin-framework/internal/toproto6"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 func TestApplyResourceChangeResponse(t *testing.T) {
@@ -37,11 +37,10 @@ func TestApplyResourceChangeResponse(t *testing.T) {
 
 	testState := &tfsdk.State{
 		Raw: testProto6Value,
-		Schema: tfsdk.Schema{
-			Attributes: map[string]tfsdk.Attribute{
-				"test_attribute": {
+		Schema: schema.Schema{
+			Attributes: map[string]schema.Attribute{
+				"test_attribute": schema.StringAttribute{
 					Required: true,
-					Type:     types.StringType,
 				},
 			},
 		},
@@ -49,11 +48,10 @@ func TestApplyResourceChangeResponse(t *testing.T) {
 
 	testStateInvalid := &tfsdk.State{
 		Raw: testProto6Value,
-		Schema: tfsdk.Schema{
-			Attributes: map[string]tfsdk.Attribute{
-				"test_attribute": {
+		Schema: schema.Schema{
+			Attributes: map[string]schema.Attribute{
+				"test_attribute": schema.BoolAttribute{
 					Required: true,
-					Type:     types.BoolType,
 				},
 			},
 		},

--- a/internal/toproto6/block_test.go
+++ b/internal/toproto6/block_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/toproto6"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -27,11 +28,13 @@ func TestBlock(t *testing.T) {
 	tests := map[string]testCase{
 		"nestingmode-invalid": {
 			name: "test",
-			block: tfsdk.Block{
-				Attributes: map[string]tfsdk.Attribute{
-					"sub_test": {
-						Type:     types.StringType,
-						Optional: true,
+			block: testschema.Block{
+				NestedObject: testschema.NestedBlockObject{
+					Attributes: map[string]fwschema.Attribute{
+						"sub_test": testschema.Attribute{
+							Type:     types.StringType,
+							Optional: true,
+						},
 					},
 				},
 			},
@@ -40,11 +43,13 @@ func TestBlock(t *testing.T) {
 		},
 		"nestingmode-list-attributes": {
 			name: "test",
-			block: tfsdk.Block{
-				Attributes: map[string]tfsdk.Attribute{
-					"sub_test": {
-						Type:     types.StringType,
-						Optional: true,
+			block: testschema.Block{
+				NestedObject: testschema.NestedBlockObject{
+					Attributes: map[string]fwschema.Attribute{
+						"sub_test": testschema.Attribute{
+							Type:     types.StringType,
+							Optional: true,
+						},
 					},
 				},
 				NestingMode: tfsdk.BlockNestingModeList,
@@ -66,22 +71,26 @@ func TestBlock(t *testing.T) {
 		},
 		"nestingmode-list-attributes-and-blocks": {
 			name: "test",
-			block: tfsdk.Block{
-				Attributes: map[string]tfsdk.Attribute{
-					"sub_attr": {
-						Type:     types.StringType,
-						Optional: true,
-					},
-				},
-				Blocks: map[string]tfsdk.Block{
-					"sub_block": {
-						Attributes: map[string]tfsdk.Attribute{
-							"sub_block_attr": {
-								Type:     types.StringType,
-								Optional: true,
-							},
+			block: testschema.Block{
+				NestedObject: testschema.NestedBlockObject{
+					Attributes: map[string]fwschema.Attribute{
+						"sub_attr": testschema.Attribute{
+							Type:     types.StringType,
+							Optional: true,
 						},
-						NestingMode: tfsdk.BlockNestingModeList,
+					},
+					Blocks: map[string]fwschema.Block{
+						"sub_block": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"sub_block_attr": testschema.Attribute{
+										Type:     types.StringType,
+										Optional: true,
+									},
+								},
+							},
+							NestingMode: tfsdk.BlockNestingModeList,
+						},
 					},
 				},
 				NestingMode: tfsdk.BlockNestingModeList,
@@ -118,16 +127,20 @@ func TestBlock(t *testing.T) {
 		},
 		"nestingmode-list-blocks": {
 			name: "test",
-			block: tfsdk.Block{
-				Blocks: map[string]tfsdk.Block{
-					"sub_block": {
-						Attributes: map[string]tfsdk.Attribute{
-							"sub_block_attr": {
-								Type:     types.StringType,
-								Optional: true,
+			block: testschema.Block{
+				NestedObject: testschema.NestedBlockObject{
+					Blocks: map[string]fwschema.Block{
+						"sub_block": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"sub_block_attr": testschema.Attribute{
+										Type:     types.StringType,
+										Optional: true,
+									},
+								},
 							},
+							NestingMode: tfsdk.BlockNestingModeList,
 						},
-						NestingMode: tfsdk.BlockNestingModeList,
 					},
 				},
 				NestingMode: tfsdk.BlockNestingModeList,
@@ -157,11 +170,13 @@ func TestBlock(t *testing.T) {
 		},
 		"nestingmode-set-attributes": {
 			name: "test",
-			block: tfsdk.Block{
-				Attributes: map[string]tfsdk.Attribute{
-					"sub_test": {
-						Type:     types.StringType,
-						Optional: true,
+			block: testschema.Block{
+				NestedObject: testschema.NestedBlockObject{
+					Attributes: map[string]fwschema.Attribute{
+						"sub_test": testschema.Attribute{
+							Type:     types.StringType,
+							Optional: true,
+						},
 					},
 				},
 				NestingMode: tfsdk.BlockNestingModeSet,
@@ -183,22 +198,26 @@ func TestBlock(t *testing.T) {
 		},
 		"nestingmode-set-attributes-and-blocks": {
 			name: "test",
-			block: tfsdk.Block{
-				Attributes: map[string]tfsdk.Attribute{
-					"sub_attr": {
-						Type:     types.StringType,
-						Optional: true,
-					},
-				},
-				Blocks: map[string]tfsdk.Block{
-					"sub_block": {
-						Attributes: map[string]tfsdk.Attribute{
-							"sub_block_attr": {
-								Type:     types.StringType,
-								Optional: true,
-							},
+			block: testschema.Block{
+				NestedObject: testschema.NestedBlockObject{
+					Attributes: map[string]fwschema.Attribute{
+						"sub_attr": testschema.Attribute{
+							Type:     types.StringType,
+							Optional: true,
 						},
-						NestingMode: tfsdk.BlockNestingModeSet,
+					},
+					Blocks: map[string]fwschema.Block{
+						"sub_block": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"sub_block_attr": testschema.Attribute{
+										Type:     types.StringType,
+										Optional: true,
+									},
+								},
+							},
+							NestingMode: tfsdk.BlockNestingModeSet,
+						},
 					},
 				},
 				NestingMode: tfsdk.BlockNestingModeSet,
@@ -235,16 +254,20 @@ func TestBlock(t *testing.T) {
 		},
 		"nestingmode-set-blocks": {
 			name: "test",
-			block: tfsdk.Block{
-				Blocks: map[string]tfsdk.Block{
-					"sub_block": {
-						Attributes: map[string]tfsdk.Attribute{
-							"sub_block_attr": {
-								Type:     types.StringType,
-								Optional: true,
+			block: testschema.Block{
+				NestedObject: testschema.NestedBlockObject{
+					Blocks: map[string]fwschema.Block{
+						"sub_block": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"sub_block_attr": testschema.Attribute{
+										Type:     types.StringType,
+										Optional: true,
+									},
+								},
 							},
+							NestingMode: tfsdk.BlockNestingModeSet,
 						},
-						NestingMode: tfsdk.BlockNestingModeSet,
 					},
 				},
 				NestingMode: tfsdk.BlockNestingModeSet,
@@ -274,11 +297,13 @@ func TestBlock(t *testing.T) {
 		},
 		"nestingmode-single-attributes": {
 			name: "test",
-			block: tfsdk.Block{
-				Attributes: map[string]tfsdk.Attribute{
-					"sub_test": {
-						Type:     types.StringType,
-						Optional: true,
+			block: testschema.Block{
+				NestedObject: testschema.NestedBlockObject{
+					Attributes: map[string]fwschema.Attribute{
+						"sub_test": testschema.Attribute{
+							Type:     types.StringType,
+							Optional: true,
+						},
 					},
 				},
 				NestingMode: tfsdk.BlockNestingModeSingle,
@@ -300,22 +325,26 @@ func TestBlock(t *testing.T) {
 		},
 		"nestingmode-single-attributes-and-blocks": {
 			name: "test",
-			block: tfsdk.Block{
-				Attributes: map[string]tfsdk.Attribute{
-					"sub_attr": {
-						Type:     types.StringType,
-						Optional: true,
-					},
-				},
-				Blocks: map[string]tfsdk.Block{
-					"sub_block": {
-						Attributes: map[string]tfsdk.Attribute{
-							"sub_block_attr": {
-								Type:     types.StringType,
-								Optional: true,
-							},
+			block: testschema.Block{
+				NestedObject: testschema.NestedBlockObject{
+					Attributes: map[string]fwschema.Attribute{
+						"sub_attr": testschema.Attribute{
+							Type:     types.StringType,
+							Optional: true,
 						},
-						NestingMode: tfsdk.BlockNestingModeSingle,
+					},
+					Blocks: map[string]fwschema.Block{
+						"sub_block": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"sub_block_attr": testschema.Attribute{
+										Type:     types.StringType,
+										Optional: true,
+									},
+								},
+							},
+							NestingMode: tfsdk.BlockNestingModeSingle,
+						},
 					},
 				},
 				NestingMode: tfsdk.BlockNestingModeSingle,
@@ -352,16 +381,20 @@ func TestBlock(t *testing.T) {
 		},
 		"nestingmode-single-blocks": {
 			name: "test",
-			block: tfsdk.Block{
-				Blocks: map[string]tfsdk.Block{
-					"sub_block": {
-						Attributes: map[string]tfsdk.Attribute{
-							"sub_block_attr": {
-								Type:     types.StringType,
-								Optional: true,
+			block: testschema.Block{
+				NestedObject: testschema.NestedBlockObject{
+					Blocks: map[string]fwschema.Block{
+						"sub_block": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"sub_block_attr": testschema.Attribute{
+										Type:     types.StringType,
+										Optional: true,
+									},
+								},
 							},
+							NestingMode: tfsdk.BlockNestingModeSingle,
 						},
-						NestingMode: tfsdk.BlockNestingModeSingle,
 					},
 				},
 				NestingMode: tfsdk.BlockNestingModeSingle,
@@ -391,11 +424,13 @@ func TestBlock(t *testing.T) {
 		},
 		"deprecationmessage": {
 			name: "test",
-			block: tfsdk.Block{
-				Attributes: map[string]tfsdk.Attribute{
-					"sub_test": {
-						Type:     types.StringType,
-						Optional: true,
+			block: testschema.Block{
+				NestedObject: testschema.NestedBlockObject{
+					Attributes: map[string]fwschema.Attribute{
+						"sub_test": testschema.Attribute{
+							Type:     types.StringType,
+							Optional: true,
+						},
 					},
 				},
 				DeprecationMessage: "deprecated, use something else instead",
@@ -419,11 +454,13 @@ func TestBlock(t *testing.T) {
 		},
 		"description": {
 			name: "test",
-			block: tfsdk.Block{
-				Attributes: map[string]tfsdk.Attribute{
-					"sub_test": {
-						Type:     types.StringType,
-						Optional: true,
+			block: testschema.Block{
+				NestedObject: testschema.NestedBlockObject{
+					Attributes: map[string]fwschema.Attribute{
+						"sub_test": testschema.Attribute{
+							Type:     types.StringType,
+							Optional: true,
+						},
 					},
 				},
 				Description: "test description",
@@ -448,11 +485,13 @@ func TestBlock(t *testing.T) {
 		},
 		"description-and-markdowndescription": {
 			name: "test",
-			block: tfsdk.Block{
-				Attributes: map[string]tfsdk.Attribute{
-					"sub_test": {
-						Type:     types.StringType,
-						Optional: true,
+			block: testschema.Block{
+				NestedObject: testschema.NestedBlockObject{
+					Attributes: map[string]fwschema.Attribute{
+						"sub_test": testschema.Attribute{
+							Type:     types.StringType,
+							Optional: true,
+						},
 					},
 				},
 				Description:         "test plain description",
@@ -478,11 +517,13 @@ func TestBlock(t *testing.T) {
 		},
 		"markdowndescription": {
 			name: "test",
-			block: tfsdk.Block{
-				Attributes: map[string]tfsdk.Attribute{
-					"sub_test": {
-						Type:     types.StringType,
-						Optional: true,
+			block: testschema.Block{
+				NestedObject: testschema.NestedBlockObject{
+					Attributes: map[string]fwschema.Attribute{
+						"sub_test": testschema.Attribute{
+							Type:     types.StringType,
+							Optional: true,
+						},
 					},
 				},
 				MarkdownDescription: "test description",
@@ -507,11 +548,13 @@ func TestBlock(t *testing.T) {
 		},
 		"maxitems": {
 			name: "test",
-			block: tfsdk.Block{
-				Attributes: map[string]tfsdk.Attribute{
-					"sub_test": {
-						Type:     types.StringType,
-						Optional: true,
+			block: testschema.Block{
+				NestedObject: testschema.NestedBlockObject{
+					Attributes: map[string]fwschema.Attribute{
+						"sub_test": testschema.Attribute{
+							Type:     types.StringType,
+							Optional: true,
+						},
 					},
 				},
 				MaxItems:    10,
@@ -535,11 +578,13 @@ func TestBlock(t *testing.T) {
 		},
 		"minitems": {
 			name: "test",
-			block: tfsdk.Block{
-				Attributes: map[string]tfsdk.Attribute{
-					"sub_test": {
-						Type:     types.StringType,
-						Optional: true,
+			block: testschema.Block{
+				NestedObject: testschema.NestedBlockObject{
+					Attributes: map[string]fwschema.Attribute{
+						"sub_test": testschema.Attribute{
+							Type:     types.StringType,
+							Optional: true,
+						},
 					},
 				},
 				MinItems:    10,

--- a/internal/toproto6/config_test.go
+++ b/internal/toproto6/config_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/toproto6"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -34,9 +36,9 @@ func TestConfig(t *testing.T) {
 
 	testConfig := &tfsdk.Config{
 		Raw: testProto6Value,
-		Schema: tfsdk.Schema{
-			Attributes: map[string]tfsdk.Attribute{
-				"test_attribute": {
+		Schema: testschema.Schema{
+			Attributes: map[string]fwschema.Attribute{
+				"test_attribute": testschema.Attribute{
 					Required: true,
 					Type:     types.StringType,
 				},
@@ -46,9 +48,9 @@ func TestConfig(t *testing.T) {
 
 	testConfigInvalid := &tfsdk.Config{
 		Raw: testProto6Value,
-		Schema: tfsdk.Schema{
-			Attributes: map[string]tfsdk.Attribute{
-				"test_attribute": {
+		Schema: testschema.Schema{
+			Attributes: map[string]fwschema.Attribute{
+				"test_attribute": testschema.Attribute{
 					Required: true,
 					Type:     types.BoolType,
 				},

--- a/internal/toproto6/getproviderschema_test.go
+++ b/internal/toproto6/getproviderschema_test.go
@@ -6,10 +6,13 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	datasourceschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
 	"github.com/hashicorp/terraform-plugin-framework/internal/toproto6"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/provider/metaschema"
+	providerschema "github.com/hashicorp/terraform-plugin-framework/provider/schema"
+	resourceschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
@@ -33,19 +36,17 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"data-source-multiple-data-sources": {
 			input: &fwserver.GetProviderSchemaResponse{
 				DataSourceSchemas: map[string]fwschema.Schema{
-					"test_data_source_1": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_data_source_1": datasourceschema.Schema{
+						Attributes: map[string]datasourceschema.Attribute{
+							"test_attribute": datasourceschema.BoolAttribute{
 								Computed: true,
-								Type:     types.BoolType,
 							},
 						},
 					},
-					"test_data_source_2": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_data_source_2": datasourceschema.Schema{
+						Attributes: map[string]datasourceschema.Attribute{
+							"test_attribute": datasourceschema.BoolAttribute{
 								Computed: true,
-								Type:     types.BoolType,
 							},
 						},
 					},
@@ -82,11 +83,10 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"data-source-attribute-computed": {
 			input: &fwserver.GetProviderSchemaResponse{
 				DataSourceSchemas: map[string]fwschema.Schema{
-					"test_data_source": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_data_source": datasourceschema.Schema{
+						Attributes: map[string]datasourceschema.Attribute{
+							"test_attribute": datasourceschema.BoolAttribute{
 								Computed: true,
-								Type:     types.BoolType,
 							},
 						},
 					},
@@ -112,12 +112,11 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"data-source-attribute-deprecated": {
 			input: &fwserver.GetProviderSchemaResponse{
 				DataSourceSchemas: map[string]fwschema.Schema{
-					"test_data_source": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_data_source": datasourceschema.Schema{
+						Attributes: map[string]datasourceschema.Attribute{
+							"test_attribute": datasourceschema.BoolAttribute{
 								DeprecationMessage: "deprecated",
 								Optional:           true,
-								Type:               types.BoolType,
 							},
 						},
 					},
@@ -144,11 +143,10 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"data-source-attribute-optional": {
 			input: &fwserver.GetProviderSchemaResponse{
 				DataSourceSchemas: map[string]fwschema.Schema{
-					"test_data_source": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_data_source": datasourceschema.Schema{
+						Attributes: map[string]datasourceschema.Attribute{
+							"test_attribute": datasourceschema.BoolAttribute{
 								Optional: true,
-								Type:     types.BoolType,
 							},
 						},
 					},
@@ -174,12 +172,11 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"data-source-attribute-optional-computed": {
 			input: &fwserver.GetProviderSchemaResponse{
 				DataSourceSchemas: map[string]fwschema.Schema{
-					"test_data_source": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_data_source": datasourceschema.Schema{
+						Attributes: map[string]datasourceschema.Attribute{
+							"test_attribute": datasourceschema.BoolAttribute{
 								Computed: true,
 								Optional: true,
-								Type:     types.BoolType,
 							},
 						},
 					},
@@ -206,11 +203,10 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"data-source-attribute-required": {
 			input: &fwserver.GetProviderSchemaResponse{
 				DataSourceSchemas: map[string]fwschema.Schema{
-					"test_data_source": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_data_source": datasourceschema.Schema{
+						Attributes: map[string]datasourceschema.Attribute{
+							"test_attribute": datasourceschema.BoolAttribute{
 								Required: true,
-								Type:     types.BoolType,
 							},
 						},
 					},
@@ -236,12 +232,11 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"data-source-attribute-sensitive": {
 			input: &fwserver.GetProviderSchemaResponse{
 				DataSourceSchemas: map[string]fwschema.Schema{
-					"test_data_source": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_data_source": datasourceschema.Schema{
+						Attributes: map[string]datasourceschema.Attribute{
+							"test_attribute": datasourceschema.BoolAttribute{
 								Computed:  true,
 								Sensitive: true,
-								Type:      types.BoolType,
 							},
 						},
 					},
@@ -268,11 +263,10 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"data-source-attribute-type-bool": {
 			input: &fwserver.GetProviderSchemaResponse{
 				DataSourceSchemas: map[string]fwschema.Schema{
-					"test_data_source": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_data_source": datasourceschema.Schema{
+						Attributes: map[string]datasourceschema.Attribute{
+							"test_attribute": datasourceschema.BoolAttribute{
 								Required: true,
-								Type:     types.BoolType,
 							},
 						},
 					},
@@ -298,11 +292,10 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"data-source-attribute-type-float64": {
 			input: &fwserver.GetProviderSchemaResponse{
 				DataSourceSchemas: map[string]fwschema.Schema{
-					"test_data_source": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_data_source": datasourceschema.Schema{
+						Attributes: map[string]datasourceschema.Attribute{
+							"test_attribute": datasourceschema.Float64Attribute{
 								Required: true,
-								Type:     types.Float64Type,
 							},
 						},
 					},
@@ -328,11 +321,10 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"data-source-attribute-type-int64": {
 			input: &fwserver.GetProviderSchemaResponse{
 				DataSourceSchemas: map[string]fwschema.Schema{
-					"test_data_source": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_data_source": datasourceschema.Schema{
+						Attributes: map[string]datasourceschema.Attribute{
+							"test_attribute": datasourceschema.Int64Attribute{
 								Required: true,
-								Type:     types.Int64Type,
 							},
 						},
 					},
@@ -358,14 +350,12 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"data-source-attribute-type-list-list-string": {
 			input: &fwserver.GetProviderSchemaResponse{
 				DataSourceSchemas: map[string]fwschema.Schema{
-					"test_data_source": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_data_source": datasourceschema.Schema{
+						Attributes: map[string]datasourceschema.Attribute{
+							"test_attribute": datasourceschema.ListAttribute{
 								Required: true,
-								Type: types.ListType{
-									ElemType: types.ListType{
-										ElemType: types.StringType,
-									},
+								ElementType: types.ListType{
+									ElemType: types.StringType,
 								},
 							},
 						},
@@ -396,15 +386,16 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"data-source-attribute-type-list-nested-attributes": {
 			input: &fwserver.GetProviderSchemaResponse{
 				DataSourceSchemas: map[string]fwschema.Schema{
-					"test_data_source": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
-								Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
-									"test_nested_attribute": {
-										Type:     types.StringType,
-										Required: true,
+					"test_data_source": datasourceschema.Schema{
+						Attributes: map[string]datasourceschema.Attribute{
+							"test_attribute": datasourceschema.ListNestedAttribute{
+								NestedObject: datasourceschema.NestedAttributeObject{
+									Attributes: map[string]datasourceschema.Attribute{
+										"test_nested_attribute": datasourceschema.StringAttribute{
+											Required: true,
+										},
 									},
-								}),
+								},
 								Required: true,
 							},
 						},
@@ -440,15 +431,13 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"data-source-attribute-type-list-object": {
 			input: &fwserver.GetProviderSchemaResponse{
 				DataSourceSchemas: map[string]fwschema.Schema{
-					"test_data_source": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_data_source": datasourceschema.Schema{
+						Attributes: map[string]datasourceschema.Attribute{
+							"test_attribute": datasourceschema.ListAttribute{
 								Required: true,
-								Type: types.ListType{
-									ElemType: types.ObjectType{
-										AttrTypes: map[string]attr.Type{
-											"test_object_attribute": types.StringType,
-										},
+								ElementType: types.ObjectType{
+									AttrTypes: map[string]attr.Type{
+										"test_object_attribute": types.StringType,
 									},
 								},
 							},
@@ -482,13 +471,11 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"data-source-attribute-type-list-string": {
 			input: &fwserver.GetProviderSchemaResponse{
 				DataSourceSchemas: map[string]fwschema.Schema{
-					"test_data_source": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
-								Required: true,
-								Type: types.ListType{
-									ElemType: types.StringType,
-								},
+					"test_data_source": datasourceschema.Schema{
+						Attributes: map[string]datasourceschema.Attribute{
+							"test_attribute": datasourceschema.ListAttribute{
+								Required:    true,
+								ElementType: types.StringType,
 							},
 						},
 					},
@@ -516,15 +503,16 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"data-source-attribute-type-map-nested-attributes": {
 			input: &fwserver.GetProviderSchemaResponse{
 				DataSourceSchemas: map[string]fwschema.Schema{
-					"test_data_source": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
-								Attributes: tfsdk.MapNestedAttributes(map[string]tfsdk.Attribute{
-									"test_nested_attribute": {
-										Type:     types.StringType,
-										Required: true,
+					"test_data_source": datasourceschema.Schema{
+						Attributes: map[string]datasourceschema.Attribute{
+							"test_attribute": datasourceschema.MapNestedAttribute{
+								NestedObject: datasourceschema.NestedAttributeObject{
+									Attributes: map[string]datasourceschema.Attribute{
+										"test_nested_attribute": datasourceschema.StringAttribute{
+											Required: true,
+										},
 									},
-								}),
+								},
 								Required: true,
 							},
 						},
@@ -560,13 +548,11 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"data-source-attribute-type-map-string": {
 			input: &fwserver.GetProviderSchemaResponse{
 				DataSourceSchemas: map[string]fwschema.Schema{
-					"test_data_source": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
-								Required: true,
-								Type: types.MapType{
-									ElemType: types.StringType,
-								},
+					"test_data_source": datasourceschema.Schema{
+						Attributes: map[string]datasourceschema.Attribute{
+							"test_attribute": datasourceschema.MapAttribute{
+								Required:    true,
+								ElementType: types.StringType,
 							},
 						},
 					},
@@ -594,11 +580,10 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"data-source-attribute-type-number": {
 			input: &fwserver.GetProviderSchemaResponse{
 				DataSourceSchemas: map[string]fwschema.Schema{
-					"test_data_source": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_data_source": datasourceschema.Schema{
+						Attributes: map[string]datasourceschema.Attribute{
+							"test_attribute": datasourceschema.NumberAttribute{
 								Required: true,
-								Type:     types.NumberType,
 							},
 						},
 					},
@@ -624,14 +609,12 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"data-source-attribute-type-object": {
 			input: &fwserver.GetProviderSchemaResponse{
 				DataSourceSchemas: map[string]fwschema.Schema{
-					"test_data_source": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_data_source": datasourceschema.Schema{
+						Attributes: map[string]datasourceschema.Attribute{
+							"test_attribute": datasourceschema.ObjectAttribute{
 								Required: true,
-								Type: types.ObjectType{
-									AttrTypes: map[string]attr.Type{
-										"test_object_attribute": types.StringType,
-									},
+								AttributeTypes: map[string]attr.Type{
+									"test_object_attribute": types.StringType,
 								},
 							},
 						},
@@ -662,15 +645,16 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"data-source-attribute-type-set-nested-attributes": {
 			input: &fwserver.GetProviderSchemaResponse{
 				DataSourceSchemas: map[string]fwschema.Schema{
-					"test_data_source": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
-								Attributes: tfsdk.SetNestedAttributes(map[string]tfsdk.Attribute{
-									"test_nested_attribute": {
-										Type:     types.StringType,
-										Required: true,
+					"test_data_source": datasourceschema.Schema{
+						Attributes: map[string]datasourceschema.Attribute{
+							"test_attribute": datasourceschema.SetNestedAttribute{
+								NestedObject: datasourceschema.NestedAttributeObject{
+									Attributes: map[string]datasourceschema.Attribute{
+										"test_nested_attribute": datasourceschema.StringAttribute{
+											Required: true,
+										},
 									},
-								}),
+								},
 								Required: true,
 							},
 						},
@@ -706,15 +690,13 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"data-source-attribute-type-set-object": {
 			input: &fwserver.GetProviderSchemaResponse{
 				DataSourceSchemas: map[string]fwschema.Schema{
-					"test_data_source": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_data_source": datasourceschema.Schema{
+						Attributes: map[string]datasourceschema.Attribute{
+							"test_attribute": datasourceschema.SetAttribute{
 								Required: true,
-								Type: types.SetType{
-									ElemType: types.ObjectType{
-										AttrTypes: map[string]attr.Type{
-											"test_object_attribute": types.StringType,
-										},
+								ElementType: types.ObjectType{
+									AttrTypes: map[string]attr.Type{
+										"test_object_attribute": types.StringType,
 									},
 								},
 							},
@@ -748,14 +730,12 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"data-source-attribute-type-set-set-string": {
 			input: &fwserver.GetProviderSchemaResponse{
 				DataSourceSchemas: map[string]fwschema.Schema{
-					"test_data_source": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_data_source": datasourceschema.Schema{
+						Attributes: map[string]datasourceschema.Attribute{
+							"test_attribute": datasourceschema.SetAttribute{
 								Required: true,
-								Type: types.SetType{
-									ElemType: types.SetType{
-										ElemType: types.StringType,
-									},
+								ElementType: types.SetType{
+									ElemType: types.StringType,
 								},
 							},
 						},
@@ -786,13 +766,11 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"data-source-attribute-type-set-string": {
 			input: &fwserver.GetProviderSchemaResponse{
 				DataSourceSchemas: map[string]fwschema.Schema{
-					"test_data_source": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
-								Required: true,
-								Type: types.SetType{
-									ElemType: types.StringType,
-								},
+					"test_data_source": datasourceschema.Schema{
+						Attributes: map[string]datasourceschema.Attribute{
+							"test_attribute": datasourceschema.SetAttribute{
+								Required:    true,
+								ElementType: types.StringType,
 							},
 						},
 					},
@@ -820,15 +798,14 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"data-source-attribute-type-single-nested-attributes": {
 			input: &fwserver.GetProviderSchemaResponse{
 				DataSourceSchemas: map[string]fwschema.Schema{
-					"test_data_source": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
-								Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
-									"test_nested_attribute": {
-										Type:     types.StringType,
+					"test_data_source": datasourceschema.Schema{
+						Attributes: map[string]datasourceschema.Attribute{
+							"test_attribute": datasourceschema.SingleNestedAttribute{
+								Attributes: map[string]datasourceschema.Attribute{
+									"test_nested_attribute": datasourceschema.StringAttribute{
 										Required: true,
 									},
-								}),
+								},
 								Required: true,
 							},
 						},
@@ -864,11 +841,10 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"data-source-attribute-type-string": {
 			input: &fwserver.GetProviderSchemaResponse{
 				DataSourceSchemas: map[string]fwschema.Schema{
-					"test_data_source": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_data_source": datasourceschema.Schema{
+						Attributes: map[string]datasourceschema.Attribute{
+							"test_attribute": datasourceschema.StringAttribute{
 								Required: true,
-								Type:     types.StringType,
 							},
 						},
 					},
@@ -894,16 +870,16 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"data-source-block-list": {
 			input: &fwserver.GetProviderSchemaResponse{
 				DataSourceSchemas: map[string]fwschema.Schema{
-					"test_data_source": &tfsdk.Schema{
-						Blocks: map[string]tfsdk.Block{
-							"test_block": {
-								Attributes: map[string]tfsdk.Attribute{
-									"test_attribute": {
-										Type:     types.StringType,
-										Required: true,
+					"test_data_source": datasourceschema.Schema{
+						Blocks: map[string]datasourceschema.Block{
+							"test_block": datasourceschema.ListNestedBlock{
+								NestedObject: datasourceschema.NestedBlockObject{
+									Attributes: map[string]datasourceschema.Attribute{
+										"test_attribute": datasourceschema.StringAttribute{
+											Required: true,
+										},
 									},
 								},
-								NestingMode: tfsdk.BlockNestingModeList,
 							},
 						},
 					},
@@ -937,16 +913,16 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"data-source-block-set": {
 			input: &fwserver.GetProviderSchemaResponse{
 				DataSourceSchemas: map[string]fwschema.Schema{
-					"test_data_source": &tfsdk.Schema{
-						Blocks: map[string]tfsdk.Block{
-							"test_block": {
-								Attributes: map[string]tfsdk.Attribute{
-									"test_attribute": {
-										Type:     types.StringType,
-										Required: true,
+					"test_data_source": datasourceschema.Schema{
+						Blocks: map[string]datasourceschema.Block{
+							"test_block": datasourceschema.SetNestedBlock{
+								NestedObject: datasourceschema.NestedBlockObject{
+									Attributes: map[string]datasourceschema.Attribute{
+										"test_attribute": datasourceschema.StringAttribute{
+											Required: true,
+										},
 									},
 								},
-								NestingMode: tfsdk.BlockNestingModeSet,
 							},
 						},
 					},
@@ -980,16 +956,14 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"data-source-block-single": {
 			input: &fwserver.GetProviderSchemaResponse{
 				DataSourceSchemas: map[string]fwschema.Schema{
-					"test_data_source": &tfsdk.Schema{
-						Blocks: map[string]tfsdk.Block{
-							"test_block": {
-								Attributes: map[string]tfsdk.Attribute{
-									"test_attribute": {
-										Type:     types.StringType,
+					"test_data_source": datasourceschema.Schema{
+						Blocks: map[string]datasourceschema.Block{
+							"test_block": datasourceschema.SingleNestedBlock{
+								Attributes: map[string]datasourceschema.Attribute{
+									"test_attribute": datasourceschema.StringAttribute{
 										Required: true,
 									},
 								},
-								NestingMode: tfsdk.BlockNestingModeSingle,
 							},
 						},
 					},
@@ -1020,59 +994,13 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				ResourceSchemas: map[string]*tfprotov6.Schema{},
 			},
 		},
-		"data-source-version": {
-			input: &fwserver.GetProviderSchemaResponse{
-				DataSourceSchemas: map[string]fwschema.Schema{
-					"test_data_source": &tfsdk.Schema{
-						Version: 123,
-					},
-				},
-			},
-			expected: &tfprotov6.GetProviderSchemaResponse{
-				DataSourceSchemas: map[string]*tfprotov6.Schema{
-					"test_data_source": {
-						Block:   &tfprotov6.SchemaBlock{},
-						Version: 123,
-					},
-				},
-				ResourceSchemas: map[string]*tfprotov6.Schema{},
-			},
-		},
-		"provider-attribute-computed": {
-			input: &fwserver.GetProviderSchemaResponse{
-				Provider: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
-							Computed: true,
-							Type:     types.BoolType,
-						},
-					},
-				},
-			},
-			expected: &tfprotov6.GetProviderSchemaResponse{
-				DataSourceSchemas: map[string]*tfprotov6.Schema{},
-				Provider: &tfprotov6.Schema{
-					Block: &tfprotov6.SchemaBlock{
-						Attributes: []*tfprotov6.SchemaAttribute{
-							{
-								Computed: true,
-								Name:     "test_attribute",
-								Type:     tftypes.Bool,
-							},
-						},
-					},
-				},
-				ResourceSchemas: map[string]*tfprotov6.Schema{},
-			},
-		},
 		"provider-attribute-deprecated": {
 			input: &fwserver.GetProviderSchemaResponse{
-				Provider: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
+				Provider: providerschema.Schema{
+					Attributes: map[string]providerschema.Attribute{
+						"test_attribute": providerschema.BoolAttribute{
 							DeprecationMessage: "deprecated",
 							Optional:           true,
-							Type:               types.BoolType,
 						},
 					},
 				},
@@ -1096,11 +1024,10 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-attribute-optional": {
 			input: &fwserver.GetProviderSchemaResponse{
-				Provider: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
+				Provider: providerschema.Schema{
+					Attributes: map[string]providerschema.Attribute{
+						"test_attribute": providerschema.BoolAttribute{
 							Optional: true,
-							Type:     types.BoolType,
 						},
 					},
 				},
@@ -1111,35 +1038,6 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 					Block: &tfprotov6.SchemaBlock{
 						Attributes: []*tfprotov6.SchemaAttribute{
 							{
-								Name:     "test_attribute",
-								Optional: true,
-								Type:     tftypes.Bool,
-							},
-						},
-					},
-				},
-				ResourceSchemas: map[string]*tfprotov6.Schema{},
-			},
-		},
-		"provider-attribute-optional-computed": {
-			input: &fwserver.GetProviderSchemaResponse{
-				Provider: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
-							Computed: true,
-							Optional: true,
-							Type:     types.BoolType,
-						},
-					},
-				},
-			},
-			expected: &tfprotov6.GetProviderSchemaResponse{
-				DataSourceSchemas: map[string]*tfprotov6.Schema{},
-				Provider: &tfprotov6.Schema{
-					Block: &tfprotov6.SchemaBlock{
-						Attributes: []*tfprotov6.SchemaAttribute{
-							{
-								Computed: true,
 								Name:     "test_attribute",
 								Optional: true,
 								Type:     tftypes.Bool,
@@ -1152,11 +1050,10 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-attribute-required": {
 			input: &fwserver.GetProviderSchemaResponse{
-				Provider: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
+				Provider: providerschema.Schema{
+					Attributes: map[string]providerschema.Attribute{
+						"test_attribute": providerschema.BoolAttribute{
 							Required: true,
-							Type:     types.BoolType,
 						},
 					},
 				},
@@ -1179,12 +1076,11 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-attribute-sensitive": {
 			input: &fwserver.GetProviderSchemaResponse{
-				Provider: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
-							Computed:  true,
+				Provider: providerschema.Schema{
+					Attributes: map[string]providerschema.Attribute{
+						"test_attribute": providerschema.BoolAttribute{
+							Optional:  true,
 							Sensitive: true,
-							Type:      types.BoolType,
 						},
 					},
 				},
@@ -1195,8 +1091,8 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 					Block: &tfprotov6.SchemaBlock{
 						Attributes: []*tfprotov6.SchemaAttribute{
 							{
-								Computed:  true,
 								Name:      "test_attribute",
+								Optional:  true,
 								Sensitive: true,
 								Type:      tftypes.Bool,
 							},
@@ -1208,11 +1104,10 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-attribute-type-bool": {
 			input: &fwserver.GetProviderSchemaResponse{
-				Provider: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
+				Provider: providerschema.Schema{
+					Attributes: map[string]providerschema.Attribute{
+						"test_attribute": providerschema.BoolAttribute{
 							Required: true,
-							Type:     types.BoolType,
 						},
 					},
 				},
@@ -1235,11 +1130,10 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-attribute-type-float64": {
 			input: &fwserver.GetProviderSchemaResponse{
-				Provider: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
+				Provider: providerschema.Schema{
+					Attributes: map[string]providerschema.Attribute{
+						"test_attribute": providerschema.Float64Attribute{
 							Required: true,
-							Type:     types.Float64Type,
 						},
 					},
 				},
@@ -1262,11 +1156,10 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-attribute-type-int64": {
 			input: &fwserver.GetProviderSchemaResponse{
-				Provider: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
+				Provider: providerschema.Schema{
+					Attributes: map[string]providerschema.Attribute{
+						"test_attribute": providerschema.Int64Attribute{
 							Required: true,
-							Type:     types.Int64Type,
 						},
 					},
 				},
@@ -1289,14 +1182,12 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-attribute-type-list-list-string": {
 			input: &fwserver.GetProviderSchemaResponse{
-				Provider: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
+				Provider: providerschema.Schema{
+					Attributes: map[string]providerschema.Attribute{
+						"test_attribute": providerschema.ListAttribute{
 							Required: true,
-							Type: types.ListType{
-								ElemType: types.ListType{
-									ElemType: types.StringType,
-								},
+							ElementType: types.ListType{
+								ElemType: types.StringType,
 							},
 						},
 					},
@@ -1324,15 +1215,16 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-attribute-type-list-nested-attributes": {
 			input: &fwserver.GetProviderSchemaResponse{
-				Provider: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
-							Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
-								"test_nested_attribute": {
-									Type:     types.StringType,
-									Required: true,
+				Provider: providerschema.Schema{
+					Attributes: map[string]providerschema.Attribute{
+						"test_attribute": providerschema.ListNestedAttribute{
+							NestedObject: providerschema.NestedAttributeObject{
+								Attributes: map[string]providerschema.Attribute{
+									"test_nested_attribute": providerschema.StringAttribute{
+										Required: true,
+									},
 								},
-							}),
+							},
 							Required: true,
 						},
 					},
@@ -1365,15 +1257,13 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-attribute-type-list-object": {
 			input: &fwserver.GetProviderSchemaResponse{
-				Provider: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
+				Provider: providerschema.Schema{
+					Attributes: map[string]providerschema.Attribute{
+						"test_attribute": providerschema.ListAttribute{
 							Required: true,
-							Type: types.ListType{
-								ElemType: types.ObjectType{
-									AttrTypes: map[string]attr.Type{
-										"test_object_attribute": types.StringType,
-									},
+							ElementType: types.ObjectType{
+								AttrTypes: map[string]attr.Type{
+									"test_object_attribute": types.StringType,
 								},
 							},
 						},
@@ -1404,13 +1294,11 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-attribute-type-list-string": {
 			input: &fwserver.GetProviderSchemaResponse{
-				Provider: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
-							Required: true,
-							Type: types.ListType{
-								ElemType: types.StringType,
-							},
+				Provider: providerschema.Schema{
+					Attributes: map[string]providerschema.Attribute{
+						"test_attribute": providerschema.ListAttribute{
+							Required:    true,
+							ElementType: types.StringType,
 						},
 					},
 				},
@@ -1435,15 +1323,16 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-attribute-type-map-nested-attributes": {
 			input: &fwserver.GetProviderSchemaResponse{
-				Provider: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
-							Attributes: tfsdk.MapNestedAttributes(map[string]tfsdk.Attribute{
-								"test_nested_attribute": {
-									Type:     types.StringType,
-									Required: true,
+				Provider: providerschema.Schema{
+					Attributes: map[string]providerschema.Attribute{
+						"test_attribute": providerschema.MapNestedAttribute{
+							NestedObject: providerschema.NestedAttributeObject{
+								Attributes: map[string]providerschema.Attribute{
+									"test_nested_attribute": providerschema.StringAttribute{
+										Required: true,
+									},
 								},
-							}),
+							},
 							Required: true,
 						},
 					},
@@ -1476,13 +1365,11 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-attribute-type-map-string": {
 			input: &fwserver.GetProviderSchemaResponse{
-				Provider: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
-							Required: true,
-							Type: types.MapType{
-								ElemType: types.StringType,
-							},
+				Provider: providerschema.Schema{
+					Attributes: map[string]providerschema.Attribute{
+						"test_attribute": providerschema.MapAttribute{
+							Required:    true,
+							ElementType: types.StringType,
 						},
 					},
 				},
@@ -1507,11 +1394,10 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-attribute-type-number": {
 			input: &fwserver.GetProviderSchemaResponse{
-				Provider: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
+				Provider: providerschema.Schema{
+					Attributes: map[string]providerschema.Attribute{
+						"test_attribute": providerschema.NumberAttribute{
 							Required: true,
-							Type:     types.NumberType,
 						},
 					},
 				},
@@ -1534,14 +1420,12 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-attribute-type-object": {
 			input: &fwserver.GetProviderSchemaResponse{
-				Provider: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
+				Provider: providerschema.Schema{
+					Attributes: map[string]providerschema.Attribute{
+						"test_attribute": providerschema.ObjectAttribute{
 							Required: true,
-							Type: types.ObjectType{
-								AttrTypes: map[string]attr.Type{
-									"test_object_attribute": types.StringType,
-								},
+							AttributeTypes: map[string]attr.Type{
+								"test_object_attribute": types.StringType,
 							},
 						},
 					},
@@ -1569,15 +1453,16 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-attribute-type-set-nested-attributes": {
 			input: &fwserver.GetProviderSchemaResponse{
-				Provider: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
-							Attributes: tfsdk.SetNestedAttributes(map[string]tfsdk.Attribute{
-								"test_nested_attribute": {
-									Type:     types.StringType,
-									Required: true,
+				Provider: providerschema.Schema{
+					Attributes: map[string]providerschema.Attribute{
+						"test_attribute": providerschema.SetNestedAttribute{
+							NestedObject: providerschema.NestedAttributeObject{
+								Attributes: map[string]providerschema.Attribute{
+									"test_nested_attribute": providerschema.StringAttribute{
+										Required: true,
+									},
 								},
-							}),
+							},
 							Required: true,
 						},
 					},
@@ -1610,15 +1495,13 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-attribute-type-set-object": {
 			input: &fwserver.GetProviderSchemaResponse{
-				Provider: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
+				Provider: providerschema.Schema{
+					Attributes: map[string]providerschema.Attribute{
+						"test_attribute": providerschema.SetAttribute{
 							Required: true,
-							Type: types.SetType{
-								ElemType: types.ObjectType{
-									AttrTypes: map[string]attr.Type{
-										"test_object_attribute": types.StringType,
-									},
+							ElementType: types.ObjectType{
+								AttrTypes: map[string]attr.Type{
+									"test_object_attribute": types.StringType,
 								},
 							},
 						},
@@ -1649,14 +1532,12 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-attribute-type-set-set-string": {
 			input: &fwserver.GetProviderSchemaResponse{
-				Provider: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
+				Provider: providerschema.Schema{
+					Attributes: map[string]providerschema.Attribute{
+						"test_attribute": providerschema.SetAttribute{
 							Required: true,
-							Type: types.SetType{
-								ElemType: types.SetType{
-									ElemType: types.StringType,
-								},
+							ElementType: types.SetType{
+								ElemType: types.StringType,
 							},
 						},
 					},
@@ -1684,13 +1565,11 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-attribute-type-set-string": {
 			input: &fwserver.GetProviderSchemaResponse{
-				Provider: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
-							Required: true,
-							Type: types.SetType{
-								ElemType: types.StringType,
-							},
+				Provider: providerschema.Schema{
+					Attributes: map[string]providerschema.Attribute{
+						"test_attribute": providerschema.SetAttribute{
+							Required:    true,
+							ElementType: types.StringType,
 						},
 					},
 				},
@@ -1715,15 +1594,14 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-attribute-type-single-nested-attributes": {
 			input: &fwserver.GetProviderSchemaResponse{
-				Provider: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
-							Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
-								"test_nested_attribute": {
-									Type:     types.StringType,
+				Provider: providerschema.Schema{
+					Attributes: map[string]providerschema.Attribute{
+						"test_attribute": providerschema.SingleNestedAttribute{
+							Attributes: map[string]providerschema.Attribute{
+								"test_nested_attribute": providerschema.StringAttribute{
 									Required: true,
 								},
-							}),
+							},
 							Required: true,
 						},
 					},
@@ -1756,11 +1634,10 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-attribute-type-string": {
 			input: &fwserver.GetProviderSchemaResponse{
-				Provider: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
+				Provider: providerschema.Schema{
+					Attributes: map[string]providerschema.Attribute{
+						"test_attribute": providerschema.StringAttribute{
 							Required: true,
-							Type:     types.StringType,
 						},
 					},
 				},
@@ -1783,16 +1660,16 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-block-list": {
 			input: &fwserver.GetProviderSchemaResponse{
-				Provider: &tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"test_block": {
-							Attributes: map[string]tfsdk.Attribute{
-								"test_attribute": {
-									Type:     types.StringType,
-									Required: true,
+				Provider: providerschema.Schema{
+					Blocks: map[string]providerschema.Block{
+						"test_block": providerschema.ListNestedBlock{
+							NestedObject: providerschema.NestedBlockObject{
+								Attributes: map[string]providerschema.Attribute{
+									"test_attribute": providerschema.StringAttribute{
+										Required: true,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeList,
 						},
 					},
 				},
@@ -1823,16 +1700,16 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-block-set": {
 			input: &fwserver.GetProviderSchemaResponse{
-				Provider: &tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"test_block": {
-							Attributes: map[string]tfsdk.Attribute{
-								"test_attribute": {
-									Type:     types.StringType,
-									Required: true,
+				Provider: providerschema.Schema{
+					Blocks: map[string]providerschema.Block{
+						"test_block": providerschema.SetNestedBlock{
+							NestedObject: providerschema.NestedBlockObject{
+								Attributes: map[string]providerschema.Attribute{
+									"test_attribute": providerschema.StringAttribute{
+										Required: true,
+									},
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeSet,
 						},
 					},
 				},
@@ -1863,16 +1740,14 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-block-single": {
 			input: &fwserver.GetProviderSchemaResponse{
-				Provider: &tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"test_block": {
-							Attributes: map[string]tfsdk.Attribute{
-								"test_attribute": {
-									Type:     types.StringType,
+				Provider: providerschema.Schema{
+					Blocks: map[string]providerschema.Block{
+						"test_block": providerschema.SingleNestedBlock{
+							Attributes: map[string]providerschema.Attribute{
+								"test_attribute": providerschema.StringAttribute{
 									Required: true,
 								},
 							},
-							NestingMode: tfsdk.BlockNestingModeSingle,
 						},
 					},
 				},
@@ -1901,84 +1776,12 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				ResourceSchemas: map[string]*tfprotov6.Schema{},
 			},
 		},
-		"provider-version": {
-			input: &fwserver.GetProviderSchemaResponse{
-				Provider: &tfsdk.Schema{
-					Version: 123,
-				},
-			},
-			expected: &tfprotov6.GetProviderSchemaResponse{
-				DataSourceSchemas: map[string]*tfprotov6.Schema{},
-				Provider: &tfprotov6.Schema{
-					Block:   &tfprotov6.SchemaBlock{},
-					Version: 123,
-				},
-				ResourceSchemas: map[string]*tfprotov6.Schema{},
-			},
-		},
-		"provider-meta-attribute-computed": {
-			input: &fwserver.GetProviderSchemaResponse{
-				ProviderMeta: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
-							Computed: true,
-							Type:     types.BoolType,
-						},
-					},
-				},
-			},
-			expected: &tfprotov6.GetProviderSchemaResponse{
-				DataSourceSchemas: map[string]*tfprotov6.Schema{},
-				ProviderMeta: &tfprotov6.Schema{
-					Block: &tfprotov6.SchemaBlock{
-						Attributes: []*tfprotov6.SchemaAttribute{
-							{
-								Computed: true,
-								Name:     "test_attribute",
-								Type:     tftypes.Bool,
-							},
-						},
-					},
-				},
-				ResourceSchemas: map[string]*tfprotov6.Schema{},
-			},
-		},
-		"provider-meta-attribute-deprecated": {
-			input: &fwserver.GetProviderSchemaResponse{
-				ProviderMeta: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
-							DeprecationMessage: "deprecated",
-							Optional:           true,
-							Type:               types.BoolType,
-						},
-					},
-				},
-			},
-			expected: &tfprotov6.GetProviderSchemaResponse{
-				DataSourceSchemas: map[string]*tfprotov6.Schema{},
-				ProviderMeta: &tfprotov6.Schema{
-					Block: &tfprotov6.SchemaBlock{
-						Attributes: []*tfprotov6.SchemaAttribute{
-							{
-								Deprecated: true,
-								Name:       "test_attribute",
-								Optional:   true,
-								Type:       tftypes.Bool,
-							},
-						},
-					},
-				},
-				ResourceSchemas: map[string]*tfprotov6.Schema{},
-			},
-		},
 		"provider-meta-attribute-optional": {
 			input: &fwserver.GetProviderSchemaResponse{
-				ProviderMeta: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
+				ProviderMeta: metaschema.Schema{
+					Attributes: map[string]metaschema.Attribute{
+						"test_attribute": metaschema.BoolAttribute{
 							Optional: true,
-							Type:     types.BoolType,
 						},
 					},
 				},
@@ -1989,35 +1792,6 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 					Block: &tfprotov6.SchemaBlock{
 						Attributes: []*tfprotov6.SchemaAttribute{
 							{
-								Name:     "test_attribute",
-								Optional: true,
-								Type:     tftypes.Bool,
-							},
-						},
-					},
-				},
-				ResourceSchemas: map[string]*tfprotov6.Schema{},
-			},
-		},
-		"provider-meta-attribute-optional-computed": {
-			input: &fwserver.GetProviderSchemaResponse{
-				ProviderMeta: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
-							Computed: true,
-							Optional: true,
-							Type:     types.BoolType,
-						},
-					},
-				},
-			},
-			expected: &tfprotov6.GetProviderSchemaResponse{
-				DataSourceSchemas: map[string]*tfprotov6.Schema{},
-				ProviderMeta: &tfprotov6.Schema{
-					Block: &tfprotov6.SchemaBlock{
-						Attributes: []*tfprotov6.SchemaAttribute{
-							{
-								Computed: true,
 								Name:     "test_attribute",
 								Optional: true,
 								Type:     tftypes.Bool,
@@ -2030,11 +1804,10 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-meta-attribute-required": {
 			input: &fwserver.GetProviderSchemaResponse{
-				ProviderMeta: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
+				ProviderMeta: metaschema.Schema{
+					Attributes: map[string]metaschema.Attribute{
+						"test_attribute": metaschema.BoolAttribute{
 							Required: true,
-							Type:     types.BoolType,
 						},
 					},
 				},
@@ -2055,42 +1828,12 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				ResourceSchemas: map[string]*tfprotov6.Schema{},
 			},
 		},
-		"provider-meta-attribute-sensitive": {
-			input: &fwserver.GetProviderSchemaResponse{
-				ProviderMeta: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
-							Computed:  true,
-							Sensitive: true,
-							Type:      types.BoolType,
-						},
-					},
-				},
-			},
-			expected: &tfprotov6.GetProviderSchemaResponse{
-				DataSourceSchemas: map[string]*tfprotov6.Schema{},
-				ProviderMeta: &tfprotov6.Schema{
-					Block: &tfprotov6.SchemaBlock{
-						Attributes: []*tfprotov6.SchemaAttribute{
-							{
-								Computed:  true,
-								Name:      "test_attribute",
-								Sensitive: true,
-								Type:      tftypes.Bool,
-							},
-						},
-					},
-				},
-				ResourceSchemas: map[string]*tfprotov6.Schema{},
-			},
-		},
 		"provider-meta-attribute-type-bool": {
 			input: &fwserver.GetProviderSchemaResponse{
-				ProviderMeta: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
+				ProviderMeta: metaschema.Schema{
+					Attributes: map[string]metaschema.Attribute{
+						"test_attribute": metaschema.BoolAttribute{
 							Required: true,
-							Type:     types.BoolType,
 						},
 					},
 				},
@@ -2113,11 +1856,10 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-meta-attribute-type-float64": {
 			input: &fwserver.GetProviderSchemaResponse{
-				ProviderMeta: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
+				ProviderMeta: metaschema.Schema{
+					Attributes: map[string]metaschema.Attribute{
+						"test_attribute": metaschema.Float64Attribute{
 							Required: true,
-							Type:     types.Float64Type,
 						},
 					},
 				},
@@ -2140,11 +1882,10 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-meta-attribute-type-int64": {
 			input: &fwserver.GetProviderSchemaResponse{
-				ProviderMeta: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
+				ProviderMeta: metaschema.Schema{
+					Attributes: map[string]metaschema.Attribute{
+						"test_attribute": metaschema.Int64Attribute{
 							Required: true,
-							Type:     types.Int64Type,
 						},
 					},
 				},
@@ -2167,14 +1908,12 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-meta-attribute-type-list-list-string": {
 			input: &fwserver.GetProviderSchemaResponse{
-				ProviderMeta: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
+				ProviderMeta: metaschema.Schema{
+					Attributes: map[string]metaschema.Attribute{
+						"test_attribute": metaschema.ListAttribute{
 							Required: true,
-							Type: types.ListType{
-								ElemType: types.ListType{
-									ElemType: types.StringType,
-								},
+							ElementType: types.ListType{
+								ElemType: types.StringType,
 							},
 						},
 					},
@@ -2202,15 +1941,16 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-meta-attribute-type-list-nested-attributes": {
 			input: &fwserver.GetProviderSchemaResponse{
-				ProviderMeta: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
-							Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
-								"test_nested_attribute": {
-									Type:     types.StringType,
-									Required: true,
+				ProviderMeta: metaschema.Schema{
+					Attributes: map[string]metaschema.Attribute{
+						"test_attribute": metaschema.ListNestedAttribute{
+							NestedObject: metaschema.NestedAttributeObject{
+								Attributes: map[string]metaschema.Attribute{
+									"test_nested_attribute": metaschema.StringAttribute{
+										Required: true,
+									},
 								},
-							}),
+							},
 							Required: true,
 						},
 					},
@@ -2243,15 +1983,13 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-meta-attribute-type-list-object": {
 			input: &fwserver.GetProviderSchemaResponse{
-				ProviderMeta: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
+				ProviderMeta: metaschema.Schema{
+					Attributes: map[string]metaschema.Attribute{
+						"test_attribute": metaschema.ListAttribute{
 							Required: true,
-							Type: types.ListType{
-								ElemType: types.ObjectType{
-									AttrTypes: map[string]attr.Type{
-										"test_nested_attribute": types.StringType,
-									},
+							ElementType: types.ObjectType{
+								AttrTypes: map[string]attr.Type{
+									"test_nested_attribute": types.StringType,
 								},
 							},
 						},
@@ -2282,13 +2020,11 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-meta-attribute-type-list-string": {
 			input: &fwserver.GetProviderSchemaResponse{
-				ProviderMeta: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
-							Required: true,
-							Type: types.ListType{
-								ElemType: types.StringType,
-							},
+				ProviderMeta: metaschema.Schema{
+					Attributes: map[string]metaschema.Attribute{
+						"test_attribute": metaschema.ListAttribute{
+							Required:    true,
+							ElementType: types.StringType,
 						},
 					},
 				},
@@ -2313,15 +2049,16 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-meta-attribute-type-map-nested-attributes": {
 			input: &fwserver.GetProviderSchemaResponse{
-				ProviderMeta: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
-							Attributes: tfsdk.MapNestedAttributes(map[string]tfsdk.Attribute{
-								"test_nested_attribute": {
-									Type:     types.StringType,
-									Required: true,
+				ProviderMeta: metaschema.Schema{
+					Attributes: map[string]metaschema.Attribute{
+						"test_attribute": metaschema.MapNestedAttribute{
+							NestedObject: metaschema.NestedAttributeObject{
+								Attributes: map[string]metaschema.Attribute{
+									"test_nested_attribute": metaschema.StringAttribute{
+										Required: true,
+									},
 								},
-							}),
+							},
 							Required: true,
 						},
 					},
@@ -2354,13 +2091,11 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-meta-attribute-type-map-string": {
 			input: &fwserver.GetProviderSchemaResponse{
-				ProviderMeta: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
-							Required: true,
-							Type: types.MapType{
-								ElemType: types.StringType,
-							},
+				ProviderMeta: metaschema.Schema{
+					Attributes: map[string]metaschema.Attribute{
+						"test_attribute": metaschema.MapAttribute{
+							Required:    true,
+							ElementType: types.StringType,
 						},
 					},
 				},
@@ -2385,11 +2120,10 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-meta-attribute-type-number": {
 			input: &fwserver.GetProviderSchemaResponse{
-				ProviderMeta: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
+				ProviderMeta: metaschema.Schema{
+					Attributes: map[string]metaschema.Attribute{
+						"test_attribute": metaschema.NumberAttribute{
 							Required: true,
-							Type:     types.NumberType,
 						},
 					},
 				},
@@ -2412,14 +2146,12 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-meta-attribute-type-object": {
 			input: &fwserver.GetProviderSchemaResponse{
-				ProviderMeta: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
+				ProviderMeta: metaschema.Schema{
+					Attributes: map[string]metaschema.Attribute{
+						"test_attribute": metaschema.ObjectAttribute{
 							Required: true,
-							Type: types.ObjectType{
-								AttrTypes: map[string]attr.Type{
-									"test_object_attribute": types.StringType,
-								},
+							AttributeTypes: map[string]attr.Type{
+								"test_object_attribute": types.StringType,
 							},
 						},
 					},
@@ -2447,15 +2179,16 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-meta-attribute-type-set-nested-attributes": {
 			input: &fwserver.GetProviderSchemaResponse{
-				ProviderMeta: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
-							Attributes: tfsdk.SetNestedAttributes(map[string]tfsdk.Attribute{
-								"test_nested_attribute": {
-									Type:     types.StringType,
-									Required: true,
+				ProviderMeta: metaschema.Schema{
+					Attributes: map[string]metaschema.Attribute{
+						"test_attribute": metaschema.SetNestedAttribute{
+							NestedObject: metaschema.NestedAttributeObject{
+								Attributes: map[string]metaschema.Attribute{
+									"test_nested_attribute": metaschema.StringAttribute{
+										Required: true,
+									},
 								},
-							}),
+							},
 							Required: true,
 						},
 					},
@@ -2488,15 +2221,13 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-meta-attribute-type-set-object": {
 			input: &fwserver.GetProviderSchemaResponse{
-				ProviderMeta: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
+				ProviderMeta: metaschema.Schema{
+					Attributes: map[string]metaschema.Attribute{
+						"test_attribute": metaschema.SetAttribute{
 							Required: true,
-							Type: types.SetType{
-								ElemType: types.ObjectType{
-									AttrTypes: map[string]attr.Type{
-										"test_object_attribute": types.StringType,
-									},
+							ElementType: types.ObjectType{
+								AttrTypes: map[string]attr.Type{
+									"test_object_attribute": types.StringType,
 								},
 							},
 						},
@@ -2527,14 +2258,12 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-meta-attribute-type-set-set-string": {
 			input: &fwserver.GetProviderSchemaResponse{
-				ProviderMeta: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
+				ProviderMeta: metaschema.Schema{
+					Attributes: map[string]metaschema.Attribute{
+						"test_attribute": metaschema.SetAttribute{
 							Required: true,
-							Type: types.SetType{
-								ElemType: types.SetType{
-									ElemType: types.StringType,
-								},
+							ElementType: types.SetType{
+								ElemType: types.StringType,
 							},
 						},
 					},
@@ -2562,13 +2291,11 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-meta-attribute-type-set-string": {
 			input: &fwserver.GetProviderSchemaResponse{
-				ProviderMeta: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
-							Required: true,
-							Type: types.SetType{
-								ElemType: types.StringType,
-							},
+				ProviderMeta: metaschema.Schema{
+					Attributes: map[string]metaschema.Attribute{
+						"test_attribute": metaschema.SetAttribute{
+							Required:    true,
+							ElementType: types.StringType,
 						},
 					},
 				},
@@ -2593,15 +2320,14 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-meta-attribute-type-single-nested-attributes": {
 			input: &fwserver.GetProviderSchemaResponse{
-				ProviderMeta: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
-							Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
-								"test_nested_attribute": {
-									Type:     types.StringType,
+				ProviderMeta: metaschema.Schema{
+					Attributes: map[string]metaschema.Attribute{
+						"test_attribute": metaschema.SingleNestedAttribute{
+							Attributes: map[string]metaschema.Attribute{
+								"test_nested_attribute": metaschema.StringAttribute{
 									Required: true,
 								},
-							}),
+							},
 							Required: true,
 						},
 					},
@@ -2634,11 +2360,10 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		},
 		"provider-meta-attribute-type-string": {
 			input: &fwserver.GetProviderSchemaResponse{
-				ProviderMeta: &tfsdk.Schema{
-					Attributes: map[string]tfsdk.Attribute{
-						"test_attribute": {
+				ProviderMeta: metaschema.Schema{
+					Attributes: map[string]metaschema.Attribute{
+						"test_attribute": metaschema.StringAttribute{
 							Required: true,
-							Type:     types.StringType,
 						},
 					},
 				},
@@ -2659,157 +2384,20 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				ResourceSchemas: map[string]*tfprotov6.Schema{},
 			},
 		},
-		"provider-meta-block-list": {
-			input: &fwserver.GetProviderSchemaResponse{
-				ProviderMeta: &tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"test_block": {
-							Attributes: map[string]tfsdk.Attribute{
-								"test_attribute": {
-									Type:     types.StringType,
-									Required: true,
-								},
-							},
-							NestingMode: tfsdk.BlockNestingModeList,
-						},
-					},
-				},
-			},
-			expected: &tfprotov6.GetProviderSchemaResponse{
-				DataSourceSchemas: map[string]*tfprotov6.Schema{},
-				ProviderMeta: &tfprotov6.Schema{
-					Block: &tfprotov6.SchemaBlock{
-						BlockTypes: []*tfprotov6.SchemaNestedBlock{
-							{
-								Block: &tfprotov6.SchemaBlock{
-									Attributes: []*tfprotov6.SchemaAttribute{
-										{
-											Name:     "test_attribute",
-											Type:     tftypes.String,
-											Required: true,
-										},
-									},
-								},
-								Nesting:  tfprotov6.SchemaNestedBlockNestingModeList,
-								TypeName: "test_block",
-							},
-						},
-					},
-				},
-				ResourceSchemas: map[string]*tfprotov6.Schema{},
-			},
-		},
-		"provider-meta-block-set": {
-			input: &fwserver.GetProviderSchemaResponse{
-				ProviderMeta: &tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"test_block": {
-							Attributes: map[string]tfsdk.Attribute{
-								"test_attribute": {
-									Type:     types.StringType,
-									Required: true,
-								},
-							},
-							NestingMode: tfsdk.BlockNestingModeSet,
-						},
-					},
-				},
-			},
-			expected: &tfprotov6.GetProviderSchemaResponse{
-				DataSourceSchemas: map[string]*tfprotov6.Schema{},
-				ProviderMeta: &tfprotov6.Schema{
-					Block: &tfprotov6.SchemaBlock{
-						BlockTypes: []*tfprotov6.SchemaNestedBlock{
-							{
-								Block: &tfprotov6.SchemaBlock{
-									Attributes: []*tfprotov6.SchemaAttribute{
-										{
-											Name:     "test_attribute",
-											Type:     tftypes.String,
-											Required: true,
-										},
-									},
-								},
-								Nesting:  tfprotov6.SchemaNestedBlockNestingModeSet,
-								TypeName: "test_block",
-							},
-						},
-					},
-				},
-				ResourceSchemas: map[string]*tfprotov6.Schema{},
-			},
-		},
-		"provider-meta-block-single": {
-			input: &fwserver.GetProviderSchemaResponse{
-				ProviderMeta: &tfsdk.Schema{
-					Blocks: map[string]tfsdk.Block{
-						"test_block": {
-							Attributes: map[string]tfsdk.Attribute{
-								"test_attribute": {
-									Type:     types.StringType,
-									Required: true,
-								},
-							},
-							NestingMode: tfsdk.BlockNestingModeSingle,
-						},
-					},
-				},
-			},
-			expected: &tfprotov6.GetProviderSchemaResponse{
-				DataSourceSchemas: map[string]*tfprotov6.Schema{},
-				ProviderMeta: &tfprotov6.Schema{
-					Block: &tfprotov6.SchemaBlock{
-						BlockTypes: []*tfprotov6.SchemaNestedBlock{
-							{
-								Block: &tfprotov6.SchemaBlock{
-									Attributes: []*tfprotov6.SchemaAttribute{
-										{
-											Name:     "test_attribute",
-											Type:     tftypes.String,
-											Required: true,
-										},
-									},
-								},
-								Nesting:  tfprotov6.SchemaNestedBlockNestingModeSingle,
-								TypeName: "test_block",
-							},
-						},
-					},
-				},
-				ResourceSchemas: map[string]*tfprotov6.Schema{},
-			},
-		},
-		"provider-meta-version": {
-			input: &fwserver.GetProviderSchemaResponse{
-				ProviderMeta: &tfsdk.Schema{
-					Version: 123,
-				},
-			},
-			expected: &tfprotov6.GetProviderSchemaResponse{
-				DataSourceSchemas: map[string]*tfprotov6.Schema{},
-				ProviderMeta: &tfprotov6.Schema{
-					Block:   &tfprotov6.SchemaBlock{},
-					Version: 123,
-				},
-				ResourceSchemas: map[string]*tfprotov6.Schema{},
-			},
-		},
 		"resource-multiple-resources": {
 			input: &fwserver.GetProviderSchemaResponse{
 				ResourceSchemas: map[string]fwschema.Schema{
-					"test_resource_1": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_resource_1": resourceschema.Schema{
+						Attributes: map[string]resourceschema.Attribute{
+							"test_attribute": resourceschema.BoolAttribute{
 								Computed: true,
-								Type:     types.BoolType,
 							},
 						},
 					},
-					"test_resource_2": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_resource_2": resourceschema.Schema{
+						Attributes: map[string]resourceschema.Attribute{
+							"test_attribute": resourceschema.BoolAttribute{
 								Computed: true,
-								Type:     types.BoolType,
 							},
 						},
 					},
@@ -2846,11 +2434,10 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"resource-attribute-computed": {
 			input: &fwserver.GetProviderSchemaResponse{
 				ResourceSchemas: map[string]fwschema.Schema{
-					"test_resource": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_resource": resourceschema.Schema{
+						Attributes: map[string]resourceschema.Attribute{
+							"test_attribute": resourceschema.BoolAttribute{
 								Computed: true,
-								Type:     types.BoolType,
 							},
 						},
 					},
@@ -2876,12 +2463,11 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"resource-attribute-deprecated": {
 			input: &fwserver.GetProviderSchemaResponse{
 				ResourceSchemas: map[string]fwschema.Schema{
-					"test_resource": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_resource": resourceschema.Schema{
+						Attributes: map[string]resourceschema.Attribute{
+							"test_attribute": resourceschema.BoolAttribute{
 								DeprecationMessage: "deprecated",
 								Optional:           true,
-								Type:               types.BoolType,
 							},
 						},
 					},
@@ -2908,11 +2494,10 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"resource-attribute-optional": {
 			input: &fwserver.GetProviderSchemaResponse{
 				ResourceSchemas: map[string]fwschema.Schema{
-					"test_resource": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_resource": resourceschema.Schema{
+						Attributes: map[string]resourceschema.Attribute{
+							"test_attribute": resourceschema.BoolAttribute{
 								Optional: true,
-								Type:     types.BoolType,
 							},
 						},
 					},
@@ -2938,12 +2523,11 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"resource-attribute-optional-computed": {
 			input: &fwserver.GetProviderSchemaResponse{
 				ResourceSchemas: map[string]fwschema.Schema{
-					"test_resource": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_resource": resourceschema.Schema{
+						Attributes: map[string]resourceschema.Attribute{
+							"test_attribute": resourceschema.BoolAttribute{
 								Computed: true,
 								Optional: true,
-								Type:     types.BoolType,
 							},
 						},
 					},
@@ -2970,11 +2554,10 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"resource-attribute-required": {
 			input: &fwserver.GetProviderSchemaResponse{
 				ResourceSchemas: map[string]fwschema.Schema{
-					"test_resource": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_resource": resourceschema.Schema{
+						Attributes: map[string]resourceschema.Attribute{
+							"test_attribute": resourceschema.BoolAttribute{
 								Required: true,
-								Type:     types.BoolType,
 							},
 						},
 					},
@@ -3000,12 +2583,11 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"resource-attribute-sensitive": {
 			input: &fwserver.GetProviderSchemaResponse{
 				ResourceSchemas: map[string]fwschema.Schema{
-					"test_resource": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_resource": resourceschema.Schema{
+						Attributes: map[string]resourceschema.Attribute{
+							"test_attribute": resourceschema.BoolAttribute{
 								Computed:  true,
 								Sensitive: true,
-								Type:      types.BoolType,
 							},
 						},
 					},
@@ -3032,11 +2614,10 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"resource-attribute-type-bool": {
 			input: &fwserver.GetProviderSchemaResponse{
 				ResourceSchemas: map[string]fwschema.Schema{
-					"test_resource": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_resource": resourceschema.Schema{
+						Attributes: map[string]resourceschema.Attribute{
+							"test_attribute": resourceschema.BoolAttribute{
 								Required: true,
-								Type:     types.BoolType,
 							},
 						},
 					},
@@ -3062,11 +2643,10 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"resource-attribute-type-float64": {
 			input: &fwserver.GetProviderSchemaResponse{
 				ResourceSchemas: map[string]fwschema.Schema{
-					"test_resource": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_resource": resourceschema.Schema{
+						Attributes: map[string]resourceschema.Attribute{
+							"test_attribute": resourceschema.Float64Attribute{
 								Required: true,
-								Type:     types.Float64Type,
 							},
 						},
 					},
@@ -3092,11 +2672,10 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"resource-attribute-type-int64": {
 			input: &fwserver.GetProviderSchemaResponse{
 				ResourceSchemas: map[string]fwschema.Schema{
-					"test_resource": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_resource": resourceschema.Schema{
+						Attributes: map[string]resourceschema.Attribute{
+							"test_attribute": resourceschema.Int64Attribute{
 								Required: true,
-								Type:     types.Int64Type,
 							},
 						},
 					},
@@ -3122,14 +2701,12 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"resource-attribute-type-list-list-string": {
 			input: &fwserver.GetProviderSchemaResponse{
 				ResourceSchemas: map[string]fwschema.Schema{
-					"test_resource": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_resource": resourceschema.Schema{
+						Attributes: map[string]resourceschema.Attribute{
+							"test_attribute": resourceschema.ListAttribute{
 								Required: true,
-								Type: types.ListType{
-									ElemType: types.ListType{
-										ElemType: types.StringType,
-									},
+								ElementType: types.ListType{
+									ElemType: types.StringType,
 								},
 							},
 						},
@@ -3160,15 +2737,16 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"resource-attribute-type-list-nested-attributes": {
 			input: &fwserver.GetProviderSchemaResponse{
 				ResourceSchemas: map[string]fwschema.Schema{
-					"test_resource": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
-								Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
-									"test_nested_attribute": {
-										Type:     types.StringType,
-										Required: true,
+					"test_resource": resourceschema.Schema{
+						Attributes: map[string]resourceschema.Attribute{
+							"test_attribute": resourceschema.ListNestedAttribute{
+								NestedObject: resourceschema.NestedAttributeObject{
+									Attributes: map[string]resourceschema.Attribute{
+										"test_nested_attribute": resourceschema.StringAttribute{
+											Required: true,
+										},
 									},
-								}),
+								},
 								Required: true,
 							},
 						},
@@ -3204,15 +2782,13 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"resource-attribute-type-list-object": {
 			input: &fwserver.GetProviderSchemaResponse{
 				ResourceSchemas: map[string]fwschema.Schema{
-					"test_resource": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_resource": resourceschema.Schema{
+						Attributes: map[string]resourceschema.Attribute{
+							"test_attribute": resourceschema.ListAttribute{
 								Required: true,
-								Type: types.ListType{
-									ElemType: types.ObjectType{
-										AttrTypes: map[string]attr.Type{
-											"test_object_attribute": types.StringType,
-										},
+								ElementType: types.ObjectType{
+									AttrTypes: map[string]attr.Type{
+										"test_object_attribute": types.StringType,
 									},
 								},
 							},
@@ -3246,13 +2822,11 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"resource-attribute-type-list-string": {
 			input: &fwserver.GetProviderSchemaResponse{
 				ResourceSchemas: map[string]fwschema.Schema{
-					"test_resource": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
-								Required: true,
-								Type: types.ListType{
-									ElemType: types.StringType,
-								},
+					"test_resource": resourceschema.Schema{
+						Attributes: map[string]resourceschema.Attribute{
+							"test_attribute": resourceschema.ListAttribute{
+								Required:    true,
+								ElementType: types.StringType,
 							},
 						},
 					},
@@ -3280,15 +2854,16 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"resource-attribute-type-map-nested-attributes": {
 			input: &fwserver.GetProviderSchemaResponse{
 				ResourceSchemas: map[string]fwschema.Schema{
-					"test_resource": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
-								Attributes: tfsdk.MapNestedAttributes(map[string]tfsdk.Attribute{
-									"test_nested_attribute": {
-										Type:     types.StringType,
-										Required: true,
+					"test_resource": resourceschema.Schema{
+						Attributes: map[string]resourceschema.Attribute{
+							"test_attribute": resourceschema.MapNestedAttribute{
+								NestedObject: resourceschema.NestedAttributeObject{
+									Attributes: map[string]resourceschema.Attribute{
+										"test_nested_attribute": resourceschema.StringAttribute{
+											Required: true,
+										},
 									},
-								}),
+								},
 								Required: true,
 							},
 						},
@@ -3324,13 +2899,11 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"resource-attribute-type-map-string": {
 			input: &fwserver.GetProviderSchemaResponse{
 				ResourceSchemas: map[string]fwschema.Schema{
-					"test_resource": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
-								Required: true,
-								Type: types.MapType{
-									ElemType: types.StringType,
-								},
+					"test_resource": resourceschema.Schema{
+						Attributes: map[string]resourceschema.Attribute{
+							"test_attribute": resourceschema.MapAttribute{
+								Required:    true,
+								ElementType: types.StringType,
 							},
 						},
 					},
@@ -3358,11 +2931,10 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"resource-attribute-type-number": {
 			input: &fwserver.GetProviderSchemaResponse{
 				ResourceSchemas: map[string]fwschema.Schema{
-					"test_resource": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_resource": resourceschema.Schema{
+						Attributes: map[string]resourceschema.Attribute{
+							"test_attribute": resourceschema.NumberAttribute{
 								Required: true,
-								Type:     types.NumberType,
 							},
 						},
 					},
@@ -3388,14 +2960,12 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"resource-attribute-type-object": {
 			input: &fwserver.GetProviderSchemaResponse{
 				ResourceSchemas: map[string]fwschema.Schema{
-					"test_resource": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_resource": resourceschema.Schema{
+						Attributes: map[string]resourceschema.Attribute{
+							"test_attribute": resourceschema.ObjectAttribute{
 								Required: true,
-								Type: types.ObjectType{
-									AttrTypes: map[string]attr.Type{
-										"test_object_attribute": types.StringType,
-									},
+								AttributeTypes: map[string]attr.Type{
+									"test_object_attribute": types.StringType,
 								},
 							},
 						},
@@ -3426,15 +2996,16 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"resource-attribute-type-set-nested-attributes": {
 			input: &fwserver.GetProviderSchemaResponse{
 				ResourceSchemas: map[string]fwschema.Schema{
-					"test_resource": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
-								Attributes: tfsdk.SetNestedAttributes(map[string]tfsdk.Attribute{
-									"test_nested_attribute": {
-										Type:     types.StringType,
-										Required: true,
+					"test_resource": resourceschema.Schema{
+						Attributes: map[string]resourceschema.Attribute{
+							"test_attribute": resourceschema.SetNestedAttribute{
+								NestedObject: resourceschema.NestedAttributeObject{
+									Attributes: map[string]resourceschema.Attribute{
+										"test_nested_attribute": resourceschema.StringAttribute{
+											Required: true,
+										},
 									},
-								}),
+								},
 								Required: true,
 							},
 						},
@@ -3470,15 +3041,13 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"resource-attribute-type-set-object": {
 			input: &fwserver.GetProviderSchemaResponse{
 				ResourceSchemas: map[string]fwschema.Schema{
-					"test_resource": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_resource": resourceschema.Schema{
+						Attributes: map[string]resourceschema.Attribute{
+							"test_attribute": resourceschema.SetAttribute{
 								Required: true,
-								Type: types.SetType{
-									ElemType: types.ObjectType{
-										AttrTypes: map[string]attr.Type{
-											"test_object_attribute": types.StringType,
-										},
+								ElementType: types.ObjectType{
+									AttrTypes: map[string]attr.Type{
+										"test_object_attribute": types.StringType,
 									},
 								},
 							},
@@ -3512,14 +3081,12 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"resource-attribute-type-set-set-string": {
 			input: &fwserver.GetProviderSchemaResponse{
 				ResourceSchemas: map[string]fwschema.Schema{
-					"test_resource": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_resource": resourceschema.Schema{
+						Attributes: map[string]resourceschema.Attribute{
+							"test_attribute": resourceschema.SetAttribute{
 								Required: true,
-								Type: types.SetType{
-									ElemType: types.SetType{
-										ElemType: types.StringType,
-									},
+								ElementType: types.SetType{
+									ElemType: types.StringType,
 								},
 							},
 						},
@@ -3550,13 +3117,11 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"resource-attribute-type-set-string": {
 			input: &fwserver.GetProviderSchemaResponse{
 				ResourceSchemas: map[string]fwschema.Schema{
-					"test_resource": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
-								Required: true,
-								Type: types.SetType{
-									ElemType: types.StringType,
-								},
+					"test_resource": resourceschema.Schema{
+						Attributes: map[string]resourceschema.Attribute{
+							"test_attribute": resourceschema.SetAttribute{
+								Required:    true,
+								ElementType: types.StringType,
 							},
 						},
 					},
@@ -3584,15 +3149,14 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"resource-attribute-type-single-nested-attributes": {
 			input: &fwserver.GetProviderSchemaResponse{
 				ResourceSchemas: map[string]fwschema.Schema{
-					"test_resource": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
-								Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
-									"test_nested_attribute": {
-										Type:     types.StringType,
+					"test_resource": resourceschema.Schema{
+						Attributes: map[string]resourceschema.Attribute{
+							"test_attribute": resourceschema.SingleNestedAttribute{
+								Attributes: map[string]resourceschema.Attribute{
+									"test_nested_attribute": resourceschema.StringAttribute{
 										Required: true,
 									},
-								}),
+								},
 								Required: true,
 							},
 						},
@@ -3628,11 +3192,10 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"resource-attribute-type-string": {
 			input: &fwserver.GetProviderSchemaResponse{
 				ResourceSchemas: map[string]fwschema.Schema{
-					"test_resource": &tfsdk.Schema{
-						Attributes: map[string]tfsdk.Attribute{
-							"test_attribute": {
+					"test_resource": resourceschema.Schema{
+						Attributes: map[string]resourceschema.Attribute{
+							"test_attribute": resourceschema.StringAttribute{
 								Required: true,
-								Type:     types.StringType,
 							},
 						},
 					},
@@ -3658,16 +3221,16 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"resource-block-list": {
 			input: &fwserver.GetProviderSchemaResponse{
 				ResourceSchemas: map[string]fwschema.Schema{
-					"test_resource": &tfsdk.Schema{
-						Blocks: map[string]tfsdk.Block{
-							"test_block": {
-								Attributes: map[string]tfsdk.Attribute{
-									"test_attribute": {
-										Type:     types.StringType,
-										Required: true,
+					"test_resource": resourceschema.Schema{
+						Blocks: map[string]resourceschema.Block{
+							"test_block": resourceschema.ListNestedBlock{
+								NestedObject: resourceschema.NestedBlockObject{
+									Attributes: map[string]resourceschema.Attribute{
+										"test_attribute": resourceschema.StringAttribute{
+											Required: true,
+										},
 									},
 								},
-								NestingMode: tfsdk.BlockNestingModeList,
 							},
 						},
 					},
@@ -3701,16 +3264,16 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"resource-block-set": {
 			input: &fwserver.GetProviderSchemaResponse{
 				ResourceSchemas: map[string]fwschema.Schema{
-					"test_resource": &tfsdk.Schema{
-						Blocks: map[string]tfsdk.Block{
-							"test_block": {
-								Attributes: map[string]tfsdk.Attribute{
-									"test_attribute": {
-										Type:     types.StringType,
-										Required: true,
+					"test_resource": resourceschema.Schema{
+						Blocks: map[string]resourceschema.Block{
+							"test_block": resourceschema.SetNestedBlock{
+								NestedObject: resourceschema.NestedBlockObject{
+									Attributes: map[string]resourceschema.Attribute{
+										"test_attribute": resourceschema.StringAttribute{
+											Required: true,
+										},
 									},
 								},
-								NestingMode: tfsdk.BlockNestingModeSet,
 							},
 						},
 					},
@@ -3744,16 +3307,14 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"resource-block-single": {
 			input: &fwserver.GetProviderSchemaResponse{
 				ResourceSchemas: map[string]fwschema.Schema{
-					"test_resource": &tfsdk.Schema{
-						Blocks: map[string]tfsdk.Block{
-							"test_block": {
-								Attributes: map[string]tfsdk.Attribute{
-									"test_attribute": {
-										Type:     types.StringType,
+					"test_resource": resourceschema.Schema{
+						Blocks: map[string]resourceschema.Block{
+							"test_block": resourceschema.SingleNestedBlock{
+								Attributes: map[string]resourceschema.Attribute{
+									"test_attribute": resourceschema.StringAttribute{
 										Required: true,
 									},
 								},
-								NestingMode: tfsdk.BlockNestingModeSingle,
 							},
 						},
 					},
@@ -3787,7 +3348,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 		"resource-version": {
 			input: &fwserver.GetProviderSchemaResponse{
 				ResourceSchemas: map[string]fwschema.Schema{
-					"test_resource": &tfsdk.Schema{
+					"test_resource": resourceschema.Schema{
 						Version: 123,
 					},
 				},

--- a/internal/toproto6/importedresource_test.go
+++ b/internal/toproto6/importedresource_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
 	"github.com/hashicorp/terraform-plugin-framework/internal/privatestate"
 	"github.com/hashicorp/terraform-plugin-framework/internal/toproto6"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 func TestImportResourceStateResponse(t *testing.T) {
@@ -49,11 +49,10 @@ func TestImportResourceStateResponse(t *testing.T) {
 
 	testState := tfsdk.State{
 		Raw: testProto6Value,
-		Schema: tfsdk.Schema{
-			Attributes: map[string]tfsdk.Attribute{
-				"test_attribute": {
+		Schema: schema.Schema{
+			Attributes: map[string]schema.Attribute{
+				"test_attribute": schema.StringAttribute{
 					Required: true,
-					Type:     types.StringType,
 				},
 			},
 		},
@@ -61,11 +60,10 @@ func TestImportResourceStateResponse(t *testing.T) {
 
 	testStateInvalid := tfsdk.State{
 		Raw: testProto6Value,
-		Schema: tfsdk.Schema{
-			Attributes: map[string]tfsdk.Attribute{
-				"test_attribute": {
+		Schema: schema.Schema{
+			Attributes: map[string]schema.Attribute{
+				"test_attribute": schema.BoolAttribute{
 					Required: true,
-					Type:     types.BoolType,
 				},
 			},
 		},
@@ -73,8 +71,8 @@ func TestImportResourceStateResponse(t *testing.T) {
 
 	testEmptyState := tfsdk.State{
 		Raw: testProto6Value,
-		Schema: tfsdk.Schema{
-			Attributes: map[string]tfsdk.Attribute{},
+		Schema: schema.Schema{
+			Attributes: map[string]schema.Attribute{},
 		},
 	}
 

--- a/internal/toproto6/planresourcechange_test.go
+++ b/internal/toproto6/planresourcechange_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/internal/privatestate"
 	"github.com/hashicorp/terraform-plugin-framework/internal/toproto6"
 	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 func TestPlanResourceChangeResponse(t *testing.T) {
@@ -38,11 +38,10 @@ func TestPlanResourceChangeResponse(t *testing.T) {
 
 	testState := &tfsdk.State{
 		Raw: testProto6Value,
-		Schema: tfsdk.Schema{
-			Attributes: map[string]tfsdk.Attribute{
-				"test_attribute": {
+		Schema: schema.Schema{
+			Attributes: map[string]schema.Attribute{
+				"test_attribute": schema.StringAttribute{
 					Required: true,
-					Type:     types.StringType,
 				},
 			},
 		},
@@ -50,11 +49,10 @@ func TestPlanResourceChangeResponse(t *testing.T) {
 
 	testStateInvalid := &tfsdk.State{
 		Raw: testProto6Value,
-		Schema: tfsdk.Schema{
-			Attributes: map[string]tfsdk.Attribute{
-				"test_attribute": {
+		Schema: schema.Schema{
+			Attributes: map[string]schema.Attribute{
+				"test_attribute": schema.BoolAttribute{
 					Required: true,
-					Type:     types.BoolType,
 				},
 			},
 		},

--- a/internal/toproto6/readdatasource_test.go
+++ b/internal/toproto6/readdatasource_test.go
@@ -5,11 +5,11 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
 	"github.com/hashicorp/terraform-plugin-framework/internal/toproto6"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
@@ -35,11 +35,10 @@ func TestReadDataSourceResponse(t *testing.T) {
 
 	testState := &tfsdk.State{
 		Raw: testProto6Value,
-		Schema: tfsdk.Schema{
-			Attributes: map[string]tfsdk.Attribute{
-				"test_attribute": {
+		Schema: schema.Schema{
+			Attributes: map[string]schema.Attribute{
+				"test_attribute": schema.StringAttribute{
 					Required: true,
-					Type:     types.StringType,
 				},
 			},
 		},
@@ -47,11 +46,10 @@ func TestReadDataSourceResponse(t *testing.T) {
 
 	testStateInvalid := &tfsdk.State{
 		Raw: testProto6Value,
-		Schema: tfsdk.Schema{
-			Attributes: map[string]tfsdk.Attribute{
-				"test_attribute": {
+		Schema: schema.Schema{
+			Attributes: map[string]schema.Attribute{
+				"test_attribute": schema.BoolAttribute{
 					Required: true,
-					Type:     types.BoolType,
 				},
 			},
 		},

--- a/internal/toproto6/readresource_test.go
+++ b/internal/toproto6/readresource_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
 	"github.com/hashicorp/terraform-plugin-framework/internal/privatestate"
 	"github.com/hashicorp/terraform-plugin-framework/internal/toproto6"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 func TestReadResourceResponse(t *testing.T) {
@@ -37,11 +37,10 @@ func TestReadResourceResponse(t *testing.T) {
 
 	testState := &tfsdk.State{
 		Raw: testProto6Value,
-		Schema: tfsdk.Schema{
-			Attributes: map[string]tfsdk.Attribute{
-				"test_attribute": {
+		Schema: schema.Schema{
+			Attributes: map[string]schema.Attribute{
+				"test_attribute": schema.StringAttribute{
 					Required: true,
-					Type:     types.StringType,
 				},
 			},
 		},
@@ -49,11 +48,10 @@ func TestReadResourceResponse(t *testing.T) {
 
 	testStateInvalid := &tfsdk.State{
 		Raw: testProto6Value,
-		Schema: tfsdk.Schema{
-			Attributes: map[string]tfsdk.Attribute{
-				"test_attribute": {
+		Schema: schema.Schema{
+			Attributes: map[string]schema.Attribute{
+				"test_attribute": schema.BoolAttribute{
 					Required: true,
-					Type:     types.BoolType,
 				},
 			},
 		},

--- a/internal/toproto6/schema_attribute_test.go
+++ b/internal/toproto6/schema_attribute_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/toproto6"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
@@ -28,7 +28,7 @@ func TestSchemaAttribute(t *testing.T) {
 	tests := map[string]testCase{
 		"deprecated": {
 			name: "string",
-			attr: tfsdk.Attribute{
+			attr: testschema.Attribute{
 				Type:               types.StringType,
 				Optional:           true,
 				DeprecationMessage: "deprecated, use new_string instead",
@@ -43,7 +43,7 @@ func TestSchemaAttribute(t *testing.T) {
 		},
 		"description-plain": {
 			name: "string",
-			attr: tfsdk.Attribute{
+			attr: testschema.Attribute{
 				Type:        types.StringType,
 				Optional:    true,
 				Description: "A string attribute",
@@ -59,7 +59,7 @@ func TestSchemaAttribute(t *testing.T) {
 		},
 		"description-markdown": {
 			name: "string",
-			attr: tfsdk.Attribute{
+			attr: testschema.Attribute{
 				Type:                types.StringType,
 				Optional:            true,
 				MarkdownDescription: "A string attribute",
@@ -75,7 +75,7 @@ func TestSchemaAttribute(t *testing.T) {
 		},
 		"description-both": {
 			name: "string",
-			attr: tfsdk.Attribute{
+			attr: testschema.Attribute{
 				Type:                types.StringType,
 				Optional:            true,
 				Description:         "A string attribute",
@@ -92,7 +92,7 @@ func TestSchemaAttribute(t *testing.T) {
 		},
 		"attr-string": {
 			name: "string",
-			attr: tfsdk.Attribute{
+			attr: testschema.Attribute{
 				Type:     types.StringType,
 				Optional: true,
 			},
@@ -105,7 +105,7 @@ func TestSchemaAttribute(t *testing.T) {
 		},
 		"attr-bool": {
 			name: "bool",
-			attr: tfsdk.Attribute{
+			attr: testschema.Attribute{
 				Type:     types.BoolType,
 				Optional: true,
 			},
@@ -118,7 +118,7 @@ func TestSchemaAttribute(t *testing.T) {
 		},
 		"attr-number": {
 			name: "number",
-			attr: tfsdk.Attribute{
+			attr: testschema.Attribute{
 				Type:     types.NumberType,
 				Optional: true,
 			},
@@ -131,7 +131,7 @@ func TestSchemaAttribute(t *testing.T) {
 		},
 		"attr-list": {
 			name: "list",
-			attr: tfsdk.Attribute{
+			attr: testschema.Attribute{
 				Type:     types.ListType{ElemType: types.NumberType},
 				Optional: true,
 			},
@@ -144,7 +144,7 @@ func TestSchemaAttribute(t *testing.T) {
 		},
 		"attr-map": {
 			name: "map",
-			attr: tfsdk.Attribute{
+			attr: testschema.Attribute{
 				Type:     types.MapType{ElemType: types.StringType},
 				Optional: true,
 			},
@@ -157,7 +157,7 @@ func TestSchemaAttribute(t *testing.T) {
 		},
 		"attr-object": {
 			name: "object",
-			attr: tfsdk.Attribute{
+			attr: testschema.Attribute{
 				Type: types.ObjectType{AttrTypes: map[string]attr.Type{
 					"foo": types.StringType,
 					"bar": types.NumberType,
@@ -178,7 +178,7 @@ func TestSchemaAttribute(t *testing.T) {
 		},
 		"attr-set": {
 			name: "set",
-			attr: tfsdk.Attribute{
+			attr: testschema.Attribute{
 				Type:     types.SetType{ElemType: types.NumberType},
 				Optional: true,
 			},
@@ -192,7 +192,7 @@ func TestSchemaAttribute(t *testing.T) {
 		// TODO: add tuple attribute when we support it
 		"required": {
 			name: "string",
-			attr: tfsdk.Attribute{
+			attr: testschema.Attribute{
 				Type:     types.StringType,
 				Required: true,
 			},
@@ -205,7 +205,7 @@ func TestSchemaAttribute(t *testing.T) {
 		},
 		"optional": {
 			name: "string",
-			attr: tfsdk.Attribute{
+			attr: testschema.Attribute{
 				Type:     types.StringType,
 				Optional: true,
 			},
@@ -218,7 +218,7 @@ func TestSchemaAttribute(t *testing.T) {
 		},
 		"computed": {
 			name: "string",
-			attr: tfsdk.Attribute{
+			attr: testschema.Attribute{
 				Type:     types.StringType,
 				Computed: true,
 			},
@@ -231,7 +231,7 @@ func TestSchemaAttribute(t *testing.T) {
 		},
 		"optional-computed": {
 			name: "string",
-			attr: tfsdk.Attribute{
+			attr: testschema.Attribute{
 				Type:     types.StringType,
 				Computed: true,
 				Optional: true,
@@ -246,7 +246,7 @@ func TestSchemaAttribute(t *testing.T) {
 		},
 		"sensitive": {
 			name: "string",
-			attr: tfsdk.Attribute{
+			attr: testschema.Attribute{
 				Type:      types.StringType,
 				Optional:  true,
 				Sensitive: true,
@@ -261,19 +261,22 @@ func TestSchemaAttribute(t *testing.T) {
 		},
 		"nested-attr-single": {
 			name: "single_nested",
-			attr: tfsdk.Attribute{
-				Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
-					"string": {
-						Type:     types.StringType,
-						Optional: true,
+			attr: testschema.NestedAttribute{
+				NestedObject: testschema.NestedAttributeObject{
+					Attributes: map[string]fwschema.Attribute{
+						"string": testschema.Attribute{
+							Type:     types.StringType,
+							Optional: true,
+						},
+						"computed": testschema.Attribute{
+							Type:      types.NumberType,
+							Computed:  true,
+							Sensitive: true,
+						},
 					},
-					"computed": {
-						Type:      types.NumberType,
-						Computed:  true,
-						Sensitive: true,
-					},
-				}),
-				Optional: true,
+				},
+				NestingMode: fwschema.NestingModeSingle,
+				Optional:    true,
 			},
 			path: tftypes.NewAttributePath(),
 			expected: &tfprotov6.SchemaAttribute{
@@ -299,19 +302,22 @@ func TestSchemaAttribute(t *testing.T) {
 		},
 		"nested-attr-list": {
 			name: "list_nested",
-			attr: tfsdk.Attribute{
-				Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
-					"string": {
-						Type:     types.StringType,
-						Optional: true,
+			attr: testschema.NestedAttribute{
+				NestedObject: testschema.NestedAttributeObject{
+					Attributes: map[string]fwschema.Attribute{
+						"string": testschema.Attribute{
+							Type:     types.StringType,
+							Optional: true,
+						},
+						"computed": testschema.Attribute{
+							Type:      types.NumberType,
+							Computed:  true,
+							Sensitive: true,
+						},
 					},
-					"computed": {
-						Type:      types.NumberType,
-						Computed:  true,
-						Sensitive: true,
-					},
-				}),
-				Optional: true,
+				},
+				NestingMode: fwschema.NestingModeList,
+				Optional:    true,
 			},
 			path: tftypes.NewAttributePath(),
 			expected: &tfprotov6.SchemaAttribute{
@@ -335,21 +341,65 @@ func TestSchemaAttribute(t *testing.T) {
 				},
 			},
 		},
+		"nested-attr-map": {
+			name: "map_nested",
+			attr: testschema.NestedAttribute{
+				NestedObject: testschema.NestedAttributeObject{
+					Attributes: map[string]fwschema.Attribute{
+						"string": testschema.Attribute{
+							Type:     types.StringType,
+							Optional: true,
+						},
+						"computed": testschema.Attribute{
+							Type:      types.NumberType,
+							Computed:  true,
+							Sensitive: true,
+						},
+					},
+				},
+				NestingMode: fwschema.NestingModeMap,
+				Optional:    true,
+			},
+			path: tftypes.NewAttributePath(),
+			expected: &tfprotov6.SchemaAttribute{
+				Name:     "map_nested",
+				Optional: true,
+				NestedType: &tfprotov6.SchemaObject{
+					Nesting: tfprotov6.SchemaObjectNestingModeMap,
+					Attributes: []*tfprotov6.SchemaAttribute{
+						{
+							Name:      "computed",
+							Computed:  true,
+							Sensitive: true,
+							Type:      tftypes.Number,
+						},
+						{
+							Name:     "string",
+							Optional: true,
+							Type:     tftypes.String,
+						},
+					},
+				},
+			},
+		},
 		"nested-attr-set": {
 			name: "set_nested",
-			attr: tfsdk.Attribute{
-				Attributes: tfsdk.SetNestedAttributes(map[string]tfsdk.Attribute{
-					"string": {
-						Type:     types.StringType,
-						Optional: true,
+			attr: testschema.NestedAttribute{
+				NestedObject: testschema.NestedAttributeObject{
+					Attributes: map[string]fwschema.Attribute{
+						"string": testschema.Attribute{
+							Type:     types.StringType,
+							Optional: true,
+						},
+						"computed": testschema.Attribute{
+							Type:      types.NumberType,
+							Computed:  true,
+							Sensitive: true,
+						},
 					},
-					"computed": {
-						Type:      types.NumberType,
-						Computed:  true,
-						Sensitive: true,
-					},
-				}),
-				Optional: true,
+				},
+				NestingMode: fwschema.NestingModeSet,
+				Optional:    true,
 			},
 			path: tftypes.NewAttributePath(),
 			expected: &tfprotov6.SchemaAttribute{
@@ -373,41 +423,9 @@ func TestSchemaAttribute(t *testing.T) {
 				},
 			},
 		},
-		"attr-and-nested-attr-set": {
-			name: "whoops",
-			attr: tfsdk.Attribute{
-				Type: types.StringType,
-				Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
-					"testing": {
-						Type:     types.StringType,
-						Optional: true,
-					},
-				}),
-				Optional: true,
-			},
-			path:        tftypes.NewAttributePath(),
-			expectedErr: "cannot have both Attributes and Type set",
-		},
-		"attr-and-nested-attr-unset": {
-			name: "whoops",
-			attr: tfsdk.Attribute{
-				Optional: true,
-			},
-			path:        tftypes.NewAttributePath(),
-			expectedErr: "must have Attributes or Type set",
-		},
-		"attr-and-nested-attr-empty": {
-			name: "whoops",
-			attr: tfsdk.Attribute{
-				Optional:   true,
-				Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{}),
-			},
-			path:        tftypes.NewAttributePath(),
-			expectedErr: "must have Attributes or Type set",
-		},
 		"missing-required-optional-and-computed": {
 			name: "whoops",
-			attr: tfsdk.Attribute{
+			attr: testschema.Attribute{
 				Type: types.StringType,
 			},
 			path:        tftypes.NewAttributePath(),

--- a/internal/toproto6/schema_test.go
+++ b/internal/toproto6/schema_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/toproto6"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
@@ -29,25 +29,25 @@ func TestSchema(t *testing.T) {
 			expected: nil,
 		},
 		"empty-val": {
-			input: &tfsdk.Schema{},
+			input: testschema.Schema{},
 			expected: &tfprotov6.Schema{
 				Block:   &tfprotov6.SchemaBlock{},
 				Version: 0,
 			},
 		},
 		"basic-attrs": {
-			input: &tfsdk.Schema{
+			input: testschema.Schema{
 				Version: 1,
-				Attributes: map[string]tfsdk.Attribute{
-					"string": {
+				Attributes: map[string]fwschema.Attribute{
+					"string": testschema.Attribute{
 						Type:     types.StringType,
 						Required: true,
 					},
-					"number": {
+					"number": testschema.Attribute{
 						Type:     types.NumberType,
 						Optional: true,
 					},
-					"bool": {
+					"bool": testschema.Attribute{
 						Type:     types.BoolType,
 						Computed: true,
 					},
@@ -77,14 +77,14 @@ func TestSchema(t *testing.T) {
 			},
 		},
 		"complex-attrs": {
-			input: &tfsdk.Schema{
+			input: testschema.Schema{
 				Version: 2,
-				Attributes: map[string]tfsdk.Attribute{
-					"list": {
+				Attributes: map[string]fwschema.Attribute{
+					"list": testschema.Attribute{
 						Type:     types.ListType{ElemType: types.StringType},
 						Required: true,
 					},
-					"object": {
+					"object": testschema.Attribute{
 						Type: types.ObjectType{AttrTypes: map[string]attr.Type{
 							"string": types.StringType,
 							"number": types.NumberType,
@@ -92,11 +92,11 @@ func TestSchema(t *testing.T) {
 						}},
 						Optional: true,
 					},
-					"map": {
+					"map": testschema.Attribute{
 						Type:     types.MapType{ElemType: types.NumberType},
 						Computed: true,
 					},
-					"set": {
+					"set": testschema.Attribute{
 						Type:     types.SetType{ElemType: types.StringType},
 						Required: true,
 					},
@@ -136,97 +136,109 @@ func TestSchema(t *testing.T) {
 			},
 		},
 		"nested-attrs": {
-			input: &tfsdk.Schema{
+			input: testschema.Schema{
 				Version: 3,
-				Attributes: map[string]tfsdk.Attribute{
-					"single": {
-						Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
-							"string": {
-								Type:     types.StringType,
-								Required: true,
+				Attributes: map[string]fwschema.Attribute{
+					"single": testschema.NestedAttribute{
+						NestedObject: testschema.NestedAttributeObject{
+							Attributes: map[string]fwschema.Attribute{
+								"string": testschema.Attribute{
+									Type:     types.StringType,
+									Required: true,
+								},
+								"number": testschema.Attribute{
+									Type:     types.NumberType,
+									Optional: true,
+								},
+								"bool": testschema.Attribute{
+									Type:     types.BoolType,
+									Computed: true,
+								},
+								"list": testschema.Attribute{
+									Type:     types.ListType{ElemType: types.StringType},
+									Computed: true,
+									Optional: true,
+								},
 							},
-							"number": {
-								Type:     types.NumberType,
-								Optional: true,
-							},
-							"bool": {
-								Type:     types.BoolType,
-								Computed: true,
-							},
-							"list": {
-								Type:     types.ListType{ElemType: types.StringType},
-								Computed: true,
-								Optional: true,
-							},
-						}),
-						Required: true,
+						},
+						NestingMode: fwschema.NestingModeSingle,
+						Required:    true,
 					},
-					"list": {
-						Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
-							"string": {
-								Type:     types.StringType,
-								Required: true,
+					"list": testschema.NestedAttribute{
+						NestedObject: testschema.NestedAttributeObject{
+							Attributes: map[string]fwschema.Attribute{
+								"string": testschema.Attribute{
+									Type:     types.StringType,
+									Required: true,
+								},
+								"number": testschema.Attribute{
+									Type:     types.NumberType,
+									Optional: true,
+								},
+								"bool": testschema.Attribute{
+									Type:     types.BoolType,
+									Computed: true,
+								},
+								"list": testschema.Attribute{
+									Type:     types.ListType{ElemType: types.StringType},
+									Computed: true,
+									Optional: true,
+								},
 							},
-							"number": {
-								Type:     types.NumberType,
-								Optional: true,
-							},
-							"bool": {
-								Type:     types.BoolType,
-								Computed: true,
-							},
-							"list": {
-								Type:     types.ListType{ElemType: types.StringType},
-								Computed: true,
-								Optional: true,
-							},
-						}),
-						Optional: true,
+						},
+						NestingMode: fwschema.NestingModeList,
+						Optional:    true,
 					},
-					"set": {
-						Attributes: tfsdk.SetNestedAttributes(map[string]tfsdk.Attribute{
-							"string": {
-								Type:     types.StringType,
-								Required: true,
+					"set": testschema.NestedAttribute{
+						NestedObject: testschema.NestedAttributeObject{
+							Attributes: map[string]fwschema.Attribute{
+								"string": testschema.Attribute{
+									Type:     types.StringType,
+									Required: true,
+								},
+								"number": testschema.Attribute{
+									Type:     types.NumberType,
+									Optional: true,
+								},
+								"bool": testschema.Attribute{
+									Type:     types.BoolType,
+									Computed: true,
+								},
+								"list": testschema.Attribute{
+									Type:     types.ListType{ElemType: types.StringType},
+									Computed: true,
+									Optional: true,
+								},
 							},
-							"number": {
-								Type:     types.NumberType,
-								Optional: true,
-							},
-							"bool": {
-								Type:     types.BoolType,
-								Computed: true,
-							},
-							"list": {
-								Type:     types.ListType{ElemType: types.StringType},
-								Computed: true,
-								Optional: true,
-							},
-						}),
-						Computed: true,
+						},
+						NestingMode: fwschema.NestingModeSet,
+						Computed:    true,
 					},
-					"map": {
-						Attributes: tfsdk.MapNestedAttributes(map[string]tfsdk.Attribute{
-							"string": {
-								Type:     types.StringType,
-								Required: true,
+					"map": testschema.NestedAttribute{
+						NestedObject: testschema.NestedAttributeObject{
+							Attributes: map[string]fwschema.Attribute{
+								"string": testschema.Attribute{
+									Type:     types.StringType,
+									Required: true,
+								},
+								"number": testschema.Attribute{
+									Type:     types.NumberType,
+									Optional: true,
+								},
+								"bool": testschema.Attribute{
+									Type:     types.BoolType,
+									Computed: true,
+								},
+								"list": testschema.Attribute{
+									Type:     types.ListType{ElemType: types.StringType},
+									Computed: true,
+									Optional: true,
+								},
 							},
-							"number": {
-								Type:     types.NumberType,
-								Optional: true,
-							},
-							"bool": {
-								Type:     types.BoolType,
-								Computed: true,
-							},
-							"list": {
-								Type:     types.ListType{ElemType: types.StringType},
-								Computed: true,
-								Optional: true,
-							},
-						}),
-						Optional: true,
-						Computed: true,
+						},
+						NestingMode: fwschema.NestingModeMap,
+						Optional:    true,
+						Computed:    true,
 					},
 				},
 			},
@@ -360,74 +372,80 @@ func TestSchema(t *testing.T) {
 			},
 		},
 		"nested-blocks": {
-			input: &tfsdk.Schema{
+			input: testschema.Schema{
 				Version: 3,
-				Blocks: map[string]tfsdk.Block{
-					"list": {
-						Attributes: map[string]tfsdk.Attribute{
-							"string": {
-								Type:     types.StringType,
-								Required: true,
-							},
-							"number": {
-								Type:     types.NumberType,
-								Optional: true,
-							},
-							"bool": {
-								Type:     types.BoolType,
-								Computed: true,
-							},
-							"list": {
-								Type:     types.ListType{ElemType: types.StringType},
-								Computed: true,
-								Optional: true,
+				Blocks: map[string]fwschema.Block{
+					"list": testschema.Block{
+						NestedObject: testschema.NestedBlockObject{
+							Attributes: map[string]fwschema.Attribute{
+								"string": testschema.Attribute{
+									Type:     types.StringType,
+									Required: true,
+								},
+								"number": testschema.Attribute{
+									Type:     types.NumberType,
+									Optional: true,
+								},
+								"bool": testschema.Attribute{
+									Type:     types.BoolType,
+									Computed: true,
+								},
+								"list": testschema.Attribute{
+									Type:     types.ListType{ElemType: types.StringType},
+									Computed: true,
+									Optional: true,
+								},
 							},
 						},
-						NestingMode: tfsdk.BlockNestingModeList,
+						NestingMode: fwschema.BlockNestingModeList,
 					},
-					"set": {
-						Attributes: map[string]tfsdk.Attribute{
-							"string": {
-								Type:     types.StringType,
-								Required: true,
-							},
-							"number": {
-								Type:     types.NumberType,
-								Optional: true,
-							},
-							"bool": {
-								Type:     types.BoolType,
-								Computed: true,
-							},
-							"list": {
-								Type:     types.ListType{ElemType: types.StringType},
-								Computed: true,
-								Optional: true,
+					"set": testschema.Block{
+						NestedObject: testschema.NestedBlockObject{
+							Attributes: map[string]fwschema.Attribute{
+								"string": testschema.Attribute{
+									Type:     types.StringType,
+									Required: true,
+								},
+								"number": testschema.Attribute{
+									Type:     types.NumberType,
+									Optional: true,
+								},
+								"bool": testschema.Attribute{
+									Type:     types.BoolType,
+									Computed: true,
+								},
+								"list": testschema.Attribute{
+									Type:     types.ListType{ElemType: types.StringType},
+									Computed: true,
+									Optional: true,
+								},
 							},
 						},
-						NestingMode: tfsdk.BlockNestingModeSet,
+						NestingMode: fwschema.BlockNestingModeSet,
 					},
-					"single": {
-						Attributes: map[string]tfsdk.Attribute{
-							"string": {
-								Type:     types.StringType,
-								Required: true,
-							},
-							"number": {
-								Type:     types.NumberType,
-								Optional: true,
-							},
-							"bool": {
-								Type:     types.BoolType,
-								Computed: true,
-							},
-							"list": {
-								Type:     types.ListType{ElemType: types.StringType},
-								Computed: true,
-								Optional: true,
+					"single": testschema.Block{
+						NestedObject: testschema.NestedBlockObject{
+							Attributes: map[string]fwschema.Attribute{
+								"string": testschema.Attribute{
+									Type:     types.StringType,
+									Required: true,
+								},
+								"number": testschema.Attribute{
+									Type:     types.NumberType,
+									Optional: true,
+								},
+								"bool": testschema.Attribute{
+									Type:     types.BoolType,
+									Computed: true,
+								},
+								"list": testschema.Attribute{
+									Type:     types.ListType{ElemType: types.StringType},
+									Computed: true,
+									Optional: true,
+								},
 							},
 						},
-						NestingMode: tfsdk.BlockNestingModeSingle,
+						NestingMode: fwschema.BlockNestingModeSingle,
 					},
 				},
 			},
@@ -527,10 +545,10 @@ func TestSchema(t *testing.T) {
 			},
 		},
 		"markdown-description": {
-			input: &tfsdk.Schema{
+			input: testschema.Schema{
 				Version: 1,
-				Attributes: map[string]tfsdk.Attribute{
-					"string": {
+				Attributes: map[string]fwschema.Attribute{
+					"string": testschema.Attribute{
 						Type:     types.StringType,
 						Required: true,
 					},
@@ -553,10 +571,10 @@ func TestSchema(t *testing.T) {
 			},
 		},
 		"plaintext-description": {
-			input: &tfsdk.Schema{
+			input: testschema.Schema{
 				Version: 1,
-				Attributes: map[string]tfsdk.Attribute{
-					"string": {
+				Attributes: map[string]fwschema.Attribute{
+					"string": testschema.Attribute{
 						Type:     types.StringType,
 						Required: true,
 					},
@@ -579,10 +597,10 @@ func TestSchema(t *testing.T) {
 			},
 		},
 		"deprecated": {
-			input: &tfsdk.Schema{
+			input: testschema.Schema{
 				Version: 1,
-				Attributes: map[string]tfsdk.Attribute{
-					"string": {
+				Attributes: map[string]fwschema.Attribute{
+					"string": testschema.Attribute{
 						Type:     types.StringType,
 						Required: true,
 					},

--- a/internal/toproto6/state_test.go
+++ b/internal/toproto6/state_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/toproto6"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -34,9 +36,9 @@ func TestState(t *testing.T) {
 
 	testState := &tfsdk.State{
 		Raw: testProto6Value,
-		Schema: tfsdk.Schema{
-			Attributes: map[string]tfsdk.Attribute{
-				"test_attribute": {
+		Schema: testschema.Schema{
+			Attributes: map[string]fwschema.Attribute{
+				"test_attribute": testschema.Attribute{
 					Required: true,
 					Type:     types.StringType,
 				},
@@ -46,9 +48,9 @@ func TestState(t *testing.T) {
 
 	testStateInvalid := &tfsdk.State{
 		Raw: testProto6Value,
-		Schema: tfsdk.Schema{
-			Attributes: map[string]tfsdk.Attribute{
-				"test_attribute": {
+		Schema: testschema.Schema{
+			Attributes: map[string]fwschema.Attribute{
+				"test_attribute": testschema.Attribute{
 					Required: true,
 					Type:     types.BoolType,
 				},

--- a/internal/toproto6/upgraderesourcestate_test.go
+++ b/internal/toproto6/upgraderesourcestate_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
 	"github.com/hashicorp/terraform-plugin-framework/internal/toproto6"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
@@ -35,11 +35,10 @@ func TestUpgradeResourceStateResponse(t *testing.T) {
 
 	testState := &tfsdk.State{
 		Raw: testProto6Value,
-		Schema: tfsdk.Schema{
-			Attributes: map[string]tfsdk.Attribute{
-				"test_attribute": {
+		Schema: schema.Schema{
+			Attributes: map[string]schema.Attribute{
+				"test_attribute": schema.StringAttribute{
 					Required: true,
-					Type:     types.StringType,
 				},
 			},
 		},
@@ -47,11 +46,10 @@ func TestUpgradeResourceStateResponse(t *testing.T) {
 
 	testStateInvalid := &tfsdk.State{
 		Raw: testProto6Value,
-		Schema: tfsdk.Schema{
-			Attributes: map[string]tfsdk.Attribute{
-				"test_attribute": {
+		Schema: schema.Schema{
+			Attributes: map[string]schema.Attribute{
+				"test_attribute": schema.BoolAttribute{
 					Required: true,
-					Type:     types.BoolType,
 				},
 			},
 		},

--- a/internal/toproto6/validateproviderconfig_test.go
+++ b/internal/toproto6/validateproviderconfig_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
 	"github.com/hashicorp/terraform-plugin-framework/internal/toproto6"
+	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
@@ -35,11 +35,10 @@ func TestValidateProviderConfigResponse(t *testing.T) {
 
 	testConfig := &tfsdk.Config{
 		Raw: testProto6Value,
-		Schema: tfsdk.Schema{
-			Attributes: map[string]tfsdk.Attribute{
-				"test_attribute": {
+		Schema: schema.Schema{
+			Attributes: map[string]schema.Attribute{
+				"test_attribute": schema.StringAttribute{
 					Required: true,
-					Type:     types.StringType,
 				},
 			},
 		},
@@ -47,11 +46,10 @@ func TestValidateProviderConfigResponse(t *testing.T) {
 
 	testConfigInvalid := &tfsdk.Config{
 		Raw: testProto6Value,
-		Schema: tfsdk.Schema{
-			Attributes: map[string]tfsdk.Attribute{
-				"test_attribute": {
+		Schema: schema.Schema{
+			Attributes: map[string]schema.Attribute{
+				"test_attribute": schema.BoolAttribute{
 					Required: true,
-					Type:     types.BoolType,
 				},
 			},
 		},


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/132

Precursor for fully removing `tfsdk` package `Schema`, `Attribute`, and `Block` types. Replaced with `internal/testing/testschema`, `datasource/schema`, `provider/metaschema`, `provider/schema`, and `resource/schema` equivalents. Removed extraneous unit testing such as datasource versioning, provider Computed, etc. since it will be no longer possible to declare invalid schemas based on the concept.