### PR TITLE
resource/schema: Prevent UseStateForUnknown data misalignment by raising implementation error when under a list or set

### DIFF
--- a/.changes/unreleased/BUG FIXES-20230406-112757.yaml
+++ b/.changes/unreleased/BUG FIXES-20230406-112757.yaml
@@ -1,0 +1,6 @@
+kind: BUG FIXES
+body: 'resource/schema: Prevent `UseStateForUnknown` plan modifier data misalignment
+  and Terraform errors by raising implementation error when defined a list or set'
+time: 2023-04-06T11:27:57.549597-04:00
+custom:
+  Issue: "711"

--- a/.changes/unreleased/BUG FIXES-20230406-112757.yaml
+++ b/.changes/unreleased/BUG FIXES-20230406-112757.yaml
@@ -1,6 +1,6 @@
 kind: BUG FIXES
 body: 'resource/schema: Prevent `UseStateForUnknown` plan modifier data misalignment
-  and Terraform errors by raising implementation error when defined a list or set'
+  and Terraform errors by raising implementation error when defined under a list or set'
 time: 2023-04-06T11:27:57.549597-04:00
 custom:
   Issue: "711"

--- a/internal/fwserver/attribute_plan_modification_test.go
+++ b/internal/fwserver/attribute_plan_modification_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema/fwxschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/planmodifierdiag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/privatestate"
 	"github.com/hashicorp/terraform-plugin-framework/internal/testing/planmodifiers"
 	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testplanmodifier"
@@ -287,6 +288,276 @@ func TestAttributeModifyPlan(t *testing.T) {
 						),
 					},
 				),
