### PR TITLE
Replace custom reflect.Struct logic with logic from encoding/json

### DIFF
--- a/internal/reflect/helpers.go
+++ b/internal/reflect/helpers.go
@@ -1,13 +1,10 @@
 package reflect
 
 import (
-	"context"
-	"fmt"
 	"reflect"
 	"regexp"
+	"sort"
 	"strings"
-
-	"github.com/hashicorp/terraform-plugin-framework/path"
 )
 
 // trueReflectValue returns the reflect.Value for `in` after derefencing all
@@ -42,43 +39,9 @@ func commaSeparatedString(in []string) string {
 	}
 }
 
-// getStructTags returns a map of Terraform field names to their position in
-// the tags of the struct `in`. `in` must be a struct.
-func getStructTags(_ context.Context, in reflect.Value, path path.Path) (map[string]int, error) {
-	tags := map[string]int{}
-	typ := trueReflectValue(in).Type()
-	if typ.Kind() != reflect.Struct {
-		return nil, fmt.Errorf("%s: can't get struct tags of %s, is not a struct", path, in.Type())
-	}
-	for i := 0; i < typ.NumField(); i++ {
-		field := typ.Field(i)
-		if field.PkgPath != "" {
-			// skip unexported fields
-			continue
-		}
-		tag := field.Tag.Get(`tfsdk`)
-		if tag == "-" {
-			// skip explicitly excluded fields
-			continue
-		}
-		if tag == "" {
-			return nil, fmt.Errorf(`%s: need a struct tag for "tfsdk" on %s`, path, field.Name)
-		}
-		path := path.AtName(tag)
-		if !isValidFieldName(tag) {
-			return nil, fmt.Errorf("%s: invalid field name, must only use lowercase letters, underscores, and numbers, and must start with a letter", path)
-		}
-		if other, ok := tags[tag]; ok {
-			return nil, fmt.Errorf("%s: can't use field name for both %s and %s", path, typ.Field(other).Name, field.Name)
-		}
-		tags[tag] = i
-	}
-	return tags, nil
-}
-
-// isValidFieldName returns true if `name` can be used as a field name in a
+// isValidTag returns true if `name` can be used as a field name in a
 // Terraform resource or data source.
