### PR TITLE
Increase timeout for golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,3 +21,7 @@ linters:
     - unparam
     - unused
     - vet
+
+run:
+  # Prevent false positive timeouts in CI
+  timeout: 5m


### PR DESCRIPTION
Reference: https://golangci-lint.run/usage/configuration/#run-configuration
Reference: https://github.com/hashicorp/terraform-plugin-framework/actions/runs/3856256179/jobs/6572249688

Updates the configuration timeout value to prevent CI false positives. Occasionally the GitHub Actions runners will take just over the 1 minute default timeout to run `golangci-lint` in this codebase, while the tool is generally fast on modern local hardware (suggesting it might be resource contention on the runners, not an inherent tooling issue).