### PR TITLE
internal/fwserver: Unit testing and changelog for ConfigValidators diagnostics overwrites

### DIFF
--- a/.changelog/619.txt
+++ b/.changelog/619.txt
@@ -1,0 +1,11 @@
+```release-note:bug
+datasource: Prevented `ConfigValidators` from unexpectedly modifying or removing prior validator diagnostics
+```
+
+```release-note:bug
+provider: Prevented `ConfigValidators` from unexpectedly modifying or removing prior validator diagnostics
+```
+
+```release-note:bug
+resource: Prevented `ConfigValidators` from unexpectedly modifying or removing prior validator diagnostics
+```


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform-plugin-framework/pull/619

Against current `main`:

```
--- FAIL: TestServerValidateDataSourceConfig (0.00s)
    --- FAIL: TestServerValidateDataSourceConfig/request-config-DataSourceWithConfigValidators-diagnostics (0.00s)
        /Users/bflad/src/github.com/hashicorp/terraform-plugin-framework/internal/fwserver/server_validatedatasourceconfig_test.go:301: unexpected difference:   &fwserver.ValidateDataSourceConfigResponse{
            - 	Diagnostics: diag.Diagnostics{diag.ErrorDiagnostic{detail: "error detail 2", summary: "error summary 2"}},
            + 	Diagnostics: diag.Diagnostics{
            + 		diag.ErrorDiagnostic{detail: "error detail 1", summary: "error summary 1"},
            + 		diag.ErrorDiagnostic{detail: "error detail 2", summary: "error summary 2"},
            + 	},
              }
--- FAIL: TestServerValidateProviderConfig (0.00s)
    --- FAIL: TestServerValidateProviderConfig/request-config-ProviderWithConfigValidators-diagnostics (0.00s)
        /Users/bflad/src/github.com/hashicorp/terraform-plugin-framework/internal/fwserver/server_validateproviderconfig_test.go:307: unexpected difference:   &fwserver.ValidateProviderConfigResponse{
              	PreparedConfig: &{Raw: s`tftypes.Object["test":tftypes.String]<"test":tftypes.String<"tes`..., Schema: schema.Schema{Attributes: {"test": schema.StringAttribute{Required: true}}}},
            - 	Diagnostics:    diag.Diagnostics{diag.ErrorDiagnostic{detail: "error detail 2", summary: "error summary 2"}},
            + 	Diagnostics: diag.Diagnostics{
            + 		diag.ErrorDiagnostic{detail: "error detail 1", summary: "error summary 1"},
            + 		diag.ErrorDiagnostic{detail: "error detail 2", summary: "error summary 2"},
            + 	},
              }
--- FAIL: TestServerValidateResourceConfig (0.00s)
    --- FAIL: TestServerValidateResourceConfig/request-config-ResourceWithConfigValidators-diagnostics (0.00s)
        /Users/bflad/src/github.com/hashicorp/terraform-plugin-framework/internal/fwserver/server_validateresourceconfig_test.go:301: unexpected difference:   &fwserver.ValidateResourceConfigResponse{
            - 	Diagnostics: diag.Diagnostics{diag.ErrorDiagnostic{detail: "error detail 2", summary: "error summary 2"}},
            + 	Diagnostics: diag.Diagnostics{
            + 		diag.ErrorDiagnostic{detail: "error detail 1", summary: "error summary 1"},
            + 		diag.ErrorDiagnostic{detail: "error detail 2", summary: "error summary 2"},
            + 	},
              }
```