### PR TITLE
types/basetypes: Fixed Float64Type value conversion to handle stringified numbers

### DIFF
--- a/types/basetypes/float64_test.go
+++ b/types/basetypes/float64_test.go
@@ -147,6 +147,39 @@ func TestFloat64TypeValueFromTerraform(t *testing.T) {
 			input:       tftypes.NewValue(tftypes.String, "oops"),
 			expectedErr: "can't unmarshal tftypes.String into *big.Float, expected *big.Float",
 		},
+		// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/647
+		"zero-string-float": {
+			input:       tftypes.NewValue(tftypes.Number, testMustParseFloat("0.0")),
+			expectation: NewFloat64Value(0.0),
+		},
+		"positive-string-float": {
+			input:       tftypes.NewValue(tftypes.Number, testMustParseFloat("123.2")),
+			expectation: NewFloat64Value(123.2),
+		},
+		"negative-string-float": {
+			input:       tftypes.NewValue(tftypes.Number, testMustParseFloat("-123.2")),
+			expectation: NewFloat64Value(-123.2),
+		},
+		// Reference: https://pkg.go.dev/math/big#Float.Float64
+		// Reference: https://pkg.go.dev/math#pkg-constants
+		"SmallestNonzeroFloat64": {
+			input:       tftypes.NewValue(tftypes.Number, big.NewFloat(math.SmallestNonzeroFloat64)),
+			expectation: NewFloat64Value(math.SmallestNonzeroFloat64),
+		},
+		"SmallestNonzeroFloat64-below": {
+			input:       tftypes.NewValue(tftypes.Number, testMustParseFloat("4.9406564584124654417656879286822137236505980e-325")),
+			expectedErr: fmt.Sprintf("Value %s cannot be represented as a 64-bit floating point.", testMustParseFloat("4.9406564584124654417656879286822137236505980e-325")),
+		},
+		// Reference: https://pkg.go.dev/math/big#Float.Float64
+		// Reference: https://pkg.go.dev/math#pkg-constants
+		"MaxFloat64": {
+			input:       tftypes.NewValue(tftypes.Number, big.NewFloat(math.MaxFloat64)),
+			expectation: NewFloat64Value(math.MaxFloat64),
+		},
+		"MaxFloat64-above": {
+			input:       tftypes.NewValue(tftypes.Number, testMustParseFloat("1.79769313486231570814527423731704356798070e+309")),
+			expectedErr: fmt.Sprintf("Value %s cannot be represented as a 64-bit floating point.", testMustParseFloat("1.79769313486231570814527423731704356798070e+309")),
+		},
 	}
 	for name, test := range tests {
 		name, test := name, test

--- a/types/basetypes/float64_type.go
+++ b/types/basetypes/float64_type.go
@@ -140,7 +140,15 @@ func (t Float64Type) ValueFromTerraform(ctx context.Context, in tftypes.Value) (
 
 	f, accuracy := bigF.Float64()
 
-	if accuracy != 0 {
+	// Underflow
+	// Reference: https://pkg.go.dev/math/big#Float.Float64
+	if f == 0 && accuracy != big.Exact {
+		return nil, fmt.Errorf("Value %s cannot be represented as a 64-bit floating point.", bigF)
+	}
+
+	// Overflow
+	// Reference: https://pkg.go.dev/math/big#Float.Float64
+	if math.IsInf(f, 0) {
 		return nil, fmt.Errorf("Value %s cannot be represented as a 64-bit floating point.", bigF)
 	}
 


### PR DESCRIPTION
closes #647 

This is a continuation of the fix implemented in #614 
> _Numbers in Terraform's type system can be represented with up to 512 bits of base 10 precision. When encoding and decoding across the protocol, the type system or MessagePack may switch the representation to be stringified, which is valid and expected._

The `ValueFromTerraform` function has the same accuracy checking logic, so this is just bringing the logic into sync with the `Validate` function.

I checked the rest of the codebase for similar accuracy checks and the only other one seems to be handling it correctly: https://github.com/hashicorp/terraform-plugin-framework/blob/e23d2856504bc02aa596ea7d7be93405b1b100b7/internal/reflect/number.go#L186