### PR TITLE
all: Refactor schema validation to support type-specific logic and prevent AttributeTypes/ElementType field panics

### DIFF
--- a/.changes/unreleased/BUG FIXES-20230329-102850.yaml
+++ b/.changes/unreleased/BUG FIXES-20230329-102850.yaml
@@ -1,0 +1,7 @@
+kind: BUG FIXES
+body: 'datasource/schema: Raise errors with `ListAttribute`, `MapAttribute`, `ObjectAttribute`,
+  and `SetAttribute` implementations instead of panics when missing required `AttributeTypes` or
+  `ElementTypes` fields'
+time: 2023-03-29T10:28:50.525346-04:00
+custom:
+  Issue: "699"

--- a/.changes/unreleased/BUG FIXES-20230329-102851.yaml
+++ b/.changes/unreleased/BUG FIXES-20230329-102851.yaml
@@ -1,0 +1,7 @@
+kind: BUG FIXES
+body: 'provider/metaschema: Raise errors with `ListAttribute`, `MapAttribute`, `ObjectAttribute`,
+  and `SetAttribute` implementations instead of panics when missing required `AttributeTypes` or
+  `ElementTypes` fields'
+time: 2023-03-29T10:28:51.525346-04:00
+custom:
+  Issue: "699"

--- a/.changes/unreleased/BUG FIXES-20230329-102852.yaml
+++ b/.changes/unreleased/BUG FIXES-20230329-102852.yaml
@@ -1,0 +1,7 @@
+kind: BUG FIXES
+body: 'provider/schema: Raise errors with `ListAttribute`, `MapAttribute`, `ObjectAttribute`,
+  and `SetAttribute` implementations instead of panics when missing required `AttributeTypes` or
+  `ElementTypes` fields'
+time: 2023-03-29T10:28:52.525346-04:00
+custom:
+  Issue: "699"

--- a/.changes/unreleased/BUG FIXES-20230329-102853.yaml
+++ b/.changes/unreleased/BUG FIXES-20230329-102853.yaml
@@ -1,0 +1,7 @@
+kind: BUG FIXES
+body: 'resource/schema: Raise errors with `ListAttribute`, `MapAttribute`, `ObjectAttribute`,
+  and `SetAttribute` implementations instead of panics when missing required `AttributeTypes` or
+  `ElementTypes` fields'
+time: 2023-03-29T10:28:53.525346-04:00
+custom:
+  Issue: "699"

--- a/.changes/unreleased/ENHANCEMENTS-20230329-102106.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20230329-102106.yaml
@@ -1,0 +1,6 @@
+kind: ENHANCEMENTS
+body: 'datasource/schema: Added `Schema` type `ValidateImplementation()` method, which performs framework-defined
+  schema validation and can be used in unit testing'
+time: 2023-03-29T10:21:06.251285-04:00
+custom:
+  Issue: "699"

--- a/.changes/unreleased/ENHANCEMENTS-20230329-102107.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20230329-102107.yaml
@@ -1,0 +1,6 @@
+kind: ENHANCEMENTS
+body: 'provider/metaschema: Added `Schema` type `ValidateImplementation()` method, which performs framework-defined
+  schema validation and can be used in unit testing'
+time: 2023-03-29T10:21:07.251285-04:00
+custom:
+  Issue: "699"

--- a/.changes/unreleased/ENHANCEMENTS-20230329-102108.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20230329-102108.yaml
@@ -1,0 +1,6 @@
+kind: ENHANCEMENTS
+body: 'provider/schema: Added `Schema` type `ValidateImplementation()` method, which performs framework-defined
+  schema validation and can be used in unit testing'
+time: 2023-03-29T10:21:08.251285-04:00
+custom:
+  Issue: "699"

--- a/.changes/unreleased/ENHANCEMENTS-20230329-102109.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20230329-102109.yaml
@@ -1,0 +1,6 @@
+kind: ENHANCEMENTS
+body: 'resource/schema: Added `Schema` type `ValidateImplementation()` method, which performs framework-defined
+  schema validation and can be used in unit testing'
+time: 2023-03-29T10:21:09.251285-04:00
+custom:
+  Issue: "699"

--- a/.changes/unreleased/NOTES-20230329-124336.yaml
+++ b/.changes/unreleased/NOTES-20230329-124336.yaml
@@ -1,0 +1,6 @@
+kind: NOTES
+body: 'datasource/schema: The `Schema` type `Validate()` method has been deprecated
+  in preference of `ValidateImplementation()`'
+time: 2023-03-29T12:43:36.636825-04:00
+custom:
+  Issue: "699"

--- a/.changes/unreleased/NOTES-20230329-124337.yaml
+++ b/.changes/unreleased/NOTES-20230329-124337.yaml
@@ -1,0 +1,6 @@
+kind: NOTES
+body: 'provider/metaschema: The `Schema` type `Validate()` method has been deprecated
+  in preference of `ValidateImplementation()`'
+time: 2023-03-29T12:43:37.636825-04:00
+custom:
+  Issue: "699"

--- a/.changes/unreleased/NOTES-20230329-124338.yaml
+++ b/.changes/unreleased/NOTES-20230329-124338.yaml
@@ -1,0 +1,6 @@
+kind: NOTES
+body: 'provider/schema: The `Schema` type `Validate()` method has been deprecated
+  in preference of `ValidateImplementation()`'
+time: 2023-03-29T12:43:38.636825-04:00
+custom:
+  Issue: "699"

--- a/.changes/unreleased/NOTES-20230329-124339.yaml
+++ b/.changes/unreleased/NOTES-20230329-124339.yaml
@@ -1,0 +1,6 @@
+kind: NOTES
+body: 'resource/schema: The `Schema` type `Validate()` method has been deprecated
+  in preference of `ValidateImplementation()`'
+time: 2023-03-29T12:43:39.636825-04:00
+custom:
+  Issue: "699"