+			},
+		},
+		"attribute-list-nested-nested-usestateforunknown-elements-rearranged": {
+			attribute: testschema.NestedAttribute{
+				NestedObject: testschema.NestedAttributeObject{
+					Attributes: map[string]fwschema.Attribute{
+						"nested_computed": testschema.AttributeWithStringPlanModifiers{
+							Computed: true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
+						},
+						"nested_required": testschema.Attribute{
+							Type:     types.StringType,
+							Required: true,
+						},
+					},
+				},
+				NestingMode: fwschema.NestingModeList,
+				Required:    true,
+			},
+			req: ModifyAttributePlanRequest{
+				AttributeConfig: types.ListValueMust(
+					types.ObjectType{
+						AttrTypes: map[string]attr.Type{
+							"nested_computed": types.StringType,
+							"nested_required": types.StringType,
+						},
+					},
+					[]attr.Value{
+						types.ObjectValueMust(
+							map[string]attr.Type{
+								"nested_computed": types.StringType,
+								"nested_required": types.StringType,
+							},
+							map[string]attr.Value{
+								"nested_computed": types.StringNull(),
+								"nested_required": types.StringValue("testvalue2"), // prior state on index 0 is testvalue1
+							},
+						),
+						types.ObjectValueMust(
+							map[string]attr.Type{
+								"nested_computed": types.StringType,
+								"nested_required": types.StringType,
+							},
+							map[string]attr.Value{
+								"nested_computed": types.StringNull(),
+								"nested_required": types.StringValue("testvalue1"), // prior state on index 1 is testvalue2
+							},
+						),
+					},
+				),
+				AttributePath: path.Root("test"),
+				AttributePlan: types.ListValueMust(
+					types.ObjectType{
+						AttrTypes: map[string]attr.Type{
+							"nested_computed": types.StringType,
+							"nested_required": types.StringType,
+						},
+					},
+					[]attr.Value{
+						types.ObjectValueMust(
+							map[string]attr.Type{
+								"nested_computed": types.StringType,
+								"nested_required": types.StringType,
+							},
+							map[string]attr.Value{
+								"nested_computed": types.StringUnknown(),
+								"nested_required": types.StringValue("testvalue2"),
+							},
+						),
+						types.ObjectValueMust(
+							map[string]attr.Type{
+								"nested_computed": types.StringType,
+								"nested_required": types.StringType,
+							},
+							map[string]attr.Value{
+								"nested_computed": types.StringUnknown(),
+								"nested_required": types.StringValue("testvalue1"),
+							},
+						),
+					},
+				),
+				AttributeState: types.ListValueMust(
+					types.ObjectType{
+						AttrTypes: map[string]attr.Type{
+							"nested_computed": types.StringType,
+							"nested_required": types.StringType,
+						},
+					},
+					[]attr.Value{
+						types.ObjectValueMust(
+							map[string]attr.Type{
+								"nested_computed": types.StringType,
+								"nested_required": types.StringType,
+							},
+							map[string]attr.Value{
+								"nested_computed": types.StringValue("statevalue1"),
+								"nested_required": types.StringValue("testvalue1"),
+							},
+						),
+						types.ObjectValueMust(
+							map[string]attr.Type{
+								"nested_computed": types.StringType,
+								"nested_required": types.StringType,
+							},
+							map[string]attr.Value{
+								"nested_computed": types.StringValue("statevalue2"),
+								"nested_required": types.StringValue("testvalue2"),
+							},
+						),
+					},
+				),
+			},
+			expectedResp: ModifyAttributePlanResponse{
+				AttributePlan: types.ListValueMust(
+					types.ObjectType{
+						AttrTypes: map[string]attr.Type{
+							"nested_computed": types.StringType,
+							"nested_required": types.StringType,
+						},
+					},
+					[]attr.Value{
+						types.ObjectValueMust(
+							map[string]attr.Type{
+								"nested_computed": types.StringType,
+								"nested_required": types.StringType,
+							},
+							map[string]attr.Value{
+								"nested_computed": types.StringUnknown(),
+								"nested_required": types.StringValue("testvalue2"),
+							},
+						),
+						types.ObjectValueMust(
+							map[string]attr.Type{
+								"nested_computed": types.StringType,
+								"nested_required": types.StringType,
+							},
+							map[string]attr.Value{
+								"nested_computed": types.StringUnknown(),
+								"nested_required": types.StringValue("testvalue1"),
+							},
+						),
+					},
+				),
+				Diagnostics: diag.Diagnostics{
+					planmodifierdiag.UseStateForUnknownUnderListOrSet(
+						path.Root("test").AtListIndex(0).AtName("nested_computed"),
+					),
+				},
+			},
+		},
+		"attribute-list-nested-nested-usestateforunknown-elements-removed": {
+			attribute: testschema.NestedAttribute{
+				NestedObject: testschema.NestedAttributeObject{
+					Attributes: map[string]fwschema.Attribute{
+						"nested_computed": testschema.AttributeWithStringPlanModifiers{
+							Computed: true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
+						},
+						"nested_required": testschema.Attribute{
+							Type:     types.StringType,
+							Required: true,
+						},
+					},
+				},
+				NestingMode: fwschema.NestingModeList,
+				Required:    true,
+			},
+			req: ModifyAttributePlanRequest{
+				AttributeConfig: types.ListValueMust(
+					types.ObjectType{
+						AttrTypes: map[string]attr.Type{
+							"nested_computed": types.StringType,
+							"nested_required": types.StringType,
+						},
+					},
+					[]attr.Value{
+						types.ObjectValueMust(
+							map[string]attr.Type{
+								"nested_computed": types.StringType,
+								"nested_required": types.StringType,
+							},
+							map[string]attr.Value{
+								"nested_computed": types.StringNull(),
+								"nested_required": types.StringValue("testvalue2"), // prior state on index 0 is testvalue1
+							},
+						),
+					},
+				),
+				AttributePath: path.Root("test"),
+				AttributePlan: types.ListValueMust(
+					types.ObjectType{
+						AttrTypes: map[string]attr.Type{
+							"nested_computed": types.StringType,
+							"nested_required": types.StringType,
+						},
+					},
+					[]attr.Value{
+						types.ObjectValueMust(
+							map[string]attr.Type{
+								"nested_computed": types.StringType,
+								"nested_required": types.StringType,
+							},
+							map[string]attr.Value{
+								"nested_computed": types.StringUnknown(),
+								"nested_required": types.StringValue("testvalue2"),
+							},
+						),
+					},
+				),
+				AttributeState: types.ListValueMust(
+					types.ObjectType{
+						AttrTypes: map[string]attr.Type{
+							"nested_computed": types.StringType,
+							"nested_required": types.StringType,
+						},
+					},
+					[]attr.Value{
+						types.ObjectValueMust(
+							map[string]attr.Type{
+								"nested_computed": types.StringType,
+								"nested_required": types.StringType,
+							},
+							map[string]attr.Value{
+								"nested_computed": types.StringValue("statevalue1"),
+								"nested_required": types.StringValue("testvalue1"),
+							},
+						),
+						types.ObjectValueMust(
+							map[string]attr.Type{
+								"nested_computed": types.StringType,
+								"nested_required": types.StringType,
+							},
+							map[string]attr.Value{
+								"nested_computed": types.StringValue("statevalue2"),
+								"nested_required": types.StringValue("testvalue2"),
+							},
+						),
+					},
+				),
+			},
+			expectedResp: ModifyAttributePlanResponse{
+				AttributePlan: types.ListValueMust(
+					types.ObjectType{
+						AttrTypes: map[string]attr.Type{
+							"nested_computed": types.StringType,
+							"nested_required": types.StringType,
+						},
+					},
+					[]attr.Value{
+						types.ObjectValueMust(
+							map[string]attr.Type{
+								"nested_computed": types.StringType,
+								"nested_required": types.StringType,
+							},
+							map[string]attr.Value{
+								"nested_computed": types.StringUnknown(),
+								"nested_required": types.StringValue("testvalue2"),
+							},
+						),
+					},
+				),
+				Diagnostics: diag.Diagnostics{
+					planmodifierdiag.UseStateForUnknownUnderListOrSet(
+						path.Root("test").AtListIndex(0).AtName("nested_computed"),
+					),
+				},
 			},
 		},
 		"attribute-set-nested-private": {
@@ -578,6 +849,135 @@ func TestAttributeModifyPlan(t *testing.T) {
 								"nested_required": types.StringType,
 							},
 							map[string]attr.Value{
+								"nested_computed": types.StringUnknown(),
+								"nested_required": types.StringValue("testvalue1"),
+							},
+						),
+						types.ObjectValueMust(
+							map[string]attr.Type{
+								"nested_computed": types.StringType,
+								"nested_required": types.StringType,
+							},
+							map[string]attr.Value{
+								"nested_computed": types.StringUnknown(),
+								"nested_required": types.StringValue("testvalue2"),
+							},
+						),
+					},
+				),
+				Diagnostics: diag.Diagnostics{
+					planmodifierdiag.UseStateForUnknownUnderListOrSet(
+						path.Root("test").AtSetValue(
+							types.ObjectValueMust(
+								map[string]attr.Type{
+									"nested_computed": types.StringType,
+									"nested_required": types.StringType,
+								},
+								map[string]attr.Value{
+									"nested_computed": types.StringUnknown(),
+									"nested_required": types.StringValue("testvalue1"),
+								},
+							),
+						).AtName("nested_computed"),
+					),
+				},
+			},
+		},
+		"attribute-set-nested-nested-usestateforunknown-elements-rearranged": {
+			attribute: testschema.NestedAttribute{
+				NestedObject: testschema.NestedAttributeObject{
+					Attributes: map[string]fwschema.Attribute{
+						"nested_computed": testschema.AttributeWithStringPlanModifiers{
+							Computed: true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
+						},
+						"nested_required": testschema.Attribute{
+							Type:     types.StringType,
+							Required: true,
+						},
+					},
+				},
+				NestingMode: fwschema.NestingModeSet,
+				Required:    true,
+			},
+			req: ModifyAttributePlanRequest{
+				AttributeConfig: types.SetValueMust(
+					types.ObjectType{
+						AttrTypes: map[string]attr.Type{
+							"nested_computed": types.StringType,
+							"nested_required": types.StringType,
+						},
+					},
+					[]attr.Value{
+						types.ObjectValueMust(
+							map[string]attr.Type{
+								"nested_computed": types.StringType,
+								"nested_required": types.StringType,
+							},
+							map[string]attr.Value{
+								"nested_computed": types.StringNull(),
+								"nested_required": types.StringValue("testvalue2"), // prior state on index 0 is testvalue1
+							},
+						),
+						types.ObjectValueMust(
+							map[string]attr.Type{
+								"nested_computed": types.StringType,
+								"nested_required": types.StringType,
+							},
+							map[string]attr.Value{
+								"nested_computed": types.StringNull(),
+								"nested_required": types.StringValue("testvalue1"), // prior state on index 1 is testvalue2
+							},
+						),
+					},
+				),
+				AttributePath: path.Root("test"),
+				AttributePlan: types.SetValueMust(
+					types.ObjectType{
+						AttrTypes: map[string]attr.Type{
+							"nested_computed": types.StringType,
+							"nested_required": types.StringType,
+						},
+					},
+					[]attr.Value{
+						types.ObjectValueMust(
+							map[string]attr.Type{
+								"nested_computed": types.StringType,
+								"nested_required": types.StringType,
+							},
+							map[string]attr.Value{
+								"nested_computed": types.StringUnknown(),
+								"nested_required": types.StringValue("testvalue2"),
+							},
+						),
+						types.ObjectValueMust(
+							map[string]attr.Type{
+								"nested_computed": types.StringType,
+								"nested_required": types.StringType,
+							},
+							map[string]attr.Value{
+								"nested_computed": types.StringUnknown(),
+								"nested_required": types.StringValue("testvalue1"),
+							},
+						),
+					},
+				),
+				AttributeState: types.SetValueMust(
+					types.ObjectType{
+						AttrTypes: map[string]attr.Type{
+							"nested_computed": types.StringType,
+							"nested_required": types.StringType,
+						},
+					},
+					[]attr.Value{
+						types.ObjectValueMust(
+							map[string]attr.Type{
+								"nested_computed": types.StringType,
+								"nested_required": types.StringType,
+							},
+							map[string]attr.Value{
 								"nested_computed": types.StringValue("statevalue1"),
 								"nested_required": types.StringValue("testvalue1"),
 							},
@@ -594,6 +994,185 @@ func TestAttributeModifyPlan(t *testing.T) {
 						),
 					},
 				),
+			},
+			expectedResp: ModifyAttributePlanResponse{
+				AttributePlan: types.SetValueMust(
+					types.ObjectType{
+						AttrTypes: map[string]attr.Type{
+							"nested_computed": types.StringType,
+							"nested_required": types.StringType,
+						},
+					},
+					[]attr.Value{
+						types.ObjectValueMust(
+							map[string]attr.Type{
+								"nested_computed": types.StringType,
+								"nested_required": types.StringType,
+							},
+							map[string]attr.Value{
+								"nested_computed": types.StringUnknown(),
+								"nested_required": types.StringValue("testvalue2"),
+							},
+						),
+						types.ObjectValueMust(
+							map[string]attr.Type{
+								"nested_computed": types.StringType,
+								"nested_required": types.StringType,
+							},
+							map[string]attr.Value{
+								"nested_computed": types.StringUnknown(),
+								"nested_required": types.StringValue("testvalue1"),
+							},
+						),
+					},
+				),
+				Diagnostics: diag.Diagnostics{
+					planmodifierdiag.UseStateForUnknownUnderListOrSet(
+						path.Root("test").AtSetValue(
+							types.ObjectValueMust(
+								map[string]attr.Type{
+									"nested_computed": types.StringType,
+									"nested_required": types.StringType,
+								},
+								map[string]attr.Value{
+									"nested_computed": types.StringUnknown(),
+									"nested_required": types.StringValue("testvalue2"),
+								},
+							),
+						).AtName("nested_computed"),
+					),
+				},
+			},
+		},
+		"attribute-set-nested-nested-usestateforunknown-elements-removed": {
+			attribute: testschema.NestedAttribute{
+				NestedObject: testschema.NestedAttributeObject{
+					Attributes: map[string]fwschema.Attribute{
+						"nested_computed": testschema.AttributeWithStringPlanModifiers{
+							Computed: true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
+						},
+						"nested_required": testschema.Attribute{
+							Type:     types.StringType,
+							Required: true,
+						},
+					},
+				},
+				NestingMode: fwschema.NestingModeSet,
+				Required:    true,
+			},
+			req: ModifyAttributePlanRequest{
+				AttributeConfig: types.SetValueMust(
+					types.ObjectType{
+						AttrTypes: map[string]attr.Type{
+							"nested_computed": types.StringType,
+							"nested_required": types.StringType,
+						},
+					},
+					[]attr.Value{
+						types.ObjectValueMust(
+							map[string]attr.Type{
+								"nested_computed": types.StringType,
+								"nested_required": types.StringType,
+							},
+							map[string]attr.Value{
+								"nested_computed": types.StringNull(),
+								"nested_required": types.StringValue("testvalue2"), // prior state on index 0 is testvalue1
+							},
+						),
+					},
+				),
+				AttributePath: path.Root("test"),
+				AttributePlan: types.SetValueMust(
+					types.ObjectType{
+						AttrTypes: map[string]attr.Type{
+							"nested_computed": types.StringType,
+							"nested_required": types.StringType,
+						},
+					},
+					[]attr.Value{
+						types.ObjectValueMust(
+							map[string]attr.Type{
+								"nested_computed": types.StringType,
+								"nested_required": types.StringType,
+							},
+							map[string]attr.Value{
+								"nested_computed": types.StringUnknown(),
+								"nested_required": types.StringValue("testvalue2"),
+							},
+						),
+					},
+				),
+				AttributeState: types.SetValueMust(
+					types.ObjectType{
+						AttrTypes: map[string]attr.Type{
+							"nested_computed": types.StringType,
+							"nested_required": types.StringType,
+						},
+					},
+					[]attr.Value{
+						types.ObjectValueMust(
+							map[string]attr.Type{
+								"nested_computed": types.StringType,
+								"nested_required": types.StringType,
+							},
+							map[string]attr.Value{
+								"nested_computed": types.StringValue("statevalue1"),
+								"nested_required": types.StringValue("testvalue1"),
+							},
+						),
+						types.ObjectValueMust(
+							map[string]attr.Type{
+								"nested_computed": types.StringType,
+								"nested_required": types.StringType,
+							},
+							map[string]attr.Value{
+								"nested_computed": types.StringValue("statevalue2"),
+								"nested_required": types.StringValue("testvalue2"),
+							},
+						),
+					},
+				),
+			},
+			expectedResp: ModifyAttributePlanResponse{
+				AttributePlan: types.SetValueMust(
+					types.ObjectType{
+						AttrTypes: map[string]attr.Type{
+							"nested_computed": types.StringType,
+							"nested_required": types.StringType,
+						},
+					},
+					[]attr.Value{
+						types.ObjectValueMust(
+							map[string]attr.Type{
+								"nested_computed": types.StringType,
+								"nested_required": types.StringType,
+							},
+							map[string]attr.Value{
+								"nested_computed": types.StringUnknown(),
+								"nested_required": types.StringValue("testvalue2"),
+							},
+						),
+					},
+				),
+				Diagnostics: diag.Diagnostics{
+					planmodifierdiag.UseStateForUnknownUnderListOrSet(
+						path.Root("test").AtSetValue(
+							types.ObjectValueMust(
+								map[string]attr.Type{
+									"nested_computed": types.StringType,
+									"nested_required": types.StringType,
+								},
+								map[string]attr.Value{
+									"nested_computed": types.StringUnknown(),
+									"nested_required": types.StringValue("testvalue2"),
+								},
+							),
+						).AtName("nested_computed"),
+					),
+				},
 			},
 		},
 		"attribute-map-nested-private": {

--- a/internal/fwserver/schema_plan_modification_test.go
+++ b/internal/fwserver/schema_plan_modification_test.go
@@ -7,8 +7,10 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/planmodifierdiag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/privatestate"
 	"github.com/hashicorp/terraform-plugin-framework/internal/testing/planmodifiers"
 	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testplanmodifier"
@@ -1400,7 +1402,7 @@ func TestSchemaModifyPlan(t *testing.T) {
 											},
 										},
 										map[string]tftypes.Value{
-											"nested_computed": tftypes.NewValue(tftypes.String, "statevalue1"),
+											"nested_computed": tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
 											"nested_required": tftypes.NewValue(tftypes.String, "testvalue1"),
 										},
 									),