-func isValidFieldName(name string) bool {
+func isValidTag(name string) bool {
 	re := regexp.MustCompile("^[a-z][a-z0-9_]*$")
 	return re.MatchString(name)
 }
@@ -93,4 +56,215 @@ func canBeNil(target reflect.Value) bool {
 		// nothing else can be set to nil
 		return false
 	}
+}
+
+// The following logic was adapted from encoding/json:
+// https://cs.opensource.google/go/go/+/refs/tags/go1.20:src/encoding/json/encode.go;l=1212
+
+// A field represents a single field found in a struct.
+type field struct {
+	name  string
+	tag   bool
+	index []int
+	typ   reflect.Type
+}
+
+// byIndex sorts field by index sequence.
+type byIndex []field
+
+func (x byIndex) Len() int { return len(x) }
+
+func (x byIndex) Swap(i, j int) { x[i], x[j] = x[j], x[i] }
+
+func (x byIndex) Less(i, j int) bool {
+	for k, xik := range x[i].index {
+		if k >= len(x[j].index) {
+			return false
+		}
+		if xik != x[j].index[k] {
+			return xik < x[j].index[k]
+		}
+	}
+	return len(x[i].index) < len(x[j].index)
+}
+
+type structFields struct {
+	list      []field
+	nameIndex map[string]int
+}
+
+// typeFields returns a list of fields that Terraform should recognize for the given type.
+// The algorithm is breadth-first search over the set of structs to include - the top struct
+// and then any reachable anonymous structs.
+func typeFields(t reflect.Type) structFields {
+	// Anonymous fields to explore at the current level and the next.
+	current := []field{}
+	next := []field{{typ: t}}
+
+	// Count of queued names for current level and the next.
+	var count, nextCount map[reflect.Type]int
+
+	// Types already visited at an earlier level.
+	visited := map[reflect.Type]bool{}
+
+	// Fields found.
+	var fields []field
+
+	for len(next) > 0 {
+		current, next = next, current[:0]
+		count, nextCount = nextCount, map[reflect.Type]int{}
+
+		for _, f := range current {
+			if visited[f.typ] {
+				continue
+			}
+			visited[f.typ] = true
+
+			// Scan f.typ for fields to include.
+			for i := 0; i < f.typ.NumField(); i++ {
+				sf := f.typ.Field(i)
+				if sf.Anonymous {
+					t := sf.Type
+					if t.Kind() == reflect.Pointer {
+						t = t.Elem()
+					}
+					if !sf.IsExported() && t.Kind() != reflect.Struct {
+						// Ignore embedded fields of unexported non-struct types.
+						continue
+					}
+					// Do not ignore embedded fields of unexported struct types
+					// since they may have exported fields.
+				} else if !sf.IsExported() {
+					// Ignore unexported non-embedded fields.
+					continue
+				}
+				name := sf.Tag.Get("tfsdk")
+				if name == "-" {
+					continue
+				}
+				if !isValidTag(name) {
+					name = ""
+				}
+				index := make([]int, len(f.index)+1)
+				copy(index, f.index)
+				index[len(f.index)] = i
+
+				ft := sf.Type
+				if ft.Name() == "" && ft.Kind() == reflect.Pointer {
+					// Follow pointer.
+					ft = ft.Elem()
+				}
+
+				// Record found field and index sequence.
+				if name != "" || !sf.Anonymous || ft.Kind() != reflect.Struct {
+					tagged := name != ""
+					if name == "" {
+						name = sf.Name
+					}
+					field := field{
+						name:  name,
+						tag:   tagged,
+						index: index,
+						typ:   ft,
+					}
+
+					fields = append(fields, field)
+					if count[f.typ] > 1 {
+						// If there were multiple instances, add a second,
+						// so that the annihilation code will see a duplicate.
+						// It only cares about the distinction between 1 or 2,
+						// so don't bother generating any more copies.
+						fields = append(fields, fields[len(fields)-1])
+					}
+					continue
+				}
+
+				// Record new anonymous struct to explore in next round.
+				nextCount[ft]++
+				if nextCount[ft] == 1 {
+					next = append(next, field{name: ft.Name(), index: index, typ: ft})
+				}
+			}
+		}
+	}
+
+	sort.Slice(fields, func(i, j int) bool {
+		x := fields
+		// sort field by name, breaking ties with depth, then
+		// breaking ties with "name came from tfsdk tag", then
+		// breaking ties with index sequence.
+		if x[i].name != x[j].name {
+			return x[i].name < x[j].name
+		}
+		if len(x[i].index) != len(x[j].index) {
+			return len(x[i].index) < len(x[j].index)
+		}
+		if x[i].tag != x[j].tag {
+			return x[i].tag
+		}
+		return byIndex(x).Less(i, j)
+	})
+
+	// Delete all fields that are hidden by the Go rules for embedded fields,
+	// except that fields with tfsdk tags are promoted.
+
+	// The fields are sorted in primary order of name, secondary order
+	// of field index length. Loop over names; for each name, delete
+	// hidden fields by choosing the one dominant field that survives.
+	out := fields[:0]
+	for advance, i := 0, 0; i < len(fields); i += advance {
+		// One iteration per name.
+		// Find the sequence of fields with the name of this first field.
+		fi := fields[i]
+		name := fi.name
+		for advance = 1; i+advance < len(fields); advance++ {
+			fj := fields[i+advance]
+			if fj.name != name {
+				break
+			}
+		}
+		if advance == 1 { // Only one field with this name
+			out = append(out, fi)
+			continue
+		}
+		dominant, ok := dominantField(fields[i : i+advance])
+		if ok {
+			out = append(out, dominant)
+		}
+	}
+
+	fields = out
+	sort.Sort(byIndex(fields))
+
+	nameIndex := make(map[string]int, len(fields))
+	for i, field := range fields {
+		nameIndex[field.name] = i
+	}
+	return structFields{fields, nameIndex}
+}
+
+// dominantField looks through the fields, all of which are known to
+// have the same name, to find the single field that dominates the
+// others using Go's embedding rules, modified by the presence of
+// tfsdk tags. If there are multiple top-level fields, the boolean
+// will be false: This condition is an error in Go and we skip all
+// the fields.
+func dominantField(fields []field) (field, bool) {
+	// The fields are sorted in increasing index-length order, then by presence of tag.
+	// That means that the first field is the dominant one. We need only check
+	// for error cases: two fields at top level, either both tagged or neither tagged.
+	if len(fields) > 1 && len(fields[0].index) == len(fields[1].index) && fields[0].tag == fields[1].tag {
+		return field{}, false
+	}
+	return fields[0], true
+}
+
+func fieldByIndex(t reflect.Value, index []int) reflect.Value {
+	for _, i := range index {
+		if t.Kind() == reflect.Pointer {
+			t = t.Elem()
+		}
+		t = t.Field(i)
+	}
+	return t
 }


### PR DESCRIPTION
This PR replaces the existing custom struct reflection logic with the logic from encoding/json.

The code is taken from https://cs.opensource.google/go/go/+/refs/tags/go1.20:src/encoding/json/encode.go;l=1212. It was simplified a bit to remove unneeded code and fields. The core logic is still untouched.

Pros:
- Standard handling according to Go visibility rules
- Supports embedded structs
- Support untagged fields
- "If it works in encoding/json it should work here" :tm: 

Cons:
- Silent errors (just like encoding/json)
  For example, if you supply the same tag twice, the new logic will drop it completely. Luckily, this will be caught by the logic in the upper layers ("Object defines fields not found in struct: ...") so this might not be such a big deal?
- Can panic (just like encoding/json) if supplied wrong types etc.

There are definitely some trade-offs here. I just needed it to support embedded structs (closes #242) but found that implementing that would be far more difficult than just replacing the logic with the existing logic from the stdlib.

Let me know what you think!