### PR TITLE
Added lint rule + fix broken doc links

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,7 @@ linters:
     - gosimple
     - ineffassign
     - makezero
+    - misspell
     - nilerr
     - paralleltest
     - predeclared

--- a/website/docs/plugin/framework/getting-started/code-walkthrough.mdx
+++ b/website/docs/plugin/framework/getting-started/code-walkthrough.mdx
@@ -367,7 +367,7 @@ resource "example_resource" "example" {
 
 The `configurable_attribute` is defined within the [schema](#resource) as a string type attribute.
 
-Examples of the various types of attributes and their representation within Terraform configuration and schema definitions is detailed in [Core Configuration Concepts](/plugin/framework/getting-started/core-configuration-concepts).
+Examples of the various types of attributes and their representation within Terraform configuration and schema definitions are detailed in [Terraform Concepts](/plugin/framework/handling-data/terraform-concepts).
 
 ### Data Source Configuration
 
@@ -379,4 +379,4 @@ data "example_datasource" "example" {
 
 The `configurable_attribute` is defined within the [schema](#data-source) as a string type attribute.
 
-Examples of the various types of attributes and their representation within Terraform configuration and schema definitions is detailed in [Core Configuration Concepts](/plugin/framework/getting-started/core-configuration-concepts).
+Examples of the various types of attributes and their representation within Terraform configuration and schema definitions are detailed in [Terraform Concepts](/plugin/framework/handling-data/terraform-concepts).

--- a/website/docs/plugin/framework/getting-started/code-walkthrough.mdx
+++ b/website/docs/plugin/framework/getting-started/code-walkthrough.mdx
@@ -73,7 +73,7 @@ Refer to [Provider Servers](/plugin/framework/provider-servers) for more details
 
 The provider wraps resources and data sources which are typically used for interacting with cloud providers, SaaS providers, or other APIs.
 
-In this example the provider wraps a resource and a data source which simply interact with Terraform state. Refer to the [tutorial](/tutorials/providers-plugin-framework/providers-plugin-framework-provider-configure) for an example of provider configuration that configures an API client.
+In this example the provider wraps a resource and a data source which simply interact with Terraform state. Refer to the [tutorial](https://developer.hashicorp.com/terraform/tutorials/providers-plugin-framework/providers-plugin-framework-provider-configure) for an example of provider configuration that configures an API client.
 
 `New()` returns a function which returns a type that satisfies the `provider.Provider` interface. The `New()` function is called by the [provider server](#provider-server) to obtain the provider.
 

--- a/website/docs/plugin/framework/migrating/attributes-blocks/types.mdx
+++ b/website/docs/plugin/framework/migrating/attributes-blocks/types.mdx
@@ -172,5 +172,5 @@ func (r *exampleResource) Schema(ctx context.Context, req resource.SchemaRequest
             /* ... */
 ```
 
-Refer to [Core Configuration Concepts - Attributes](/plugin/framework/getting-started/core-configuration-concepts#attributes)
+Refer to [Terraform Concepts - Attributes](/plugin/framework/handling-data/terraform-concepts#attributes)
 for further examples of different types of schema attributes in the Framework.


### PR DESCRIPTION
### Lints
- Added `misspell`, ref https://github.com/hashicorp/terraform-providers-devex-internal/issues/83
- I decided to not add `forcetypeassert` in this PR as it had a number of hits:
<details>
  <summary>

#### `forcetypeassert` errors

</summary>

  ```bash
$ golangci-lint run

internal/reflect/interfaces_test.go:272:4: type assertion must be checked (forcetypeassert)
			got := res.Interface().(*unknownableString)
			^
internal/reflect/interfaces_test.go:370:4: type assertion must be checked (forcetypeassert)
			got := res.Interface().(*nullableString)
			^
internal/reflect/interfaces_test.go:460:4: type assertion must be checked (forcetypeassert)
			got := res.Interface().(types.String)
			^
internal/reflect/interfaces_test.go:557:4: type assertion must be checked (forcetypeassert)
			got := res.Interface().(*valueConverter)
			^
internal/reflect/pointer_test.go:50:7: type assertion must be checked (forcetypeassert)
	if *(got.Interface().(*string)) != "hello" {
	     ^
internal/reflect/pointer_test.go:51:45: type assertion must be checked (forcetypeassert)
		t.Errorf("Expected \"hello\", got %+v", *(got.Interface().(*string)))
		                                          ^
internal/reflect/pointer_test.go:66:7: type assertion must be checked (forcetypeassert)
	if *(got.Interface().(*string)) != "hello" {
	     ^
internal/reflect/pointer_test.go:67:45: type assertion must be checked (forcetypeassert)
		t.Errorf("Expected \"hello\", got %+v", *(got.Interface().(*string)))
		                                          ^
internal/reflect/pointer_test.go:82:8: type assertion must be checked (forcetypeassert)
	if **(got.Interface().(**string)) != "hello" {
	      ^
internal/reflect/pointer_test.go:83:46: type assertion must be checked (forcetypeassert)
		t.Errorf("Expected \"hello\", got %+v", **(got.Interface().(**string)))
		                                           ^
internal/testing/types/boolwithvalidate.go:27:2: type assertion must be checked (forcetypeassert)
	newBool := res.(Bool)
	^
internal/testing/types/boolwithvalidate.go:41:2: type assertion must be checked (forcetypeassert)
	newBool := res.(Bool)
	^
internal/testing/types/numberwithvalidate.go:39:2: type assertion must be checked (forcetypeassert)
	newNumber := res.(Number)
	^
internal/testing/types/numberwithvalidate.go:49:2: type assertion must be checked (forcetypeassert)
	newNumber := res.(Number)
	^
internal/testing/types/stringwithvalidate.go:35:2: type assertion must be checked (forcetypeassert)
	newString := res.(String)
	^
internal/testing/types/stringwithvalidate.go:61:2: type assertion must be checked (forcetypeassert)
	newString := res.(String)
	^
internal/reflect/pointer_zero_test.go:14:5: type assertion must be checked (forcetypeassert)
	if got.Interface().(string) != "" {
	   ^
internal/reflect/pointer_zero_test.go:24:33: type assertion must be checked (forcetypeassert)
	if got.Interface() != nil && *(got.Interface().(*string)) != "" {
	                               ^
internal/reflect/pointer_zero_test.go:34:34: type assertion must be checked (forcetypeassert)
	if got.Interface() != nil && **(got.Interface().(**string)) != "" {
	                                ^
internal/reflect/pointer_zero_test.go:44:35: type assertion must be checked (forcetypeassert)
	if got.Interface() != nil && ***(got.Interface().(***string)) != "" {
	                                 ^
internal/reflect/pointer_zero_test.go:54:42: type assertion must be checked (forcetypeassert)
	if got.Interface() != nil && **********(got.Interface().(**********string)) != "" {
	                                        ^
tfsdk/value_as.go:18:5: type assertion must be checked (forcetypeassert)
		*(target.(*attr.Value)) = val
		  ^
tfsdk/value_as_test.go:356:8: type assertion must be checked (forcetypeassert)
				if diff := (*tc.expected.(**big.Float)).Cmp(*tc.target.(**big.Float)); diff != 0 {
				   ^
internal/fwserver/server_createresource.go:51:3: type assertion must be checked (forcetypeassert)
		req.Resource.(resource.ResourceWithConfigure).Configure(ctx, configureReq, &configureResp)
		^
internal/fwserver/server_deleteresource.go:50:3: type assertion must be checked (forcetypeassert)
		req.Resource.(resource.ResourceWithConfigure).Configure(ctx, configureReq, &configureResp)
		^
internal/fwserver/server_importresourcestate.go:59:3: type assertion must be checked (forcetypeassert)
		req.Resource.(resource.ResourceWithConfigure).Configure(ctx, configureReq, &configureResp)
		^
internal/fwserver/server_planresourcechange.go:56:3: type assertion must be checked (forcetypeassert)
		req.Resource.(resource.ResourceWithConfigure).Configure(ctx, configureReq, &configureResp)
		^
internal/fwserver/server_planresourcechange.go:280:47: type assertion must be checked (forcetypeassert)
		} else if err != tftypes.ErrInvalidStep && !configVal.(tftypes.Value).IsNull() {
		                                            ^
internal/fwserver/server_readdatasource.go:44:3: type assertion must be checked (forcetypeassert)
		req.DataSource.(datasource.DataSourceWithConfigure).Configure(ctx, configureReq, &configureResp)
		^
internal/fwserver/server_readresource.go:55:3: type assertion must be checked (forcetypeassert)
		req.Resource.(resource.ResourceWithConfigure).Configure(ctx, configureReq, &configureResp)
		^
internal/fwserver/server_updateresource.go:52:3: type assertion must be checked (forcetypeassert)
		req.Resource.(resource.ResourceWithConfigure).Configure(ctx, configureReq, &configureResp)
		^
internal/fwserver/server_upgraderesourcestate.go:111:3: type assertion must be checked (forcetypeassert)
		req.Resource.(resource.ResourceWithConfigure).Configure(ctx, configureReq, &configureResp)
		^
internal/fwserver/server_validatedatasourceconfig.go:40:3: type assertion must be checked (forcetypeassert)
		req.DataSource.(datasource.DataSourceWithConfigure).Configure(ctx, configureReq, &configureResp)
		^
internal/fwserver/server_validateresourceconfig.go:40:3: type assertion must be checked (forcetypeassert)
		req.Resource.(resource.ResourceWithConfigure).Configure(ctx, configureReq, &configureResp)
		^
internal/fwschemadata/data_get_at_path.go:36:5: type assertion must be checked (forcetypeassert)
		*(target.(*attr.Value)) = attrValue
		  ^
  ```

</details>


### Docs
- Found a couple broken links, I looked through #554 and 85aff913dfcb01bf4d61d6034d274c57946e9bca to fix the `core configuration concepts` one, lmk if that looks incorrect

