### PR TITLE
ci: added `forcetypeassert` lint rule + resolved all lint warnings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,7 @@ linters:
     - durationcheck
     - errcheck
     - exportloopref
+    - forcetypeassert
     - gofmt
     - gosimple
     - ineffassign

--- a/internal/fwschemadata/data_get_at_path.go
+++ b/internal/fwschemadata/data_get_at_path.go
@@ -33,6 +33,7 @@ func (d Data) GetAtPath(ctx context.Context, schemaPath path.Path, target any) d
 	}
 
 	if reflect.IsGenericAttrValue(ctx, target) {
+		//nolint:forcetypeassert // Type assertion is guaranteed by the above `reflect.IsGenericAttrValue` function
 		*(target.(*attr.Value)) = attrValue
 		return nil
 	}

--- a/internal/fwserver/server_createresource.go
+++ b/internal/fwserver/server_createresource.go
@@ -39,7 +39,7 @@ func (s *Server) CreateResource(ctx context.Context, req *CreateResourceRequest,
 		return
 	}
 
-	if _, ok := req.Resource.(resource.ResourceWithConfigure); ok {
+	if resourceWithConfigure, ok := req.Resource.(resource.ResourceWithConfigure); ok {
 		logging.FrameworkTrace(ctx, "Resource implements ResourceWithConfigure")
 
 		configureReq := resource.ConfigureRequest{
@@ -48,7 +48,7 @@ func (s *Server) CreateResource(ctx context.Context, req *CreateResourceRequest,
 		configureResp := resource.ConfigureResponse{}
 
 		logging.FrameworkDebug(ctx, "Calling provider defined Resource Configure")
-		req.Resource.(resource.ResourceWithConfigure).Configure(ctx, configureReq, &configureResp)
+		resourceWithConfigure.Configure(ctx, configureReq, &configureResp)
 		logging.FrameworkDebug(ctx, "Called provider defined Resource Configure")
 
 		resp.Diagnostics.Append(configureResp.Diagnostics...)

--- a/internal/fwserver/server_deleteresource.go
+++ b/internal/fwserver/server_deleteresource.go
@@ -38,7 +38,7 @@ func (s *Server) DeleteResource(ctx context.Context, req *DeleteResourceRequest,
 		return
 	}
 
-	if _, ok := req.Resource.(resource.ResourceWithConfigure); ok {
+	if resourceWithConfigure, ok := req.Resource.(resource.ResourceWithConfigure); ok {
 		logging.FrameworkTrace(ctx, "Resource implements ResourceWithConfigure")
 
 		configureReq := resource.ConfigureRequest{
@@ -47,7 +47,7 @@ func (s *Server) DeleteResource(ctx context.Context, req *DeleteResourceRequest,
 		configureResp := resource.ConfigureResponse{}
 
 		logging.FrameworkDebug(ctx, "Calling provider defined Resource Configure")
-		req.Resource.(resource.ResourceWithConfigure).Configure(ctx, configureReq, &configureResp)
+		resourceWithConfigure.Configure(ctx, configureReq, &configureResp)
 		logging.FrameworkDebug(ctx, "Called provider defined Resource Configure")
 
 		resp.Diagnostics.Append(configureResp.Diagnostics...)

--- a/internal/fwserver/server_importresourcestate.go
+++ b/internal/fwserver/server_importresourcestate.go
@@ -47,7 +47,7 @@ func (s *Server) ImportResourceState(ctx context.Context, req *ImportResourceSta
 		return
 	}
 
-	if _, ok := req.Resource.(resource.ResourceWithConfigure); ok {
+	if resourceWithConfigure, ok := req.Resource.(resource.ResourceWithConfigure); ok {
 		logging.FrameworkTrace(ctx, "Resource implements ResourceWithConfigure")
 
 		configureReq := resource.ConfigureRequest{
@@ -56,7 +56,7 @@ func (s *Server) ImportResourceState(ctx context.Context, req *ImportResourceSta
 		configureResp := resource.ConfigureResponse{}
 
 		logging.FrameworkDebug(ctx, "Calling provider defined Resource Configure")
-		req.Resource.(resource.ResourceWithConfigure).Configure(ctx, configureReq, &configureResp)
+		resourceWithConfigure.Configure(ctx, configureReq, &configureResp)
 		logging.FrameworkDebug(ctx, "Called provider defined Resource Configure")
 
 		resp.Diagnostics.Append(configureResp.Diagnostics...)

--- a/internal/fwserver/server_planresourcechange.go
+++ b/internal/fwserver/server_planresourcechange.go
@@ -44,7 +44,7 @@ func (s *Server) PlanResourceChange(ctx context.Context, req *PlanResourceChange
 		return
 	}
 
-	if _, ok := req.Resource.(resource.ResourceWithConfigure); ok {
+	if resourceWithConfigure, ok := req.Resource.(resource.ResourceWithConfigure); ok {
 		logging.FrameworkTrace(ctx, "Resource implements ResourceWithConfigure")
 
 		configureReq := resource.ConfigureRequest{
@@ -53,7 +53,7 @@ func (s *Server) PlanResourceChange(ctx context.Context, req *PlanResourceChange
 		configureResp := resource.ConfigureResponse{}
 
 		logging.FrameworkDebug(ctx, "Calling provider defined Resource Configure")
-		req.Resource.(resource.ResourceWithConfigure).Configure(ctx, configureReq, &configureResp)
+		resourceWithConfigure.Configure(ctx, configureReq, &configureResp)
 		logging.FrameworkDebug(ctx, "Called provider defined Resource Configure")
 
 		resp.Diagnostics.Append(configureResp.Diagnostics...)

--- a/internal/fwserver/server_planresourcechange.go
+++ b/internal/fwserver/server_planresourcechange.go
@@ -277,7 +277,7 @@ func MarkComputedNilsAsUnknown(ctx context.Context, config tftypes.Value, resour
 		if err != tftypes.ErrInvalidStep && err != nil {
 			logging.FrameworkError(ctx, "error walking attribute path")
 			return val, err
-		} else if err != tftypes.ErrInvalidStep && !configVal.(tftypes.Value).IsNull() {
+		} else if err != tftypes.ErrInvalidStep && !configVal.(tftypes.Value).IsNull() { //nolint:forcetypeassert // Not sure the best comment for here? Should we handle this?
 			logging.FrameworkTrace(ctx, "attribute not null in config, not marking unknown")
 			return val, nil
 		}

--- a/internal/fwserver/server_readdatasource.go
+++ b/internal/fwserver/server_readdatasource.go
@@ -32,7 +32,7 @@ func (s *Server) ReadDataSource(ctx context.Context, req *ReadDataSourceRequest,
 		return
 	}
 
-	if _, ok := req.DataSource.(datasource.DataSourceWithConfigure); ok {
+	if dataSourceWithConfigure, ok := req.DataSource.(datasource.DataSourceWithConfigure); ok {
 		logging.FrameworkTrace(ctx, "DataSource implements DataSourceWithConfigure")
 
 		configureReq := datasource.ConfigureRequest{
@@ -41,7 +41,7 @@ func (s *Server) ReadDataSource(ctx context.Context, req *ReadDataSourceRequest,
 		configureResp := datasource.ConfigureResponse{}
 
 		logging.FrameworkDebug(ctx, "Calling provider defined DataSource Configure")
-		req.DataSource.(datasource.DataSourceWithConfigure).Configure(ctx, configureReq, &configureResp)
+		dataSourceWithConfigure.Configure(ctx, configureReq, &configureResp)
 		logging.FrameworkDebug(ctx, "Called provider defined DataSource Configure")
 
 		resp.Diagnostics.Append(configureResp.Diagnostics...)

--- a/internal/fwserver/server_readresource.go
+++ b/internal/fwserver/server_readresource.go
@@ -43,7 +43,7 @@ func (s *Server) ReadResource(ctx context.Context, req *ReadResourceRequest, res
 		return
 	}
 
-	if _, ok := req.Resource.(resource.ResourceWithConfigure); ok {
+	if resourceWithConfigure, ok := req.Resource.(resource.ResourceWithConfigure); ok {
 		logging.FrameworkTrace(ctx, "Resource implements ResourceWithConfigure")
 
 		configureReq := resource.ConfigureRequest{
@@ -52,7 +52,7 @@ func (s *Server) ReadResource(ctx context.Context, req *ReadResourceRequest, res
 		configureResp := resource.ConfigureResponse{}
 
 		logging.FrameworkDebug(ctx, "Calling provider defined Resource Configure")
-		req.Resource.(resource.ResourceWithConfigure).Configure(ctx, configureReq, &configureResp)
+		resourceWithConfigure.Configure(ctx, configureReq, &configureResp)
 		logging.FrameworkDebug(ctx, "Called provider defined Resource Configure")
 
 		resp.Diagnostics.Append(configureResp.Diagnostics...)

--- a/internal/fwserver/server_updateresource.go
+++ b/internal/fwserver/server_updateresource.go
@@ -40,7 +40,7 @@ func (s *Server) UpdateResource(ctx context.Context, req *UpdateResourceRequest,
 		return
 	}
 
-	if _, ok := req.Resource.(resource.ResourceWithConfigure); ok {
+	if resourceWithConfigure, ok := req.Resource.(resource.ResourceWithConfigure); ok {
 		logging.FrameworkTrace(ctx, "Resource implements ResourceWithConfigure")
 
 		configureReq := resource.ConfigureRequest{
@@ -49,7 +49,7 @@ func (s *Server) UpdateResource(ctx context.Context, req *UpdateResourceRequest,
 		configureResp := resource.ConfigureResponse{}
 
 		logging.FrameworkDebug(ctx, "Calling provider defined Resource Configure")
-		req.Resource.(resource.ResourceWithConfigure).Configure(ctx, configureReq, &configureResp)
+		resourceWithConfigure.Configure(ctx, configureReq, &configureResp)
 		logging.FrameworkDebug(ctx, "Called provider defined Resource Configure")
 
 		resp.Diagnostics.Append(configureResp.Diagnostics...)

--- a/internal/fwserver/server_upgraderesourcestate.go
+++ b/internal/fwserver/server_upgraderesourcestate.go
@@ -99,7 +99,7 @@ func (s *Server) UpgradeResourceState(ctx context.Context, req *UpgradeResourceS
 		return
 	}
 
-	if _, ok := req.Resource.(resource.ResourceWithConfigure); ok {
+	if resourceWithConfigure, ok := req.Resource.(resource.ResourceWithConfigure); ok {
 		logging.FrameworkTrace(ctx, "Resource implements ResourceWithConfigure")
 
 		configureReq := resource.ConfigureRequest{
@@ -108,7 +108,7 @@ func (s *Server) UpgradeResourceState(ctx context.Context, req *UpgradeResourceS
 		configureResp := resource.ConfigureResponse{}
 
 		logging.FrameworkDebug(ctx, "Calling provider defined Resource Configure")
-		req.Resource.(resource.ResourceWithConfigure).Configure(ctx, configureReq, &configureResp)
+		resourceWithConfigure.Configure(ctx, configureReq, &configureResp)
 		logging.FrameworkDebug(ctx, "Called provider defined Resource Configure")
 
 		resp.Diagnostics.Append(configureResp.Diagnostics...)

--- a/internal/fwserver/server_validatedatasourceconfig.go
+++ b/internal/fwserver/server_validatedatasourceconfig.go
@@ -28,7 +28,7 @@ func (s *Server) ValidateDataSourceConfig(ctx context.Context, req *ValidateData
 		return
 	}
 
-	if _, ok := req.DataSource.(datasource.DataSourceWithConfigure); ok {
+	if dataSourceWithConfigure, ok := req.DataSource.(datasource.DataSourceWithConfigure); ok {
 		logging.FrameworkTrace(ctx, "DataSource implements DataSourceWithConfigure")
 
 		configureReq := datasource.ConfigureRequest{
@@ -37,7 +37,7 @@ func (s *Server) ValidateDataSourceConfig(ctx context.Context, req *ValidateData
 		configureResp := datasource.ConfigureResponse{}
 
 		logging.FrameworkDebug(ctx, "Calling provider defined DataSource Configure")
-		req.DataSource.(datasource.DataSourceWithConfigure).Configure(ctx, configureReq, &configureResp)
+		dataSourceWithConfigure.Configure(ctx, configureReq, &configureResp)
 		logging.FrameworkDebug(ctx, "Called provider defined DataSource Configure")
 
 		resp.Diagnostics.Append(configureResp.Diagnostics...)

--- a/internal/fwserver/server_validateresourceconfig.go
+++ b/internal/fwserver/server_validateresourceconfig.go
@@ -28,7 +28,7 @@ func (s *Server) ValidateResourceConfig(ctx context.Context, req *ValidateResour
 		return
 	}
 
-	if _, ok := req.Resource.(resource.ResourceWithConfigure); ok {
+	if resourceWithConfigure, ok := req.Resource.(resource.ResourceWithConfigure); ok {
 		logging.FrameworkTrace(ctx, "Resource implements ResourceWithConfigure")
 
 		configureReq := resource.ConfigureRequest{
@@ -37,7 +37,7 @@ func (s *Server) ValidateResourceConfig(ctx context.Context, req *ValidateResour
 		configureResp := resource.ConfigureResponse{}
 
 		logging.FrameworkDebug(ctx, "Calling provider defined Resource Configure")
-		req.Resource.(resource.ResourceWithConfigure).Configure(ctx, configureReq, &configureResp)
+		resourceWithConfigure.Configure(ctx, configureReq, &configureResp)
 		logging.FrameworkDebug(ctx, "Called provider defined Resource Configure")
 
 		resp.Diagnostics.Append(configureResp.Diagnostics...)

--- a/internal/reflect/interfaces_test.go
+++ b/internal/reflect/interfaces_test.go
@@ -269,7 +269,10 @@ func TestNewUnknownable(t *testing.T) {
 				return
 			}
 
-			got := res.Interface().(*unknownableString)
+			got, ok := res.Interface().(*unknownableString)
+			if !ok {
+				t.Fatalf("Expected type of *unknownableString, got %T", res.Interface())
+			}
 
 			if got.Unknown != tc.expected {
 				t.Errorf("Expected %v, got %v", tc.expected, got.Unknown)
@@ -367,7 +370,10 @@ func TestNewNullable(t *testing.T) {
 				return
 			}
 
-			got := res.Interface().(*nullableString)
+			got, ok := res.Interface().(*nullableString)
+			if !ok {
+				t.Fatalf("Expected type of *nullableString, got %T", res.Interface())
+			}
 
 			if got.Null != tc.expected {
 				t.Errorf("Expected %v, got %v", tc.expected, got.Null)
@@ -457,7 +463,10 @@ func TestNewAttributeValue(t *testing.T) {
 				return
 			}
 
-			got := res.Interface().(types.String)
+			got, ok := res.Interface().(types.String)
+			if !ok {
+				t.Fatalf("Expected type of types.String, got %T", res.Interface())
+			}
 
 			if diff := cmp.Diff(got, tc.expected); diff != "" {
 				t.Errorf("unexpected result (+wanted, -got): %s", diff)
@@ -554,7 +563,10 @@ func TestNewValueConverter(t *testing.T) {
 				return
 			}
 
-			got := res.Interface().(*valueConverter)
+			got, ok := res.Interface().(*valueConverter)
+			if !ok {
+				t.Fatalf("Expected type of *valueConverter, got %T", res.Interface())
+			}
 
 			if diff := cmp.Diff(got, tc.expected); diff != "" {
 				t.Errorf("unexpected result (+wanted, -got): %s", diff)

--- a/internal/reflect/pointer_test.go
+++ b/internal/reflect/pointer_test.go
@@ -47,8 +47,12 @@ func TestPointer_nilPointer(t *testing.T) {
 	if got.Interface() == nil {
 		t.Error("Expected \"hello\", got nil")
 	}
-	if *(got.Interface().(*string)) != "hello" {
-		t.Errorf("Expected \"hello\", got %+v", *(got.Interface().(*string)))
+	gotStr, ok := got.Interface().(*string)
+	if !ok {
+		t.Fatalf("Expected type of *string, got %T", got.Interface())
+	}
+	if *(gotStr) != "hello" {
+		t.Errorf("Expected \"hello\", got %+v", *(gotStr))
 	}
 }
 
@@ -63,8 +67,12 @@ func TestPointer_simple(t *testing.T) {
 	if got.Interface() == nil {
 		t.Error("Expected \"hello\", got nil")
 	}
-	if *(got.Interface().(*string)) != "hello" {
-		t.Errorf("Expected \"hello\", got %+v", *(got.Interface().(*string)))
+	gotStr, ok := got.Interface().(*string)
+	if !ok {
+		t.Fatalf("Expected type of *string, got %T", got.Interface())
+	}
+	if *(gotStr) != "hello" {
+		t.Errorf("Expected \"hello\", got %+v", *(gotStr))
 	}
 }
 
@@ -79,8 +87,12 @@ func TestPointer_pointerPointer(t *testing.T) {
 	if got.Interface() == nil {
 		t.Error("Expected \"hello\", got nil")
 	}
-	if **(got.Interface().(**string)) != "hello" {
-		t.Errorf("Expected \"hello\", got %+v", **(got.Interface().(**string)))
+	gotStr, ok := got.Interface().(**string)
+	if !ok {
+		t.Fatalf("Expected type of **string, got %T", got.Interface())
+	}
+	if **(gotStr) != "hello" {
+		t.Errorf("Expected \"hello\", got %+v", **(gotStr))
 	}
 }
 

--- a/internal/reflect/pointer_zero_test.go
+++ b/internal/reflect/pointer_zero_test.go
@@ -11,7 +11,13 @@ func TestPointerSafeZeroValue_zeroPointers(t *testing.T) {
 
 	var s string
 	got := pointerSafeZeroValue(context.Background(), reflect.ValueOf(s))
-	if got.Interface().(string) != "" {
+
+	gotStr, ok := got.Interface().(string)
+	if !ok {
+		t.Fatalf("expected type of string, got %T", got.Interface())
+	}
+
+	if gotStr != "" {
 		t.Errorf("expected \"\", got %v", got.Interface())
 	}
 }
@@ -21,7 +27,13 @@ func TestPointerSafeZeroValue_onePointer(t *testing.T) {
 
 	var s *string
 	got := pointerSafeZeroValue(context.Background(), reflect.ValueOf(s))
-	if got.Interface() != nil && *(got.Interface().(*string)) != "" {
+
+	gotStr, ok := got.Interface().(*string)
+	if !ok {
+		t.Fatalf("expected type of *string, got %T", got.Interface())
+	}
+
+	if got.Interface() != nil && *(gotStr) != "" {
 		t.Errorf("expected \"\", got %v", got.Interface())
 	}
 }
@@ -31,7 +43,13 @@ func TestPointerSafeZeroValue_twoPointers(t *testing.T) {
 
 	var s **string
 	got := pointerSafeZeroValue(context.Background(), reflect.ValueOf(s))
-	if got.Interface() != nil && **(got.Interface().(**string)) != "" {
+
+	gotStr, ok := got.Interface().(**string)
+	if !ok {
+		t.Fatalf("expected type of **string, got %T", got.Interface())
+	}
+
+	if got.Interface() != nil && **(gotStr) != "" {
 		t.Errorf("expected \"\", got %v", got.Interface())
 	}
 }
@@ -41,7 +59,13 @@ func TestPointerSafeZeroValue_threePointers(t *testing.T) {
 
 	var s ***string
 	got := pointerSafeZeroValue(context.Background(), reflect.ValueOf(s))
-	if got.Interface() != nil && ***(got.Interface().(***string)) != "" {
+
+	gotStr, ok := got.Interface().(***string)
+	if !ok {
+		t.Fatalf("expected type of ***string, got %T", got.Interface())
+	}
+
+	if got.Interface() != nil && ***(gotStr) != "" {
 		t.Errorf("expected \"\", got %v", got.Interface())
 	}
 }
@@ -51,7 +75,13 @@ func TestPointerSafeZeroValue_tenPointers(t *testing.T) {
 
 	var s **********string
 	got := pointerSafeZeroValue(context.Background(), reflect.ValueOf(s))
-	if got.Interface() != nil && **********(got.Interface().(**********string)) != "" {
+
+	gotStr, ok := got.Interface().(**********string)
+	if !ok {
+		t.Fatalf("expected type of **********string, got %T", got.Interface())
+	}
+
+	if got.Interface() != nil && **********(gotStr) != "" {
 		t.Errorf("expected \"\", got %v", got.Interface())
 	}
 }

--- a/internal/testing/types/boolwithvalidate.go
+++ b/internal/testing/types/boolwithvalidate.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/attr/xattr"
@@ -25,8 +26,10 @@ func (b BoolTypeWithValidateError) ValueFromTerraform(ctx context.Context, in tf
 		return nil, err
 	}
 
-	//nolint:forcetypeassert // This type is used for testing only
-	newBool := res.(Bool)
+	newBool, ok := res.(Bool)
+	if !ok {
+		return nil, fmt.Errorf("unexpected value type of %T", res)
+	}
 	newBool.CreatedBy = b
 	return newBool, nil
 }
@@ -41,8 +44,10 @@ func (b BoolTypeWithValidateWarning) ValueFromTerraform(ctx context.Context, in 
 		return nil, err
 	}
 
-	//nolint:forcetypeassert // This type is used for testing only
-	newBool := res.(Bool)
+	newBool, ok := res.(Bool)
+	if !ok {
+		return nil, fmt.Errorf("unexpected value type of %T", res)
+	}
 	newBool.CreatedBy = b
 	return newBool, nil
 }

--- a/internal/testing/types/boolwithvalidate.go
+++ b/internal/testing/types/boolwithvalidate.go
@@ -24,6 +24,8 @@ func (b BoolTypeWithValidateError) ValueFromTerraform(ctx context.Context, in tf
 	if err != nil {
 		return nil, err
 	}
+
+	//nolint:forcetypeassert // This type is used for testing only
 	newBool := res.(Bool)
 	newBool.CreatedBy = b
 	return newBool, nil
@@ -38,6 +40,8 @@ func (b BoolTypeWithValidateWarning) ValueFromTerraform(ctx context.Context, in 
 	if err != nil {
 		return nil, err
 	}
+
+	//nolint:forcetypeassert // This type is used for testing only
 	newBool := res.(Bool)
 	newBool.CreatedBy = b
 	return newBool, nil

--- a/internal/testing/types/numberwithvalidate.go
+++ b/internal/testing/types/numberwithvalidate.go
@@ -36,6 +36,8 @@ func (n NumberTypeWithValidateError) ValueFromTerraform(ctx context.Context, in 
 	if err != nil {
 		return nil, err
 	}
+
+	//nolint:forcetypeassert // This type is used for testing only
 	newNumber := res.(Number)
 	newNumber.CreatedBy = n
 	return newNumber, nil
@@ -46,6 +48,8 @@ func (n NumberTypeWithValidateWarning) ValueFromTerraform(ctx context.Context, i
 	if err != nil {
 		return nil, err
 	}
+
+	//nolint:forcetypeassert // This type is used for testing only
 	newNumber := res.(Number)
 	newNumber.CreatedBy = n
 	return newNumber, nil

--- a/internal/testing/types/numberwithvalidate.go
+++ b/internal/testing/types/numberwithvalidate.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/attr/xattr"
@@ -37,8 +38,10 @@ func (n NumberTypeWithValidateError) ValueFromTerraform(ctx context.Context, in 
 		return nil, err
 	}
 
-	//nolint:forcetypeassert // This type is used for testing only
-	newNumber := res.(Number)
+	newNumber, ok := res.(Number)
+	if !ok {
+		return nil, fmt.Errorf("unexpected value type of %T", res)
+	}
 	newNumber.CreatedBy = n
 	return newNumber, nil
 }
@@ -49,8 +52,10 @@ func (n NumberTypeWithValidateWarning) ValueFromTerraform(ctx context.Context, i
 		return nil, err
 	}
 
-	//nolint:forcetypeassert // This type is used for testing only
-	newNumber := res.(Number)
+	newNumber, ok := res.(Number)
+	if !ok {
+		return nil, fmt.Errorf("unexpected value type of %T", res)
+	}
 	newNumber.CreatedBy = n
 	return newNumber, nil
 }

--- a/internal/testing/types/stringwithvalidate.go
+++ b/internal/testing/types/stringwithvalidate.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/attr/xattr"
@@ -33,8 +34,10 @@ func (s StringTypeWithValidateError) ValueFromTerraform(ctx context.Context, in 
 		return nil, err
 	}
 
-	//nolint:forcetypeassert // This type is used for testing only
-	newString := res.(String)
+	newString, ok := res.(String)
+	if !ok {
+		return nil, fmt.Errorf("unexpected value type of %T", res)
+	}
 	newString.CreatedBy = s
 	return newString, nil
 }
@@ -61,8 +64,10 @@ func (s StringTypeWithValidateWarning) ValueFromTerraform(ctx context.Context, i
 		return nil, err
 	}
 
-	//nolint:forcetypeassert // This type is used for testing only
-	newString := res.(String)
+	newString, ok := res.(String)
+	if !ok {
+		return nil, fmt.Errorf("unexpected value type of %T", res)
+	}
 	newString.CreatedBy = s
 	return newString, nil
 }

--- a/internal/testing/types/stringwithvalidate.go
+++ b/internal/testing/types/stringwithvalidate.go
@@ -32,6 +32,8 @@ func (s StringTypeWithValidateError) ValueFromTerraform(ctx context.Context, in 
 	if err != nil {
 		return nil, err
 	}
+
+	//nolint:forcetypeassert // This type is used for testing only
 	newString := res.(String)
 	newString.CreatedBy = s
 	return newString, nil
@@ -58,6 +60,8 @@ func (s StringTypeWithValidateWarning) ValueFromTerraform(ctx context.Context, i
 	if err != nil {
 		return nil, err
 	}
+
+	//nolint:forcetypeassert // This type is used for testing only
 	newString := res.(String)
 	newString.CreatedBy = s
 	return newString, nil

--- a/tfsdk/value_as.go
+++ b/tfsdk/value_as.go
@@ -15,6 +15,7 @@ import (
 // This is achieved using reflection rules provided by the internal/reflect package.
 func ValueAs(ctx context.Context, val attr.Value, target interface{}) diag.Diagnostics {
 	if reflect.IsGenericAttrValue(ctx, target) {
+		//nolint:forcetypeassert // Type assertion is guaranteed by the above `reflect.IsGenericAttrValue` function
 		*(target.(*attr.Value)) = val
 		return nil
 	}

--- a/tfsdk/value_as_test.go
+++ b/tfsdk/value_as_test.go
@@ -353,6 +353,7 @@ func TestValueAs(t *testing.T) {
 			// cmp.Comparer is used to generate a type-specific comparison for big.Float as cmp.Diff
 			// cannot be used owing to the unexported (*big.Float).prec field.
 			opt := cmp.Comparer(func(expected **big.Float, target **big.Float) bool {
+				//nolint:forcetypeassert // Type assertion is guaranteed by the above `cmp.Comparer` function
 				if diff := (*tc.expected.(**big.Float)).Cmp(*tc.target.(**big.Float)); diff != 0 {
 					return false
 				}


### PR DESCRIPTION
contributes to: https://github.com/hashicorp/terraform-providers-devex-internal/issues/102

I used the surrounding code's context as clues to how to handle the type assertions, lmk if there are more appropriate ways to handle them.