### PR TITLE
website: Point overview muxing link at migration guide content

### DIFF
--- a/website/docs/plugin/framework/migrating/index.mdx
+++ b/website/docs/plugin/framework/migrating/index.mdx
@@ -24,7 +24,7 @@ Before you migrate your provider to the Framework, ensure it meets the following
 
 Consider muxing when you need to migrate a provider that contains many resources or data sources. Muxing lets you use two versions of the same provider concurrently, with each serving different resources or data sources. This lets you migrate individual resources or data sources to the Framework one at a time.
 
-Refer to the [Combining and Translating documentation](/plugin/mux) for details about muxing configuration.
+Refer to the [Provider muxing documentation](/plugin/framework/migrating/providers#muxing) for details about muxing configuration.
 
 ## Testing Migration
 


### PR DESCRIPTION
The overview page tries to hint that muxing can be used to iteratively migrate providers from SDK to framework, however the current link points to the generic mux documentation. The migration guide providers page has excellent content that is specific for this situation so it seems ideal to point there (which also links out to the generic mux documentation) rather than giving developers less directly useful information.