--- a/datasource/schema/list_attribute.go
+++ b/datasource/schema/list_attribute.go
@@ -1,6 +1,8 @@
 package schema
 
 import (
+	"context"
+
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema/fwxschema"
@@ -12,8 +14,9 @@ import (
 
 // Ensure the implementation satisifies the desired interfaces.
 var (
-	_ Attribute                             = ListAttribute{}
-	_ fwxschema.AttributeWithListValidators = ListAttribute{}
+	_ Attribute                                    = ListAttribute{}
+	_ fwschema.AttributeWithValidateImplementation = ListAttribute{}
+	_ fwxschema.AttributeWithListValidators        = ListAttribute{}
 )
 
 // ListAttribute represents a schema attribute that is a list with a single
@@ -194,4 +197,14 @@ func (a ListAttribute) IsSensitive() bool {
 // ListValidators returns the Validators field value.
 func (a ListAttribute) ListValidators() []validator.List {
 	return a.Validators
+}
+
+// ValidateImplementation contains logic for validating the
+// provider-defined implementation of the attribute to prevent unexpected
+// errors or panics. This logic runs during the GetProviderSchema RPC
+// and should never include false positives.
+func (a ListAttribute) ValidateImplementation(ctx context.Context, req fwschema.ValidateImplementationRequest, resp *fwschema.ValidateImplementationResponse) {
+	if a.CustomType == nil && a.ElementType == nil {
+		resp.Diagnostics.Append(fwschema.AttributeMissingElementTypeDiag(req.Path))
+	}
 }

--- a/datasource/schema/list_attribute_test.go
+++ b/datasource/schema/list_attribute_test.go
@@ -1,6 +1,7 @@
 package schema_test
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -8,8 +9,11 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
+	testtypes "github.com/hashicorp/terraform-plugin-framework/internal/testing/types"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
@@ -417,6 +421,74 @@ func TestListAttributeListValidators(t *testing.T) {
 			t.Parallel()
 
 			got := testCase.attribute.ListValidators()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestListAttributeValidateImplementation(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.ListAttribute
+		request   fwschema.ValidateImplementationRequest
+		expected  *fwschema.ValidateImplementationResponse
+	}{
+		"customtype": {
+			attribute: schema.ListAttribute{
+				Computed:   true,
+				CustomType: testtypes.ListType{},
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{},
+		},
+		"elementtype": {
+			attribute: schema.ListAttribute{
+				Computed:    true,
+				ElementType: types.StringType,
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{},
+		},
+		"elementtype-missing": {
+			attribute: schema.ListAttribute{
+				Computed: true,
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic(
+						"Invalid Attribute Implementation",
+						"When validating the schema, an implementation issue was found. "+
+							"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+							"\"test\" is missing the CustomType or ElementType field on a collection Attribute. "+
+							"One of these fields is required to prevent other unexpected errors or panics.",
+					),
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := &fwschema.ValidateImplementationResponse{}
+			testCase.attribute.ValidateImplementation(context.Background(), testCase.request, got)
 
 			if diff := cmp.Diff(got, testCase.expected); diff != "" {
 				t.Errorf("unexpected difference: %s", diff)

--- a/datasource/schema/map_attribute.go
+++ b/datasource/schema/map_attribute.go
@@ -1,6 +1,8 @@
 package schema
 
 import (
+	"context"
+
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema/fwxschema"
@@ -12,8 +14,9 @@ import (
 
 // Ensure the implementation satisifies the desired interfaces.
 var (
-	_ Attribute                            = MapAttribute{}
-	_ fwxschema.AttributeWithMapValidators = MapAttribute{}
+	_ Attribute                                    = MapAttribute{}
+	_ fwschema.AttributeWithValidateImplementation = MapAttribute{}
+	_ fwxschema.AttributeWithMapValidators         = MapAttribute{}
 )
 
 // MapAttribute represents a schema attribute that is a list with a single
@@ -197,4 +200,14 @@ func (a MapAttribute) IsSensitive() bool {
 // MapValidators returns the Validators field value.
 func (a MapAttribute) MapValidators() []validator.Map {
 	return a.Validators
+}
+
+// ValidateImplementation contains logic for validating the
+// provider-defined implementation of the attribute to prevent unexpected
+// errors or panics. This logic runs during the GetProviderSchema RPC
+// and should never include false positives.
+func (a MapAttribute) ValidateImplementation(ctx context.Context, req fwschema.ValidateImplementationRequest, resp *fwschema.ValidateImplementationResponse) {
+	if a.CustomType == nil && a.ElementType == nil {
+		resp.Diagnostics.Append(fwschema.AttributeMissingElementTypeDiag(req.Path))
+	}
 }

--- a/datasource/schema/object_attribute.go
+++ b/datasource/schema/object_attribute.go
@@ -1,6 +1,8 @@
 package schema
 
 import (
+	"context"
+
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema/fwxschema"
@@ -12,8 +14,9 @@ import (
 
 // Ensure the implementation satisifies the desired interfaces.
 var (
-	_ Attribute                               = ObjectAttribute{}
-	_ fwxschema.AttributeWithObjectValidators = ObjectAttribute{}
+	_ Attribute                                    = ObjectAttribute{}
+	_ fwschema.AttributeWithValidateImplementation = ObjectAttribute{}
+	_ fwxschema.AttributeWithObjectValidators      = ObjectAttribute{}
 )
 
 // ObjectAttribute represents a schema attribute that is an object with only
@@ -196,4 +199,14 @@ func (a ObjectAttribute) IsSensitive() bool {
 // ObjectValidators returns the Validators field value.
 func (a ObjectAttribute) ObjectValidators() []validator.Object {
 	return a.Validators
+}
+
+// ValidateImplementation contains logic for validating the
+// provider-defined implementation of the attribute to prevent unexpected
+// errors or panics. This logic runs during the GetProviderSchema RPC
+// and should never include false positives.
+func (a ObjectAttribute) ValidateImplementation(ctx context.Context, req fwschema.ValidateImplementationRequest, resp *fwschema.ValidateImplementationResponse) {
+	if a.AttributeTypes == nil && a.CustomType == nil {
+		resp.Diagnostics.Append(fwschema.AttributeMissingAttributeTypesDiag(req.Path))
+	}
 }

--- a/datasource/schema/object_attribute_test.go
+++ b/datasource/schema/object_attribute_test.go
@@ -1,6 +1,7 @@
 package schema_test
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -8,8 +9,11 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
+	testtypes "github.com/hashicorp/terraform-plugin-framework/internal/testing/types"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
@@ -423,6 +427,76 @@ func TestObjectAttributeObjectValidators(t *testing.T) {
 			t.Parallel()
 
 			got := testCase.attribute.ObjectValidators()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestObjectAttributeValidateImplementation(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.ObjectAttribute
+		request   fwschema.ValidateImplementationRequest
+		expected  *fwschema.ValidateImplementationResponse
+	}{
+		"attributetypes": {
+			attribute: schema.ObjectAttribute{
+				AttributeTypes: map[string]attr.Type{
+					"test_attr": types.StringType,
+				},
+				Computed: true,
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{},
+		},
+		"attributetypes-missing": {
+			attribute: schema.ObjectAttribute{
+				Computed: true,
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic(
+						"Invalid Attribute Implementation",
+						"When validating the schema, an implementation issue was found. "+
+							"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+							"\"test\" is missing the AttributeTypes or CustomType field on an object Attribute. "+
+							"One of these fields is required to prevent other unexpected errors or panics.",
+					),
+				},
+			},
+		},
+		"customtype": {
+			attribute: schema.ObjectAttribute{
+				Computed:   true,
+				CustomType: testtypes.ObjectType{},
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := &fwschema.ValidateImplementationResponse{}
+			testCase.attribute.ValidateImplementation(context.Background(), testCase.request, got)
 
 			if diff := cmp.Diff(got, testCase.expected); diff != "" {
 				t.Errorf("unexpected difference: %s", diff)

--- a/datasource/schema/schema.go
+++ b/datasource/schema/schema.go
@@ -2,8 +2,6 @@ package schema
 
 import (
 	"context"
-	"fmt"
-	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 
@@ -126,124 +124,38 @@ func (s Schema) TypeAtTerraformPath(ctx context.Context, p *tftypes.AttributePat
 }
 
 // Validate verifies that the schema is not using a reserved field name for a top-level attribute.
+//
+// Deprecated: Use the ValidateImplementation method instead.
 func (s Schema) Validate() diag.Diagnostics {
-	var diags diag.Diagnostics
-
-	// Raise error diagnostics when data source configuration uses reserved
-	// field names for root-level attributes.
-	reservedFieldNames := map[string]struct{}{
-		"connection":  {},
-		"count":       {},
-		"depends_on":  {},
-		"lifecycle":   {},
-		"provider":    {},
-		"provisioner": {},
-	}
-
-	attributes := s.GetAttributes()
-
-	for k, v := range attributes {
-		if _, ok := reservedFieldNames[k]; ok {
-			diags.AddAttributeError(
-				path.Root(k),
-				"Schema Using Reserved Field Name",
-				fmt.Sprintf("%q is a reserved field name", k),
-			)
-		}
-
-		d := validateAttributeFieldName(path.Root(k), k, v)
-
-		diags.Append(d...)
-	}
-
-	blocks := s.GetBlocks()
-
-	for k, v := range blocks {
-		if _, ok := reservedFieldNames[k]; ok {
-			diags.AddAttributeError(
-				path.Root(k),
-				"Schema Using Reserved Field Name",
-				fmt.Sprintf("%q is a reserved field name", k),
-			)
-		}
-
-		d := validateBlockFieldName(path.Root(k), k, v)
-
-		diags.Append(d...)
-	}
-
-	return diags
+	return s.ValidateImplementation(context.Background())
 }
 
-// validFieldNameRegex is used to verify that name used for attributes and blocks
-// comply with the defined regular expression.
-var validFieldNameRegex = regexp.MustCompile("^[a-z0-9_]+$")
-
-// validateAttributeFieldName verifies that the name used for an attribute complies with the regular
-// expression defined in validFieldNameRegex.
-func validateAttributeFieldName(path path.Path, name string, attr fwschema.Attribute) diag.Diagnostics {
+// ValidateImplementation contains logic for validating the provider-defined
+// implementation of the schema and underlying attributes and blocks to prevent
+// unexpected errors or panics. This logic runs during the GetProviderSchema
+// RPC, or via provider-defined unit testing, and should never include false
+// positives.
+func (s Schema) ValidateImplementation(ctx context.Context) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	if !validFieldNameRegex.MatchString(name) {
-		diags.AddAttributeError(
-			path,
-			"Invalid Schema Field Name",
-			fmt.Sprintf("Field name %q is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.", name),
-		)
-	}
-
-	if na, ok := attr.(fwschema.NestedAttribute); ok {
-		nestedObject := na.GetNestedObject()
-
-		if nestedObject == nil {
-			return diags
+	for attributeName, attribute := range s.GetAttributes() {
+		req := fwschema.ValidateImplementationRequest{
+			Name: attributeName,
+			Path: path.Root(attributeName),
 		}
 
-		attributes := nestedObject.GetAttributes()
+		diags.Append(fwschema.IsReservedResourceAttributeName(req.Name, req.Path)...)
+		diags.Append(fwschema.ValidateAttributeImplementation(ctx, attribute, req)...)
+	}
 
-		for k, v := range attributes {
-			d := validateAttributeFieldName(path.AtName(k), k, v)
-
-			diags.Append(d...)
+	for blockName, block := range s.GetBlocks() {
+		req := fwschema.ValidateImplementationRequest{
+			Name: blockName,
+			Path: path.Root(blockName),
 		}
-	}
 
-	return diags
-}
-
-// validateBlockFieldName verifies that the name used for a block complies with the regular
-// expression defined in validFieldNameRegex.
-func validateBlockFieldName(path path.Path, name string, b fwschema.Block) diag.Diagnostics {
-	var diags diag.Diagnostics
-
-	if !validFieldNameRegex.MatchString(name) {
-		diags.AddAttributeError(
-			path,
-			"Invalid Schema Field Name",
-			fmt.Sprintf("Field name %q is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.", name),
-		)
-	}
-
-	nestedObject := b.GetNestedObject()
-
-	if nestedObject == nil {
-		return diags
-	}
-
-	blocks := nestedObject.GetBlocks()
-
-	for k, v := range blocks {
-		d := validateBlockFieldName(path.AtName(k), k, v)
-
-		diags.Append(d...)
-	}
-
-	attributes := nestedObject.GetAttributes()
-
-	for k, v := range attributes {
-		d := validateAttributeFieldName(path.AtName(k), k, v)
-
-		diags.Append(d...)
+		diags.Append(fwschema.IsReservedResourceAttributeName(req.Name, req.Path)...)
+		diags.Append(fwschema.ValidateBlockImplementation(ctx, block, req)...)
 	}
 
 	return diags

--- a/datasource/schema/schema_test.go
+++ b/datasource/schema/schema_test.go
@@ -1007,6 +1007,49 @@ func TestSchemaValidate(t *testing.T) {
 		"empty-schema": {
 			schema: schema.Schema{},
 		},
+		"validate-implementation-error": {
+			schema: schema.Schema{
+				Attributes: map[string]schema.Attribute{
+					"depends_on": schema.StringAttribute{},
+				},
+			},
+			expectedDiags: diag.Diagnostics{
+				diag.NewErrorDiagnostic(
+					"Reserved Root Attribute/Block Name",
+					"When validating the resource or data source schema, an implementation issue was found. "+
+						"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+						"\"depends_on\" is a reserved root attribute/block name. "+
+						"This is to prevent practitioners from needing special Terraform configuration syntax.",
+				),
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			diags := testCase.schema.Validate()
+
+			if diff := cmp.Diff(diags, testCase.expectedDiags); diff != "" {
+				t.Errorf("Unexpected diagnostics (+wanted, -got): %s", diff)
+			}
+		})
+	}
+}
+
+func TestSchemaValidateImplementation(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		schema        schema.Schema
+		expectedDiags diag.Diagnostics
+	}{
+		"empty-schema": {
+			schema: schema.Schema{},
+		},
 		"attribute-using-reserved-field-name": {
 			schema: schema.Schema{
 				Attributes: map[string]schema.Attribute{
@@ -1014,10 +1057,12 @@ func TestSchemaValidate(t *testing.T) {
 				},
 			},
 			expectedDiags: diag.Diagnostics{
-				diag.NewAttributeErrorDiagnostic(
-					path.Root("depends_on"),
-					"Schema Using Reserved Field Name",
-					`"depends_on" is a reserved field name`,
+				diag.NewErrorDiagnostic(
+					"Reserved Root Attribute/Block Name",
+					"When validating the resource or data source schema, an implementation issue was found. "+
+						"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+						"\"depends_on\" is a reserved root attribute/block name. "+
+						"This is to prevent practitioners from needing special Terraform configuration syntax.",
 				),
 			},
 		},
@@ -1028,14 +1073,16 @@ func TestSchemaValidate(t *testing.T) {
 				},
 			},
 			expectedDiags: diag.Diagnostics{
-				diag.NewAttributeErrorDiagnostic(
-					path.Root("connection"),
-					"Schema Using Reserved Field Name",
-					`"connection" is a reserved field name`,
+				diag.NewErrorDiagnostic(
+					"Reserved Root Attribute/Block Name",
+					"When validating the resource or data source schema, an implementation issue was found. "+
+						"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+						"\"connection\" is a reserved root attribute/block name. "+
+						"This is to prevent practitioners from needing special Terraform configuration syntax.",
 				),
 			},
 		},
-		"single-nested-attribute-using-nested-reserved-field-name": {
+		"nested-attribute-using-nested-reserved-field-name": {
 			schema: schema.Schema{
 				Attributes: map[string]schema.Attribute{
 					"single_nested_attribute": schema.SingleNestedAttribute{
@@ -1046,38 +1093,12 @@ func TestSchemaValidate(t *testing.T) {
 				},
 			},
 		},
-		"single-nested-block-using-nested-reserved-field-name": {
+		"nested-block-using-nested-reserved-field-name": {
 			schema: schema.Schema{
 				Blocks: map[string]schema.Block{
 					"single_nested_block": schema.SingleNestedBlock{
 						Attributes: map[string]schema.Attribute{
 							"connection": schema.BoolAttribute{},
-						},
-					},
-				},
-			},
-		},
-		"list-nested-attribute-using-nested-reserved-field-name": {
-			schema: schema.Schema{
-				Attributes: map[string]schema.Attribute{
-					"list_nested_attribute": schema.ListNestedAttribute{
-						NestedObject: schema.NestedAttributeObject{
-							Attributes: map[string]schema.Attribute{
-								"depends_on": schema.Int64Attribute{},
-							},
-						},
-					},
-				},
-			},
-		},
-		"list-nested-block-using-nested-reserved-field-name": {
-			schema: schema.Schema{
-				Blocks: map[string]schema.Block{
-					"list_nested_block": schema.ListNestedBlock{
-						NestedObject: schema.NestedBlockObject{
-							Attributes: map[string]schema.Attribute{
-								"connection": schema.BoolAttribute{},
-							},
 						},
 					},
 				},
@@ -1093,15 +1114,19 @@ func TestSchemaValidate(t *testing.T) {
 				},
 			},
 			expectedDiags: diag.Diagnostics{
-				diag.NewAttributeErrorDiagnostic(
-					path.Root("depends_on"),
-					"Schema Using Reserved Field Name",
-					`"depends_on" is a reserved field name`,
+				diag.NewErrorDiagnostic(
+					"Reserved Root Attribute/Block Name",
+					"When validating the resource or data source schema, an implementation issue was found. "+
+						"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+						"\"depends_on\" is a reserved root attribute/block name. "+
+						"This is to prevent practitioners from needing special Terraform configuration syntax.",
 				),
-				diag.NewAttributeErrorDiagnostic(
-					path.Root("connection"),
-					"Schema Using Reserved Field Name",
-					`"connection" is a reserved field name`,
+				diag.NewErrorDiagnostic(
+					"Reserved Root Attribute/Block Name",
+					"When validating the resource or data source schema, an implementation issue was found. "+
+						"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+						"\"connection\" is a reserved root attribute/block name. "+
+						"This is to prevent practitioners from needing special Terraform configuration syntax.",
 				),
 			},
 		},
@@ -1112,10 +1137,12 @@ func TestSchemaValidate(t *testing.T) {
 				},
 			},
 			expectedDiags: diag.Diagnostics{
-				diag.NewAttributeErrorDiagnostic(
-					path.Root("^"),
-					"Invalid Schema Field Name",
-					`Field name "^" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
+				diag.NewErrorDiagnostic(
+					"Invalid Attribute/Block Name",
+					"When validating the schema, an implementation issue was found. "+
+						"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+						"\"^\" at schema path \"^\" is an invalid attribute/block name. "+
+						"Names must only contain lowercase alphanumeric characters (a-z, 0-9) and underscores (_).",
 				),
 			},
 		},
@@ -1126,14 +1153,16 @@ func TestSchemaValidate(t *testing.T) {
 				},
 			},
 			expectedDiags: diag.Diagnostics{
-				diag.NewAttributeErrorDiagnostic(
-					path.Root("^"),
-					"Invalid Schema Field Name",
-					`Field name "^" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
+				diag.NewErrorDiagnostic(
+					"Invalid Attribute/Block Name",
+					"When validating the schema, an implementation issue was found. "+
+						"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+						"\"^\" at schema path \"^\" is an invalid attribute/block name. "+
+						"Names must only contain lowercase alphanumeric characters (a-z, 0-9) and underscores (_).",
 				),
 			},
 		},
-		"single-nested-attribute-using-nested-invalid-field-name": {
+		"nested-attribute-using-nested-invalid-field-name": {
 			schema: schema.Schema{
 				Attributes: map[string]schema.Attribute{
 					"single_nested_attribute": schema.SingleNestedAttribute{
@@ -1144,14 +1173,16 @@ func TestSchemaValidate(t *testing.T) {
 				},
 			},
 			expectedDiags: diag.Diagnostics{
-				diag.NewAttributeErrorDiagnostic(
-					path.Root("single_nested_attribute").AtName("^"),
-					"Invalid Schema Field Name",
-					`Field name "^" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
+				diag.NewErrorDiagnostic(
+					"Invalid Attribute/Block Name",
+					"When validating the schema, an implementation issue was found. "+
+						"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+						"\"^\" at schema path \"single_nested_attribute.^\" is an invalid attribute/block name. "+
+						"Names must only contain lowercase alphanumeric characters (a-z, 0-9) and underscores (_).",
 				),
 			},
 		},
-		"single-nested-block-using-nested-invalid-field-name": {
+		"nested-block-using-nested-invalid-field-name": {
 			schema: schema.Schema{
 				Blocks: map[string]schema.Block{
 					"single_nested_block": schema.SingleNestedBlock{
@@ -1162,60 +1193,16 @@ func TestSchemaValidate(t *testing.T) {
 				},
 			},
 			expectedDiags: diag.Diagnostics{
-				diag.NewAttributeErrorDiagnostic(
-					path.Root("single_nested_block").AtName("^"),
-					"Invalid Schema Field Name",
-					`Field name "^" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
+				diag.NewErrorDiagnostic(
+					"Invalid Attribute/Block Name",
+					"When validating the schema, an implementation issue was found. "+
+						"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+						"\"^\" at schema path \"single_nested_block.^\" is an invalid attribute/block name. "+
+						"Names must only contain lowercase alphanumeric characters (a-z, 0-9) and underscores (_).",
 				),
 			},
 		},
-		"single-nested-attribute-using-invalid-field-names": {
-			schema: schema.Schema{
-				Attributes: map[string]schema.Attribute{
-					"$": schema.SingleNestedAttribute{
-						Attributes: map[string]schema.Attribute{
-							"^": schema.BoolAttribute{},
-						},
-					},
-				},
-			},
-			expectedDiags: diag.Diagnostics{
-				diag.NewAttributeErrorDiagnostic(
-					path.Root("$"),
-					"Invalid Schema Field Name",
-					`Field name "$" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
-				),
-				diag.NewAttributeErrorDiagnostic(
-					path.Root("$").AtName("^"),
-					"Invalid Schema Field Name",
-					`Field name "^" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
-				),
-			},
-		},
-		"single-nested-block-using-invalid-field-names": {
-			schema: schema.Schema{
-				Blocks: map[string]schema.Block{
-					"$": schema.SingleNestedBlock{
-						Attributes: map[string]schema.Attribute{
-							"^": schema.BoolAttribute{},
-						},
-					},
-				},
-			},
-			expectedDiags: diag.Diagnostics{
-				diag.NewAttributeErrorDiagnostic(
-					path.Root("$"),
-					"Invalid Schema Field Name",
-					`Field name "$" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
-				),
-				diag.NewAttributeErrorDiagnostic(
-					path.Root("$").AtName("^"),
-					"Invalid Schema Field Name",
-					`Field name "^" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
-				),
-			},
-		},
-		"single-nested-block-with-nested-block-using-invalid-field-names": {
+		"nested-block-with-nested-block-using-invalid-field-names": {
 			schema: schema.Schema{
 				Blocks: map[string]schema.Block{
 					"$": schema.SingleNestedBlock{
@@ -1230,122 +1217,108 @@ func TestSchemaValidate(t *testing.T) {
 				},
 			},
 			expectedDiags: diag.Diagnostics{
-				diag.NewAttributeErrorDiagnostic(
-					path.Root("$"),
-					"Invalid Schema Field Name",
-					`Field name "$" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
+				diag.NewErrorDiagnostic(
+					"Invalid Attribute/Block Name",
+					"When validating the schema, an implementation issue was found. "+
+						"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+						"\"$\" at schema path \"$\" is an invalid attribute/block name. "+
+						"Names must only contain lowercase alphanumeric characters (a-z, 0-9) and underscores (_).",
 				),
-				diag.NewAttributeErrorDiagnostic(
-					path.Root("$").AtName("^"),
-					"Invalid Schema Field Name",
-					`Field name "^" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
+				diag.NewErrorDiagnostic(
+					"Invalid Attribute/Block Name",
+					"When validating the schema, an implementation issue was found. "+
+						"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+						"\"^\" at schema path \"$.^\" is an invalid attribute/block name. "+
+						"Names must only contain lowercase alphanumeric characters (a-z, 0-9) and underscores (_).",
 				),
-				diag.NewAttributeErrorDiagnostic(
-					path.Root("$").AtName("^").AtName("!"),
-					"Invalid Schema Field Name",
-					`Field name "!" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
+				diag.NewErrorDiagnostic(
+					"Invalid Attribute/Block Name",
+					"When validating the schema, an implementation issue was found. "+
+						"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+						"\"!\" at schema path \"$.^.!\" is an invalid attribute/block name. "+
+						"Names must only contain lowercase alphanumeric characters (a-z, 0-9) and underscores (_).",
 				),
 			},
 		},
-		"list-nested-attribute-using-nested-invalid-field-name": {
+		"attribute-with-validate-attribute-implementation-error": {
+			schema: schema.Schema{
+				Attributes: map[string]schema.Attribute{
+					"test": schema.ListAttribute{
+						Computed: true,
+					},
+				},
+			},
+			expectedDiags: diag.Diagnostics{
+				diag.NewErrorDiagnostic(
+					"Invalid Attribute Implementation",
+					"When validating the schema, an implementation issue was found. "+
+						"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+						"\"test\" is missing the CustomType or ElementType field on a collection Attribute. "+
+						"One of these fields is required to prevent other unexpected errors or panics.",
+				),
+			},
+		},
+		"nested-attribute-with-validate-attribute-implementation-error": {
 			schema: schema.Schema{
 				Attributes: map[string]schema.Attribute{
 					"list_nested_attribute": schema.ListNestedAttribute{
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
-								"^": schema.Int64Attribute{},
+								"test": schema.ListAttribute{
+									Computed: true,
+								},
 							},
 						},
 					},
 				},
 			},
 			expectedDiags: diag.Diagnostics{
-				diag.NewAttributeErrorDiagnostic(
-					path.Root("list_nested_attribute").AtName("^"),
-					"Invalid Schema Field Name",
-					`Field name "^" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
+				diag.NewErrorDiagnostic(
+					"Invalid Attribute Implementation",
+					"When validating the schema, an implementation issue was found. "+
+						"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+						"\"list_nested_attribute.test\" is missing the CustomType or ElementType field on a collection Attribute. "+
+						"One of these fields is required to prevent other unexpected errors or panics.",
 				),
 			},
 		},
-		"list-nested-block-using-nested-invalid-field-name": {
+		"nested-block-attribute-with-validate-attribute-implementation-error": {
 			schema: schema.Schema{
 				Blocks: map[string]schema.Block{
 					"list_nested_block": schema.ListNestedBlock{
 						NestedObject: schema.NestedBlockObject{
 							Attributes: map[string]schema.Attribute{
-								"^": schema.Int64Attribute{},
+								"test": schema.ListAttribute{
+									Computed: true,
+								},
 							},
 						},
 					},
 				},
 			},
 			expectedDiags: diag.Diagnostics{
-				diag.NewAttributeErrorDiagnostic(
-					path.Root("list_nested_block").AtName("^"),
-					"Invalid Schema Field Name",
-					`Field name "^" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
+				diag.NewErrorDiagnostic(
+					"Invalid Attribute Implementation",
+					"When validating the schema, an implementation issue was found. "+
+						"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+						"\"list_nested_block.test\" is missing the CustomType or ElementType field on a collection Attribute. "+
+						"One of these fields is required to prevent other unexpected errors or panics.",
 				),
 			},
 		},
-		"list-nested-attribute-using-invalid-field-names": {
-			schema: schema.Schema{
-				Attributes: map[string]schema.Attribute{
-					"$": schema.ListNestedAttribute{
-						NestedObject: schema.NestedAttributeObject{
-							Attributes: map[string]schema.Attribute{
-								"^": schema.Int64Attribute{},
-							},
-						},
-					},
-				},
-			},
-			expectedDiags: diag.Diagnostics{
-				diag.NewAttributeErrorDiagnostic(
-					path.Root("$"),
-					"Invalid Schema Field Name",
-					`Field name "$" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
-				),
-				diag.NewAttributeErrorDiagnostic(
-					path.Root("$").AtName("^"),
-					"Invalid Schema Field Name",
-					`Field name "^" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
-				),
-			},
-		},
-		"list-nested-block-using-invalid-field-names": {
+		"nested-nested-block-attribute-with-validate-attribute-implementation-error": {
 			schema: schema.Schema{
 				Blocks: map[string]schema.Block{
-					"$": schema.ListNestedBlock{
-						NestedObject: schema.NestedBlockObject{
-							Attributes: map[string]schema.Attribute{
-								"^": schema.Int64Attribute{},
-							},
-						},
-					},
-				},
-			},
-			expectedDiags: diag.Diagnostics{
-				diag.NewAttributeErrorDiagnostic(
-					path.Root("$"),
-					"Invalid Schema Field Name",
-					`Field name "$" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
-				),
-				diag.NewAttributeErrorDiagnostic(
-					path.Root("$").AtName("^"),
-					"Invalid Schema Field Name",
-					`Field name "^" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
-				),
-			},
-		},
-		"list-nested-block-with-nested-block-using-invalid-field-names": {
-			schema: schema.Schema{
-				Blocks: map[string]schema.Block{
-					"$": schema.ListNestedBlock{
+					"list_nested_block": schema.ListNestedBlock{
 						NestedObject: schema.NestedBlockObject{
 							Blocks: map[string]schema.Block{
-								"^": schema.SingleNestedBlock{
-									Attributes: map[string]schema.Attribute{
-										"!": schema.BoolAttribute{},
+								"list_nested_nested_block": schema.ListNestedBlock{
+									NestedObject: schema.NestedBlockObject{
+										Attributes: map[string]schema.Attribute{
+											"test": schema.ListAttribute{
+												Computed: true,
+											},
+										},
 									},
 								},
 							},
@@ -1354,20 +1327,12 @@ func TestSchemaValidate(t *testing.T) {
 				},
 			},
 			expectedDiags: diag.Diagnostics{
-				diag.NewAttributeErrorDiagnostic(
-					path.Root("$"),
-					"Invalid Schema Field Name",
-					`Field name "$" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
-				),
-				diag.NewAttributeErrorDiagnostic(
-					path.Root("$").AtName("^"),
-					"Invalid Schema Field Name",
-					`Field name "^" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
-				),
-				diag.NewAttributeErrorDiagnostic(
-					path.Root("$").AtName("^").AtName("!"),
-					"Invalid Schema Field Name",
-					`Field name "!" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
+				diag.NewErrorDiagnostic(
+					"Invalid Attribute Implementation",
+					"When validating the schema, an implementation issue was found. "+
+						"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+						"\"list_nested_block.list_nested_nested_block.test\" is missing the CustomType or ElementType field on a collection Attribute. "+
+						"One of these fields is required to prevent other unexpected errors or panics.",
 				),
 			},
 		},
@@ -1379,7 +1344,7 @@ func TestSchemaValidate(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			diags := testCase.schema.Validate()
+			diags := testCase.schema.ValidateImplementation(context.Background())
 
 			if diff := cmp.Diff(diags, testCase.expectedDiags); diff != "" {
 				t.Errorf("Unexpected diagnostics (+wanted, -got): %s", diff)

--- a/datasource/schema/set_attribute_test.go
+++ b/datasource/schema/set_attribute_test.go
@@ -1,6 +1,7 @@
 package schema_test
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -8,8 +9,11 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
+	testtypes "github.com/hashicorp/terraform-plugin-framework/internal/testing/types"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
@@ -417,6 +421,74 @@ func TestSetAttributeSetValidators(t *testing.T) {
 			t.Parallel()
 
 			got := testCase.attribute.SetValidators()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestSetAttributeValidateImplementation(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.SetAttribute
+		request   fwschema.ValidateImplementationRequest
+		expected  *fwschema.ValidateImplementationResponse
+	}{
+		"customtype": {
+			attribute: schema.SetAttribute{
+				CustomType: testtypes.SetType{},
+				Optional:   true,
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{},
+		},
+		"elementtype": {
+			attribute: schema.SetAttribute{
+				Computed:    true,
+				ElementType: types.StringType,
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{},
+		},
+		"elementtype-missing": {
+			attribute: schema.SetAttribute{
+				Computed: true,
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic(
+						"Invalid Attribute Implementation",
+						"When validating the schema, an implementation issue was found. "+
+							"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+							"\"test\" is missing the CustomType or ElementType field on a collection Attribute. "+
+							"One of these fields is required to prevent other unexpected errors or panics.",
+					),
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := &fwschema.ValidateImplementationResponse{}
+			testCase.attribute.ValidateImplementation(context.Background(), testCase.request, got)
 
 			if diff := cmp.Diff(got, testCase.expected); diff != "" {
 				t.Errorf("unexpected difference: %s", diff)

--- a/internal/fwschema/attribute_name_validation.go
+++ b/internal/fwschema/attribute_name_validation.go
@@ -1,0 +1,149 @@
+package fwschema
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+)
+
+// ReservedProviderAttributeNames contains the list of root attribute names
+// which should not be included in provider-defined provider schemas since
+// they require practitioners to implement special syntax in their
+// configurations to be usable by the provider.
+var ReservedProviderAttributeNames = []string{
+	// Reference: https://developer.hashicorp.com/terraform/language/providers/configuration#alias-multiple-provider-configurations
+	"alias",
+	// Reference: https://developer.hashicorp.com/terraform/language/providers/configuration#version-deprecated
+	"version",
+}
+
+// ReservedResourceAttributeNames contains the list of root attribute names
+// which should not be included in provider-defined managed resource and
+// data source schemas since they require practitioners to implement special
+// syntax in their configurations to be usable by the provider resource.
+var ReservedResourceAttributeNames = []string{
+	// Reference: https://developer.hashicorp.com/terraform/language/resources/provisioners/connection
+	"connection",
+	// Reference: https://developer.hashicorp.com/terraform/language/meta-arguments/count
+	"count",
+	// Reference: https://developer.hashicorp.com/terraform/language/meta-arguments/depends_on
+	"depends_on",
+	// TODO: Validate for_each
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/704
+	// Reference: https://developer.hashicorp.com/terraform/language/meta-arguments/for_each
+	// "for_each",
+	// Reference: https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle
+	"lifecycle",
+	// Reference: https://developer.hashicorp.com/terraform/language/meta-arguments/resource-provider
+	"provider",
+	// Reference: https://developer.hashicorp.com/terraform/language/resources/provisioners/syntax
+	"provisioner",
+}
+
+// ValidAttributeNameRegex contains the regular expression to validate
+// attribute names, which are considered [identifiers] in the Terraform
+// configuration language.
+//
+// Hyphen characters (-) are technically valid in identifiers, however they are
+// explicitly not validated due to the provider ecosystem conventionally never
+// including them in attribute names. Introducing them could cause practitioner
+// confusion.
+//
+// TODO: Validate leading numeric characters
+// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/705
+//
+// [identifiers]: https://developer.hashicorp.com/terraform/language/syntax/configuration#identifiers
+var ValidAttributeNameRegex = regexp.MustCompile("^[a-z0-9_]+$")
+
+// IsReservedProviderAttributeName returns an error diagnostic if the given
+// attribute path represents a root attribute name in
+// ReservedProviderAttributeNames. Other paths are automatically skipped
+// without error.
+func IsReservedProviderAttributeName(name string, attributePath path.Path) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	// Check that given path is root attribute name. This simplifies calling
+	// logic to not worry about conditionalizing this check.
+	if len(attributePath.Steps()) != 1 {
+		return diags
+	}
+
+	for _, reservedName := range ReservedProviderAttributeNames {
+		if name == reservedName {
+			// The diagnostic path is intentionally omitted as it is invalid
+			// in this context. Diagnostic paths are intended to be mapped to
+			// actual data, while this path information must be synthesized.
+			diags.AddError(
+				"Reserved Root Attribute/Block Name",
+				"When validating the provider schema, an implementation issue was found. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("%q is a reserved root attribute/block name. ", name)+
+					"This is to prevent practitioners from needing special Terraform configuration syntax.",
+			)
+
+			break
+		}
+	}
+
+	return diags
+}
+
+// IsReservedResourceAttributeName returns an error diagnostic if the given
+// attribute path represents a root attribute name in
+// ReservedResourceAttributeNames. Other paths are automatically skipped
+// without error.
+func IsReservedResourceAttributeName(name string, attributePath path.Path) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	// Check that given path is root attribute name. This simplifies calling
+	// logic to not worry about conditionalizing this check.
+	if len(attributePath.Steps()) != 1 {
+		return diags
+	}
+
+	for _, reservedName := range ReservedResourceAttributeNames {
+		if name == reservedName {
+			// The diagnostic path is intentionally omitted as it is invalid
+			// in this context. Diagnostic paths are intended to be mapped to
+			// actual data, while this path information must be synthesized.
+			diags.AddError(
+				"Reserved Root Attribute/Block Name",
+				"When validating the resource or data source schema, an implementation issue was found. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("%q is a reserved root attribute/block name. ", name)+
+					"This is to prevent practitioners from needing special Terraform configuration syntax.",
+			)
+
+			break
+		}
+	}
+
+	return diags
+}
+
+// IsValidAttributeName returns an error diagnostic if the given
+// attribute path has an invalid attribute name according to
+// ValidAttributeNameRegex. Non-AttributeName paths are automatically skipped
+// without error.
+func IsValidAttributeName(name string, attributePath path.Path) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	if ValidAttributeNameRegex.MatchString(name) {
+		return diags
+	}
+
+	// The diagnostic path is intentionally omitted as it is invalid in this
+	// context. Diagnostic paths are intended to be mapped to actual data,
+	// while this path information must be synthesized.
+	diags.AddError(
+		"Invalid Attribute/Block Name",
+		"When validating the schema, an implementation issue was found. "+
+			"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+			fmt.Sprintf("%q at schema path %q is an invalid attribute/block name. ", name, attributePath)+
+			"Names must only contain lowercase alphanumeric characters (a-z, 0-9) and underscores (_).",
+	)
+
+	return diags
+}

--- a/internal/fwschema/attribute_name_validation_test.go
+++ b/internal/fwschema/attribute_name_validation_test.go
@@ -1,0 +1,219 @@
+package fwschema_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+)
+
+func TestIsReservedProviderAttributeName(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		name          string
+		attributePath path.Path
+		expected      diag.Diagnostics
+	}{
+		"empty-path": {
+			name:          "",
+			attributePath: path.Empty(),
+			expected:      nil,
+		},
+		"invalid-path": {
+			name:          "",
+			attributePath: path.Empty().AtListIndex(0),
+			expected:      nil,
+		},
+		"non-root-attribute-name": {
+			name:          "alias",
+			attributePath: path.Root("test").AtName("alias"),
+			expected:      nil,
+		},
+		"alias": {
+			name:          "alias",
+			attributePath: path.Root("alias"),
+			expected: diag.Diagnostics{
+				diag.NewErrorDiagnostic(
+					"Reserved Root Attribute/Block Name",
+					"When validating the provider schema, an implementation issue was found. "+
+						"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+						"\"alias\" is a reserved root attribute/block name. "+
+						"This is to prevent practitioners from needing special Terraform configuration syntax.",
+				),
+			},
+		},
+		"version": {
+			name:          "version",
+			attributePath: path.Root("version"),
+			expected: diag.Diagnostics{
+				diag.NewErrorDiagnostic(
+					"Reserved Root Attribute/Block Name",
+					"When validating the provider schema, an implementation issue was found. "+
+						"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+						"\"version\" is a reserved root attribute/block name. "+
+						"This is to prevent practitioners from needing special Terraform configuration syntax.",
+				),
+			},
+		},
+		"other": {
+			name:          "other",
+			attributePath: path.Root("other"),
+			expected:      nil,
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := fwschema.IsReservedProviderAttributeName(testCase.name, testCase.attributePath)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestIsReservedResourceAttributeName(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		name          string
+		attributePath path.Path
+		expected      diag.Diagnostics
+	}{
+		"empty-path": {
+			name:          "",
+			attributePath: path.Empty(),
+			expected:      nil,
+		},
+		"invalid-path": {
+			name:          "",
+			attributePath: path.Empty().AtListIndex(0),
+			expected:      nil,
+		},
+		"non-root-attribute-name": {
+			name:          "count",
+			attributePath: path.Root("test").AtName("count"),
+			expected:      nil,
+		},
+		"connection": {
+			name:          "connection",
+			attributePath: path.Root("connection"),
+			expected: diag.Diagnostics{
+				diag.NewErrorDiagnostic(
+					"Reserved Root Attribute/Block Name",
+					"When validating the resource or data source schema, an implementation issue was found. "+
+						"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+						"\"connection\" is a reserved root attribute/block name. "+
+						"This is to prevent practitioners from needing special Terraform configuration syntax.",
+				),
+			},
+		},
+		"count": {
+			name:          "count",
+			attributePath: path.Root("count"),
+			expected: diag.Diagnostics{
+				diag.NewErrorDiagnostic(
+					"Reserved Root Attribute/Block Name",
+					"When validating the resource or data source schema, an implementation issue was found. "+
+						"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+						"\"count\" is a reserved root attribute/block name. "+
+						"This is to prevent practitioners from needing special Terraform configuration syntax.",
+				),
+			},
+		},
+		"depends_on": {
+			name:          "depends_on",
+			attributePath: path.Root("depends_on"),
+			expected: diag.Diagnostics{
+				diag.NewErrorDiagnostic(
+					"Reserved Root Attribute/Block Name",
+					"When validating the resource or data source schema, an implementation issue was found. "+
+						"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+						"\"depends_on\" is a reserved root attribute/block name. "+
+						"This is to prevent practitioners from needing special Terraform configuration syntax.",
+				),
+			},
+		},
+		// TODO: Validate for_each
+		// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/704
+		// "for_each": {
+		// 	name: "for_each",
+		//	attributePath: path.Root("for_each"),
+		// 	expected: diag.Diagnostics{
+		// 		diag.NewErrorDiagnostic(
+		// 			"Reserved Root Attribute/Block Name",
+		// 			"When validating the resource or data source schema, an implementation issue was found. "+
+		// 				"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+		// 				"\"for_each\" is a reserved root attribute/block name. "+
+		// 				"This is to prevent practitioners from needing special Terraform configuration syntax.",
+		// 		),
+		// 	},
+		// },
+		"lifecycle": {
+			name:          "lifecycle",
+			attributePath: path.Root("lifecycle"),
+			expected: diag.Diagnostics{
+				diag.NewErrorDiagnostic(
+					"Reserved Root Attribute/Block Name",
+					"When validating the resource or data source schema, an implementation issue was found. "+
+						"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+						"\"lifecycle\" is a reserved root attribute/block name. "+
+						"This is to prevent practitioners from needing special Terraform configuration syntax.",
+				),
+			},
+		},
+		"provider": {
+			name:          "provider",
+			attributePath: path.Root("provider"),
+			expected: diag.Diagnostics{
+				diag.NewErrorDiagnostic(
+					"Reserved Root Attribute/Block Name",
+					"When validating the resource or data source schema, an implementation issue was found. "+
+						"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+						"\"provider\" is a reserved root attribute/block name. "+
+						"This is to prevent practitioners from needing special Terraform configuration syntax.",
+				),
+			},
+		},
+		"provisioner": {
+			name:          "provisioner",
+			attributePath: path.Root("provisioner"),
+			expected: diag.Diagnostics{
+				diag.NewErrorDiagnostic(
+					"Reserved Root Attribute/Block Name",
+					"When validating the resource or data source schema, an implementation issue was found. "+
+						"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+						"\"provisioner\" is a reserved root attribute/block name. "+
+						"This is to prevent practitioners from needing special Terraform configuration syntax.",
+				),
+			},
+		},
+		"other": {
+			name:          "other",
+			attributePath: path.Root("other"),
+			expected:      nil,
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := fwschema.IsReservedResourceAttributeName(testCase.name, testCase.attributePath)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}

--- a/internal/fwschema/attribute_validate_implementation.go
+++ b/internal/fwschema/attribute_validate_implementation.go
@@ -1,0 +1,97 @@
+package fwschema
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+)
+
+// AttributeWithValidateImplementation is an optional interface on
+// Attribute which enables validation of the provider-defined implementation
+// for the Attribute. This logic runs during Validate* RPCs, or via
+// provider-defined unit testing, to ensure the provider's definition is valid
+// before further usage could cause other unexpected errors or panics.
+type AttributeWithValidateImplementation interface {
+	Attribute
+
+	// ValidateImplementation should contain the logic which validates
+	// the Attribute implementation. Since this logic can prevent the provider
+	// from being usable, it should be very targeted and defensive against
+	// false positives.
+	ValidateImplementation(context.Context, ValidateImplementationRequest, *ValidateImplementationResponse)
+}
+
+// ValidateImplementation contains the generic Attribute
+// implementation validation logic for all types.
+//
+// This logic currently:
+//   - Checks whether the given AttributeName in the path is a valid identifier
+//   - If the given Attribute implements the
+//     AttributeWithValidateImplementation interface, calls the method
+//   - If the given Attribute implements the NestedAttribute interface,
+//     recursively calls this function on nested attributes
+func ValidateAttributeImplementation(ctx context.Context, attribute Attribute, req ValidateImplementationRequest) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	diags.Append(IsValidAttributeName(req.Name, req.Path)...)
+
+	if attributeWithValidateImplementation, ok := attribute.(AttributeWithValidateImplementation); ok {
+		resp := &ValidateImplementationResponse{}
+
+		attributeWithValidateImplementation.ValidateImplementation(ctx, req, resp)
+
+		diags.Append(resp.Diagnostics...)
+	}
+
+	nestedAttribute, ok := attribute.(NestedAttribute)
+
+	if !ok {
+		return diags
+	}
+
+	nestedObject := nestedAttribute.GetNestedObject()
+
+	if nestedObject == nil {
+		return diags
+	}
+
+	nestingMode := nestedAttribute.GetNestingMode()
+
+	for nestedAttributeName, nestedAttribute := range nestedObject.GetAttributes() {
+		var nestedAttributePath path.Path
+
+		// TODO: path.Path and path.PathExpression are intended to map onto
+		// actual data implementations, however we need some representation
+		// for schema paths without data. It may make sense to introduce an
+		// internal "schema path" to simplify outputting specialized
+		// strings for these types of diagnostics.
+		//
+		// The below choices of AtListIndex(0), etc. are arbitrary in this
+		// situation.
+		//
+		// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/574
+		switch nestingMode {
+		// case NestingModeList:
+		// 	nestedAttributePath = req.Path.AtListIndex(0).AtName(nestedAttributeName)
+		// case NestingModeMap:
+		// 	nestedAttributePath = req.Path.AtMapKey("*").AtName(nestedAttributeName)
+		// case NestingModeSet:
+		// 	nestedAttributePath = req.Path.AtSetValue(types.StringValue("*")).AtName(nestedAttributeName)
+		// case NestingModeSingle:
+		// 	nestedAttributePath = req.Path.AtName(nestedAttributeName)
+		default:
+			// This is purely to preserve the prior logic. Refer to above comment.
+			nestedAttributePath = req.Path.AtName(nestedAttributeName)
+		}
+
+		nestedReq := ValidateImplementationRequest{
+			Name: nestedAttributeName,
+			Path: nestedAttributePath,
+		}
+
+		diags.Append(ValidateAttributeImplementation(ctx, nestedAttribute, nestedReq)...)
+	}
+
+	return diags
+}

--- a/internal/fwschema/block_validate_implementation.go
+++ b/internal/fwschema/block_validate_implementation.go
@@ -1,0 +1,122 @@
+package fwschema
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+)
+
+// BlockWithValidateImplementation is an optional interface on
+// Block which enables validation of the provider-defined implementation
+// for the Block. This logic runs during Validate* RPCs, or via
+// provider-defined unit testing, to ensure the provider's definition is valid
+// before further usage could cause other unexpected errors or panics.
+type BlockWithValidateImplementation interface {
+	Block
+
+	// ValidateImplementation should contain the logic which validates
+	// the Block implementation. Since this logic can prevent the provider
+	// from being usable, it should be very targeted and defensive against
+	// false positives.
+	ValidateImplementation(context.Context, ValidateImplementationRequest, *ValidateImplementationResponse)
+}
+
+// ValidateBlockImplementation contains the generic Block implementation
+// validation logic for all types.
+//
+// This logic currently:
+//   - Checks whether the given AttributeName in the path is a valid identifier
+//   - If the given Block implements the BlockWithValidateImplementation
+//     interface, calls the method
+//   - Recursively calls this function on nested attributes and blocks
+func ValidateBlockImplementation(ctx context.Context, block Block, req ValidateImplementationRequest) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	diags.Append(IsReservedResourceAttributeName(req.Name, req.Path)...)
+	diags.Append(IsValidAttributeName(req.Name, req.Path)...)
+
+	if blockWithValidateImplementation, ok := block.(BlockWithValidateImplementation); ok {
+		resp := &ValidateImplementationResponse{}
+
+		blockWithValidateImplementation.ValidateImplementation(ctx, req, resp)
+
+		diags.Append(resp.Diagnostics...)
+	}
+
+	nestedObject := block.GetNestedObject()
+
+	if nestedObject == nil {
+		return diags
+	}
+
+	nestingMode := block.GetNestingMode()
+
+	for nestedAttributeName, nestedAttribute := range nestedObject.GetAttributes() {
+		var nestedAttributePath path.Path
+
+		// TODO: path.Path and path.PathExpression are intended to map onto
+		// actual data implementations, however we need some representation
+		// for schema paths without data. It may make sense to introduce an
+		// internal "schema path" to simplify outputting specialized
+		// strings for these types of diagnostics.
+		//
+		// The below choices of AtListIndex(0), etc. are arbitrary in this
+		// situation.
+		//
+		// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/574
+		switch nestingMode {
+		// case BlockNestingModeList:
+		// 	nestedAttributePath = req.Path.AtListIndex(0).AtName(nestedAttributeName)
+		// case BlockNestingModeSet:
+		// 	nestedAttributePath = req.Path.AtSetValue(types.StringValue("*")).AtName(nestedAttributeName)
+		// case BlockNestingModeSingle:
+		// 	nestedAttributePath = req.Path.AtName(nestedAttributeName)
+		default:
+			// This is purely to preserve the prior logic. Refer to above comment.
+			nestedAttributePath = req.Path.AtName(nestedAttributeName)
+		}
+
+		nestedReq := ValidateImplementationRequest{
+			Name: nestedAttributeName,
+			Path: nestedAttributePath,
+		}
+
+		diags.Append(ValidateAttributeImplementation(ctx, nestedAttribute, nestedReq)...)
+	}
+
+	for nestedBlockName, nestedBlock := range nestedObject.GetBlocks() {
+		var nestedBlockPath path.Path
+
+		// TODO: path.Path and path.PathExpression are intended to map onto
+		// actual data implementations, however we need some representation
+		// for schema paths without data. It may make sense to introduce an
+		// internal "schema path" to simplify outputting specialized
+		// strings for these types of diagnostics.
+		//
+		// The below choices of AtListIndex(0), etc. are arbitrary in this
+		// situation.
+		//
+		// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/574
+		switch nestingMode {
+		// case BlockNestingModeList:
+		// 	nestedBlockPath = req.Path.AtListIndex(0).AtName(nestedBlockName)
+		// case BlockNestingModeSet:
+		// 	nestedBlockPath = req.Path.AtSetValue(types.StringValue("*")).AtName(nestedBlockName)
+		// case BlockNestingModeSingle:
+		// 	nestedBlockPath = req.Path.AtName(nestedBlockName)
+		default:
+			// This is purely to preserve the prior logic. Refer to above comment.
+			nestedBlockPath = req.Path.AtName(nestedBlockName)
+		}
+
+		nestedReq := ValidateImplementationRequest{
+			Name: nestedBlockName,
+			Path: nestedBlockPath,
+		}
+
+		diags.Append(ValidateBlockImplementation(ctx, nestedBlock, nestedReq)...)
+	}
+
+	return diags
+}

--- a/internal/fwschema/diagnostics.go
+++ b/internal/fwschema/diagnostics.go
@@ -1,0 +1,42 @@
+package fwschema
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+)
+
+// AttributeMissingAttributeTypesDiag returns an error diagnostic to provider
+// developers about missing the AttributeTypes field on an Attribute
+// implementation. This can cause unexpected errors or panics.
+// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/699
+func AttributeMissingAttributeTypesDiag(attributePath path.Path) diag.Diagnostic {
+	// The diagnostic path is intentionally omitted as it is invalid in this
+	// context. Diagnostic paths are intended to be mapped to actual data,
+	// while this path information must be synthesized.
+	return diag.NewErrorDiagnostic(
+		"Invalid Attribute Implementation",
+		"When validating the schema, an implementation issue was found. "+
+			"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+			fmt.Sprintf("%q is missing the AttributeTypes or CustomType field on an object Attribute. ", attributePath)+
+			"One of these fields is required to prevent other unexpected errors or panics.",
+	)
+}
+
+// AttributeMissingElementTypeDiag returns an error diagnostic to provider
+// developers about missing the ElementType field on an Attribute
+// implementation. This can cause unexpected errors or panics.
+// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/699
+func AttributeMissingElementTypeDiag(attributePath path.Path) diag.Diagnostic {
+	// The diagnostic path is intentionally omitted as it is invalid in this
+	// context. Diagnostic paths are intended to be mapped to actual data,
+	// while this path information must be synthesized.
+	return diag.NewErrorDiagnostic(
+		"Invalid Attribute Implementation",
+		"When validating the schema, an implementation issue was found. "+
+			"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+			fmt.Sprintf("%q is missing the CustomType or ElementType field on a collection Attribute. ", attributePath)+
+			"One of these fields is required to prevent other unexpected errors or panics.",
+	)
+}

--- a/internal/fwschema/validate_implementation.go
+++ b/internal/fwschema/validate_implementation.go
@@ -1,0 +1,34 @@
+package fwschema
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+)
+
+// ValidateImplementationRequest contains the information available
+// during a ValidateImplementation call to validate the Attribute
+// definition. ValidateImplementationResponse is the type used for
+// responses.
+type ValidateImplementationRequest struct {
+	// Name contains the current Attribute name.
+	Name string
+
+	// Path contains the current Attribute path. This path information is
+	// synthesized for any Attribute which is nested below other Attribute or
+	// Block since path.Path is intended to represent actual data, but schema
+	// paths represent any element in collection types. Rather than being
+	// intended for diagnostic paths, like most path information, this is
+	// intended for being stringified into diagnostic details.
+	Path path.Path
+}
+
+// ValidateImplementationResponse contains the returned data from a
+// ValidateImplementation method call to validate the Attribute
+// implementation. ValidateImplementationRequest is the type used for
+// requests.
+type ValidateImplementationResponse struct {
+	// Diagnostics report errors or warnings related to validating the
+	// definition of the Attribute. An empty slice indicates success, with no
+	// warnings or errors generated.
+	Diagnostics diag.Diagnostics
+}

--- a/internal/fwserver/server.go
+++ b/internal/fwserver/server.go
@@ -243,7 +243,7 @@ func (s *Server) DataSourceSchemas(ctx context.Context) (map[string]fwschema.Sch
 			return s.dataSourceSchemas, s.dataSourceSchemasDiags
 		}
 
-		s.dataSourceSchemasDiags.Append(schemaResp.Schema.Validate()...)
+		s.dataSourceSchemasDiags.Append(schemaResp.Schema.ValidateImplementation(ctx)...)
 
 		if s.dataSourceSchemasDiags.HasError() {
 			return s.dataSourceSchemas, s.dataSourceSchemasDiags
@@ -276,7 +276,7 @@ func (s *Server) ProviderSchema(ctx context.Context) (fwschema.Schema, diag.Diag
 	s.providerSchema = schemaResp.Schema
 	s.providerSchemaDiags = schemaResp.Diagnostics
 
-	s.providerSchemaDiags.Append(schemaResp.Schema.Validate()...)
+	s.providerSchemaDiags.Append(schemaResp.Schema.ValidateImplementation(ctx)...)
 
 	return s.providerSchema, s.providerSchemaDiags
 }
@@ -310,7 +310,7 @@ func (s *Server) ProviderMetaSchema(ctx context.Context) (fwschema.Schema, diag.
 	s.providerMetaSchema = resp.Schema
 	s.providerMetaSchemaDiags = resp.Diagnostics
 
-	s.providerMetaSchemaDiags.Append(resp.Schema.Validate()...)
+	s.providerMetaSchemaDiags.Append(resp.Schema.ValidateImplementation(ctx)...)
 
 	return s.providerMetaSchema, s.providerMetaSchemaDiags
 }
@@ -440,7 +440,7 @@ func (s *Server) ResourceSchemas(ctx context.Context) (map[string]fwschema.Schem
 			return s.resourceSchemas, s.resourceSchemasDiags
 		}
 
-		s.resourceSchemasDiags.Append(schemaResp.Schema.Validate()...)
+		s.resourceSchemasDiags.Append(schemaResp.Schema.ValidateImplementation(ctx)...)
 
 		if s.resourceSchemasDiags.HasError() {
 			return s.resourceSchemas, s.resourceSchemasDiags

--- a/internal/fwserver/server_getproviderschema_test.go
+++ b/internal/fwserver/server_getproviderschema_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
 	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testprovider"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/provider/metaschema"
 	providerschema "github.com/hashicorp/terraform-plugin-framework/provider/schema"
@@ -156,10 +155,12 @@ func TestServerGetProviderSchema(t *testing.T) {
 					PlanDestroy: true,
 				},
 				Diagnostics: diag.Diagnostics{
-					diag.NewAttributeErrorDiagnostic(
-						path.Root("$"),
-						"Invalid Schema Field Name",
-						`Field name "$" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
+					diag.NewErrorDiagnostic(
+						"Invalid Attribute/Block Name",
+						"When validating the schema, an implementation issue was found. "+
+							"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+							"\"$\" at schema path \"$\" is an invalid attribute/block name. "+
+							"Names must only contain lowercase alphanumeric characters (a-z, 0-9) and underscores (_).",
 					),
 				},
 			},
@@ -352,10 +353,12 @@ func TestServerGetProviderSchema(t *testing.T) {
 					PlanDestroy: true,
 				},
 				Diagnostics: diag.Diagnostics{
-					diag.NewAttributeErrorDiagnostic(
-						path.Root("$"),
-						"Invalid Schema Field Name",
-						`Field name "$" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
+					diag.NewErrorDiagnostic(
+						"Invalid Attribute/Block Name",
+						"When validating the schema, an implementation issue was found. "+
+							"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+							"\"$\" at schema path \"$\" is an invalid attribute/block name. "+
+							"Names must only contain lowercase alphanumeric characters (a-z, 0-9) and underscores (_).",
 					),
 				},
 			},
@@ -414,10 +417,12 @@ func TestServerGetProviderSchema(t *testing.T) {
 					PlanDestroy: true,
 				},
 				Diagnostics: diag.Diagnostics{
-					diag.NewAttributeErrorDiagnostic(
-						path.Root("$"),
-						"Invalid Schema Field Name",
-						`Field name "$" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
+					diag.NewErrorDiagnostic(
+						"Invalid Attribute/Block Name",
+						"When validating the schema, an implementation issue was found. "+
+							"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+							"\"$\" at schema path \"$\" is an invalid attribute/block name. "+
+							"Names must only contain lowercase alphanumeric characters (a-z, 0-9) and underscores (_).",
 					),
 				},
 			},
@@ -536,10 +541,12 @@ func TestServerGetProviderSchema(t *testing.T) {
 					PlanDestroy: true,
 				},
 				Diagnostics: diag.Diagnostics{
-					diag.NewAttributeErrorDiagnostic(
-						path.Root("$"),
-						"Invalid Schema Field Name",
-						`Field name "$" is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.`,
+					diag.NewErrorDiagnostic(
+						"Invalid Attribute/Block Name",
+						"When validating the schema, an implementation issue was found. "+
+							"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+							"\"$\" at schema path \"$\" is an invalid attribute/block name. "+
+							"Names must only contain lowercase alphanumeric characters (a-z, 0-9) and underscores (_).",
 					),
 				},
 			},

--- a/internal/testing/types/list.go
+++ b/internal/testing/types/list.go
@@ -1,0 +1,16 @@
+package types
+
+import "github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+
+var (
+	_ basetypes.ListTypable  = ListType{}
+	_ basetypes.ListValuable = ListValue{}
+)
+
+type ListType struct {
+	basetypes.ListType
+}
+
+type ListValue struct {
+	basetypes.ListValue
+}

--- a/internal/testing/types/map.go
+++ b/internal/testing/types/map.go
@@ -1,0 +1,16 @@
+package types
+
+import "github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+
+var (
+	_ basetypes.MapTypable  = MapType{}
+	_ basetypes.MapValuable = MapValue{}
+)
+
+type MapType struct {
+	basetypes.MapType
+}
+
+type MapValue struct {
+	basetypes.MapValue
+}

--- a/internal/testing/types/object.go
+++ b/internal/testing/types/object.go
@@ -1,0 +1,16 @@
+package types
+
+import "github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+
+var (
+	_ basetypes.ObjectTypable  = ObjectType{}
+	_ basetypes.ObjectValuable = ObjectValue{}
+)
+
+type ObjectType struct {
+	basetypes.ObjectType
+}
+
+type ObjectValue struct {
+	basetypes.ObjectValue
+}

--- a/internal/testing/types/set.go
+++ b/internal/testing/types/set.go
@@ -1,0 +1,16 @@
+package types
+
+import "github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+
+var (
+	_ basetypes.SetTypable  = SetType{}
+	_ basetypes.SetValuable = SetValue{}
+)
+
+type SetType struct {
+	basetypes.SetType
+}
+
+type SetValue struct {
+	basetypes.SetValue
+}

--- a/provider/metaschema/list_attribute.go
+++ b/provider/metaschema/list_attribute.go
@@ -1,6 +1,8 @@
 package metaschema
 
 import (
+	"context"
+
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -10,7 +12,8 @@ import (
 
 // Ensure the implementation satisifies the desired interfaces.
 var (
-	_ Attribute = ListAttribute{}
+	_ Attribute                                    = ListAttribute{}
+	_ fwschema.AttributeWithValidateImplementation = ListAttribute{}
 )
 
 // ListAttribute represents a schema attribute that is a list with a single
@@ -126,4 +129,14 @@ func (a ListAttribute) IsRequired() bool {
 // schema data.
 func (a ListAttribute) IsSensitive() bool {
 	return false
+}
+
+// ValidateImplementation contains logic for validating the
+// provider-defined implementation of the attribute to prevent unexpected
+// errors or panics. This logic runs during the GetProviderSchema RPC
+// and should never include false positives.
+func (a ListAttribute) ValidateImplementation(ctx context.Context, req fwschema.ValidateImplementationRequest, resp *fwschema.ValidateImplementationResponse) {
+	if a.CustomType == nil && a.ElementType == nil {
+		resp.Diagnostics.Append(fwschema.AttributeMissingElementTypeDiag(req.Path))
+	}
 }

--- a/provider/metaschema/list_attribute_test.go
+++ b/provider/metaschema/list_attribute_test.go
@@ -1,14 +1,18 @@
 package metaschema_test
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
+	testtypes "github.com/hashicorp/terraform-plugin-framework/internal/testing/types"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/provider/metaschema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
@@ -364,6 +368,74 @@ func TestListAttributeIsSensitive(t *testing.T) {
 			t.Parallel()
 
 			got := testCase.attribute.IsSensitive()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestListAttributeValidateImplementation(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute metaschema.ListAttribute
+		request   fwschema.ValidateImplementationRequest
+		expected  *fwschema.ValidateImplementationResponse
+	}{
+		"customtype": {
+			attribute: metaschema.ListAttribute{
+				CustomType: testtypes.ListType{},
+				Optional:   true,
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{},
+		},
+		"elementtype": {
+			attribute: metaschema.ListAttribute{
+				ElementType: types.StringType,
+				Optional:    true,
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{},
+		},
+		"elementtype-missing": {
+			attribute: metaschema.ListAttribute{
+				Optional: true,
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic(
+						"Invalid Attribute Implementation",
+						"When validating the schema, an implementation issue was found. "+
+							"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+							"\"test\" is missing the CustomType or ElementType field on a collection Attribute. "+
+							"One of these fields is required to prevent other unexpected errors or panics.",
+					),
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := &fwschema.ValidateImplementationResponse{}
+			testCase.attribute.ValidateImplementation(context.Background(), testCase.request, got)
 
 			if diff := cmp.Diff(got, testCase.expected); diff != "" {
 				t.Errorf("unexpected difference: %s", diff)

--- a/provider/metaschema/map_attribute.go
+++ b/provider/metaschema/map_attribute.go
@@ -1,6 +1,8 @@
 package metaschema
 
 import (
+	"context"
+
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -10,7 +12,8 @@ import (
 
 // Ensure the implementation satisifies the desired interfaces.
 var (
-	_ Attribute = MapAttribute{}
+	_ Attribute                                    = MapAttribute{}
+	_ fwschema.AttributeWithValidateImplementation = MapAttribute{}
 )
 
 // MapAttribute represents a schema attribute that is a list with a single
@@ -129,4 +132,14 @@ func (a MapAttribute) IsRequired() bool {
 // schema data.
 func (a MapAttribute) IsSensitive() bool {
 	return false
+}
+
+// ValidateImplementation contains logic for validating the
+// provider-defined implementation of the attribute to prevent unexpected
+// errors or panics. This logic runs during the GetProviderSchema RPC
+// and should never include false positives.
+func (a MapAttribute) ValidateImplementation(ctx context.Context, req fwschema.ValidateImplementationRequest, resp *fwschema.ValidateImplementationResponse) {
+	if a.CustomType == nil && a.ElementType == nil {
+		resp.Diagnostics.Append(fwschema.AttributeMissingElementTypeDiag(req.Path))
+	}
 }

--- a/provider/metaschema/object_attribute.go
+++ b/provider/metaschema/object_attribute.go
@@ -1,6 +1,8 @@
 package metaschema
 
 import (
+	"context"
+
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -10,7 +12,8 @@ import (
 
 // Ensure the implementation satisifies the desired interfaces.
 var (
-	_ Attribute = ObjectAttribute{}
+	_ Attribute                                    = ObjectAttribute{}
+	_ fwschema.AttributeWithValidateImplementation = ObjectAttribute{}
 )
 
 // ObjectAttribute represents a schema attribute that is an object with only
@@ -128,4 +131,14 @@ func (a ObjectAttribute) IsRequired() bool {
 // schema data.
 func (a ObjectAttribute) IsSensitive() bool {
 	return false
+}
+
+// ValidateImplementation contains logic for validating the
+// provider-defined implementation of the attribute to prevent unexpected
+// errors or panics. This logic runs during the GetProviderSchema RPC
+// and should never include false positives.
+func (a ObjectAttribute) ValidateImplementation(ctx context.Context, req fwschema.ValidateImplementationRequest, resp *fwschema.ValidateImplementationResponse) {
+	if a.AttributeTypes == nil && a.CustomType == nil {
+		resp.Diagnostics.Append(fwschema.AttributeMissingAttributeTypesDiag(req.Path))
+	}
 }

--- a/provider/metaschema/object_attribute_test.go
+++ b/provider/metaschema/object_attribute_test.go
@@ -1,14 +1,18 @@
 package metaschema_test
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
+	testtypes "github.com/hashicorp/terraform-plugin-framework/internal/testing/types"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/provider/metaschema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
@@ -370,6 +374,76 @@ func TestObjectAttributeIsSensitive(t *testing.T) {
 			t.Parallel()
 
 			got := testCase.attribute.IsSensitive()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestObjectAttributeValidateImplementation(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute metaschema.ObjectAttribute
+		request   fwschema.ValidateImplementationRequest
+		expected  *fwschema.ValidateImplementationResponse
+	}{
+		"attributetypes": {
+			attribute: metaschema.ObjectAttribute{
+				AttributeTypes: map[string]attr.Type{
+					"test_attr": types.StringType,
+				},
+				Optional: true,
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{},
+		},
+		"attributetypes-missing": {
+			attribute: metaschema.ObjectAttribute{
+				Optional: true,
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic(
+						"Invalid Attribute Implementation",
+						"When validating the schema, an implementation issue was found. "+
+							"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+							"\"test\" is missing the AttributeTypes or CustomType field on an object Attribute. "+
+							"One of these fields is required to prevent other unexpected errors or panics.",
+					),
+				},
+			},
+		},
+		"customtype": {
+			attribute: metaschema.ObjectAttribute{
+				CustomType: testtypes.ObjectType{},
+				Optional:   true,
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := &fwschema.ValidateImplementationResponse{}
+			testCase.attribute.ValidateImplementation(context.Background(), testCase.request, got)
 
 			if diff := cmp.Diff(got, testCase.expected); diff != "" {
 				t.Errorf("unexpected difference: %s", diff)

--- a/provider/metaschema/schema.go
+++ b/provider/metaschema/schema.go
@@ -2,8 +2,6 @@ package metaschema
 
 import (
 	"context"
-	"fmt"
-	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 
@@ -121,42 +119,6 @@ func (s Schema) ValidateImplementation(ctx context.Context) diag.Diagnostics {
 		}
 
 		diags.Append(fwschema.ValidateAttributeImplementation(ctx, attribute, req)...)
-	}
-
-	return diags
-}
-
-// validFieldNameRegex is used to verify that name used for attributes and blocks
-// comply with the defined regular expression.
-var validFieldNameRegex = regexp.MustCompile("^[a-z0-9_]+$")
-
-// validateAttributeFieldName verifies that the name used for an attribute complies with the regular
-// expression defined in validFieldNameRegex.
-func validateAttributeFieldName(path path.Path, name string, attr fwschema.Attribute) diag.Diagnostics {
-	var diags diag.Diagnostics
-
-	if !validFieldNameRegex.MatchString(name) {
-		diags.AddAttributeError(
-			path,
-			"Invalid Attribute/Block Name",
-			fmt.Sprintf("Field name %q is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.", name),
-		)
-	}
-
-	if na, ok := attr.(fwschema.NestedAttribute); ok {
-		nestedObject := na.GetNestedObject()
-
-		if nestedObject == nil {
-			return diags
-		}
-
-		attributes := nestedObject.GetAttributes()
-
-		for k, v := range attributes {
-			d := validateAttributeFieldName(path.AtName(k), k, v)
-
-			diags.Append(d...)
-		}
 	}
 
 	return diags

--- a/provider/metaschema/set_attribute.go
+++ b/provider/metaschema/set_attribute.go
@@ -1,6 +1,8 @@
 package metaschema
 
 import (
+	"context"
+
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -10,7 +12,8 @@ import (
 
 // Ensure the implementation satisifies the desired interfaces.
 var (
-	_ Attribute = SetAttribute{}
+	_ Attribute                                    = SetAttribute{}
+	_ fwschema.AttributeWithValidateImplementation = SetAttribute{}
 )
 
 // SetAttribute represents a schema attribute that is a set with a single
@@ -124,4 +127,14 @@ func (a SetAttribute) IsRequired() bool {
 // schema data.
 func (a SetAttribute) IsSensitive() bool {
 	return false
+}
+
+// ValidateImplementation contains logic for validating the
+// provider-defined implementation of the attribute to prevent unexpected
+// errors or panics. This logic runs during the GetProviderSchema RPC
+// and should never include false positives.
+func (a SetAttribute) ValidateImplementation(ctx context.Context, req fwschema.ValidateImplementationRequest, resp *fwschema.ValidateImplementationResponse) {
+	if a.CustomType == nil && a.ElementType == nil {
+		resp.Diagnostics.Append(fwschema.AttributeMissingElementTypeDiag(req.Path))
+	}
 }

--- a/provider/metaschema/set_attribute_test.go
+++ b/provider/metaschema/set_attribute_test.go
@@ -1,14 +1,18 @@
 package metaschema_test
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
+	testtypes "github.com/hashicorp/terraform-plugin-framework/internal/testing/types"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/provider/metaschema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
@@ -364,6 +368,74 @@ func TestSetAttributeIsSensitive(t *testing.T) {
 			t.Parallel()
 
 			got := testCase.attribute.IsSensitive()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestSetAttributeValidateImplementation(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute metaschema.SetAttribute
+		request   fwschema.ValidateImplementationRequest
+		expected  *fwschema.ValidateImplementationResponse
+	}{
+		"customtype": {
+			attribute: metaschema.SetAttribute{
+				CustomType: testtypes.SetType{},
+				Optional:   true,
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{},
+		},
+		"elementtype": {
+			attribute: metaschema.SetAttribute{
+				ElementType: types.StringType,
+				Optional:    true,
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{},
+		},
+		"elementtype-missing": {
+			attribute: metaschema.SetAttribute{
+				Optional: true,
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic(
+						"Invalid Attribute Implementation",
+						"When validating the schema, an implementation issue was found. "+
+							"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+							"\"test\" is missing the CustomType or ElementType field on a collection Attribute. "+
+							"One of these fields is required to prevent other unexpected errors or panics.",
+					),
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := &fwschema.ValidateImplementationResponse{}
+			testCase.attribute.ValidateImplementation(context.Background(), testCase.request, got)
 
 			if diff := cmp.Diff(got, testCase.expected); diff != "" {
 				t.Errorf("unexpected difference: %s", diff)

--- a/provider/schema/list_attribute.go
+++ b/provider/schema/list_attribute.go
@@ -1,6 +1,8 @@
 package schema
 
 import (
+	"context"
+
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema/fwxschema"
@@ -12,8 +14,9 @@ import (
 
 // Ensure the implementation satisifies the desired interfaces.
 var (
-	_ Attribute                             = ListAttribute{}
-	_ fwxschema.AttributeWithListValidators = ListAttribute{}
+	_ Attribute                                    = ListAttribute{}
+	_ fwschema.AttributeWithValidateImplementation = ListAttribute{}
+	_ fwxschema.AttributeWithListValidators        = ListAttribute{}
 )
 
 // ListAttribute represents a schema attribute that is a list with a single
@@ -187,4 +190,14 @@ func (a ListAttribute) IsSensitive() bool {
 // ListValidators returns the Validators field value.
 func (a ListAttribute) ListValidators() []validator.List {
 	return a.Validators
+}
+
+// ValidateImplementation contains logic for validating the
+// provider-defined implementation of the attribute to prevent unexpected
+// errors or panics. This logic runs during the GetProviderSchema RPC
+// and should never include false positives.
+func (a ListAttribute) ValidateImplementation(ctx context.Context, req fwschema.ValidateImplementationRequest, resp *fwschema.ValidateImplementationResponse) {
+	if a.CustomType == nil && a.ElementType == nil {
+		resp.Diagnostics.Append(fwschema.AttributeMissingElementTypeDiag(req.Path))
+	}
 }

--- a/provider/schema/list_attribute_test.go
+++ b/provider/schema/list_attribute_test.go
@@ -1,14 +1,18 @@
 package schema_test
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
+	testtypes "github.com/hashicorp/terraform-plugin-framework/internal/testing/types"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -411,6 +415,74 @@ func TestListAttributeListValidators(t *testing.T) {
 			t.Parallel()
 
 			got := testCase.attribute.ListValidators()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestListAttributeValidateImplementation(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.ListAttribute
+		request   fwschema.ValidateImplementationRequest
+		expected  *fwschema.ValidateImplementationResponse
+	}{
+		"customtype": {
+			attribute: schema.ListAttribute{
+				Optional:   true,
+				CustomType: testtypes.ListType{},
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{},
+		},
+		"elementtype": {
+			attribute: schema.ListAttribute{
+				Optional:    true,
+				ElementType: types.StringType,
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{},
+		},
+		"elementtype-missing": {
+			attribute: schema.ListAttribute{
+				Optional: true,
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic(
+						"Invalid Attribute Implementation",
+						"When validating the schema, an implementation issue was found. "+
+							"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+							"\"test\" is missing the CustomType or ElementType field on a collection Attribute. "+
+							"One of these fields is required to prevent other unexpected errors or panics.",
+					),
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := &fwschema.ValidateImplementationResponse{}
+			testCase.attribute.ValidateImplementation(context.Background(), testCase.request, got)
 
 			if diff := cmp.Diff(got, testCase.expected); diff != "" {
 				t.Errorf("unexpected difference: %s", diff)

--- a/provider/schema/map_attribute.go
+++ b/provider/schema/map_attribute.go
@@ -1,6 +1,8 @@
 package schema
 
 import (
+	"context"
+
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema/fwxschema"
@@ -12,8 +14,9 @@ import (
 
 // Ensure the implementation satisifies the desired interfaces.
 var (
-	_ Attribute                            = MapAttribute{}
-	_ fwxschema.AttributeWithMapValidators = MapAttribute{}
+	_ Attribute                                    = MapAttribute{}
+	_ fwschema.AttributeWithValidateImplementation = MapAttribute{}
+	_ fwxschema.AttributeWithMapValidators         = MapAttribute{}
 )
 
 // MapAttribute represents a schema attribute that is a list with a single
@@ -190,4 +193,14 @@ func (a MapAttribute) IsSensitive() bool {
 // MapValidators returns the Validators field value.
 func (a MapAttribute) MapValidators() []validator.Map {
 	return a.Validators
+}
+
+// ValidateImplementation contains logic for validating the
+// provider-defined implementation of the attribute to prevent unexpected
+// errors or panics. This logic runs during the GetProviderSchema RPC
+// and should never include false positives.
+func (a MapAttribute) ValidateImplementation(ctx context.Context, req fwschema.ValidateImplementationRequest, resp *fwschema.ValidateImplementationResponse) {
+	if a.CustomType == nil && a.ElementType == nil {
+		resp.Diagnostics.Append(fwschema.AttributeMissingElementTypeDiag(req.Path))
+	}
 }

--- a/provider/schema/map_attribute_test.go
+++ b/provider/schema/map_attribute_test.go
@@ -1,14 +1,18 @@
 package schema_test
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
+	testtypes "github.com/hashicorp/terraform-plugin-framework/internal/testing/types"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -411,6 +415,74 @@ func TestMapAttributeMapValidators(t *testing.T) {
 			t.Parallel()
 
 			got := testCase.attribute.MapValidators()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestMapAttributeValidateImplementation(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.MapAttribute
+		request   fwschema.ValidateImplementationRequest
+		expected  *fwschema.ValidateImplementationResponse
+	}{
+		"customtype": {
+			attribute: schema.MapAttribute{
+				Optional:   true,
+				CustomType: testtypes.MapType{},
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{},
+		},
+		"elementtype": {
+			attribute: schema.MapAttribute{
+				Optional:    true,
+				ElementType: types.StringType,
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{},
+		},
+		"elementtype-missing": {
+			attribute: schema.MapAttribute{
+				Optional: true,
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic(
+						"Invalid Attribute Implementation",
+						"When validating the schema, an implementation issue was found. "+
+							"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+							"\"test\" is missing the CustomType or ElementType field on a collection Attribute. "+
+							"One of these fields is required to prevent other unexpected errors or panics.",
+					),
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := &fwschema.ValidateImplementationResponse{}
+			testCase.attribute.ValidateImplementation(context.Background(), testCase.request, got)
 
 			if diff := cmp.Diff(got, testCase.expected); diff != "" {
 				t.Errorf("unexpected difference: %s", diff)

--- a/provider/schema/object_attribute.go
+++ b/provider/schema/object_attribute.go
@@ -1,6 +1,8 @@
 package schema
 
 import (
+	"context"
+
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema/fwxschema"
@@ -12,8 +14,9 @@ import (
 
 // Ensure the implementation satisifies the desired interfaces.
 var (
-	_ Attribute                               = ObjectAttribute{}
-	_ fwxschema.AttributeWithObjectValidators = ObjectAttribute{}
+	_ Attribute                                    = ObjectAttribute{}
+	_ fwschema.AttributeWithValidateImplementation = ObjectAttribute{}
+	_ fwxschema.AttributeWithObjectValidators      = ObjectAttribute{}
 )
 
 // ObjectAttribute represents a schema attribute that is an object with only
@@ -189,4 +192,14 @@ func (a ObjectAttribute) IsSensitive() bool {
 // ObjectValidators returns the Validators field value.
 func (a ObjectAttribute) ObjectValidators() []validator.Object {
 	return a.Validators
+}
+
+// ValidateImplementation contains logic for validating the
+// provider-defined implementation of the attribute to prevent unexpected
+// errors or panics. This logic runs during the GetProviderSchema RPC
+// and should never include false positives.
+func (a ObjectAttribute) ValidateImplementation(ctx context.Context, req fwschema.ValidateImplementationRequest, resp *fwschema.ValidateImplementationResponse) {
+	if a.AttributeTypes == nil && a.CustomType == nil {
+		resp.Diagnostics.Append(fwschema.AttributeMissingAttributeTypesDiag(req.Path))
+	}
 }

--- a/provider/schema/schema.go
+++ b/provider/schema/schema.go
@@ -2,8 +2,6 @@ package schema
 
 import (
 	"context"
-	"fmt"
-	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 
@@ -124,120 +122,38 @@ func (s Schema) TypeAtTerraformPath(ctx context.Context, p *tftypes.AttributePat
 }
 
 // Validate verifies that the schema is not using a reserved field name for a top-level attribute.
+//
+// Deprecated: Use the ValidateImplementation method instead.
 func (s Schema) Validate() diag.Diagnostics {
-	var diags diag.Diagnostics
-
-	// Raise error diagnostics when data source configuration uses reserved
-	// field names for root-level attributes.
-	reservedFieldNames := map[string]struct{}{
-		"alias":   {},
-		"version": {},
-	}
-
-	attributes := s.GetAttributes()
-
-	for k, v := range attributes {
-		if _, ok := reservedFieldNames[k]; ok {
-			diags.AddAttributeError(
-				path.Root(k),
-				"Schema Using Reserved Field Name",
-				fmt.Sprintf("%q is a reserved field name", k),
-			)
-		}
-
-		d := validateAttributeFieldName(path.Root(k), k, v)
-
-		diags.Append(d...)
-	}
-
-	blocks := s.GetBlocks()
-
-	for k, v := range blocks {
-		if _, ok := reservedFieldNames[k]; ok {
-			diags.AddAttributeError(
-				path.Root(k),
-				"Schema Using Reserved Field Name",
-				fmt.Sprintf("%q is a reserved field name", k),
-			)
-		}
-
-		d := validateBlockFieldName(path.Root(k), k, v)
-
-		diags.Append(d...)
-	}
-
-	return diags
+	return s.ValidateImplementation(context.Background())
 }
 
-// validFieldNameRegex is used to verify that name used for attributes and blocks
-// comply with the defined regular expression.
-var validFieldNameRegex = regexp.MustCompile("^[a-z0-9_]+$")
-
-// validateAttributeFieldName verifies that the name used for an attribute complies with the regular
-// expression defined in validFieldNameRegex.
-func validateAttributeFieldName(path path.Path, name string, attr fwschema.Attribute) diag.Diagnostics {
+// ValidateImplementation contains logic for validating the provider-defined
+// implementation of the schema and underlying attributes and blocks to prevent
+// unexpected errors or panics. This logic runs during the GetProviderSchema
+// RPC, or via provider-defined unit testing, and should never include false
+// positives.
+func (s Schema) ValidateImplementation(ctx context.Context) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	if !validFieldNameRegex.MatchString(name) {
-		diags.AddAttributeError(
-			path,
-			"Invalid Schema Field Name",
-			fmt.Sprintf("Field name %q is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.", name),
-		)
-	}
-
-	if na, ok := attr.(fwschema.NestedAttribute); ok {
-		nestedObject := na.GetNestedObject()
-
-		if nestedObject == nil {
-			return diags
+	for attributeName, attribute := range s.GetAttributes() {
+		req := fwschema.ValidateImplementationRequest{
+			Name: attributeName,
+			Path: path.Root(attributeName),
 		}
 
-		attributes := nestedObject.GetAttributes()
+		diags.Append(fwschema.IsReservedProviderAttributeName(req.Name, req.Path)...)
+		diags.Append(fwschema.ValidateAttributeImplementation(ctx, attribute, req)...)
+	}
 
-		for k, v := range attributes {
-			d := validateAttributeFieldName(path.AtName(k), k, v)
-
-			diags.Append(d...)
+	for blockName, block := range s.GetBlocks() {
+		req := fwschema.ValidateImplementationRequest{
+			Name: blockName,
+			Path: path.Root(blockName),
 		}
-	}
 
-	return diags
-}
-
-// validateBlockFieldName verifies that the name used for a block complies with the regular
-// expression defined in validFieldNameRegex.
-func validateBlockFieldName(path path.Path, name string, b fwschema.Block) diag.Diagnostics {
-	var diags diag.Diagnostics
-
-	if !validFieldNameRegex.MatchString(name) {
-		diags.AddAttributeError(
-			path,
-			"Invalid Schema Field Name",
-			fmt.Sprintf("Field name %q is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.", name),
-		)
-	}
-
-	nestedObject := b.GetNestedObject()
-
-	if nestedObject == nil {
-		return diags
-	}
-
-	blocks := nestedObject.GetBlocks()
-
-	for k, v := range blocks {
-		d := validateBlockFieldName(path.AtName(k), k, v)
-
-		diags.Append(d...)
-	}
-
-	attributes := nestedObject.GetAttributes()
-
-	for k, v := range attributes {
-		d := validateAttributeFieldName(path.AtName(k), k, v)
-
-		diags.Append(d...)
+		diags.Append(fwschema.IsReservedProviderAttributeName(req.Name, req.Path)...)
+		diags.Append(fwschema.ValidateBlockImplementation(ctx, block, req)...)
 	}
 
 	return diags

--- a/provider/schema/set_attribute.go
+++ b/provider/schema/set_attribute.go
@@ -1,6 +1,8 @@
 package schema
 
 import (
+	"context"
+
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema/fwxschema"
@@ -12,8 +14,9 @@ import (
 
 // Ensure the implementation satisifies the desired interfaces.
 var (
-	_ Attribute                            = SetAttribute{}
-	_ fwxschema.AttributeWithSetValidators = SetAttribute{}
+	_ Attribute                                    = SetAttribute{}
+	_ fwschema.AttributeWithValidateImplementation = SetAttribute{}
+	_ fwxschema.AttributeWithSetValidators         = SetAttribute{}
 )
 
 // SetAttribute represents a schema attribute that is a set with a single
@@ -185,4 +188,14 @@ func (a SetAttribute) IsSensitive() bool {
 // SetValidators returns the Validators field value.
 func (a SetAttribute) SetValidators() []validator.Set {
 	return a.Validators
+}
+
+// ValidateImplementation contains logic for validating the
+// provider-defined implementation of the attribute to prevent unexpected
+// errors or panics. This logic runs during the GetProviderSchema RPC
+// and should never include false positives.
+func (a SetAttribute) ValidateImplementation(ctx context.Context, req fwschema.ValidateImplementationRequest, resp *fwschema.ValidateImplementationResponse) {
+	if a.CustomType == nil && a.ElementType == nil {
+		resp.Diagnostics.Append(fwschema.AttributeMissingElementTypeDiag(req.Path))
+	}
 }

--- a/provider/schema/set_attribute_test.go
+++ b/provider/schema/set_attribute_test.go
@@ -1,14 +1,18 @@
 package schema_test
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
+	testtypes "github.com/hashicorp/terraform-plugin-framework/internal/testing/types"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -411,6 +415,74 @@ func TestSetAttributeSetValidators(t *testing.T) {
 			t.Parallel()
 
 			got := testCase.attribute.SetValidators()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestSetAttributeValidateImplementation(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.SetAttribute
+		request   fwschema.ValidateImplementationRequest
+		expected  *fwschema.ValidateImplementationResponse
+	}{
+		"customtype": {
+			attribute: schema.SetAttribute{
+				Optional:   true,
+				CustomType: testtypes.SetType{},
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{},
+		},
+		"elementtype": {
+			attribute: schema.SetAttribute{
+				Optional:    true,
+				ElementType: types.StringType,
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{},
+		},
+		"elementtype-missing": {
+			attribute: schema.SetAttribute{
+				Optional: true,
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic(
+						"Invalid Attribute Implementation",
+						"When validating the schema, an implementation issue was found. "+
+							"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+							"\"test\" is missing the CustomType or ElementType field on a collection Attribute. "+
+							"One of these fields is required to prevent other unexpected errors or panics.",
+					),
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := &fwschema.ValidateImplementationResponse{}
+			testCase.attribute.ValidateImplementation(context.Background(), testCase.request, got)
 
 			if diff := cmp.Diff(got, testCase.expected); diff != "" {
 				t.Errorf("unexpected difference: %s", diff)

--- a/resource/schema/bool_attribute_test.go
+++ b/resource/schema/bool_attribute_test.go
@@ -10,9 +10,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
 	testtypes "github.com/hashicorp/terraform-plugin-framework/internal/testing/types"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/defaults"
@@ -499,6 +501,71 @@ func TestBoolAttributeIsSensitive(t *testing.T) {
 			t.Parallel()
 
 			got := testCase.attribute.IsSensitive()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestBoolAttributeValidateImplementation(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.BoolAttribute
+		request   fwschema.ValidateImplementationRequest
+		expected  *fwschema.ValidateImplementationResponse
+	}{
+		"computed": {
+			attribute: schema.BoolAttribute{
+				Computed: true,
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{},
+		},
+		"default-without-computed": {
+			attribute: schema.BoolAttribute{
+				Default: booldefault.StaticBool(true),
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic(
+						"Schema Using Attribute Default For Non-Computed Attribute",
+						"Attribute \"test\" must be computed when using default. "+
+							"This is an issue with the provider and should be reported to the provider developers.",
+					),
+				},
+			},
+		},
+		"default-with-computed": {
+			attribute: schema.BoolAttribute{
+				Computed: true,
+				Default:  booldefault.StaticBool(true),
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := &fwschema.ValidateImplementationResponse{}
+			testCase.attribute.ValidateImplementation(context.Background(), testCase.request, got)
 
 			if diff := cmp.Diff(got, testCase.expected); diff != "" {
 				t.Errorf("unexpected difference: %s", diff)

--- a/resource/schema/float64_attribute.go
+++ b/resource/schema/float64_attribute.go
@@ -1,6 +1,8 @@
 package schema
 
 import (
+	"context"
+
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -15,10 +17,11 @@ import (
 
 // Ensure the implementation satisfies the desired interfaces.
 var (
-	_ Attribute                                   = Float64Attribute{}
-	_ fwschema.AttributeWithFloat64DefaultValue   = Float64Attribute{}
-	_ fwxschema.AttributeWithFloat64PlanModifiers = Float64Attribute{}
-	_ fwxschema.AttributeWithFloat64Validators    = Float64Attribute{}
+	_ Attribute                                    = Float64Attribute{}
+	_ fwschema.AttributeWithValidateImplementation = Float64Attribute{}
+	_ fwschema.AttributeWithFloat64DefaultValue    = Float64Attribute{}
+	_ fwxschema.AttributeWithFloat64PlanModifiers  = Float64Attribute{}
+	_ fwxschema.AttributeWithFloat64Validators     = Float64Attribute{}
 )
 
 // Float64Attribute represents a schema attribute that is a 64-bit floating
@@ -224,4 +227,14 @@ func (a Float64Attribute) IsRequired() bool {
 // IsSensitive returns the Sensitive field value.
 func (a Float64Attribute) IsSensitive() bool {
 	return a.Sensitive
+}
+
+// ValidateImplementation contains logic for validating the
+// provider-defined implementation of the attribute to prevent unexpected
+// errors or panics. This logic runs during the GetProviderSchema RPC and
+// should never include false positives.
+func (a Float64Attribute) ValidateImplementation(ctx context.Context, req fwschema.ValidateImplementationRequest, resp *fwschema.ValidateImplementationResponse) {
+	if !a.IsComputed() && a.Float64DefaultValue() != nil {
+		resp.Diagnostics.Append(nonComputedAttributeWithDefaultDiag(req.Path))
+	}
 }

--- a/resource/schema/float64_attribute_test.go
+++ b/resource/schema/float64_attribute_test.go
@@ -10,8 +10,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/defaults"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/float64default"
@@ -498,6 +500,71 @@ func TestFloat64AttributeIsSensitive(t *testing.T) {
 			t.Parallel()
 
 			got := testCase.attribute.IsSensitive()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestFloat64AttributeValidateImplementation(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.Float64Attribute
+		request   fwschema.ValidateImplementationRequest
+		expected  *fwschema.ValidateImplementationResponse
+	}{
+		"computed": {
+			attribute: schema.Float64Attribute{
+				Computed: true,
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{},
+		},
+		"default-without-computed": {
+			attribute: schema.Float64Attribute{
+				Default: float64default.StaticFloat64(1.2),
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic(
+						"Schema Using Attribute Default For Non-Computed Attribute",
+						"Attribute \"test\" must be computed when using default. "+
+							"This is an issue with the provider and should be reported to the provider developers.",
+					),
+				},
+			},
+		},
+		"default-with-computed": {
+			attribute: schema.Float64Attribute{
+				Computed: true,
+				Default:  float64default.StaticFloat64(1.2),
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := &fwschema.ValidateImplementationResponse{}
+			testCase.attribute.ValidateImplementation(context.Background(), testCase.request, got)
 
 			if diff := cmp.Diff(got, testCase.expected); diff != "" {
 				t.Errorf("unexpected difference: %s", diff)

--- a/resource/schema/int64_attribute.go
+++ b/resource/schema/int64_attribute.go
@@ -1,6 +1,8 @@
 package schema
 
 import (
+	"context"
+
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -15,10 +17,11 @@ import (
 
 // Ensure the implementation satisfies the desired interfaces.
 var (
-	_ Attribute                                 = Int64Attribute{}
-	_ fwschema.AttributeWithInt64DefaultValue   = Int64Attribute{}
-	_ fwxschema.AttributeWithInt64PlanModifiers = Int64Attribute{}
-	_ fwxschema.AttributeWithInt64Validators    = Int64Attribute{}
+	_ Attribute                                    = Int64Attribute{}
+	_ fwschema.AttributeWithValidateImplementation = Int64Attribute{}
+	_ fwschema.AttributeWithInt64DefaultValue      = Int64Attribute{}
+	_ fwxschema.AttributeWithInt64PlanModifiers    = Int64Attribute{}
+	_ fwxschema.AttributeWithInt64Validators       = Int64Attribute{}
 )
 
 // Int64Attribute represents a schema attribute that is a 64-bit integer.
@@ -224,4 +227,14 @@ func (a Int64Attribute) IsRequired() bool {
 // IsSensitive returns the Sensitive field value.
 func (a Int64Attribute) IsSensitive() bool {
 	return a.Sensitive
+}
+
+// ValidateImplementation contains logic for validating the
+// provider-defined implementation of the attribute to prevent unexpected
+// errors or panics. This logic runs during the GetProviderSchema RPC and
+// should never include false positives.
+func (a Int64Attribute) ValidateImplementation(ctx context.Context, req fwschema.ValidateImplementationRequest, resp *fwschema.ValidateImplementationResponse) {
+	if !a.IsComputed() && a.Int64DefaultValue() != nil {
+		resp.Diagnostics.Append(nonComputedAttributeWithDefaultDiag(req.Path))
+	}
 }

--- a/resource/schema/int64_attribute_test.go
+++ b/resource/schema/int64_attribute_test.go
@@ -10,8 +10,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/defaults"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
@@ -498,6 +500,71 @@ func TestInt64AttributeIsSensitive(t *testing.T) {
 			t.Parallel()
 
 			got := testCase.attribute.IsSensitive()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestInt64AttributeValidateImplementation(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.Int64Attribute
+		request   fwschema.ValidateImplementationRequest
+		expected  *fwschema.ValidateImplementationResponse
+	}{
+		"computed": {
+			attribute: schema.Int64Attribute{
+				Computed: true,
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{},
+		},
+		"default-without-computed": {
+			attribute: schema.Int64Attribute{
+				Default: int64default.StaticInt64(123),
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic(
+						"Schema Using Attribute Default For Non-Computed Attribute",
+						"Attribute \"test\" must be computed when using default. "+
+							"This is an issue with the provider and should be reported to the provider developers.",
+					),
+				},
+			},
+		},
+		"default-with-computed": {
+			attribute: schema.Int64Attribute{
+				Computed: true,
+				Default:  int64default.StaticInt64(123),
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := &fwschema.ValidateImplementationResponse{}
+			testCase.attribute.ValidateImplementation(context.Background(), testCase.request, got)
 
 			if diff := cmp.Diff(got, testCase.expected); diff != "" {
 				t.Errorf("unexpected difference: %s", diff)

--- a/resource/schema/list_nested_attribute_test.go
+++ b/resource/schema/list_nested_attribute_test.go
@@ -10,8 +10,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/defaults"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listdefault"
@@ -679,6 +681,128 @@ func TestListNestedAttributeListValidators(t *testing.T) {
 			t.Parallel()
 
 			got := testCase.attribute.ListValidators()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestListNestedAttributeValidateImplementation(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.ListNestedAttribute
+		request   fwschema.ValidateImplementationRequest
+		expected  *fwschema.ValidateImplementationResponse
+	}{
+		"computed": {
+			attribute: schema.ListNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"test_attr": schema.StringAttribute{
+							Computed: true,
+						},
+					},
+				},
+				Computed: true,
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{},
+		},
+		"default-without-computed": {
+			attribute: schema.ListNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"test_attr": schema.StringAttribute{
+							Computed: true,
+						},
+					},
+				},
+				Default: listdefault.StaticValue(
+					types.ListValueMust(
+						types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"test_attr": types.StringType,
+							},
+						},
+						[]attr.Value{
+							types.ObjectValueMust(
+								map[string]attr.Type{
+									"test_attr": types.StringType,
+								},
+								map[string]attr.Value{
+									"test_attr": types.StringValue("testvalue"),
+								},
+							),
+						},
+					),
+				),
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic(
+						"Schema Using Attribute Default For Non-Computed Attribute",
+						"Attribute \"test\" must be computed when using default. "+
+							"This is an issue with the provider and should be reported to the provider developers.",
+					),
+				},
+			},
+		},
+		"default-with-computed": {
+			attribute: schema.ListNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"test_attr": schema.StringAttribute{
+							Computed: true,
+						},
+					},
+				},
+				Computed: true,
+				Default: listdefault.StaticValue(
+					types.ListValueMust(
+						types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"test_attr": types.StringType,
+							},
+						},
+						[]attr.Value{
+							types.ObjectValueMust(
+								map[string]attr.Type{
+									"test_attr": types.StringType,
+								},
+								map[string]attr.Value{
+									"test_attr": types.StringValue("testvalue"),
+								},
+							),
+						},
+					),
+				),
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := &fwschema.ValidateImplementationResponse{}
+			testCase.attribute.ValidateImplementation(context.Background(), testCase.request, got)
 
 			if diff := cmp.Diff(got, testCase.expected); diff != "" {
 				t.Errorf("unexpected difference: %s", diff)

--- a/resource/schema/map_attribute_test.go
+++ b/resource/schema/map_attribute_test.go
@@ -10,8 +10,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
+	testtypes "github.com/hashicorp/terraform-plugin-framework/internal/testing/types"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/defaults"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapdefault"
@@ -516,6 +519,130 @@ func TestMapAttributeMapValidators(t *testing.T) {
 			t.Parallel()
 
 			got := testCase.attribute.MapValidators()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestMapAttributeValidateImplementation(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.MapAttribute
+		request   fwschema.ValidateImplementationRequest
+		expected  *fwschema.ValidateImplementationResponse
+	}{
+		"computed": {
+			attribute: schema.MapAttribute{
+				Computed:    true,
+				ElementType: types.StringType,
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{},
+		},
+		"customtype": {
+			attribute: schema.MapAttribute{
+				Computed:   true,
+				CustomType: testtypes.MapType{},
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{},
+		},
+		"default-without-computed": {
+			attribute: schema.MapAttribute{
+				Default: mapdefault.StaticValue(
+					types.MapValueMust(
+						types.StringType,
+						map[string]attr.Value{
+							"testkey": types.StringValue("testvalue"),
+						},
+					),
+				),
+				ElementType: types.StringType,
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic(
+						"Schema Using Attribute Default For Non-Computed Attribute",
+						"Attribute \"test\" must be computed when using default. "+
+							"This is an issue with the provider and should be reported to the provider developers.",
+					),
+				},
+			},
+		},
+		"default-with-computed": {
+			attribute: schema.MapAttribute{
+				Computed: true,
+				Default: mapdefault.StaticValue(
+					types.MapValueMust(
+						types.StringType,
+						map[string]attr.Value{
+							"testkey": types.StringValue("testvalue"),
+						},
+					),
+				),
+				ElementType: types.StringType,
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{},
+		},
+		"elementtype": {
+			attribute: schema.MapAttribute{
+				Computed:    true,
+				ElementType: types.StringType,
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{},
+		},
+		"elementtype-missing": {
+			attribute: schema.MapAttribute{
+				Computed: true,
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic(
+						"Invalid Attribute Implementation",
+						"When validating the schema, an implementation issue was found. "+
+							"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+							"\"test\" is missing the CustomType or ElementType field on a collection Attribute. "+
+							"One of these fields is required to prevent other unexpected errors or panics.",
+					),
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := &fwschema.ValidateImplementationResponse{}
+			testCase.attribute.ValidateImplementation(context.Background(), testCase.request, got)
 
 			if diff := cmp.Diff(got, testCase.expected); diff != "" {
 				t.Errorf("unexpected difference: %s", diff)

--- a/resource/schema/map_nested_attribute_test.go
+++ b/resource/schema/map_nested_attribute_test.go
@@ -10,8 +10,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/defaults"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapdefault"
@@ -679,6 +681,128 @@ func TestMapNestedAttributeMapNestedValidators(t *testing.T) {
 			t.Parallel()
 
 			got := testCase.attribute.MapValidators()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestMapNestedAttributeValidateImplementation(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.MapNestedAttribute
+		request   fwschema.ValidateImplementationRequest
+		expected  *fwschema.ValidateImplementationResponse
+	}{
+		"computed": {
+			attribute: schema.MapNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"test_attr": schema.StringAttribute{
+							Computed: true,
+						},
+					},
+				},
+				Computed: true,
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{},
+		},
+		"default-without-computed": {
+			attribute: schema.MapNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"test_attr": schema.StringAttribute{
+							Computed: true,
+						},
+					},
+				},
+				Default: mapdefault.StaticValue(
+					types.MapValueMust(
+						types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"test_attr": types.StringType,
+							},
+						},
+						map[string]attr.Value{
+							"testkey": types.ObjectValueMust(
+								map[string]attr.Type{
+									"test_attr": types.StringType,
+								},
+								map[string]attr.Value{
+									"test_attr": types.StringValue("testvalue"),
+								},
+							),
+						},
+					),
+				),
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic(
+						"Schema Using Attribute Default For Non-Computed Attribute",
+						"Attribute \"test\" must be computed when using default. "+
+							"This is an issue with the provider and should be reported to the provider developers.",
+					),
+				},
+			},
+		},
+		"default-with-computed": {
+			attribute: schema.MapNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"test_attr": schema.StringAttribute{
+							Computed: true,
+						},
+					},
+				},
+				Computed: true,
+				Default: mapdefault.StaticValue(
+					types.MapValueMust(
+						types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"test_attr": types.StringType,
+							},
+						},
+						map[string]attr.Value{
+							"testkey": types.ObjectValueMust(
+								map[string]attr.Type{
+									"test_attr": types.StringType,
+								},
+								map[string]attr.Value{
+									"test_attr": types.StringValue("testvalue"),
+								},
+							),
+						},
+					),
+				),
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := &fwschema.ValidateImplementationResponse{}
+			testCase.attribute.ValidateImplementation(context.Background(), testCase.request, got)
 
 			if diff := cmp.Diff(got, testCase.expected); diff != "" {
 				t.Errorf("unexpected difference: %s", diff)

--- a/resource/schema/number_attribute_test.go
+++ b/resource/schema/number_attribute_test.go
@@ -11,9 +11,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
 	testtypes "github.com/hashicorp/terraform-plugin-framework/internal/testing/types"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/defaults"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/numberdefault"
@@ -504,6 +506,71 @@ func TestNumberAttributeNumberValidators(t *testing.T) {
 			t.Parallel()
 
 			got := testCase.attribute.NumberValidators()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestNumberAttributeValidateImplementation(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.NumberAttribute
+		request   fwschema.ValidateImplementationRequest
+		expected  *fwschema.ValidateImplementationResponse
+	}{
+		"computed": {
+			attribute: schema.NumberAttribute{
+				Computed: true,
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{},
+		},
+		"default-without-computed": {
+			attribute: schema.NumberAttribute{
+				Default: numberdefault.StaticBigFloat(big.NewFloat(1.2)),
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic(
+						"Schema Using Attribute Default For Non-Computed Attribute",
+						"Attribute \"test\" must be computed when using default. "+
+							"This is an issue with the provider and should be reported to the provider developers.",
+					),
+				},
+			},
+		},
+		"default-with-computed": {
+			attribute: schema.NumberAttribute{
+				Computed: true,
+				Default:  numberdefault.StaticBigFloat(big.NewFloat(1.2)),
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := &fwschema.ValidateImplementationResponse{}
+			testCase.attribute.ValidateImplementation(context.Background(), testCase.request, got)
 
 			if diff := cmp.Diff(got, testCase.expected); diff != "" {
 				t.Errorf("unexpected difference: %s", diff)

--- a/resource/schema/object_attribute.go
+++ b/resource/schema/object_attribute.go
@@ -1,6 +1,8 @@
 package schema
 
 import (
+	"context"
+
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -15,10 +17,11 @@ import (
 
 // Ensure the implementation satisfies the desired interfaces.
 var (
-	_ Attribute                                  = ObjectAttribute{}
-	_ fwschema.AttributeWithObjectDefaultValue   = ObjectAttribute{}
-	_ fwxschema.AttributeWithObjectPlanModifiers = ObjectAttribute{}
-	_ fwxschema.AttributeWithObjectValidators    = ObjectAttribute{}
+	_ Attribute                                    = ObjectAttribute{}
+	_ fwschema.AttributeWithValidateImplementation = ObjectAttribute{}
+	_ fwschema.AttributeWithObjectDefaultValue     = ObjectAttribute{}
+	_ fwxschema.AttributeWithObjectPlanModifiers   = ObjectAttribute{}
+	_ fwxschema.AttributeWithObjectValidators      = ObjectAttribute{}
 )
 
 // ObjectAttribute represents a schema attribute that is an object with only
@@ -236,4 +239,18 @@ func (a ObjectAttribute) ObjectPlanModifiers() []planmodifier.Object {
 // ObjectValidators returns the Validators field value.
 func (a ObjectAttribute) ObjectValidators() []validator.Object {
 	return a.Validators
+}
+
+// ValidateImplementation contains logic for validating the
+// provider-defined implementation of the attribute to prevent unexpected
+// errors or panics. This logic runs during the GetProviderSchema RPC and
+// should never include false positives.
+func (a ObjectAttribute) ValidateImplementation(ctx context.Context, req fwschema.ValidateImplementationRequest, resp *fwschema.ValidateImplementationResponse) {
+	if a.AttributeTypes == nil && a.CustomType == nil {
+		resp.Diagnostics.Append(fwschema.AttributeMissingAttributeTypesDiag(req.Path))
+	}
+
+	if !a.IsComputed() && a.ObjectDefaultValue() != nil {
+		resp.Diagnostics.Append(nonComputedAttributeWithDefaultDiag(req.Path))
+	}
 }

--- a/resource/schema/object_attribute_test.go
+++ b/resource/schema/object_attribute_test.go
@@ -10,8 +10,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
+	testtypes "github.com/hashicorp/terraform-plugin-framework/internal/testing/types"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/defaults"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
@@ -527,6 +530,142 @@ func TestObjectAttributeObjectValidators(t *testing.T) {
 			t.Parallel()
 
 			got := testCase.attribute.ObjectValidators()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestObjectAttributeValidateImplementation(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.ObjectAttribute
+		request   fwschema.ValidateImplementationRequest
+		expected  *fwschema.ValidateImplementationResponse
+	}{
+		"attributetypes": {
+			attribute: schema.ObjectAttribute{
+				AttributeTypes: map[string]attr.Type{
+					"test_attr": types.StringType,
+				},
+				Computed: true,
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{},
+		},
+		"attributetypes-missing": {
+			attribute: schema.ObjectAttribute{
+				Computed: true,
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic(
+						"Invalid Attribute Implementation",
+						"When validating the schema, an implementation issue was found. "+
+							"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+							"\"test\" is missing the AttributeTypes or CustomType field on an object Attribute. "+
+							"One of these fields is required to prevent other unexpected errors or panics.",
+					),
+				},
+			},
+		},
+		"computed": {
+			attribute: schema.ObjectAttribute{
+				AttributeTypes: map[string]attr.Type{
+					"test_attr": types.StringType,
+				},
+				Computed: true,
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{},
+		},
+		"customtype": {
+			attribute: schema.ObjectAttribute{
+				Computed:   true,
+				CustomType: testtypes.ObjectType{},
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{},
+		},
+		"default-without-computed": {
+			attribute: schema.ObjectAttribute{
+				AttributeTypes: map[string]attr.Type{
+					"test_attr": types.StringType,
+				},
+				Default: objectdefault.StaticValue(
+					types.ObjectValueMust(
+						map[string]attr.Type{
+							"test_attr": types.StringType,
+						},
+						map[string]attr.Value{
+							"test_attr": types.StringValue("testvalue"),
+						},
+					),
+				),
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic(
+						"Schema Using Attribute Default For Non-Computed Attribute",
+						"Attribute \"test\" must be computed when using default. "+
+							"This is an issue with the provider and should be reported to the provider developers.",
+					),
+				},
+			},
+		},
+		"default-with-computed": {
+			attribute: schema.ObjectAttribute{
+				AttributeTypes: map[string]attr.Type{
+					"test_attr": types.StringType,
+				},
+				Computed: true,
+				Default: objectdefault.StaticValue(
+					types.ObjectValueMust(
+						map[string]attr.Type{
+							"test_attr": types.StringType,
+						},
+						map[string]attr.Value{
+							"test_attr": types.StringValue("testvalue"),
+						},
+					),
+				),
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := &fwschema.ValidateImplementationResponse{}
+			testCase.attribute.ValidateImplementation(context.Background(), testCase.request, got)
 
 			if diff := cmp.Diff(got, testCase.expected); diff != "" {
 				t.Errorf("unexpected difference: %s", diff)

--- a/resource/schema/schema.go
+++ b/resource/schema/schema.go
@@ -3,7 +3,6 @@ package schema
 import (
 	"context"
 	"fmt"
-	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 
@@ -136,132 +135,38 @@ func (s Schema) TypeAtTerraformPath(ctx context.Context, p *tftypes.AttributePat
 }
 
 // Validate verifies that the schema is not using a reserved field name for a top-level attribute.
+//
+// Deprecated: Use the ValidateImplementation method instead.
 func (s Schema) Validate() diag.Diagnostics {
-	var diags diag.Diagnostics
-
-	// Raise error diagnostics when data source configuration uses reserved
-	// field names for root-level attributes.
-	reservedFieldNames := map[string]struct{}{
-		"connection":  {},
-		"count":       {},
-		"depends_on":  {},
-		"lifecycle":   {},
-		"provider":    {},
-		"provisioner": {},
-	}
-
-	attributes := s.GetAttributes()
-
-	for k, v := range attributes {
-		if _, ok := reservedFieldNames[k]; ok {
-			diags.AddAttributeError(
-				path.Root(k),
-				"Schema Using Reserved Field Name",
-				fmt.Sprintf("%q is a reserved field name", k),
-			)
-		}
-
-		d := validateAttributeFieldName(path.Root(k), k, v)
-
-		diags.Append(d...)
-
-		d = validateDefaultsOnlyOnComputedAttributes(path.Root(k), v)
-
-		diags.Append(d...)
-	}
-
-	blocks := s.GetBlocks()
-
-	for k, v := range blocks {
-		if _, ok := reservedFieldNames[k]; ok {
-			diags.AddAttributeError(
-				path.Root(k),
-				"Schema Using Reserved Field Name",
-				fmt.Sprintf("%q is a reserved field name", k),
-			)
-		}
-
-		d := validateBlockFieldName(path.Root(k), k, v)
-
-		diags.Append(d...)
-
-		d = validateDefaultsOnlyOnComputedAttributesInBlocks(path.Root(k), v)
-
-		diags.Append(d...)
-	}
-
-	return diags
+	return s.ValidateImplementation(context.Background())
 }
 
-// validFieldNameRegex is used to verify that name used for attributes and blocks
-// comply with the defined regular expression.
-var validFieldNameRegex = regexp.MustCompile("^[a-z0-9_]+$")
-
-// validateAttributeFieldName verifies that the name used for an attribute complies with the regular
-// expression defined in validFieldNameRegex.
-func validateAttributeFieldName(path path.Path, name string, attr fwschema.Attribute) diag.Diagnostics {
+// ValidateImplementation contains logic for validating the provider-defined
+// implementation of the schema and underlying attributes and blocks to prevent
+// unexpected errors or panics. This logic runs during the
+// ValidateResourceConfig RPC, or via provider-defined unit testing, and should
+// never include false positives.
+func (s Schema) ValidateImplementation(ctx context.Context) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	if !validFieldNameRegex.MatchString(name) {
-		diags.AddAttributeError(
-			path,
-			"Invalid Schema Field Name",
-			fmt.Sprintf("Field name %q is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.", name),
-		)
-	}
-
-	if na, ok := attr.(fwschema.NestedAttribute); ok {
-		nestedObject := na.GetNestedObject()
-
-		if nestedObject == nil {
-			return diags
+	for attributeName, attribute := range s.GetAttributes() {
+		req := fwschema.ValidateImplementationRequest{
+			Name: attributeName,
+			Path: path.Root(attributeName),
 		}
 
-		attributes := nestedObject.GetAttributes()
+		diags.Append(fwschema.IsReservedResourceAttributeName(req.Name, req.Path)...)
+		diags.Append(fwschema.ValidateAttributeImplementation(ctx, attribute, req)...)
+	}
 
-		for k, v := range attributes {
-			d := validateAttributeFieldName(path.AtName(k), k, v)
-
-			diags.Append(d...)
+	for blockName, block := range s.GetBlocks() {
+		req := fwschema.ValidateImplementationRequest{
+			Name: blockName,
+			Path: path.Root(blockName),
 		}
-	}
 
-	return diags
-}
-
-// validateBlockFieldName verifies that the name used for a block complies with the regular
-// expression defined in validFieldNameRegex.
-func validateBlockFieldName(path path.Path, name string, b fwschema.Block) diag.Diagnostics {
-	var diags diag.Diagnostics
-
-	if !validFieldNameRegex.MatchString(name) {
-		diags.AddAttributeError(
-			path,
-			"Invalid Schema Field Name",
-			fmt.Sprintf("Field name %q is invalid, the only allowed characters are a-z, 0-9 and _. This is always a problem with the provider and should be reported to the provider developer.", name),
-		)
-	}
-
-	nestedObject := b.GetNestedObject()
-
-	if nestedObject == nil {
-		return diags
-	}
-
-	blocks := nestedObject.GetBlocks()
-
-	for k, v := range blocks {
-		d := validateBlockFieldName(path.AtName(k), k, v)
-
-		diags.Append(d...)
-	}
-
-	attributes := nestedObject.GetAttributes()
-
-	for k, v := range attributes {
-		d := validateAttributeFieldName(path.AtName(k), k, v)
-
-		diags.Append(d...)
+		diags.Append(fwschema.IsReservedResourceAttributeName(req.Name, req.Path)...)
+		diags.Append(fwschema.ValidateBlockImplementation(ctx, block, req)...)
 	}
 
 	return diags
@@ -289,106 +194,13 @@ func schemaBlocks(blocks map[string]Block) map[string]fwschema.Block {
 	return result
 }
 
-// validateDefaultsOnlyOnComputedAttributes is used to check that {TYPE}DefaultValue is only
-// present when the attribute is computed.
-func validateDefaultsOnlyOnComputedAttributes(path path.Path, attr fwschema.Attribute) diag.Diagnostics {
-	var diags diag.Diagnostics
-
-	if !attr.IsComputed() {
-		switch d := attr.(type) {
-		case fwschema.AttributeWithBoolDefaultValue:
-			if d.BoolDefaultValue() != nil {
-				diags.Append(nonComputedAttributeWithDefaultDiag(path))
-			}
-		case fwschema.AttributeWithFloat64DefaultValue:
-			if d.Float64DefaultValue() != nil {
-				diags.Append(nonComputedAttributeWithDefaultDiag(path))
-			}
-		case fwschema.AttributeWithInt64DefaultValue:
-			if d.Int64DefaultValue() != nil {
-				diags.Append(nonComputedAttributeWithDefaultDiag(path))
-			}
-		case fwschema.AttributeWithListDefaultValue:
-			if d.ListDefaultValue() != nil {
-				diags.Append(nonComputedAttributeWithDefaultDiag(path))
-			}
-		case fwschema.AttributeWithMapDefaultValue:
-			if d.MapDefaultValue() != nil {
-				diags.Append(nonComputedAttributeWithDefaultDiag(path))
-			}
-		case fwschema.AttributeWithNumberDefaultValue:
-			if d.NumberDefaultValue() != nil {
-				diags.Append(nonComputedAttributeWithDefaultDiag(path))
-			}
-		case fwschema.AttributeWithObjectDefaultValue:
-			if d.ObjectDefaultValue() != nil {
-				diags.Append(nonComputedAttributeWithDefaultDiag(path))
-			}
-		case fwschema.AttributeWithSetDefaultValue:
-			if d.SetDefaultValue() != nil {
-				diags.Append(nonComputedAttributeWithDefaultDiag(path))
-			}
-		case fwschema.AttributeWithStringDefaultValue:
-			if d.StringDefaultValue() != nil {
-				diags.Append(nonComputedAttributeWithDefaultDiag(path))
-			}
-		}
-	}
-
-	if na, ok := attr.(fwschema.NestedAttribute); ok {
-		nestedObject := na.GetNestedObject()
-
-		if nestedObject == nil {
-			return diags
-		}
-
-		attributes := nestedObject.GetAttributes()
-
-		for k, v := range attributes {
-			d := validateDefaultsOnlyOnComputedAttributes(path.AtName(k), v)
-
-			diags.Append(d...)
-		}
-	}
-
-	return diags
-}
-
-// validateDefaultsOnlyOnComputedAttributesInBlocks is used to check that {TYPE}DefaultValue is only
-// present when attributes within blocks are computed.
-func validateDefaultsOnlyOnComputedAttributesInBlocks(path path.Path, b fwschema.Block) diag.Diagnostics {
-	var diags diag.Diagnostics
-
-	nestedObject := b.GetNestedObject()
-
-	if nestedObject == nil {
-		return diags
-	}
-
-	blocks := nestedObject.GetBlocks()
-
-	for k, v := range blocks {
-		d := validateDefaultsOnlyOnComputedAttributesInBlocks(path.AtName(k), v)
-
-		diags.Append(d...)
-	}
-
-	attributes := nestedObject.GetAttributes()
-
-	for k, v := range attributes {
-		d := validateDefaultsOnlyOnComputedAttributes(path.AtName(k), v)
-
-		diags.Append(d...)
-	}
-
-	return diags
-}
-
 // nonComputedAttributeWithDefaultDiag returns a diagnostic for use when a non-computed
 // attribute is using a default value.
 func nonComputedAttributeWithDefaultDiag(path path.Path) diag.Diagnostic {
-	return diag.NewAttributeErrorDiagnostic(
-		path,
+	// The diagnostic path is intentionally omitted as it is invalid in this
+	// context. Diagnostic paths are intended to be mapped to actual data,
+	// while this path information must be synthesized.
+	return diag.NewErrorDiagnostic(
 		"Schema Using Attribute Default For Non-Computed Attribute",
 		fmt.Sprintf("Attribute %q must be computed when using default. ", path.String())+
 			"This is an issue with the provider and should be reported to the provider developers.",

--- a/resource/schema/set_attribute_test.go
+++ b/resource/schema/set_attribute_test.go
@@ -10,8 +10,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/defaults"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -517,6 +519,119 @@ func TestSetAttributeSetValidators(t *testing.T) {
 			t.Parallel()
 
 			got := testCase.attribute.SetValidators()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestSetAttributeValidateImplementation(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.SetAttribute
+		request   fwschema.ValidateImplementationRequest
+		expected  *fwschema.ValidateImplementationResponse
+	}{
+		"computed": {
+			attribute: schema.SetAttribute{
+				Computed:    true,
+				ElementType: types.StringType,
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{},
+		},
+		"default-without-computed": {
+			attribute: schema.SetAttribute{
+				Default: setdefault.StaticValue(
+					types.SetValueMust(
+						types.StringType,
+						[]attr.Value{
+							types.StringValue("test"),
+						},
+					),
+				),
+				ElementType: types.StringType,
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic(
+						"Schema Using Attribute Default For Non-Computed Attribute",
+						"Attribute \"test\" must be computed when using default. "+
+							"This is an issue with the provider and should be reported to the provider developers.",
+					),
+				},
+			},
+		},
+		"default-with-computed": {
+			attribute: schema.SetAttribute{
+				Computed: true,
+				Default: setdefault.StaticValue(
+					types.SetValueMust(
+						types.StringType,
+						[]attr.Value{
+							types.StringValue("test"),
+						},
+					),
+				),
+				ElementType: types.StringType,
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{},
+		},
+		"elementtype": {
+			attribute: schema.SetAttribute{
+				Computed:    true,
+				ElementType: types.StringType,
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{},
+		},
+		"elementtype-missing": {
+			attribute: schema.SetAttribute{
+				Computed: true,
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic(
+						"Invalid Attribute Implementation",
+						"When validating the schema, an implementation issue was found. "+
+							"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+							"\"test\" is missing the CustomType or ElementType field on a collection Attribute. "+
+							"One of these fields is required to prevent other unexpected errors or panics.",
+					),
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := &fwschema.ValidateImplementationResponse{}
+			testCase.attribute.ValidateImplementation(context.Background(), testCase.request, got)
 
 			if diff := cmp.Diff(got, testCase.expected); diff != "" {
 				t.Errorf("unexpected difference: %s", diff)

--- a/resource/schema/set_nested_attribute_test.go
+++ b/resource/schema/set_nested_attribute_test.go
@@ -10,8 +10,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/defaults"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -679,6 +681,128 @@ func TestSetNestedAttributeSetValidators(t *testing.T) {
 			t.Parallel()
 
 			got := testCase.attribute.SetValidators()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestSetNestedAttributeValidateImplementation(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.SetNestedAttribute
+		request   fwschema.ValidateImplementationRequest
+		expected  *fwschema.ValidateImplementationResponse
+	}{
+		"computed": {
+			attribute: schema.SetNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"test_attr": schema.StringAttribute{
+							Computed: true,
+						},
+					},
+				},
+				Computed: true,
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{},
+		},
+		"default-without-computed": {
+			attribute: schema.SetNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"test_attr": schema.StringAttribute{
+							Computed: true,
+						},
+					},
+				},
+				Default: setdefault.StaticValue(
+					types.SetValueMust(
+						types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"test_attr": types.StringType,
+							},
+						},
+						[]attr.Value{
+							types.ObjectValueMust(
+								map[string]attr.Type{
+									"test_attr": types.StringType,
+								},
+								map[string]attr.Value{
+									"test_attr": types.StringValue("testvalue"),
+								},
+							),
+						},
+					),
+				),
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic(
+						"Schema Using Attribute Default For Non-Computed Attribute",
+						"Attribute \"test\" must be computed when using default. "+
+							"This is an issue with the provider and should be reported to the provider developers.",
+					),
+				},
+			},
+		},
+		"default-with-computed": {
+			attribute: schema.SetNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"test_attr": schema.StringAttribute{
+							Computed: true,
+						},
+					},
+				},
+				Computed: true,
+				Default: setdefault.StaticValue(
+					types.SetValueMust(
+						types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"test_attr": types.StringType,
+							},
+						},
+						[]attr.Value{
+							types.ObjectValueMust(
+								map[string]attr.Type{
+									"test_attr": types.StringType,
+								},
+								map[string]attr.Value{
+									"test_attr": types.StringValue("testvalue"),
+								},
+							),
+						},
+					),
+				),
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := &fwschema.ValidateImplementationResponse{}
+			testCase.attribute.ValidateImplementation(context.Background(), testCase.request, got)
 
 			if diff := cmp.Diff(got, testCase.expected); diff != "" {
 				t.Errorf("unexpected difference: %s", diff)

--- a/resource/schema/single_nested_attribute_test.go
+++ b/resource/schema/single_nested_attribute_test.go
@@ -10,8 +10,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/defaults"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
@@ -647,6 +649,104 @@ func TestSingleNestedAttributeObjectValidators(t *testing.T) {
 			t.Parallel()
 
 			got := testCase.attribute.ObjectValidators()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestSingleNestedAttributeValidateImplementation(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.SingleNestedAttribute
+		request   fwschema.ValidateImplementationRequest
+		expected  *fwschema.ValidateImplementationResponse
+	}{
+		"computed": {
+			attribute: schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"test_attr": schema.StringAttribute{
+						Computed: true,
+					},
+				},
+				Computed: true,
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{},
+		},
+		"default-without-computed": {
+			attribute: schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"test_attr": schema.StringAttribute{
+						Computed: true,
+					},
+				},
+				Default: objectdefault.StaticValue(
+					types.ObjectValueMust(
+						map[string]attr.Type{
+							"test_attr": types.StringType,
+						},
+						map[string]attr.Value{
+							"test_attr": types.StringValue("testvalue"),
+						},
+					),
+				),
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic(
+						"Schema Using Attribute Default For Non-Computed Attribute",
+						"Attribute \"test\" must be computed when using default. "+
+							"This is an issue with the provider and should be reported to the provider developers.",
+					),
+				},
+			},
+		},
+		"default-with-computed": {
+			attribute: schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"test_attr": schema.StringAttribute{
+						Computed: true,
+					},
+				},
+				Computed: true,
+				Default: objectdefault.StaticValue(
+					types.ObjectValueMust(
+						map[string]attr.Type{
+							"test_attr": types.StringType,
+						},
+						map[string]attr.Value{
+							"test_attr": types.StringValue("testvalue"),
+						},
+					),
+				),
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := &fwschema.ValidateImplementationResponse{}
+			testCase.attribute.ValidateImplementation(context.Background(), testCase.request, got)
 
 			if diff := cmp.Diff(got, testCase.expected); diff != "" {
 				t.Errorf("unexpected difference: %s", diff)

--- a/website/docs/plugin/framework/handling-data/schemas.mdx
+++ b/website/docs/plugin/framework/handling-data/schemas.mdx
@@ -153,3 +153,43 @@ Use a practitioner actionable recommendation in `DeprecationMessage`, such as `"
 Each attribute can implement [value validation](/terraform/plugin/framework/validation), either by specifying the [`Attribute` type `Validators` field](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/tfsdk#Attribute.Validators) and/or by declaring a custom type in the `Type` field that [implements its own validators](/terraform/plugin/framework/validation#type-validation). Common use case validators can be found in the [terraform-plugin-framework-validators Go module](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework-validators).
 
 During execution of the [`terraform validate`](/terraform/cli/commands/validate), [`terraform plan`](/terraform/cli/commands/plan) and [`terraform apply`](/terraform/cli/commands/apply) commands, Terraform calls the provider [`ValidateProviderConfig`](/terraform/plugin/framework/internals/rpcs#validateproviderconfig-rpc), [`ValidateResourceConfig`](/terraform/plugin/framework/internals/rpcs#validateresourceconfig-rpc) and [`ValidateDataResourceConfig`](/terraform/plugin/framework/internals/rpcs#validatedataresourceconfig-rpc) RPCs, during which [value validation](/terraform/plugin/framework/validation) takes place.
+
+## Unit Testing
+
+Schemas can be unit tested via each of the `schema.Schema` type `ValidateImplementation()` methods. This unit testing raises schema implementation issues more quickly in comparison to [acceptance tests](/terraform/plugin/framework/acctests), but does not replace the purpose of acceptance testing.
+
+In this example, a `thing_resource_test.go` file is created alongside the `thing_resource.go` implementation file:
+
+```go
+import (
+  "context"
+  "testing"
+
+  // The fwresource import alias is so there is no collistion
+  // with the more typical acceptance testing import:
+  // "github.com/hashicorp/terraform-plugin-testing/helper/resource"
+  fwresource "github.com/hashicorp/terraform-plugin-framework/resource"
+)
+
+func TestThingResourceSchema(t *testing.T) {
+  t.Parallel()
+
+  ctx := context.Background()
+  schemaRequest := fwresource.SchemaRequest{}
+  schemaResponse := &fwresource.SchemaResponse{}
+
+  // Instantiate the resource.Resource and call its Schema method
+  NewThingResource().Schema(ctx, schemaRequest, schemaResponse)
+
+  if schemaResponse.Diagnostics.HasError() {
+    t.Fatalf("Schema method diagnostics: %+v", schemaResponse.Diagnostics)
+  }
+
+  // Validate the schema
+  diagnostics := schemaResponse.Schema.ValidateImplementation(ctx)
+
+  if diagnostics.HasError() {
+    t.Fatalf("Schema validation diagnostics: %+v", diagnostics)
+  }
+}
+```


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/574
Closes #699
Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/704
Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/705

The goal of this change is to enable easier schema validation within the framework logic. This is achieved by implementing new internal interfaces that implement shared logic across all schema types, then introduce methods on attribute types which currently implement type-specific validation logic.

The `Schema` type `Validate()` method deprecations are necessary to ensure that the framework logic can pass the available `context.Context`. While no framework logic is currently dependent on the `context.Context`, its possible that future logic may want to use `tfsdklog`.

The new `ValidateImplementation()` methods on attribute types, while technically exported, cannot be implemented externally due to their usage of internal types. This follows the existing implementation of the framework where attribute types already cannot be extended due to the `Equal(fwschema.Attribute)` method requirement. Therefore these new `ValidateImplementation()` methods do not need to worry about compatibility promises and can be modified or removed in the future.

This change also includes some breadcrumbs for other schema validation requests.