### PR TITLE
ci: Enable paralleltest linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,7 +13,7 @@ linters:
     - ineffassign
     - makezero
     - nilerr
-    # - paralleltest # Reference: https://github.com/kunwardeep/paralleltest/issues/14
+    - paralleltest
     - predeclared
     - staticcheck
     - tenv

--- a/datasource/schema/schema_test.go
+++ b/datasource/schema/schema_test.go
@@ -1377,6 +1377,8 @@ func TestSchemaValidate(t *testing.T) {
 		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			diags := testCase.schema.Validate()
 
 			if diff := cmp.Diff(diags, testCase.expectedDiags); diff != "" {

--- a/diag/diagnostics_test.go
+++ b/diag/diagnostics_test.go
@@ -681,6 +681,8 @@ func TestDiagnosticsErrorsCount(t *testing.T) {
 	for name, test := range tests {
 		name, test := name, test
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			got := test.diags.ErrorsCount()
 
 			if diff := cmp.Diff(test.expected, got); diff != "" {
@@ -724,6 +726,8 @@ func TestDiagnosticsWarningsCount(t *testing.T) {
 	for name, test := range tests {
 		name, test := name, test
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			got := test.diags.WarningsCount()
 
 			if diff := cmp.Diff(test.expected, got); diff != "" {
@@ -769,6 +773,8 @@ func TestDiagnosticsErrors(t *testing.T) {
 	for name, test := range tests {
 		name, test := name, test
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			got := test.diags.Errors()
 
 			if diff := cmp.Diff(test.expected, got); diff != "" {
@@ -814,6 +820,8 @@ func TestDiagnosticsWarnings(t *testing.T) {
 	for name, test := range tests {
 		name, test := name, test
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			got := test.diags.Warnings()
 
 			if diff := cmp.Diff(test.expected, got); diff != "" {

--- a/internal/privatestate/data_test.go
+++ b/internal/privatestate/data_test.go
@@ -216,6 +216,8 @@ func TestData_Bytes(t *testing.T) {
 }
 
 func TestNewData(t *testing.T) {
+	t.Parallel()
+
 	// 1 x 1 transparent gif pixel.
 	const transPixel = "\x47\x49\x46\x38\x39\x61\x01\x00\x01\x00\x80\x00\x00\x00\x00\x00\x00\x00\x00\x21\xF9\x04\x01\x00\x00\x00\x00\x2C\x00\x00\x00\x00\x01\x00\x01\x00\x00\x02\x02\x44\x01\x00\x3B"
 
@@ -445,6 +447,8 @@ func TestNewData(t *testing.T) {
 }
 
 func TestNewProviderData(t *testing.T) {
+	t.Parallel()
+
 	// 1 x 1 transparent gif pixel.
 	const transPixel = "\x47\x49\x46\x38\x39\x61\x01\x00\x01\x00\x80\x00\x00\x00\x00\x00\x00\x00\x00\x21\xF9\x04\x01\x00\x00\x00\x00\x2C\x00\x00\x00\x00\x01\x00\x01\x00\x00\x02\x02\x44\x01\x00\x3B"
 
@@ -639,6 +643,8 @@ func TestProviderDataEqual(t *testing.T) {
 }
 
 func TestProviderData_GetKey(t *testing.T) {
+	t.Parallel()
+
 	testCases := map[string]struct {
 		providerData  *ProviderData
 		key           string
@@ -703,6 +709,8 @@ func TestProviderData_GetKey(t *testing.T) {
 }
 
 func TestProviderData_SetKey(t *testing.T) {
+	t.Parallel()
+
 	// 1 x 1 transparent gif pixel.
 	const transPixel = "\x47\x49\x46\x38\x39\x61\x01\x00\x01\x00\x80\x00\x00\x00\x00\x00\x00\x00\x00\x21\xF9\x04\x01\x00\x00\x00\x00\x2C\x00\x00\x00\x00\x01\x00\x01\x00\x00\x02\x02\x44\x01\x00\x3B"
 
@@ -888,6 +896,8 @@ func TestProviderData_SetKey(t *testing.T) {
 }
 
 func TestValidateProviderDataKey(t *testing.T) {
+	t.Parallel()
+
 	testCases := map[string]struct {
 		key           string
 		expectedDiags diag.Diagnostics

--- a/internal/reflect/struct_test.go
+++ b/internal/reflect/struct_test.go
@@ -496,6 +496,8 @@ func TestNewStruct_complex(t *testing.T) {
 }
 
 func TestFromStruct_primitives(t *testing.T) {
+	t.Parallel()
+
 	type disk struct {
 		Name    string `tfsdk:"name"`
 		Age     int    `tfsdk:"age"`

--- a/provider/metaschema/schema_test.go
+++ b/provider/metaschema/schema_test.go
@@ -924,6 +924,8 @@ func TestSchemaValidate(t *testing.T) {
 		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			diags := testCase.schema.Validate()
 
 			if diff := cmp.Diff(diags, testCase.expectedDiags); diff != "" {

--- a/provider/schema/schema_test.go
+++ b/provider/schema/schema_test.go
@@ -1377,6 +1377,8 @@ func TestSchemaValidate(t *testing.T) {
 		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			diags := testCase.schema.Validate()
 
 			if diff := cmp.Diff(diags, testCase.expectedDiags); diff != "" {

--- a/providerserver/providerserver_test.go
+++ b/providerserver/providerserver_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestNewProtocol5(t *testing.T) {
+	t.Parallel()
+
 	provider := &testprovider.Provider{}
 
 	providerServerFunc := NewProtocol5(provider)
@@ -24,6 +26,8 @@ func TestNewProtocol5(t *testing.T) {
 }
 
 func TestNewProtocol5WithError(t *testing.T) {
+	t.Parallel()
+
 	provider := &testprovider.Provider{}
 
 	providerServer, err := NewProtocol5WithError(provider)()
@@ -41,6 +45,8 @@ func TestNewProtocol5WithError(t *testing.T) {
 }
 
 func TestNewProtocol6(t *testing.T) {
+	t.Parallel()
+
 	provider := &testprovider.Provider{}
 
 	providerServerFunc := NewProtocol6(provider)
@@ -55,6 +61,8 @@ func TestNewProtocol6(t *testing.T) {
 }
 
 func TestNewProtocol6WithError(t *testing.T) {
+	t.Parallel()
+
 	provider := &testprovider.Provider{}
 
 	providerServer, err := NewProtocol6WithError(provider)()

--- a/resource/schema/schema_test.go
+++ b/resource/schema/schema_test.go
@@ -1386,6 +1386,8 @@ func TestSchemaValidate(t *testing.T) {
 		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			diags := testCase.schema.Validate()
 
 			if diff := cmp.Diff(diags, testCase.expectedDiags); diff != "" {

--- a/types/basetypes/list_test.go
+++ b/types/basetypes/list_test.go
@@ -59,6 +59,8 @@ func TestListTypeTerraformType(t *testing.T) {
 	for name, test := range tests {
 		name, test := name, test
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			got := test.input.TerraformType(context.Background())
 			if !got.Equal(test.expected) {
 				t.Errorf("Expected %s, got %s", test.expected, got)
@@ -178,6 +180,8 @@ func TestListTypeValueFromTerraform(t *testing.T) {
 	for name, test := range tests {
 		name, test := name, test
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			got, gotErr := test.receiver.ValueFromTerraform(context.Background(), test.input)
 			if gotErr != nil {
 				if test.expectedErr == "" {

--- a/types/basetypes/map_test.go
+++ b/types/basetypes/map_test.go
@@ -60,6 +60,8 @@ func TestMapTypeTerraformType(t *testing.T) {
 	for name, test := range tests {
 		name, test := name, test
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			got := test.input.TerraformType(context.Background())
 			if !got.Equal(test.expected) {
 				t.Errorf("Expected %s, got %s", test.expected, got)


### PR DESCRIPTION
Reference: https://github.com/kunwardeep/paralleltest

The upstream issue with map-based `range` false positives appears to be resolved.