@@ -1412,7 +1414,7 @@ func TestSchemaModifyPlan(t *testing.T) {
 											},
 										},
 										map[string]tftypes.Value{
-											"nested_computed": tftypes.NewValue(tftypes.String, "statevalue2"),
+											"nested_computed": tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
 											"nested_required": tftypes.NewValue(tftypes.String, "testvalue2"),
 										},
 									),
@@ -1442,6 +1444,22 @@ func TestSchemaModifyPlan(t *testing.T) {
 							},
 						},
 					},
+				},
+				Diagnostics: diag.Diagnostics{
+					planmodifierdiag.UseStateForUnknownUnderListOrSet(
+						path.Root("test").AtSetValue(
+							types.ObjectValueMust(
+								map[string]attr.Type{
+									"nested_computed": types.StringType,
+									"nested_required": types.StringType,
+								},
+								map[string]attr.Value{
+									"nested_computed": types.StringUnknown(),
+									"nested_required": types.StringValue("testvalue1"),
+								},
+							),
+						).AtName("nested_computed"),
+					),
 				},
 			},
 		},

--- a/internal/parentpath/doc.go
+++ b/internal/parentpath/doc.go
@@ -1,0 +1,9 @@
+// Package parentpath contains path functionality intended for previous steps
+// of a given Path or Expression.
+//
+// This functionality is not included in the exported path package because
+// its external utility is unknown and being unexported means the functionality
+// can be modified without violating compatibility promises. If provider
+// developers are interested in any of this functionality, relevant parts can
+// be migrated to the path package or by creating a path/parentpath package.
+package parentpath

