### PR TITLE
fix incorrect field reference

### DIFF
--- a/website/docs/plugin/framework/resources/plan-modification.mdx
+++ b/website/docs/plugin/framework/resources/plan-modification.mdx
@@ -89,7 +89,7 @@ func (m stringDefaultModifier) PlanModifyString(ctx context.Context, req planmod
         return
     }
 
-    resp.AttributePlan = types.StringValue(m.Default)
+    resp.PlanValue = types.StringValue(m.Default)
 }
 ```
 


### PR DESCRIPTION
While testing out the documentation for creating a default value my LSP informed me that there was no field `AttributePlan` and upon checking the relevant type I found there was a `PlanValue` which seems to be what should be referenced in the example code.