### PR TITLE
internal/fwschema: Validate for_each as a reserved resource attribute name

### DIFF
--- a/.changes/unreleased/ENHANCEMENTS-20230330-104744.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20230330-104744.yaml
@@ -1,0 +1,7 @@
+kind: ENHANCEMENTS
+body: 'datasource/schema: Raise validation errors if attempting to use top-level `for_each`
+  attribute name, which requires special Terraform configuration syntax to be usable by
+  the data source'
+time: 2023-03-30T10:47:44.609561-04:00
+custom:
+  Issue: "704"

--- a/.changes/unreleased/ENHANCEMENTS-20230330-104745.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20230330-104745.yaml
@@ -1,0 +1,7 @@
+kind: ENHANCEMENTS
+body: 'resource/schema: Raise validation errors if attempting to use top-level `for_each`
+  attribute name, which requires special Terraform configuration syntax to be usable by
+  the resource'
+time: 2023-03-30T10:47:45.609561-04:00
+custom:
+  Issue: "704"

--- a/internal/fwschema/attribute_name_validation.go
+++ b/internal/fwschema/attribute_name_validation.go
@@ -30,10 +30,8 @@ var ReservedResourceAttributeNames = []string{
 	"count",
 	// Reference: https://developer.hashicorp.com/terraform/language/meta-arguments/depends_on
 	"depends_on",
-	// TODO: Validate for_each
-	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/704
 	// Reference: https://developer.hashicorp.com/terraform/language/meta-arguments/for_each
-	// "for_each",
+	"for_each",
 	// Reference: https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle
 	"lifecycle",
 	// Reference: https://developer.hashicorp.com/terraform/language/meta-arguments/resource-provider

--- a/internal/fwschema/attribute_name_validation_test.go
+++ b/internal/fwschema/attribute_name_validation_test.go
@@ -142,21 +142,19 @@ func TestIsReservedResourceAttributeName(t *testing.T) {
 				),
 			},
 		},
-		// TODO: Validate for_each
-		// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/704
-		// "for_each": {
-		// 	name: "for_each",
-		//	attributePath: path.Root("for_each"),
-		// 	expected: diag.Diagnostics{
-		// 		diag.NewErrorDiagnostic(
-		// 			"Reserved Root Attribute/Block Name",
-		// 			"When validating the resource or data source schema, an implementation issue was found. "+
-		// 				"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
-		// 				"\"for_each\" is a reserved root attribute/block name. "+
-		// 				"This is to prevent practitioners from needing special Terraform configuration syntax.",
-		// 		),
-		// 	},
-		// },
+		"for_each": {
+			name:          "for_each",
+			attributePath: path.Root("for_each"),
+			expected: diag.Diagnostics{
+				diag.NewErrorDiagnostic(
+					"Reserved Root Attribute/Block Name",
+					"When validating the resource or data source schema, an implementation issue was found. "+
+						"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+						"\"for_each\" is a reserved root attribute/block name. "+
+						"This is to prevent practitioners from needing special Terraform configuration syntax.",
+				),
+			},
+		},
 		"lifecycle": {
 			name:          "lifecycle",
 			attributePath: path.Root("lifecycle"),


### PR DESCRIPTION
Closes #704

Similar to the other reserved resource attribute name checks, in the unlikely event provider developers need a method to opt out of the safety check, a feature request can be created.