### PR TITLE
Move debug logs to trace

### DIFF
--- a/internal/fwschemadata/data_set_at_path.go
+++ b/internal/fwschemadata/data_set_at_path.go
@@ -68,9 +68,9 @@ func (d *Data) SetAtPath(ctx context.Context, path path.Path, val interface{}) d
 
 	if attrTypeWithValidate, ok := attrType.(xattr.TypeWithValidate); ok {
 		logging.FrameworkTrace(ctx, "Type implements TypeWithValidate")
-		logging.FrameworkDebug(ctx, "Calling provider defined Type Validate")
+		logging.FrameworkTrace(ctx, "Calling provider defined Type Validate")
 		diags.Append(attrTypeWithValidate.Validate(ctx, tfVal, path)...)
-		logging.FrameworkDebug(ctx, "Called provider defined Type Validate")
+		logging.FrameworkTrace(ctx, "Called provider defined Type Validate")
 
 		if diags.HasError() {
 			return diags
@@ -186,9 +186,9 @@ func (d Data) SetAtPathTransformFunc(ctx context.Context, path path.Path, tfVal 
 
 	if attrTypeWithValidate, ok := parentAttrType.(xattr.TypeWithValidate); ok {
 		logging.FrameworkTrace(ctx, "Type implements TypeWithValidate")
-		logging.FrameworkDebug(ctx, "Calling provider defined Type Validate")
+		logging.FrameworkTrace(ctx, "Calling provider defined Type Validate")
 		diags.Append(attrTypeWithValidate.Validate(ctx, parentValue, parentPath)...)
-		logging.FrameworkDebug(ctx, "Called provider defined Type Validate")
+		logging.FrameworkTrace(ctx, "Called provider defined Type Validate")
 
 		if diags.HasError() {
 			return nil, diags

--- a/internal/fwschemadata/data_value.go
+++ b/internal/fwschemadata/data_value.go
@@ -75,9 +75,9 @@ func (d Data) ValueAtPath(ctx context.Context, schemaPath path.Path) (attr.Value
 
 	if attrTypeWithValidate, ok := attrType.(xattr.TypeWithValidate); ok {
 		logging.FrameworkTrace(ctx, "Type implements TypeWithValidate")
-		logging.FrameworkDebug(ctx, "Calling provider defined Type Validate")
+		logging.FrameworkTrace(ctx, "Calling provider defined Type Validate")
 		diags.Append(attrTypeWithValidate.Validate(ctx, tfValue, schemaPath)...)
-		logging.FrameworkDebug(ctx, "Called provider defined Type Validate")
+		logging.FrameworkTrace(ctx, "Called provider defined Type Validate")
 
 		if diags.HasError() {
 			return nil, diags

--- a/internal/fwserver/attribute_plan_modification.go
+++ b/internal/fwserver/attribute_plan_modification.go
@@ -549,7 +549,7 @@ func AttributePlanModifyBool(ctx context.Context, attribute fwxschema.AttributeW
 			Private:   resp.Private,
 		}
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Calling provider defined planmodifier.Bool",
 			map[string]interface{}{
@@ -559,7 +559,7 @@ func AttributePlanModifyBool(ctx context.Context, attribute fwxschema.AttributeW
 
 		planModifier.PlanModifyBool(ctx, planModifyReq, planModifyResp)
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Called provider defined planmodifier.Bool",
 			map[string]interface{}{
@@ -684,7 +684,7 @@ func AttributePlanModifyFloat64(ctx context.Context, attribute fwxschema.Attribu
 			Private:   resp.Private,
 		}
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Calling provider defined planmodifier.Float64",
 			map[string]interface{}{
@@ -694,7 +694,7 @@ func AttributePlanModifyFloat64(ctx context.Context, attribute fwxschema.Attribu
 
 		planModifier.PlanModifyFloat64(ctx, planModifyReq, planModifyResp)
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Called provider defined planmodifier.Float64",
 			map[string]interface{}{
@@ -819,7 +819,7 @@ func AttributePlanModifyInt64(ctx context.Context, attribute fwxschema.Attribute
 			Private:   resp.Private,
 		}
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Calling provider defined planmodifier.Int64",
 			map[string]interface{}{
@@ -829,7 +829,7 @@ func AttributePlanModifyInt64(ctx context.Context, attribute fwxschema.Attribute
 
 		planModifier.PlanModifyInt64(ctx, planModifyReq, planModifyResp)
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Called provider defined planmodifier.Int64",
 			map[string]interface{}{
@@ -954,7 +954,7 @@ func AttributePlanModifyList(ctx context.Context, attribute fwxschema.AttributeW
 			Private:   resp.Private,
 		}
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Calling provider defined planmodifier.List",
 			map[string]interface{}{
@@ -964,7 +964,7 @@ func AttributePlanModifyList(ctx context.Context, attribute fwxschema.AttributeW
 
 		planModifier.PlanModifyList(ctx, planModifyReq, planModifyResp)
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Called provider defined planmodifier.List",
 			map[string]interface{}{
@@ -1089,7 +1089,7 @@ func AttributePlanModifyMap(ctx context.Context, attribute fwxschema.AttributeWi
 			Private:   resp.Private,
 		}
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Calling provider defined planmodifier.Map",
 			map[string]interface{}{
@@ -1099,7 +1099,7 @@ func AttributePlanModifyMap(ctx context.Context, attribute fwxschema.AttributeWi
 
 		planModifier.PlanModifyMap(ctx, planModifyReq, planModifyResp)
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Called provider defined planmodifier.Map",
 			map[string]interface{}{
@@ -1224,7 +1224,7 @@ func AttributePlanModifyNumber(ctx context.Context, attribute fwxschema.Attribut
 			Private:   resp.Private,
 		}
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Calling provider defined planmodifier.Number",
 			map[string]interface{}{
@@ -1234,7 +1234,7 @@ func AttributePlanModifyNumber(ctx context.Context, attribute fwxschema.Attribut
 
 		planModifier.PlanModifyNumber(ctx, planModifyReq, planModifyResp)
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Called provider defined planmodifier.Number",
 			map[string]interface{}{
@@ -1359,7 +1359,7 @@ func AttributePlanModifyObject(ctx context.Context, attribute fwxschema.Attribut
 			Private:   resp.Private,
 		}
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Calling provider defined planmodifier.Object",
 			map[string]interface{}{
@@ -1369,7 +1369,7 @@ func AttributePlanModifyObject(ctx context.Context, attribute fwxschema.Attribut
 
 		planModifier.PlanModifyObject(ctx, planModifyReq, planModifyResp)
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Called provider defined planmodifier.Object",
 			map[string]interface{}{
@@ -1494,7 +1494,7 @@ func AttributePlanModifySet(ctx context.Context, attribute fwxschema.AttributeWi
 			Private:   resp.Private,
 		}
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Calling provider defined planmodifier.Set",
 			map[string]interface{}{
@@ -1504,7 +1504,7 @@ func AttributePlanModifySet(ctx context.Context, attribute fwxschema.AttributeWi
 
 		planModifier.PlanModifySet(ctx, planModifyReq, planModifyResp)
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Called provider defined planmodifier.Set",
 			map[string]interface{}{
@@ -1629,7 +1629,7 @@ func AttributePlanModifyString(ctx context.Context, attribute fwxschema.Attribut
 			Private:   resp.Private,
 		}
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Calling provider defined planmodifier.String",
 			map[string]interface{}{
@@ -1639,7 +1639,7 @@ func AttributePlanModifyString(ctx context.Context, attribute fwxschema.Attribut
 
 		planModifier.PlanModifyString(ctx, planModifyReq, planModifyResp)
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Called provider defined planmodifier.String",
 			map[string]interface{}{
@@ -1673,7 +1673,7 @@ func NestedAttributeObjectPlanModify(ctx context.Context, o fwschema.NestedAttri
 				Private:   resp.Private,
 			}
 
-			logging.FrameworkDebug(
+			logging.FrameworkTrace(
 				ctx,
 				"Calling provider defined planmodifier.Object",
 				map[string]interface{}{
@@ -1683,7 +1683,7 @@ func NestedAttributeObjectPlanModify(ctx context.Context, o fwschema.NestedAttri
 
 			objectValidator.PlanModifyObject(ctx, req, planModifyResp)
 
-			logging.FrameworkDebug(
+			logging.FrameworkTrace(
 				ctx,
 				"Called provider defined planmodifier.Object",
 				map[string]interface{}{

--- a/internal/fwserver/attribute_validation.go
+++ b/internal/fwserver/attribute_validation.go
@@ -181,7 +181,7 @@ func AttributeValidateBool(ctx context.Context, attribute fwxschema.AttributeWit
 		// from modifying or removing diagnostics.
 		validateResp := &validator.BoolResponse{}
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Calling provider defined validator.Bool",
 			map[string]interface{}{
@@ -191,7 +191,7 @@ func AttributeValidateBool(ctx context.Context, attribute fwxschema.AttributeWit
 
 		attributeValidator.ValidateBool(ctx, validateReq, validateResp)
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Called provider defined validator.Bool",
 			map[string]interface{}{
@@ -246,7 +246,7 @@ func AttributeValidateFloat64(ctx context.Context, attribute fwxschema.Attribute
 		// from modifying or removing diagnostics.
 		validateResp := &validator.Float64Response{}
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Calling provider defined validator.Float64",
 			map[string]interface{}{
@@ -256,7 +256,7 @@ func AttributeValidateFloat64(ctx context.Context, attribute fwxschema.Attribute
 
 		attributeValidator.ValidateFloat64(ctx, validateReq, validateResp)
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Called provider defined validator.Float64",
 			map[string]interface{}{
@@ -311,7 +311,7 @@ func AttributeValidateInt64(ctx context.Context, attribute fwxschema.AttributeWi
 		// from modifying or removing diagnostics.
 		validateResp := &validator.Int64Response{}
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Calling provider defined validator.Int64",
 			map[string]interface{}{
@@ -321,7 +321,7 @@ func AttributeValidateInt64(ctx context.Context, attribute fwxschema.AttributeWi
 
 		attributeValidator.ValidateInt64(ctx, validateReq, validateResp)
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Called provider defined validator.Int64",
 			map[string]interface{}{
@@ -376,7 +376,7 @@ func AttributeValidateList(ctx context.Context, attribute fwxschema.AttributeWit
 		// from modifying or removing diagnostics.
 		validateResp := &validator.ListResponse{}
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Calling provider defined validator.List",
 			map[string]interface{}{
@@ -386,7 +386,7 @@ func AttributeValidateList(ctx context.Context, attribute fwxschema.AttributeWit
 
 		attributeValidator.ValidateList(ctx, validateReq, validateResp)
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Called provider defined validator.List",
 			map[string]interface{}{
@@ -441,7 +441,7 @@ func AttributeValidateMap(ctx context.Context, attribute fwxschema.AttributeWith
 		// from modifying or removing diagnostics.
 		validateResp := &validator.MapResponse{}
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Calling provider defined validator.Map",
 			map[string]interface{}{
@@ -451,7 +451,7 @@ func AttributeValidateMap(ctx context.Context, attribute fwxschema.AttributeWith
 
 		attributeValidator.ValidateMap(ctx, validateReq, validateResp)
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Called provider defined validator.Map",
 			map[string]interface{}{
@@ -506,7 +506,7 @@ func AttributeValidateNumber(ctx context.Context, attribute fwxschema.AttributeW
 		// from modifying or removing diagnostics.
 		validateResp := &validator.NumberResponse{}
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Calling provider defined validator.Number",
 			map[string]interface{}{
@@ -516,7 +516,7 @@ func AttributeValidateNumber(ctx context.Context, attribute fwxschema.AttributeW
 
 		attributeValidator.ValidateNumber(ctx, validateReq, validateResp)
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Called provider defined validator.Number",
 			map[string]interface{}{
@@ -571,7 +571,7 @@ func AttributeValidateObject(ctx context.Context, attribute fwxschema.AttributeW
 		// from modifying or removing diagnostics.
 		validateResp := &validator.ObjectResponse{}
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Calling provider defined validator.Object",
 			map[string]interface{}{
@@ -581,7 +581,7 @@ func AttributeValidateObject(ctx context.Context, attribute fwxschema.AttributeW
 
 		attributeValidator.ValidateObject(ctx, validateReq, validateResp)
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Called provider defined validator.Object",
 			map[string]interface{}{
@@ -636,7 +636,7 @@ func AttributeValidateSet(ctx context.Context, attribute fwxschema.AttributeWith
 		// from modifying or removing diagnostics.
 		validateResp := &validator.SetResponse{}
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Calling provider defined validator.Set",
 			map[string]interface{}{
@@ -646,7 +646,7 @@ func AttributeValidateSet(ctx context.Context, attribute fwxschema.AttributeWith
 
 		attributeValidator.ValidateSet(ctx, validateReq, validateResp)
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Called provider defined validator.Set",
 			map[string]interface{}{
@@ -701,7 +701,7 @@ func AttributeValidateString(ctx context.Context, attribute fwxschema.AttributeW
 		// from modifying or removing diagnostics.
 		validateResp := &validator.StringResponse{}
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Calling provider defined validator.String",
 			map[string]interface{}{
@@ -711,7 +711,7 @@ func AttributeValidateString(ctx context.Context, attribute fwxschema.AttributeW
 
 		attributeValidator.ValidateString(ctx, validateReq, validateResp)
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Called provider defined validator.String",
 			map[string]interface{}{
@@ -930,7 +930,7 @@ func NestedAttributeObjectValidate(ctx context.Context, o fwschema.NestedAttribu
 			// from modifying or removing diagnostics.
 			validateResp := &validator.ObjectResponse{}
 
-			logging.FrameworkDebug(
+			logging.FrameworkTrace(
 				ctx,
 				"Calling provider defined validator.Object",
 				map[string]interface{}{
@@ -940,7 +940,7 @@ func NestedAttributeObjectValidate(ctx context.Context, o fwschema.NestedAttribu
 
 			objectValidator.ValidateObject(ctx, validateReq, validateResp)
 
-			logging.FrameworkDebug(
+			logging.FrameworkTrace(
 				ctx,
 				"Called provider defined validator.Object",
 				map[string]interface{}{

--- a/internal/fwserver/block_plan_modification.go
+++ b/internal/fwserver/block_plan_modification.go
@@ -382,7 +382,7 @@ func BlockPlanModifyList(ctx context.Context, block fwxschema.BlockWithListPlanM
 			Private:   resp.Private,
 		}
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Calling provider defined planmodifier.List",
 			map[string]interface{}{
@@ -392,7 +392,7 @@ func BlockPlanModifyList(ctx context.Context, block fwxschema.BlockWithListPlanM
 
 		planModifier.PlanModifyList(ctx, planModifyReq, planModifyResp)
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Called provider defined planmodifier.List",
 			map[string]interface{}{
@@ -517,7 +517,7 @@ func BlockPlanModifyObject(ctx context.Context, block fwxschema.BlockWithObjectP
 			Private:   resp.Private,
 		}
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Calling provider defined planmodifier.Object",
 			map[string]interface{}{
@@ -527,7 +527,7 @@ func BlockPlanModifyObject(ctx context.Context, block fwxschema.BlockWithObjectP
 
 		planModifier.PlanModifyObject(ctx, planModifyReq, planModifyResp)
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Called provider defined planmodifier.Object",
 			map[string]interface{}{
@@ -652,7 +652,7 @@ func BlockPlanModifySet(ctx context.Context, block fwxschema.BlockWithSetPlanMod
 			Private:   resp.Private,
 		}
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Calling provider defined planmodifier.Set",
 			map[string]interface{}{
@@ -662,7 +662,7 @@ func BlockPlanModifySet(ctx context.Context, block fwxschema.BlockWithSetPlanMod
 
 		planModifier.PlanModifySet(ctx, planModifyReq, planModifyResp)
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Called provider defined planmodifier.Set",
 			map[string]interface{}{
@@ -696,7 +696,7 @@ func NestedBlockObjectPlanModify(ctx context.Context, o fwschema.NestedBlockObje
 				Private:   resp.Private,
 			}
 
-			logging.FrameworkDebug(
+			logging.FrameworkTrace(
 				ctx,
 				"Calling provider defined planmodifier.Object",
 				map[string]interface{}{

--- a/internal/fwserver/block_validation.go
+++ b/internal/fwserver/block_validation.go
@@ -211,7 +211,7 @@ func BlockValidateList(ctx context.Context, block fwxschema.BlockWithListValidat
 		// from modifying or removing diagnostics.
 		validateResp := &validator.ListResponse{}
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Calling provider defined validator.List",
 			map[string]interface{}{
@@ -221,7 +221,7 @@ func BlockValidateList(ctx context.Context, block fwxschema.BlockWithListValidat
 
 		blockValidator.ValidateList(ctx, validateReq, validateResp)
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Called provider defined validator.List",
 			map[string]interface{}{
@@ -276,7 +276,7 @@ func BlockValidateObject(ctx context.Context, block fwxschema.BlockWithObjectVal
 		// from modifying or removing diagnostics.
 		validateResp := &validator.ObjectResponse{}
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Calling provider defined validator.Object",
 			map[string]interface{}{
@@ -286,7 +286,7 @@ func BlockValidateObject(ctx context.Context, block fwxschema.BlockWithObjectVal
 
 		blockValidator.ValidateObject(ctx, validateReq, validateResp)
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Called provider defined validator.Object",
 			map[string]interface{}{
@@ -341,7 +341,7 @@ func BlockValidateSet(ctx context.Context, block fwxschema.BlockWithSetValidator
 		// from modifying or removing diagnostics.
 		validateResp := &validator.SetResponse{}
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Calling provider defined validator.Set",
 			map[string]interface{}{
@@ -351,7 +351,7 @@ func BlockValidateSet(ctx context.Context, block fwxschema.BlockWithSetValidator
 
 		blockValidator.ValidateSet(ctx, validateReq, validateResp)
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Called provider defined validator.Set",
 			map[string]interface{}{
@@ -403,7 +403,7 @@ func NestedBlockObjectValidate(ctx context.Context, o fwschema.NestedBlockObject
 			// from modifying or removing diagnostics.
 			validateResp := &validator.ObjectResponse{}
 
-			logging.FrameworkDebug(
+			logging.FrameworkTrace(
 				ctx,
 				"Calling provider defined validator.Object",
 				map[string]interface{}{
@@ -413,7 +413,7 @@ func NestedBlockObjectValidate(ctx context.Context, o fwschema.NestedBlockObject
 
 			objectValidator.ValidateObject(ctx, validateReq, validateResp)
 
-			logging.FrameworkDebug(
+			logging.FrameworkTrace(
 				ctx,
 				"Called provider defined validator.Object",
 				map[string]interface{}{

--- a/internal/fwserver/server.go
+++ b/internal/fwserver/server.go
@@ -149,9 +149,9 @@ func (s *Server) DataSourceFuncs(ctx context.Context) (map[string]func() datasou
 
 	s.dataSourceFuncs = make(map[string]func() datasource.DataSource)
 
-	logging.FrameworkDebug(ctx, "Calling provider defined Provider DataSources")
+	logging.FrameworkTrace(ctx, "Calling provider defined Provider DataSources")
 	dataSourceFuncsSlice := s.Provider.DataSources(ctx)
-	logging.FrameworkDebug(ctx, "Called provider defined Provider DataSources")
+	logging.FrameworkTrace(ctx, "Called provider defined Provider DataSources")
 
 	for _, dataSourceFunc := range dataSourceFuncsSlice {
 		dataSource := dataSourceFunc()
@@ -233,9 +233,9 @@ func (s *Server) DataSourceSchemas(ctx context.Context) (map[string]fwschema.Sch
 		schemaReq := datasource.SchemaRequest{}
 		schemaResp := datasource.SchemaResponse{}
 
-		logging.FrameworkDebug(ctx, "Calling provider defined DataSource Schema", map[string]interface{}{logging.KeyDataSourceType: dataSourceTypeName})
+		logging.FrameworkTrace(ctx, "Calling provider defined DataSource Schema", map[string]interface{}{logging.KeyDataSourceType: dataSourceTypeName})
 		dataSource.Schema(ctx, schemaReq, &schemaResp)
-		logging.FrameworkDebug(ctx, "Called provider defined DataSource Schema", map[string]interface{}{logging.KeyDataSourceType: dataSourceTypeName})
+		logging.FrameworkTrace(ctx, "Called provider defined DataSource Schema", map[string]interface{}{logging.KeyDataSourceType: dataSourceTypeName})
 
 		s.dataSourceSchemasDiags.Append(schemaResp.Diagnostics...)
 
@@ -269,9 +269,9 @@ func (s *Server) ProviderSchema(ctx context.Context) (fwschema.Schema, diag.Diag
 	schemaReq := provider.SchemaRequest{}
 	schemaResp := provider.SchemaResponse{}
 
-	logging.FrameworkDebug(ctx, "Calling provider defined Provider Schema")
+	logging.FrameworkTrace(ctx, "Calling provider defined Provider Schema")
 	s.Provider.Schema(ctx, schemaReq, &schemaResp)
-	logging.FrameworkDebug(ctx, "Called provider defined Provider Schema")
+	logging.FrameworkTrace(ctx, "Called provider defined Provider Schema")
 
 	s.providerSchema = schemaResp.Schema
 	s.providerSchemaDiags = schemaResp.Diagnostics
@@ -303,9 +303,9 @@ func (s *Server) ProviderMetaSchema(ctx context.Context) (fwschema.Schema, diag.
 	req := provider.MetaSchemaRequest{}
 	resp := &provider.MetaSchemaResponse{}
 
-	logging.FrameworkDebug(ctx, "Calling provider defined Provider MetaSchema")
+	logging.FrameworkTrace(ctx, "Calling provider defined Provider MetaSchema")
 	providerWithMetaSchema.MetaSchema(ctx, req, resp)
-	logging.FrameworkDebug(ctx, "Called provider defined Provider MetaSchema")
+	logging.FrameworkTrace(ctx, "Called provider defined Provider MetaSchema")
 
 	s.providerMetaSchema = resp.Schema
 	s.providerMetaSchemaDiags = resp.Diagnostics
@@ -346,9 +346,9 @@ func (s *Server) ResourceFuncs(ctx context.Context) (map[string]func() resource.
 
 	s.resourceFuncs = make(map[string]func() resource.Resource)
 
-	logging.FrameworkDebug(ctx, "Calling provider defined Provider Resources")
+	logging.FrameworkTrace(ctx, "Calling provider defined Provider Resources")
 	resourceFuncsSlice := s.Provider.Resources(ctx)
-	logging.FrameworkDebug(ctx, "Called provider defined Provider Resources")
+	logging.FrameworkTrace(ctx, "Called provider defined Provider Resources")
 
 	for _, resourceFunc := range resourceFuncsSlice {
 		res := resourceFunc()
@@ -430,9 +430,9 @@ func (s *Server) ResourceSchemas(ctx context.Context) (map[string]fwschema.Schem
 		schemaReq := resource.SchemaRequest{}
 		schemaResp := resource.SchemaResponse{}
 
-		logging.FrameworkDebug(ctx, "Calling provider defined Resource Schema", map[string]interface{}{logging.KeyResourceType: resourceTypeName})
+		logging.FrameworkTrace(ctx, "Calling provider defined Resource Schema", map[string]interface{}{logging.KeyResourceType: resourceTypeName})
 		res.Schema(ctx, schemaReq, &schemaResp)
-		logging.FrameworkDebug(ctx, "Called provider defined Resource Schema", map[string]interface{}{logging.KeyResourceType: resourceTypeName})
+		logging.FrameworkTrace(ctx, "Called provider defined Resource Schema", map[string]interface{}{logging.KeyResourceType: resourceTypeName})
 
 		s.resourceSchemasDiags.Append(schemaResp.Diagnostics...)
 

--- a/internal/fwserver/server_configureprovider.go
+++ b/internal/fwserver/server_configureprovider.go
@@ -9,7 +9,7 @@ import (
 
 // ConfigureProvider implements the framework server ConfigureProvider RPC.
 func (s *Server) ConfigureProvider(ctx context.Context, req *provider.ConfigureRequest, resp *provider.ConfigureResponse) {
-	logging.FrameworkDebug(ctx, "Calling provider defined Provider Configure")
+	logging.FrameworkTrace(ctx, "Calling provider defined Provider Configure")
 
 	if req != nil {
 		s.Provider.Configure(ctx, *req, resp)
@@ -17,7 +17,7 @@ func (s *Server) ConfigureProvider(ctx context.Context, req *provider.ConfigureR
 		s.Provider.Configure(ctx, provider.ConfigureRequest{}, resp)
 	}
 
-	logging.FrameworkDebug(ctx, "Called provider defined Provider Configure")
+	logging.FrameworkTrace(ctx, "Called provider defined Provider Configure")
 
 	s.DataSourceConfigureData = resp.DataSourceData
 	s.ResourceConfigureData = resp.ResourceData

--- a/internal/fwserver/server_createresource.go
+++ b/internal/fwserver/server_createresource.go
@@ -47,9 +47,9 @@ func (s *Server) CreateResource(ctx context.Context, req *CreateResourceRequest,
 		}
 		configureResp := resource.ConfigureResponse{}
 
-		logging.FrameworkDebug(ctx, "Calling provider defined Resource Configure")
+		logging.FrameworkTrace(ctx, "Calling provider defined Resource Configure")
 		resourceWithConfigure.Configure(ctx, configureReq, &configureResp)
-		logging.FrameworkDebug(ctx, "Called provider defined Resource Configure")
+		logging.FrameworkTrace(ctx, "Called provider defined Resource Configure")
 
 		resp.Diagnostics.Append(configureResp.Diagnostics...)
 
@@ -93,9 +93,9 @@ func (s *Server) CreateResource(ctx context.Context, req *CreateResourceRequest,
 		createReq.ProviderMeta = *req.ProviderMeta
 	}
 
-	logging.FrameworkDebug(ctx, "Calling provider defined Resource Create")
+	logging.FrameworkTrace(ctx, "Calling provider defined Resource Create")
 	req.Resource.Create(ctx, createReq, &createResp)
-	logging.FrameworkDebug(ctx, "Called provider defined Resource Create")
+	logging.FrameworkTrace(ctx, "Called provider defined Resource Create")
 
 	resp.Diagnostics = createResp.Diagnostics
 	resp.NewState = &createResp.State

--- a/internal/fwserver/server_deleteresource.go
+++ b/internal/fwserver/server_deleteresource.go
@@ -46,9 +46,9 @@ func (s *Server) DeleteResource(ctx context.Context, req *DeleteResourceRequest,
 		}
 		configureResp := resource.ConfigureResponse{}
 
-		logging.FrameworkDebug(ctx, "Calling provider defined Resource Configure")
+		logging.FrameworkTrace(ctx, "Calling provider defined Resource Configure")
 		resourceWithConfigure.Configure(ctx, configureReq, &configureResp)
-		logging.FrameworkDebug(ctx, "Called provider defined Resource Configure")
+		logging.FrameworkTrace(ctx, "Called provider defined Resource Configure")
 
 		resp.Diagnostics.Append(configureResp.Diagnostics...)
 
@@ -83,9 +83,9 @@ func (s *Server) DeleteResource(ctx context.Context, req *DeleteResourceRequest,
 		deleteReq.Private = req.PlannedPrivate.Provider
 	}
 
-	logging.FrameworkDebug(ctx, "Calling provider defined Resource Delete")
+	logging.FrameworkTrace(ctx, "Calling provider defined Resource Delete")
 	req.Resource.Delete(ctx, deleteReq, &deleteResp)
-	logging.FrameworkDebug(ctx, "Called provider defined Resource Delete")
+	logging.FrameworkTrace(ctx, "Called provider defined Resource Delete")
 
 	if !deleteResp.Diagnostics.HasError() {
 		logging.FrameworkTrace(ctx, "No provider defined Delete errors detected, ensuring State is cleared")

--- a/internal/fwserver/server_getproviderschema.go
+++ b/internal/fwserver/server_getproviderschema.go
@@ -33,9 +33,9 @@ func (s *Server) GetProviderSchema(ctx context.Context, req *GetProviderSchemaRe
 	metadataReq := provider.MetadataRequest{}
 	metadataResp := provider.MetadataResponse{}
 
-	logging.FrameworkDebug(ctx, "Calling provider defined Provider Metadata")
+	logging.FrameworkTrace(ctx, "Calling provider defined Provider Metadata")
 	s.Provider.Metadata(ctx, metadataReq, &metadataResp)
-	logging.FrameworkDebug(ctx, "Called provider defined Provider Metadata")
+	logging.FrameworkTrace(ctx, "Called provider defined Provider Metadata")
 
 	s.providerTypeName = metadataResp.TypeName
 

--- a/internal/fwserver/server_importresourcestate.go
+++ b/internal/fwserver/server_importresourcestate.go
@@ -55,9 +55,9 @@ func (s *Server) ImportResourceState(ctx context.Context, req *ImportResourceSta
 		}
 		configureResp := resource.ConfigureResponse{}
 
-		logging.FrameworkDebug(ctx, "Calling provider defined Resource Configure")
+		logging.FrameworkTrace(ctx, "Calling provider defined Resource Configure")
 		resourceWithConfigure.Configure(ctx, configureReq, &configureResp)
-		logging.FrameworkDebug(ctx, "Called provider defined Resource Configure")
+		logging.FrameworkTrace(ctx, "Called provider defined Resource Configure")
 
 		resp.Diagnostics.Append(configureResp.Diagnostics...)
 
@@ -100,9 +100,9 @@ func (s *Server) ImportResourceState(ctx context.Context, req *ImportResourceSta
 		Private: privateProviderData,
 	}
 
-	logging.FrameworkDebug(ctx, "Calling provider defined Resource ImportState")
+	logging.FrameworkTrace(ctx, "Calling provider defined Resource ImportState")
 	resourceWithImportState.ImportState(ctx, importReq, &importResp)
-	logging.FrameworkDebug(ctx, "Called provider defined Resource ImportState")
+	logging.FrameworkTrace(ctx, "Called provider defined Resource ImportState")
 
 	resp.Diagnostics.Append(importResp.Diagnostics...)
 

--- a/internal/fwserver/server_planresourcechange.go
+++ b/internal/fwserver/server_planresourcechange.go
@@ -54,9 +54,9 @@ func (s *Server) PlanResourceChange(ctx context.Context, req *PlanResourceChange
 		}
 		configureResp := resource.ConfigureResponse{}
 
-		logging.FrameworkDebug(ctx, "Calling provider defined Resource Configure")
+		logging.FrameworkTrace(ctx, "Calling provider defined Resource Configure")
 		resourceWithConfigure.Configure(ctx, configureReq, &configureResp)
-		logging.FrameworkDebug(ctx, "Called provider defined Resource Configure")
+		logging.FrameworkTrace(ctx, "Called provider defined Resource Configure")
 
 		resp.Diagnostics.Append(configureResp.Diagnostics...)
 
@@ -306,9 +306,9 @@ func (s *Server) PlanResourceChange(ctx context.Context, req *PlanResourceChange
 			Private:         modifyPlanReq.Private,
 		}
 
-		logging.FrameworkDebug(ctx, "Calling provider defined Resource ModifyPlan")
+		logging.FrameworkTrace(ctx, "Calling provider defined Resource ModifyPlan")
 		resourceWithModifyPlan.ModifyPlan(ctx, modifyPlanReq, &modifyPlanResp)
-		logging.FrameworkDebug(ctx, "Called provider defined Resource ModifyPlan")
+		logging.FrameworkTrace(ctx, "Called provider defined Resource ModifyPlan")
 
 		resp.Diagnostics = modifyPlanResp.Diagnostics
 		resp.PlannedState = planToState(modifyPlanResp.Plan)

--- a/internal/fwserver/server_readdatasource.go
+++ b/internal/fwserver/server_readdatasource.go
@@ -40,9 +40,9 @@ func (s *Server) ReadDataSource(ctx context.Context, req *ReadDataSourceRequest,
 		}
 		configureResp := datasource.ConfigureResponse{}
 
-		logging.FrameworkDebug(ctx, "Calling provider defined DataSource Configure")
+		logging.FrameworkTrace(ctx, "Calling provider defined DataSource Configure")
 		dataSourceWithConfigure.Configure(ctx, configureReq, &configureResp)
-		logging.FrameworkDebug(ctx, "Called provider defined DataSource Configure")
+		logging.FrameworkTrace(ctx, "Called provider defined DataSource Configure")
 
 		resp.Diagnostics.Append(configureResp.Diagnostics...)
 
@@ -71,9 +71,9 @@ func (s *Server) ReadDataSource(ctx context.Context, req *ReadDataSourceRequest,
 		readReq.ProviderMeta = *req.ProviderMeta
 	}
 
-	logging.FrameworkDebug(ctx, "Calling provider defined DataSource Read")
+	logging.FrameworkTrace(ctx, "Calling provider defined DataSource Read")
 	req.DataSource.Read(ctx, readReq, &readResp)
-	logging.FrameworkDebug(ctx, "Called provider defined DataSource Read")
+	logging.FrameworkTrace(ctx, "Called provider defined DataSource Read")
 
 	resp.Diagnostics = readResp.Diagnostics
 	resp.State = &readResp.State

--- a/internal/fwserver/server_readresource.go
+++ b/internal/fwserver/server_readresource.go
@@ -51,9 +51,9 @@ func (s *Server) ReadResource(ctx context.Context, req *ReadResourceRequest, res
 		}
 		configureResp := resource.ConfigureResponse{}
 
-		logging.FrameworkDebug(ctx, "Calling provider defined Resource Configure")
+		logging.FrameworkTrace(ctx, "Calling provider defined Resource Configure")
 		resourceWithConfigure.Configure(ctx, configureReq, &configureResp)
-		logging.FrameworkDebug(ctx, "Called provider defined Resource Configure")
+		logging.FrameworkTrace(ctx, "Called provider defined Resource Configure")
 
 		resp.Diagnostics.Append(configureResp.Diagnostics...)
 
@@ -93,9 +93,9 @@ func (s *Server) ReadResource(ctx context.Context, req *ReadResourceRequest, res
 		resp.Private = req.Private
 	}
 
-	logging.FrameworkDebug(ctx, "Calling provider defined Resource Read")
+	logging.FrameworkTrace(ctx, "Calling provider defined Resource Read")
 	req.Resource.Read(ctx, readReq, &readResp)
-	logging.FrameworkDebug(ctx, "Called provider defined Resource Read")
+	logging.FrameworkTrace(ctx, "Called provider defined Resource Read")
 
 	resp.Diagnostics = readResp.Diagnostics
 	resp.NewState = &readResp.State

--- a/internal/fwserver/server_updateresource.go
+++ b/internal/fwserver/server_updateresource.go
@@ -48,9 +48,9 @@ func (s *Server) UpdateResource(ctx context.Context, req *UpdateResourceRequest,
 		}
 		configureResp := resource.ConfigureResponse{}
 
-		logging.FrameworkDebug(ctx, "Calling provider defined Resource Configure")
+		logging.FrameworkTrace(ctx, "Calling provider defined Resource Configure")
 		resourceWithConfigure.Configure(ctx, configureReq, &configureResp)
-		logging.FrameworkDebug(ctx, "Called provider defined Resource Configure")
+		logging.FrameworkTrace(ctx, "Called provider defined Resource Configure")
 
 		resp.Diagnostics.Append(configureResp.Diagnostics...)
 
@@ -114,9 +114,9 @@ func (s *Server) UpdateResource(ctx context.Context, req *UpdateResourceRequest,
 		resp.Private = req.PlannedPrivate
 	}
 
-	logging.FrameworkDebug(ctx, "Calling provider defined Resource Update")
+	logging.FrameworkTrace(ctx, "Calling provider defined Resource Update")
 	req.Resource.Update(ctx, updateReq, &updateResp)
-	logging.FrameworkDebug(ctx, "Called provider defined Resource Update")
+	logging.FrameworkTrace(ctx, "Called provider defined Resource Update")
 
 	resp.Diagnostics = updateResp.Diagnostics
 	resp.NewState = &updateResp.State

--- a/internal/fwserver/server_upgraderesourcestate.go
+++ b/internal/fwserver/server_upgraderesourcestate.go
@@ -107,9 +107,9 @@ func (s *Server) UpgradeResourceState(ctx context.Context, req *UpgradeResourceS
 		}
 		configureResp := resource.ConfigureResponse{}
 
-		logging.FrameworkDebug(ctx, "Calling provider defined Resource Configure")
+		logging.FrameworkTrace(ctx, "Calling provider defined Resource Configure")
 		resourceWithConfigure.Configure(ctx, configureReq, &configureResp)
-		logging.FrameworkDebug(ctx, "Called provider defined Resource Configure")
+		logging.FrameworkTrace(ctx, "Called provider defined Resource Configure")
 
 		resp.Diagnostics.Append(configureResp.Diagnostics...)
 
@@ -132,9 +132,9 @@ func (s *Server) UpgradeResourceState(ctx context.Context, req *UpgradeResourceS
 
 	logging.FrameworkTrace(ctx, "Resource implements ResourceWithUpgradeState")
 
-	logging.FrameworkDebug(ctx, "Calling provider defined Resource UpgradeState")
+	logging.FrameworkTrace(ctx, "Calling provider defined Resource UpgradeState")
 	resourceStateUpgraders := resourceWithUpgradeState.UpgradeState(ctx)
-	logging.FrameworkDebug(ctx, "Called provider defined Resource UpgradeState")
+	logging.FrameworkTrace(ctx, "Called provider defined Resource UpgradeState")
 
 	// Panic prevention
 	if resourceStateUpgraders == nil {
@@ -191,9 +191,9 @@ func (s *Server) UpgradeResourceState(ctx context.Context, req *UpgradeResourceS
 	// by calling the equivalent of SetAttribute(GetAttribute()) and skipping
 	// any errors.
 
-	logging.FrameworkDebug(ctx, "Calling provider defined StateUpgrader")
+	logging.FrameworkTrace(ctx, "Calling provider defined StateUpgrader")
 	resourceStateUpgrader.StateUpgrader(ctx, upgradeResourceStateRequest, &upgradeResourceStateResponse)
-	logging.FrameworkDebug(ctx, "Called provider defined StateUpgrader")
+	logging.FrameworkTrace(ctx, "Called provider defined StateUpgrader")
 
 	resp.Diagnostics.Append(upgradeResourceStateResponse.Diagnostics...)
 

--- a/internal/fwserver/server_validatedatasourceconfig.go
+++ b/internal/fwserver/server_validatedatasourceconfig.go
@@ -36,9 +36,9 @@ func (s *Server) ValidateDataSourceConfig(ctx context.Context, req *ValidateData
 		}
 		configureResp := datasource.ConfigureResponse{}
 
-		logging.FrameworkDebug(ctx, "Calling provider defined DataSource Configure")
+		logging.FrameworkTrace(ctx, "Calling provider defined DataSource Configure")
 		dataSourceWithConfigure.Configure(ctx, configureReq, &configureResp)
-		logging.FrameworkDebug(ctx, "Called provider defined DataSource Configure")
+		logging.FrameworkTrace(ctx, "Called provider defined DataSource Configure")
 
 		resp.Diagnostics.Append(configureResp.Diagnostics...)
 
@@ -86,9 +86,9 @@ func (s *Server) ValidateDataSourceConfig(ctx context.Context, req *ValidateData
 		// from modifying or removing diagnostics.
 		vdscResp := &datasource.ValidateConfigResponse{}
 
-		logging.FrameworkDebug(ctx, "Calling provider defined DataSource ValidateConfig")
+		logging.FrameworkTrace(ctx, "Calling provider defined DataSource ValidateConfig")
 		dataSource.ValidateConfig(ctx, vdscReq, vdscResp)
-		logging.FrameworkDebug(ctx, "Called provider defined DataSource ValidateConfig")
+		logging.FrameworkTrace(ctx, "Called provider defined DataSource ValidateConfig")
 
 		resp.Diagnostics.Append(vdscResp.Diagnostics...)
 	}

--- a/internal/fwserver/server_validateproviderconfig.go
+++ b/internal/fwserver/server_validateproviderconfig.go
@@ -40,7 +40,7 @@ func (s *Server) ValidateProviderConfig(ctx context.Context, req *ValidateProvid
 			// from modifying or removing diagnostics.
 			vpcRes := &provider.ValidateConfigResponse{}
 
-			logging.FrameworkDebug(
+			logging.FrameworkTrace(
 				ctx,
 				"Calling provider defined ConfigValidator",
 				map[string]interface{}{
@@ -48,7 +48,7 @@ func (s *Server) ValidateProviderConfig(ctx context.Context, req *ValidateProvid
 				},
 			)
 			configValidator.ValidateProvider(ctx, vpcReq, vpcRes)
-			logging.FrameworkDebug(
+			logging.FrameworkTrace(
 				ctx,
 				"Called provider defined ConfigValidator",
 				map[string]interface{}{
@@ -67,9 +67,9 @@ func (s *Server) ValidateProviderConfig(ctx context.Context, req *ValidateProvid
 		// from modifying or removing diagnostics.
 		vpcRes := &provider.ValidateConfigResponse{}
 
-		logging.FrameworkDebug(ctx, "Calling provider defined Provider ValidateConfig")
+		logging.FrameworkTrace(ctx, "Calling provider defined Provider ValidateConfig")
 		providerWithValidateConfig.ValidateConfig(ctx, vpcReq, vpcRes)
-		logging.FrameworkDebug(ctx, "Called provider defined Provider ValidateConfig")
+		logging.FrameworkTrace(ctx, "Called provider defined Provider ValidateConfig")
 
 		resp.Diagnostics.Append(vpcRes.Diagnostics...)
 	}

--- a/internal/fwserver/server_validateresourceconfig.go
+++ b/internal/fwserver/server_validateresourceconfig.go
@@ -36,9 +36,9 @@ func (s *Server) ValidateResourceConfig(ctx context.Context, req *ValidateResour
 		}
 		configureResp := resource.ConfigureResponse{}
 
-		logging.FrameworkDebug(ctx, "Calling provider defined Resource Configure")
+		logging.FrameworkTrace(ctx, "Calling provider defined Resource Configure")
 		resourceWithConfigure.Configure(ctx, configureReq, &configureResp)
-		logging.FrameworkDebug(ctx, "Called provider defined Resource Configure")
+		logging.FrameworkTrace(ctx, "Called provider defined Resource Configure")
 
 		resp.Diagnostics.Append(configureResp.Diagnostics...)
 
@@ -59,7 +59,7 @@ func (s *Server) ValidateResourceConfig(ctx context.Context, req *ValidateResour
 			// from modifying or removing diagnostics.
 			vdscResp := &resource.ValidateConfigResponse{}
 
-			logging.FrameworkDebug(
+			logging.FrameworkTrace(
 				ctx,
 				"Calling provider defined ResourceConfigValidator",
 				map[string]interface{}{
@@ -67,7 +67,7 @@ func (s *Server) ValidateResourceConfig(ctx context.Context, req *ValidateResour
 				},
 			)
 			configValidator.ValidateResource(ctx, vdscReq, vdscResp)
-			logging.FrameworkDebug(
+			logging.FrameworkTrace(
 				ctx,
 				"Called provider defined ResourceConfigValidator",
 				map[string]interface{}{
@@ -86,9 +86,9 @@ func (s *Server) ValidateResourceConfig(ctx context.Context, req *ValidateResour
 		// from modifying or removing diagnostics.
 		vdscResp := &resource.ValidateConfigResponse{}
 
-		logging.FrameworkDebug(ctx, "Calling provider defined Resource ValidateConfig")
+		logging.FrameworkTrace(ctx, "Calling provider defined Resource ValidateConfig")
 		resourceWithValidateConfig.ValidateConfig(ctx, vdscReq, vdscResp)
-		logging.FrameworkDebug(ctx, "Called provider defined Resource ValidateConfig")
+		logging.FrameworkTrace(ctx, "Called provider defined Resource ValidateConfig")
 
 		resp.Diagnostics.Append(vdscResp.Diagnostics...)
 	}

--- a/internal/proto5server/server_getproviderschema_test.go
+++ b/internal/proto5server/server_getproviderschema_test.go
@@ -515,12 +515,12 @@ func TestServerGetProviderSchema_logging(t *testing.T) {
 
 	expectedEntries := []map[string]interface{}{
 		{
-			"@level":   "debug",
+			"@level":   "trace",
 			"@message": "Calling provider defined Provider Metadata",
 			"@module":  "sdk.framework",
 		},
 		{
-			"@level":   "debug",
+			"@level":   "trace",
 			"@message": "Called provider defined Provider Metadata",
 			"@module":  "sdk.framework",
 		},
@@ -530,12 +530,12 @@ func TestServerGetProviderSchema_logging(t *testing.T) {
 			"@module":  "sdk.framework",
 		},
 		{
-			"@level":   "debug",
+			"@level":   "trace",
 			"@message": "Calling provider defined Provider Schema",
 			"@module":  "sdk.framework",
 		},
 		{
-			"@level":   "debug",
+			"@level":   "trace",
 			"@message": "Called provider defined Provider Schema",
 			"@module":  "sdk.framework",
 		},
@@ -550,12 +550,12 @@ func TestServerGetProviderSchema_logging(t *testing.T) {
 			"@module":  "sdk.framework",
 		},
 		{
-			"@level":   "debug",
+			"@level":   "trace",
 			"@message": "Calling provider defined Provider Resources",
 			"@module":  "sdk.framework",
 		},
 		{
-			"@level":   "debug",
+			"@level":   "trace",
 			"@message": "Called provider defined Provider Resources",
 			"@module":  "sdk.framework",
 		},
@@ -570,12 +570,12 @@ func TestServerGetProviderSchema_logging(t *testing.T) {
 			"@module":  "sdk.framework",
 		},
 		{
-			"@level":   "debug",
+			"@level":   "trace",
 			"@message": "Calling provider defined Provider DataSources",
 			"@module":  "sdk.framework",
 		},
 		{
-			"@level":   "debug",
+			"@level":   "trace",
 			"@message": "Called provider defined Provider DataSources",
 			"@module":  "sdk.framework",
 		},

--- a/internal/proto6server/server_getproviderschema_test.go
+++ b/internal/proto6server/server_getproviderschema_test.go
@@ -515,12 +515,12 @@ func TestServerGetProviderSchema_logging(t *testing.T) {
 
 	expectedEntries := []map[string]interface{}{
 		{
-			"@level":   "debug",
+			"@level":   "trace",
 			"@message": "Calling provider defined Provider Metadata",
 			"@module":  "sdk.framework",
 		},
 		{
-			"@level":   "debug",
+			"@level":   "trace",
 			"@message": "Called provider defined Provider Metadata",
 			"@module":  "sdk.framework",
 		},
@@ -530,12 +530,12 @@ func TestServerGetProviderSchema_logging(t *testing.T) {
 			"@module":  "sdk.framework",
 		},
 		{
-			"@level":   "debug",
+			"@level":   "trace",
 			"@message": "Calling provider defined Provider Schema",
 			"@module":  "sdk.framework",
 		},
 		{
-			"@level":   "debug",
+			"@level":   "trace",
 			"@message": "Called provider defined Provider Schema",
 			"@module":  "sdk.framework",
 		},
@@ -550,12 +550,12 @@ func TestServerGetProviderSchema_logging(t *testing.T) {
 			"@module":  "sdk.framework",
 		},
 		{
-			"@level":   "debug",
+			"@level":   "trace",
 			"@message": "Calling provider defined Provider Resources",
 			"@module":  "sdk.framework",
 		},
 		{
-			"@level":   "debug",
+			"@level":   "trace",
 			"@message": "Called provider defined Provider Resources",
 			"@module":  "sdk.framework",
 		},
@@ -570,12 +570,12 @@ func TestServerGetProviderSchema_logging(t *testing.T) {
 			"@module":  "sdk.framework",
 		},
 		{
-			"@level":   "debug",
+			"@level":   "trace",
 			"@message": "Calling provider defined Provider DataSources",
 			"@module":  "sdk.framework",
 		},
 		{
-			"@level":   "debug",
+			"@level":   "trace",
 			"@message": "Called provider defined Provider DataSources",
 			"@module":  "sdk.framework",
 		},


### PR DESCRIPTION
These messages are appearing in our logs during acceptance test runs and make up the majority of the log without providing much information. We would prefer if they were logged at a lower level.