--- a/internal/parentpath/has_list_or_set.go
+++ b/internal/parentpath/has_list_or_set.go
@@ -1,0 +1,20 @@
+package parentpath
+
+import "github.com/hashicorp/terraform-plugin-framework/path"
+
+// HasListOrSet returns true if any step of given path is a list or set. This
+// cannot detect if the last step is a list or set.
+//
+// This functionality could also theoretically be a method on the path.Path
+// type, e.g. ParentHasListOrSet(), rather than a separate parentpath function.
+func HasListOrSet(p path.Path) bool {
+	for _, pathStep := range p.Steps() {
+		switch pathStep.(type) {
+		case path.PathStepElementKeyInt, path.PathStepElementKeyValue:
+			// This type of step is after a list or set attribute
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/parentpath/has_list_or_set_test.go
+++ b/internal/parentpath/has_list_or_set_test.go
@@ -1,0 +1,187 @@
+package parentpath_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/internal/parentpath"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestHasListOrSet(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		path     path.Path
+		expected bool
+	}{
+		"empty": {
+			path:     path.Empty(),
+			expected: false,
+		},
+		"AttributeName": {
+			path:     path.Root("test"),
+			expected: false,
+		},
+		"AttributeName-AttributeName": {
+			path:     path.Root("test").AtName("nested_test"),
+			expected: false,
+		},
+		"AttributeName-AttributeName-ElementKeyInt": {
+			path:     path.Root("test").AtName("nested_test").AtListIndex(0),
+			expected: true,
+		},
+		"AttributeName-AttributeName-ElementKeyInt-AttributeName": {
+			path:     path.Root("test").AtName("nested_test").AtListIndex(0).AtName("nested_nested_test"),
+			expected: true,
+		},
+		"AttributeName-AttributeName-ElementKeyString": {
+			path:     path.Root("test").AtMapKey("testkey"),
+			expected: false,
+		},
+		"AttributeName-AttributeName-ElementKeyValue": {
+			path: path.Root("test").AtSetValue(
+				types.SetValueMust(
+					types.StringType,
+					[]attr.Value{types.StringValue("testvalue")},
+				),
+			),
+			expected: true,
+		},
+		"AttributeName-ElementKeyInt": {
+			path:     path.Root("test").AtListIndex(0),
+			expected: true,
+		},
+		"AttributeName-ElementKeyInt-AttributeName": {
+			path:     path.Root("test").AtListIndex(0).AtName("nested_test"),
+			expected: true,
+		},
+		"AttributeName-ElementKeyInt-ElementKeyInt": {
+			path:     path.Root("test").AtListIndex(0).AtListIndex(0),
+			expected: true,
+		},
+		"AttributeName-ElementKeyInt-ElementKeyString": {
+			path:     path.Root("test").AtListIndex(0).AtMapKey("testkey"),
+			expected: true,
+		},
+		"AttributeName-ElementKeyInt-ElementKeyValue": {
+			path: path.Root("test").AtSetValue(
+				types.SetValueMust(
+					types.StringType,
+					[]attr.Value{types.StringValue("testvalue")},
+				),
+			),
+			expected: true,
+		},
+		"AttributeName-ElementKeyString": {
+			path:     path.Root("test").AtMapKey("testkey"),
+			expected: false,
+		},
+		"AttributeName-ElementKeyString-AttributeName": {
+			path:     path.Root("test").AtMapKey("testkey").AtName("nested_test"),
+			expected: false,
+		},
+		"AttributeName-ElementKeyString-AttributeName-ElementKeyInt": {
+			path:     path.Root("test").AtMapKey("testkey").AtName("nested_test").AtListIndex(0),
+			expected: true,
+		},
+		"AttributeName-ElementKeyString-AttributeName-ElementKeyInt-AttributeName": {
+			path:     path.Root("test").AtMapKey("testkey").AtName("nested_test").AtListIndex(0).AtName("nested_nested_test"),
+			expected: true,
+		},
+		"AttributeName-ElementKeyString-ElementKeyInt": {
+			path:     path.Root("test").AtMapKey("testkey").AtListIndex(0),
+			expected: true,
+		},
+		"AttributeName-ElementKeyString-ElementKeyInt-AttributeName": {
+			path:     path.Root("test").AtMapKey("testkey").AtListIndex(0).AtName("nested_test"),
+			expected: true,
+		},
+		"AttributeName-ElementKeyString-ElementKeyString": {
+			path:     path.Root("test").AtMapKey("testkey").AtMapKey("nested_testkey"),
+			expected: false,
+		},
+		"AttributeName-ElementKeyString-ElementKeyValue": {
+			path: path.Root("test").AtMapKey("testkey").AtSetValue(
+				types.SetValueMust(
+					types.StringType,
+					[]attr.Value{types.StringValue("testvalue")},
+				),
+			),
+			expected: true,
+		},
+		"AttributeName-ElementKeyValue": {
+			path: path.Root("test").AtSetValue(
+				types.SetValueMust(
+					types.StringType,
+					[]attr.Value{types.StringValue("testvalue")},
+				),
+			),
+			expected: true,
+		},
+		"AttributeName-ElementKeyValue-AttributeName": {
+			path: path.Root("test").AtSetValue(
+				types.SetValueMust(
+					types.StringType,
+					[]attr.Value{types.StringValue("testvalue")},
+				),
+			).AtName("nested_test"),
+			expected: true,
+		},
+		"AttributeName-ElementKeyValue-ElementKeyInt": {
+			path: path.Root("test").AtSetValue(
+				types.SetValueMust(
+					types.StringType,
+					[]attr.Value{types.StringValue("testvalue")},
+				),
+			).AtListIndex(0),
+			expected: true,
+		},
+		"AttributeName-ElementKeyValue-ElementKeyString": {
+			path: path.Root("test").AtSetValue(
+				types.SetValueMust(
+					types.StringType,
+					[]attr.Value{types.StringValue("testvalue")},
+				),
+			).AtMapKey("testkey"),
+			expected: true,
+		},
+		"AttributeName-ElementKeyValue-ElementKeyValue": {
+			path: path.Root("test").AtSetValue(
+				types.SetValueMust(
+					types.SetType{
+						ElemType: types.StringType,
+					},
+					[]attr.Value{
+						types.SetValueMust(
+							types.StringType,
+							[]attr.Value{types.StringValue("testvalue")},
+						),
+					},
+				),
+			).AtSetValue(
+				types.SetValueMust(
+					types.StringType,
+					[]attr.Value{types.StringValue("testvalue")},
+				),
+			),
+			expected: true,
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := parentpath.HasListOrSet(testCase.path)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}

--- a/internal/planmodifierdiag/doc.go
+++ b/internal/planmodifierdiag/doc.go
@@ -1,0 +1,3 @@
+// Package planmodifierdiag contains shared diag.Diagnostic for
+// framework-defined schema plan modifiers.
+package planmodifierdiag

--- a/internal/planmodifierdiag/use_state_for_unknown.go
+++ b/internal/planmodifierdiag/use_state_for_unknown.go
@@ -1,0 +1,23 @@
+package planmodifierdiag
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+)
+
+// UseStateForUnknownUnderListOrSet returns an error diagnostic intended for
+// when the UseStateForUnknown schema plan modifier is under a list or set.
+func UseStateForUnknownUnderListOrSet(p path.Path) diag.Diagnostic {
+	return diag.NewAttributeErrorDiagnostic(
+		p,
+		"Invalid Attribute Schema",
+		"Attributes under a list or set cannot use the UseStateForUnknown() plan modifier. "+
+			// TODO: Implement MatchElementStateForUnknown plan modifiers.
+			// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/717
+			// "Use the MatchElementStateForUnknown() plan modifier instead. "+
+			"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+			fmt.Sprintf("Path: %s\n", p),
+	)
+}

--- a/internal/planmodifierdiag/use_state_for_unknown_test.go
+++ b/internal/planmodifierdiag/use_state_for_unknown_test.go
@@ -1,0 +1,47 @@
+package planmodifierdiag_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/internal/planmodifierdiag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+)
+
+func TestUseStateForUnknownUnderListOrSet(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		path     path.Path
+		expected diag.Diagnostic
+	}{
+		"test": {
+			path: path.Root("test"),
+			expected: diag.NewAttributeErrorDiagnostic(
+				path.Root("test"),
+				"Invalid Attribute Schema",
+				"Attributes under a list or set cannot use the UseStateForUnknown() plan modifier. "+
+					// TODO: Implement MatchElementStateForUnknown plan modifiers.
+					// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/717
+					// "Use the MatchElementStateForUnknown() plan modifier instead. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					"Path: test\n",
+			),
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := planmodifierdiag.UseStateForUnknownUnderListOrSet(testCase.path)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}

--- a/resource/schema/boolplanmodifier/use_state_for_unknown.go
+++ b/resource/schema/boolplanmodifier/use_state_for_unknown.go
@@ -16,6 +16,11 @@ import (
 // and Computed attributes to an unknown value "(known after apply)" on update.
 // Using this plan modifier will instead display the prior state value in the
 // plan, unless a prior plan modifier adjusts the value.
+//
+// To prevent data issues and Terraform errors, this plan modifier cannot be
+// implemented on attribute values beneath lists or sets. An implementation
+// error diagnostic is raised the plan modifier logic detects a list or set
+// in the request path.
 func UseStateForUnknown() planmodifier.Bool {
 	return useStateForUnknownModifier{}
 }

--- a/resource/schema/boolplanmodifier/use_state_for_unknown.go
+++ b/resource/schema/boolplanmodifier/use_state_for_unknown.go
@@ -19,7 +19,7 @@ import (
 //
 // To prevent data issues and Terraform errors, this plan modifier cannot be
 // implemented on attribute values beneath lists or sets. An implementation
-// error diagnostic is raised the plan modifier logic detects a list or set
+// error diagnostic is raised if the plan modifier logic detects a list or set
 // in the request path.
 func UseStateForUnknown() planmodifier.Bool {
 	return useStateForUnknownModifier{}

--- a/resource/schema/float64planmodifier/use_state_for_unknown.go
+++ b/resource/schema/float64planmodifier/use_state_for_unknown.go
@@ -16,6 +16,11 @@ import (
 // and Computed attributes to an unknown value "(known after apply)" on update.
 // Using this plan modifier will instead display the prior state value in the
 // plan, unless a prior plan modifier adjusts the value.
+//
+// To prevent data issues and Terraform errors, this plan modifier cannot be
+// implemented on attribute values beneath lists or sets. An implementation
+// error diagnostic is raised the plan modifier logic detects a list or set
+// in the request path.
 func UseStateForUnknown() planmodifier.Float64 {
 	return useStateForUnknownModifier{}
 }

--- a/resource/schema/float64planmodifier/use_state_for_unknown.go
+++ b/resource/schema/float64planmodifier/use_state_for_unknown.go
@@ -3,6 +3,8 @@ package float64planmodifier
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework/internal/parentpath"
+	"github.com/hashicorp/terraform-plugin-framework/internal/planmodifierdiag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 )
 
@@ -33,6 +35,19 @@ func (m useStateForUnknownModifier) MarkdownDescription(_ context.Context) strin
 
 // PlanModifyFloat64 implements the plan modification logic.
 func (m useStateForUnknownModifier) PlanModifyFloat64(_ context.Context, req planmodifier.Float64Request, resp *planmodifier.Float64Response) {
+	// Verify this plan modifier is not being used beneath a list or set.
+	// Lists and sets do not have a generic methodology to identify/track
+	// an element if rearranged, especially within an object with multiple
+	// computed attribute values. Only the provider can determine which
+	// underlying values in an element are significant to realign a prior
+	// state value during updates.
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/709
+	if parentpath.HasListOrSet(req.Path) {
+		resp.Diagnostics.Append(planmodifierdiag.UseStateForUnknownUnderListOrSet(req.Path))
+
+		return
+	}
+
 	// Do nothing if there is no state value.
 	if req.StateValue.IsNull() {
 		return

--- a/resource/schema/float64planmodifier/use_state_for_unknown.go
+++ b/resource/schema/float64planmodifier/use_state_for_unknown.go
@@ -19,7 +19,7 @@ import (
 //
 // To prevent data issues and Terraform errors, this plan modifier cannot be
 // implemented on attribute values beneath lists or sets. An implementation
-// error diagnostic is raised the plan modifier logic detects a list or set
+// error diagnostic is raised if the plan modifier logic detects a list or set
 // in the request path.
 func UseStateForUnknown() planmodifier.Float64 {
 	return useStateForUnknownModifier{}

--- a/resource/schema/int64planmodifier/use_state_for_unknown.go
+++ b/resource/schema/int64planmodifier/use_state_for_unknown.go
@@ -19,7 +19,7 @@ import (
 //
 // To prevent data issues and Terraform errors, this plan modifier cannot be
 // implemented on attribute values beneath lists or sets. An implementation
-// error diagnostic is raised the plan modifier logic detects a list or set
+// error diagnostic is raised if the plan modifier logic detects a list or set
 // in the request path.
 func UseStateForUnknown() planmodifier.Int64 {
 	return useStateForUnknownModifier{}

--- a/resource/schema/int64planmodifier/use_state_for_unknown.go
+++ b/resource/schema/int64planmodifier/use_state_for_unknown.go
@@ -3,6 +3,8 @@ package int64planmodifier
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework/internal/parentpath"
+	"github.com/hashicorp/terraform-plugin-framework/internal/planmodifierdiag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 )
 
@@ -33,6 +35,19 @@ func (m useStateForUnknownModifier) MarkdownDescription(_ context.Context) strin
 
 // PlanModifyInt64 implements the plan modification logic.
 func (m useStateForUnknownModifier) PlanModifyInt64(_ context.Context, req planmodifier.Int64Request, resp *planmodifier.Int64Response) {
+	// Verify this plan modifier is not being used beneath a list or set.
+	// Lists and sets do not have a generic methodology to identify/track
+	// an element if rearranged, especially within an object with multiple
+	// computed attribute values. Only the provider can determine which
+	// underlying values in an element are significant to realign a prior
+	// state value during updates.
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/709
+	if parentpath.HasListOrSet(req.Path) {
+		resp.Diagnostics.Append(planmodifierdiag.UseStateForUnknownUnderListOrSet(req.Path))
+
+		return
+	}
+
 	// Do nothing if there is no state value.
 	if req.StateValue.IsNull() {
 		return

--- a/resource/schema/int64planmodifier/use_state_for_unknown.go
+++ b/resource/schema/int64planmodifier/use_state_for_unknown.go
@@ -16,6 +16,11 @@ import (
 // and Computed attributes to an unknown value "(known after apply)" on update.
 // Using this plan modifier will instead display the prior state value in the
 // plan, unless a prior plan modifier adjusts the value.
+//
+// To prevent data issues and Terraform errors, this plan modifier cannot be
+// implemented on attribute values beneath lists or sets. An implementation
+// error diagnostic is raised the plan modifier logic detects a list or set
+// in the request path.
 func UseStateForUnknown() planmodifier.Int64 {
 	return useStateForUnknownModifier{}
 }

--- a/resource/schema/listplanmodifier/use_state_for_unknown.go
+++ b/resource/schema/listplanmodifier/use_state_for_unknown.go
@@ -16,6 +16,11 @@ import (
 // and Computed attributes to an unknown value "(known after apply)" on update.
 // Using this plan modifier will instead display the prior state value in the
 // plan, unless a prior plan modifier adjusts the value.
+//
+// To prevent data issues and Terraform errors, this plan modifier cannot be
+// implemented on attribute values beneath lists or sets. An implementation
+// error diagnostic is raised the plan modifier logic detects a list or set
+// in the request path.
 func UseStateForUnknown() planmodifier.List {
 	return useStateForUnknownModifier{}
 }

--- a/resource/schema/listplanmodifier/use_state_for_unknown.go
+++ b/resource/schema/listplanmodifier/use_state_for_unknown.go
@@ -3,6 +3,8 @@ package listplanmodifier
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework/internal/parentpath"
+	"github.com/hashicorp/terraform-plugin-framework/internal/planmodifierdiag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 )
 
@@ -33,6 +35,19 @@ func (m useStateForUnknownModifier) MarkdownDescription(_ context.Context) strin
 
 // PlanModifyList implements the plan modification logic.
 func (m useStateForUnknownModifier) PlanModifyList(_ context.Context, req planmodifier.ListRequest, resp *planmodifier.ListResponse) {
+	// Verify this plan modifier is not being used beneath a list or set.
+	// Lists and sets do not have a generic methodology to identify/track
+	// an element if rearranged, especially within an object with multiple
+	// computed attribute values. Only the provider can determine which
+	// underlying values in an element are significant to realign a prior
+	// state value during updates.
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/709
+	if parentpath.HasListOrSet(req.Path) {
+		resp.Diagnostics.Append(planmodifierdiag.UseStateForUnknownUnderListOrSet(req.Path))
+
+		return
+	}
+
 	// Do nothing if there is no state value.
 	if req.StateValue.IsNull() {
 		return

--- a/resource/schema/listplanmodifier/use_state_for_unknown.go
+++ b/resource/schema/listplanmodifier/use_state_for_unknown.go
@@ -19,7 +19,7 @@ import (
 //
 // To prevent data issues and Terraform errors, this plan modifier cannot be
 // implemented on attribute values beneath lists or sets. An implementation
-// error diagnostic is raised the plan modifier logic detects a list or set
+// error diagnostic is raised if the plan modifier logic detects a list or set
 // in the request path.
 func UseStateForUnknown() planmodifier.List {
 	return useStateForUnknownModifier{}

--- a/resource/schema/listplanmodifier/use_state_for_unknown_test.go
+++ b/resource/schema/listplanmodifier/use_state_for_unknown_test.go
@@ -6,6 +6,9 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/internal/planmodifierdiag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -71,6 +74,74 @@ func TestUseStateForUnknownModifierPlanModifyList(t *testing.T) {
 				ConfigValue: types.ListUnknown(types.StringType),
 			},
 			expected: &planmodifier.ListResponse{
+				PlanValue: types.ListUnknown(types.StringType),
+			},
+		},
+		"under-list": {
+			request: planmodifier.ListRequest{
+				ConfigValue: types.ListNull(types.StringType),
+				Path:        path.Root("test").AtListIndex(0).AtName("nested_test"),
+				PlanValue:   types.ListUnknown(types.StringType),
+				StateValue:  types.ListNull(types.StringType),
+			},
+			expected: &planmodifier.ListResponse{
+				Diagnostics: diag.Diagnostics{
+					planmodifierdiag.UseStateForUnknownUnderListOrSet(
+						path.Root("test").AtListIndex(0).AtName("nested_test"),
+					),
+				},
+				PlanValue: types.ListUnknown(types.StringType),
+			},
+		},
+		"under-set": {
+			request: planmodifier.ListRequest{
+				ConfigValue: types.ListNull(types.StringType),
+				Path: path.Root("test").AtSetValue(
+					types.SetValueMust(
+						types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"nested_test": types.ListType{ElemType: types.StringType},
+							},
+						},
+						[]attr.Value{
+							types.ObjectValueMust(
+								map[string]attr.Type{
+									"nested_test": types.ListType{ElemType: types.StringType},
+								},
+								map[string]attr.Value{
+									"nested_test": types.ListUnknown(types.StringType),
+								},
+							),
+						},
+					),
+				).AtName("nested_test"),
+				PlanValue:  types.ListUnknown(types.StringType),
+				StateValue: types.ListNull(types.StringType),
+			},
+			expected: &planmodifier.ListResponse{
+				Diagnostics: diag.Diagnostics{
+					planmodifierdiag.UseStateForUnknownUnderListOrSet(
+						path.Root("test").AtSetValue(
+							types.SetValueMust(
+								types.ObjectType{
+									AttrTypes: map[string]attr.Type{
+										"nested_test": types.ListType{ElemType: types.StringType},
+									},
+								},
+								[]attr.Value{
+									types.ObjectValueMust(
+										map[string]attr.Type{
+											"nested_test": types.ListType{ElemType: types.StringType},
+										},
+										map[string]attr.Value{
+											"nested_test": types.ListUnknown(types.StringType),
+										},
+									),
+								},
+							),
+						).AtName("nested_test"),
+					),
+				},
 				PlanValue: types.ListUnknown(types.StringType),
 			},
 		},

--- a/resource/schema/mapplanmodifier/use_state_for_unknown.go
+++ b/resource/schema/mapplanmodifier/use_state_for_unknown.go
@@ -19,7 +19,7 @@ import (
 //
 // To prevent data issues and Terraform errors, this plan modifier cannot be
 // implemented on attribute values beneath lists or sets. An implementation
-// error diagnostic is raised the plan modifier logic detects a list or set
+// error diagnostic is raised if the plan modifier logic detects a list or set
 // in the request path.
 func UseStateForUnknown() planmodifier.Map {
 	return useStateForUnknownModifier{}

--- a/resource/schema/mapplanmodifier/use_state_for_unknown.go
+++ b/resource/schema/mapplanmodifier/use_state_for_unknown.go
@@ -3,6 +3,8 @@ package mapplanmodifier
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework/internal/parentpath"
+	"github.com/hashicorp/terraform-plugin-framework/internal/planmodifierdiag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 )
 
@@ -33,6 +35,19 @@ func (m useStateForUnknownModifier) MarkdownDescription(_ context.Context) strin
 
 // PlanModifyMap implements the plan modification logic.
 func (m useStateForUnknownModifier) PlanModifyMap(_ context.Context, req planmodifier.MapRequest, resp *planmodifier.MapResponse) {
+	// Verify this plan modifier is not being used beneath a list or set.
+	// Lists and sets do not have a generic methodology to identify/track
+	// an element if rearranged, especially within an object with multiple
+	// computed attribute values. Only the provider can determine which
+	// underlying values in an element are significant to realign a prior
+	// state value during updates.
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/709
+	if parentpath.HasListOrSet(req.Path) {
+		resp.Diagnostics.Append(planmodifierdiag.UseStateForUnknownUnderListOrSet(req.Path))
+
+		return
+	}
+
 	// Do nothing if there is no state value.
 	if req.StateValue.IsNull() {
 		return

--- a/resource/schema/mapplanmodifier/use_state_for_unknown.go
+++ b/resource/schema/mapplanmodifier/use_state_for_unknown.go
@@ -16,6 +16,11 @@ import (
 // and Computed attributes to an unknown value "(known after apply)" on update.
 // Using this plan modifier will instead display the prior state value in the
 // plan, unless a prior plan modifier adjusts the value.
+//
+// To prevent data issues and Terraform errors, this plan modifier cannot be
+// implemented on attribute values beneath lists or sets. An implementation
+// error diagnostic is raised the plan modifier logic detects a list or set
+// in the request path.
 func UseStateForUnknown() planmodifier.Map {
 	return useStateForUnknownModifier{}
 }

--- a/resource/schema/numberplanmodifier/use_state_for_unknown.go
+++ b/resource/schema/numberplanmodifier/use_state_for_unknown.go
@@ -3,6 +3,8 @@ package numberplanmodifier
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework/internal/parentpath"
+	"github.com/hashicorp/terraform-plugin-framework/internal/planmodifierdiag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 )
 
@@ -33,6 +35,19 @@ func (m useStateForUnknownModifier) MarkdownDescription(_ context.Context) strin
 
 // PlanModifyNumber implements the plan modification logic.
 func (m useStateForUnknownModifier) PlanModifyNumber(_ context.Context, req planmodifier.NumberRequest, resp *planmodifier.NumberResponse) {
+	// Verify this plan modifier is not being used beneath a list or set.
+	// Lists and sets do not have a generic methodology to identify/track
+	// an element if rearranged, especially within an object with multiple
+	// computed attribute values. Only the provider can determine which
+	// underlying values in an element are significant to realign a prior
+	// state value during updates.
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/709
+	if parentpath.HasListOrSet(req.Path) {
+		resp.Diagnostics.Append(planmodifierdiag.UseStateForUnknownUnderListOrSet(req.Path))
+
+		return
+	}
+
 	// Do nothing if there is no state value.
 	if req.StateValue.IsNull() {
 		return

--- a/resource/schema/numberplanmodifier/use_state_for_unknown.go
+++ b/resource/schema/numberplanmodifier/use_state_for_unknown.go
@@ -19,7 +19,7 @@ import (
 //
 // To prevent data issues and Terraform errors, this plan modifier cannot be
 // implemented on attribute values beneath lists or sets. An implementation
-// error diagnostic is raised the plan modifier logic detects a list or set
+// error diagnostic is raised if the plan modifier logic detects a list or set
 // in the request path.
 func UseStateForUnknown() planmodifier.Number {
 	return useStateForUnknownModifier{}

--- a/resource/schema/numberplanmodifier/use_state_for_unknown.go
+++ b/resource/schema/numberplanmodifier/use_state_for_unknown.go
@@ -16,6 +16,11 @@ import (
 // and Computed attributes to an unknown value "(known after apply)" on update.
 // Using this plan modifier will instead display the prior state value in the
 // plan, unless a prior plan modifier adjusts the value.
+//
+// To prevent data issues and Terraform errors, this plan modifier cannot be
+// implemented on attribute values beneath lists or sets. An implementation
+// error diagnostic is raised the plan modifier logic detects a list or set
+// in the request path.
 func UseStateForUnknown() planmodifier.Number {
 	return useStateForUnknownModifier{}
 }

--- a/resource/schema/objectplanmodifier/use_state_for_unknown.go
+++ b/resource/schema/objectplanmodifier/use_state_for_unknown.go
@@ -3,6 +3,8 @@ package objectplanmodifier
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework/internal/parentpath"
+	"github.com/hashicorp/terraform-plugin-framework/internal/planmodifierdiag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 )
 
@@ -33,6 +35,19 @@ func (m useStateForUnknownModifier) MarkdownDescription(_ context.Context) strin
 
 // PlanModifyObject implements the plan modification logic.
 func (m useStateForUnknownModifier) PlanModifyObject(_ context.Context, req planmodifier.ObjectRequest, resp *planmodifier.ObjectResponse) {
+	// Verify this plan modifier is not being used beneath a list or set.
+	// Lists and sets do not have a generic methodology to identify/track
+	// an element if rearranged, especially within an object with multiple
+	// computed attribute values. Only the provider can determine which
+	// underlying values in an element are significant to realign a prior
+	// state value during updates.
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/709
+	if parentpath.HasListOrSet(req.Path) {
+		resp.Diagnostics.Append(planmodifierdiag.UseStateForUnknownUnderListOrSet(req.Path))
+
+		return
+	}
+
 	// Do nothing if there is no state value.
 	if req.StateValue.IsNull() {
 		return

--- a/resource/schema/objectplanmodifier/use_state_for_unknown.go
+++ b/resource/schema/objectplanmodifier/use_state_for_unknown.go
@@ -19,7 +19,7 @@ import (
 //
 // To prevent data issues and Terraform errors, this plan modifier cannot be
 // implemented on attribute values beneath lists or sets. An implementation
-// error diagnostic is raised the plan modifier logic detects a list or set
+// error diagnostic is raised if the plan modifier logic detects a list or set
 // in the request path.
 func UseStateForUnknown() planmodifier.Object {
 	return useStateForUnknownModifier{}

--- a/resource/schema/objectplanmodifier/use_state_for_unknown.go
+++ b/resource/schema/objectplanmodifier/use_state_for_unknown.go
@@ -16,6 +16,11 @@ import (
 // and Computed attributes to an unknown value "(known after apply)" on update.
 // Using this plan modifier will instead display the prior state value in the
 // plan, unless a prior plan modifier adjusts the value.
+//
+// To prevent data issues and Terraform errors, this plan modifier cannot be
+// implemented on attribute values beneath lists or sets. An implementation
+// error diagnostic is raised the plan modifier logic detects a list or set
+// in the request path.
 func UseStateForUnknown() planmodifier.Object {
 	return useStateForUnknownModifier{}
 }

--- a/resource/schema/setplanmodifier/use_state_for_unknown.go
+++ b/resource/schema/setplanmodifier/use_state_for_unknown.go
@@ -16,6 +16,11 @@ import (
 // and Computed attributes to an unknown value "(known after apply)" on update.
 // Using this plan modifier will instead display the prior state value in the
 // plan, unless a prior plan modifier adjusts the value.
+//
+// To prevent data issues and Terraform errors, this plan modifier cannot be
+// implemented on attribute values beneath lists or sets. An implementation
+// error diagnostic is raised the plan modifier logic detects a list or set
+// in the request path.
 func UseStateForUnknown() planmodifier.Set {
 	return useStateForUnknownModifier{}
 }

--- a/resource/schema/setplanmodifier/use_state_for_unknown.go
+++ b/resource/schema/setplanmodifier/use_state_for_unknown.go
@@ -3,6 +3,8 @@ package setplanmodifier
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework/internal/parentpath"
+	"github.com/hashicorp/terraform-plugin-framework/internal/planmodifierdiag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 )
 
@@ -33,6 +35,19 @@ func (m useStateForUnknownModifier) MarkdownDescription(_ context.Context) strin
 
 // PlanModifySet implements the plan modification logic.
 func (m useStateForUnknownModifier) PlanModifySet(_ context.Context, req planmodifier.SetRequest, resp *planmodifier.SetResponse) {
+	// Verify this plan modifier is not being used beneath a list or set.
+	// Lists and sets do not have a generic methodology to identify/track
+	// an element if rearranged, especially within an object with multiple
+	// computed attribute values. Only the provider can determine which
+	// underlying values in an element are significant to realign a prior
+	// state value during updates.
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/709
+	if parentpath.HasListOrSet(req.Path) {
+		resp.Diagnostics.Append(planmodifierdiag.UseStateForUnknownUnderListOrSet(req.Path))
+
+		return
+	}
+
 	// Do nothing if there is no state value.
 	if req.StateValue.IsNull() {
 		return

--- a/resource/schema/setplanmodifier/use_state_for_unknown.go
+++ b/resource/schema/setplanmodifier/use_state_for_unknown.go
@@ -19,7 +19,7 @@ import (
 //
 // To prevent data issues and Terraform errors, this plan modifier cannot be
 // implemented on attribute values beneath lists or sets. An implementation
-// error diagnostic is raised the plan modifier logic detects a list or set
+// error diagnostic is raised if the plan modifier logic detects a list or set
 // in the request path.
 func UseStateForUnknown() planmodifier.Set {
 	return useStateForUnknownModifier{}

--- a/resource/schema/stringplanmodifier/use_state_for_unknown.go
+++ b/resource/schema/stringplanmodifier/use_state_for_unknown.go
@@ -16,6 +16,11 @@ import (
 // and Computed attributes to an unknown value "(known after apply)" on update.
 // Using this plan modifier will instead display the prior state value in the
 // plan, unless a prior plan modifier adjusts the value.
+//
+// To prevent data issues and Terraform errors, this plan modifier cannot be
+// implemented on attribute values beneath lists or sets. An implementation
+// error diagnostic is raised the plan modifier logic detects a list or set
+// in the request path.
 func UseStateForUnknown() planmodifier.String {
 	return useStateForUnknownModifier{}
 }

--- a/resource/schema/stringplanmodifier/use_state_for_unknown.go
+++ b/resource/schema/stringplanmodifier/use_state_for_unknown.go
@@ -19,7 +19,7 @@ import (
 //
 // To prevent data issues and Terraform errors, this plan modifier cannot be
 // implemented on attribute values beneath lists or sets. An implementation
-// error diagnostic is raised the plan modifier logic detects a list or set
+// error diagnostic is raised if the plan modifier logic detects a list or set
 // in the request path.
 func UseStateForUnknown() planmodifier.String {
 	return useStateForUnknownModifier{}

--- a/resource/schema/stringplanmodifier/use_state_for_unknown.go
+++ b/resource/schema/stringplanmodifier/use_state_for_unknown.go
@@ -3,6 +3,8 @@ package stringplanmodifier
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework/internal/parentpath"
+	"github.com/hashicorp/terraform-plugin-framework/internal/planmodifierdiag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 )
 
@@ -32,7 +34,20 @@ func (m useStateForUnknownModifier) MarkdownDescription(_ context.Context) strin
 }
 
 // PlanModifyString implements the plan modification logic.
-func (m useStateForUnknownModifier) PlanModifyString(_ context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+func (m useStateForUnknownModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	// Verify this plan modifier is not being used beneath a list or set.
+	// Lists and sets do not have a generic methodology to identify/track
+	// an element if rearranged, especially within an object with multiple
+	// computed attribute values. Only the provider can determine which
+	// underlying values in an element are significant to realign a prior
+	// state value during updates.
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/709
+	if parentpath.HasListOrSet(req.Path) {
+		resp.Diagnostics.Append(planmodifierdiag.UseStateForUnknownUnderListOrSet(req.Path))
+
+		return
+	}
+
 	// Do nothing if there is no state value.
 	if req.StateValue.IsNull() {
 		return

--- a/website/docs/plugin/framework/resources/plan-modification.mdx
+++ b/website/docs/plugin/framework/resources/plan-modification.mdx
@@ -113,6 +113,59 @@ func UseStateForUnknown() planmodifier.Bool {
 }
 ```
 
+### Caveats
+
+#### Terraform Data Consistency Rules
+
+Terraform core [implements data consistency rules](https://github.com/hashicorp/terraform/blob/main/docs/resource-instance-change-lifecycle.md) between configuration, plan, and state data. For example, if an attribute value is configured, it is never valid to change that value in the plan except being set to null on resource destroy. The framework does not raise its own targeted errors in many situations, so it is the responsibility of the developer to account for these rules when implementing plan modification logic.
+
+#### Prior State Under Lists and Sets
+
+Attribute plan modifiers under the following must take special consideration if they rely on prior state data:
+
+- List nested attributes
+- List nested blocks
+- Set nested attributes
+- Set nested blocks
+
+These data structures are implemented based on array indexing, which the framework always sends the exact representation given across the protocol. If list/set elements are rearranged or removed, Terraform nor the framework performs any re-alignment of prior state for those elements.
+
+In this example, potentially unexpected prior state may be given to attribute plan modifier request:
+
+- A list nested attribute with two elements in configuration is saved into state
+- The configuration for the first element is removed
+- The list nested attribute with now one element still receives the prior state of the first element
+
+#### Checking Resource Change Operations
+
+Plan modifiers execute on all resource change operations: creation, update, and destroy. If the plan modification logic is sensitive to these details, check the request data to determine the current operation.
+
+Implement the following to check whether the resource is being created:
+
+```go
+func (m ExampleModifier) PlanModifyString(_ context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+    // Check if the resource is being created.
+    if req.State.Raw.IsNull() {
+        // ...
+    }
+
+    // ...
+}
+```
+
+Implement the following to check whether the resource is being created:
+
+```go
+func (m ExampleModifier) PlanModifyString(_ context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+    // Check if the resource is being destroyed.
+    if req.Plan.Raw.IsNull() {
+        // ...
+    }
+
+    // ...
+}
+```
+
 ## Resource Plan Modification
 
 Resources also support plan modification across all attributes. This is helpful when working with logic that applies to the resource as a whole, or in Terraform 1.3 and later, to return diagnostics during resource destruction. Implement the [`resource.ResourceWithModifyPlan` interface](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#ResourceWithModifyPlan) to support resource-level plan modification. For example:


### PR DESCRIPTION
Closes #709
Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/717

This change will adjust the `UseStateForUnknown` plan modifiers to return an implementation error if defined on an attribute below a list or set. In any cases where the list or set elements were rearranged or removed, the plan modifier result could cause invalid data being proposed in the plan or Terraform data consistency errors. These situations require additional value identifying information from the provider developer to ensure that the prior state for an element is correctly realigned, however the `UseStateForUnknown` plan modifier takes no parameters for such information and adding those parameters would represent a breaking change to the function signature. Future framework proposals will investigate whether a second plan modifier can be introduced to cover this situation.

The new plan modification unit tests reproduced the issue prior to the new implementation error:

```
--- FAIL: TestAttributeModifyPlan (0.00s)
    --- FAIL: TestAttributeModifyPlan/attribute-set-nested-nested-usestateforunknown-elements-rearranged (0.00s)
        attribute_plan_modification_test.go:1627: Unexpected response (-wanted, +got):   fwserver.ModifyAttributePlanResponse{
            - 	AttributePlan:   s`[{"nested_computed":"statevalue2","nested_required":"testvalue2"},{"nested_computed":"statevalue1","nested_required":"testvalue1"}]`,
            + 	AttributePlan:   s`[{"nested_computed":"statevalue1","nested_required":"testvalue2"},{"nested_computed":"statevalue2","nested_required":"testvalue1"}]`,
              	Diagnostics:     nil,
              	RequiresReplace: s"[]",
              	Private:         nil,
              }
    --- FAIL: TestAttributeModifyPlan/attribute-set-nested-nested-usestateforunknown-elements-removed (0.00s)
        attribute_plan_modification_test.go:1627: Unexpected response (-wanted, +got):   fwserver.ModifyAttributePlanResponse{
            - 	AttributePlan:   s`[{"nested_computed":"statevalue2","nested_required":"testvalue2"}]`,
            + 	AttributePlan:   s`[{"nested_computed":"statevalue1","nested_required":"testvalue2"}]`,
              	Diagnostics:     nil,
              	RequiresReplace: s"[]",
              	Private:         nil,
              }
    --- FAIL: TestAttributeModifyPlan/attribute-list-nested-nested-usestateforunknown-elements-removed (0.00s)
        attribute_plan_modification_test.go:1627: Unexpected response (-wanted, +got):   fwserver.ModifyAttributePlanResponse{
            - 	AttributePlan:   s`[{"nested_computed":"statevalue2","nested_required":"testvalue2"}]`,
            + 	AttributePlan:   s`[{"nested_computed":"statevalue1","nested_required":"testvalue2"}]`,
              	Diagnostics:     nil,
              	RequiresReplace: s"[]",
              	Private:         nil,
              }
    --- FAIL: TestAttributeModifyPlan/attribute-list-nested-nested-usestateforunknown-elements-rearranged (0.00s)
        attribute_plan_modification_test.go:1627: Unexpected response (-wanted, +got):   fwserver.ModifyAttributePlanResponse{
            - 	AttributePlan:   s`[{"nested_computed":"statevalue2","nested_required":"testvalue2"},{"nested_computed":"statevalue1","nested_required":"testvalue1"}]`,
            + 	AttributePlan:   s`[{"nested_computed":"statevalue1","nested_required":"testvalue2"},{"nested_computed":"statevalue2","nested_required":"testvalue1"}]`,
              	Diagnostics:     nil,
              	RequiresReplace: s"[]",
              	Private:         nil,
              }
--- FAIL: TestBlockModifyPlan (0.00s)
    --- FAIL: TestBlockModifyPlan/block-list-nested-usestateforunknown-elements-removed (0.00s)
        block_plan_modification_test.go:2858: Unexpected response (+wanted, -got):   fwserver.ModifyAttributePlanResponse{
            - 	AttributePlan:   s`[{"nested_computed":"statevalue2","nested_required":"testvalue2"}]`,
            + 	AttributePlan:   s`[{"nested_computed":"statevalue1","nested_required":"testvalue2"}]`,
              	Diagnostics:     nil,
              	RequiresReplace: s"[]",
              	Private:         nil,
              }
    --- FAIL: TestBlockModifyPlan/block-set-nested-usestateforunknown-elements-removed (0.00s)
        block_plan_modification_test.go:2858: Unexpected response (+wanted, -got):   fwserver.ModifyAttributePlanResponse{
            - 	AttributePlan:   s`[{"nested_computed":"statevalue2","nested_required":"testvalue2"}]`,
            + 	AttributePlan:   s`[{"nested_computed":"statevalue1","nested_required":"testvalue2"}]`,
              	Diagnostics:     nil,
              	RequiresReplace: s"[]",
              	Private:         nil,
              }
    --- FAIL: TestBlockModifyPlan/block-list-nested-usestateforunknown-elements-rearranged (0.00s)
        block_plan_modification_test.go:2858: Unexpected response (+wanted, -got):   fwserver.ModifyAttributePlanResponse{
            - 	AttributePlan:   s`[{"nested_computed":"statevalue2","nested_required":"testvalue2"},{"nested_computed":"statevalue1","nested_required":"testvalue1"}]`,
            + 	AttributePlan:   s`[{"nested_computed":"statevalue1","nested_required":"testvalue2"},{"nested_computed":"statevalue2","nested_required":"testvalue1"}]`,
              	Diagnostics:     nil,
              	RequiresReplace: s"[]",
              	Private:         nil,
              }
    --- FAIL: TestBlockModifyPlan/block-set-nested-usestateforunknown-elements-rearranged (0.00s)
        block_plan_modification_test.go:2858: Unexpected response (+wanted, -got):   fwserver.ModifyAttributePlanResponse{
            - 	AttributePlan:   s`[{"nested_computed":"statevalue2","nested_required":"testvalue2"},{"nested_computed":"statevalue1","nested_required":"testvalue1"}]`,
            + 	AttributePlan:   s`[{"nested_computed":"statevalue1","nested_required":"testvalue2"},{"nested_computed":"statevalue2","nested_required":"testvalue1"}]`,
              	Diagnostics:     nil,
              	RequiresReplace: s"[]",
              	Private:         nil,
              }
```
