### PR TITLE
attr: Fix verbiage for Type and Value type Equal methods

### DIFF
--- a/attr/type.go
+++ b/attr/type.go
@@ -31,8 +31,15 @@ type Type interface {
 	// and improving error diagnostics.
 	ValueType(context.Context) Value
 
-	// Equal must return true if the Type is considered semantically equal
-	// to the Type passed as an argument.
+	// Equal should return true if the Type is considered equivalent to the
+	// Type passed as an argument.
+	//
+	// Most types should verify the associated Type is exactly equal to prevent
+	// potential data consistency issues. For example:
+	//
+	//  - basetypes.Number is inequal to basetypes.Int64 or basetypes.Float64
+	//  - basetypes.String is inequal to a custom Go type that embeds it
+	//
 	Equal(Type) bool
 
 	// String should return a human-friendly version of the Type.

--- a/attr/value.go
+++ b/attr/value.go
@@ -27,8 +27,22 @@ type Value interface {
 	// a tftypes.Value.
 	ToTerraformValue(context.Context) (tftypes.Value, error)
 
-	// Equal must return true if the Value is considered semantically equal
-	// to the Value passed as an argument.
+	// Equal should return true if the Value is considered type and data
+	// value equivalent to the Value passed as an argument.
+	//
+	// Most types should verify the associated Type is exactly equal to prevent
+	// potential data consistency issues. For example:
+	//
+	//  - basetypes.Number is inequal to basetypes.Int64 or basetypes.Float64
+	//  - basetypes.String is inequal to a custom Go type that embeds it
+	//
+	// Additionally, most types should verify that known values are compared
+	// to comply with Terraform's data consistency rules. For example:
+	//
+	//  - In a list, element order is significant
+	//  - In a string, runes are compared byte-wise (e.g. whitespace is
+	//    significant in JSON-encoded strings)
+	//
 	Equal(Value) bool
 
 	// IsNull returns true if the Value is not set, or is explicitly set to null.

--- a/types/basetypes/list.go
+++ b/types/basetypes/list.go
@@ -380,8 +380,9 @@ func (l ListValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) 
 	}
 }
 
-// Equal returns true if the List is considered semantically equal
-// (same type and same value) to the attr.Value passed as an argument.
+// Equal returns true if the given attr.Value is also a ListValue, has the
+// same element type, same value state, and contains exactly the element values
+// as defined by the Equal method of the element type.
 func (l ListValue) Equal(o attr.Value) bool {
 	other, ok := o.(ListValue)
 

--- a/types/basetypes/map.go
+++ b/types/basetypes/map.go
@@ -390,8 +390,9 @@ func (m MapValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
 	}
 }
 
-// Equal returns true if the Map is considered semantically equal
-// (same type and same value) to the attr.Value passed as an argument.
+// Equal returns true if the given attr.Value is also a MapValue, has the
+// same element type, same value state, and contains exactly the element values
+// as defined by the Equal method of the element type.
 func (m MapValue) Equal(o attr.Value) bool {
 	other, ok := o.(MapValue)
 

--- a/types/basetypes/object.go
+++ b/types/basetypes/object.go
@@ -437,8 +437,9 @@ func (o ObjectValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error
 	}
 }
 
-// Equal returns true if the Object is considered semantically equal
-// (same type and same value) to the attr.Value passed as an argument.
+// Equal returns true if the given attr.Value is also an ObjectValue, has the
+// same value state, and contains exactly the same attribute types/values as
+// defined by the Equal method of those underlying types/values.
 func (o ObjectValue) Equal(c attr.Value) bool {
 	other, ok := c.(ObjectValue)
 

--- a/types/basetypes/set.go
+++ b/types/basetypes/set.go
@@ -412,8 +412,9 @@ func (s SetValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
 	}
 }
 
-// Equal returns true if the Set is considered semantically equal
-// (same type and same value) to the attr.Value passed as an argument.
+// Equal returns true if the given attr.Value is also a SetValue, has the
+// same element type, same value state, and contains exactly the element values
+// as defined by the Equal method of the element type.
 func (s SetValue) Equal(o attr.Value) bool {
 	other, ok := o.(SetValue)
 


### PR DESCRIPTION
Closes #679

This documentation may have stemmed from an early design goal to include semantic equality within types. The initial implementation did not include that functionality, which is being tracked with https://github.com/hashicorp/terraform-plugin-framework/issues/70.