### PR TITLE
internal/reflect: Raise framework errors instead of upstream errors or panics with mismatched types

### DIFF
--- a/.changes/unreleased/BUG FIXES-20230404-211215.yaml
+++ b/.changes/unreleased/BUG FIXES-20230404-211215.yaml
@@ -1,0 +1,6 @@
+kind: BUG FIXES
+body: 'tfsdk: Raise framework errors instead of generic upstream errors or panics
+  when encountering unexpected values with `Set()` methods'
+time: 2023-04-04T21:12:15.85706-04:00
+custom:
+  Issue: "715"

--- a/internal/reflect/interfaces.go
+++ b/internal/reflect/interfaces.go
@@ -304,13 +304,35 @@ func NewAttributeValue(ctx context.Context, typ attr.Type, val tftypes.Value, ta
 }
 
 // FromAttributeValue creates an attr.Value from an attr.Value. It just returns
-// the attr.Value it is passed, but reserves the right in the future to do some
-// validation on that attr.Value to make sure it matches the type produced by
-// `typ`.
+// the attr.Value it is passed or an error if there is an unexpected mismatch
+// between the attr.Type and attr.Value.
 //
 // It is meant to be called through FromValue, not directly.
 func FromAttributeValue(ctx context.Context, typ attr.Type, val attr.Value, path path.Path) (attr.Value, diag.Diagnostics) {
 	var diags diag.Diagnostics
+
+	// Since the reflection logic is a generic Go type implementation with
+	// user input, it is possible to get into awkward situations where
+	// the logic is expecting a certain type while a value may not be
+	// compatible. This check will ensure the framework raises its own
+	// error is there is a mismatch, rather than a terraform-plugin-go
+	// error or worse a panic.
+	//
+	// If this validation causes major issues, another option is to
+	// validate via tftypes.Type for both the type and value type.
+	if !typ.Equal(val.Type(ctx)) {
+		diags.AddAttributeError(
+			path,
+			"Value Conversion Error",
+			"An unexpected error was encountered while verifying an attribute value matched its expected type to prevent unexpected behavior or panics. "+
+				"This is always an error in the provider. Please report the following to the provider developer:\n\n"+
+				fmt.Sprintf("Expected type: %s\n", typ)+
+				fmt.Sprintf("Value type: %s\n", val.Type(ctx))+
+				fmt.Sprintf("Path: %s", path),
+		)
+
+		return nil, diags
+	}
 
 	if typeWithValidate, ok := typ.(xattr.TypeWithValidate); ok {
 		tfVal, err := val.ToTerraformValue(ctx)

--- a/internal/reflect/struct.go
+++ b/internal/reflect/struct.go
@@ -164,6 +164,49 @@ func FromStruct(ctx context.Context, typ attr.TypeWithAttributeTypes, val reflec
 	}
 
 	attrTypes := typ.AttributeTypes()
+
+	var objectMissing, structMissing []string
+
+	for field := range targetFields {
+		if _, ok := attrTypes[field]; !ok {
+			objectMissing = append(objectMissing, field)
+		}
+	}
+
+	for attrName, attrType := range attrTypes {
+		if attrType == nil {
+			objectMissing = append(objectMissing, attrName)
+		}
+
+		if _, ok := targetFields[attrName]; !ok {
+			structMissing = append(structMissing, attrName)
+		}
+	}
+
+	if len(objectMissing) > 0 || len(structMissing) > 0 {
+		missing := make([]string, 0, len(objectMissing)+len(structMissing))
+
+		if len(objectMissing) > 0 {
+			missing = append(missing, fmt.Sprintf("Struct defines fields not found in object: %s.", commaSeparatedString(objectMissing)))
+		}
+
+		if len(structMissing) > 0 {
+			missing = append(missing, fmt.Sprintf("Object defines fields not found in struct: %s.", commaSeparatedString(structMissing)))
+		}
+
+		diags.AddAttributeError(
+			path,
+			"Value Conversion Error",
+			"An unexpected error was encountered trying to convert from struct into an object. "+
+				"This is always an error in the provider. Please report the following to the provider developer:\n\n"+
+				fmt.Sprintf("Mismatch between struct and object type: %s\n", strings.Join(missing, " "))+
+				fmt.Sprintf("Struct: %s\n", val.Type())+
+				fmt.Sprintf("Object type: %s", typ),
+		)
+
+		return nil, diags
+	}
+
 	for name, fieldNo := range targetFields {
 		path := path.AtName(name)
 		fieldValue := val.Field(fieldNo)
@@ -174,19 +217,6 @@ func FromStruct(ctx context.Context, typ attr.TypeWithAttributeTypes, val reflec
 		if diags.HasError() {
 			return nil, diags
 		}
-
-		attrType, ok := attrTypes[name]
-		if !ok || attrType == nil {
-			err := fmt.Errorf("couldn't find type information for attribute at %s in supplied attr.Type %T", path, typ)
-			diags.AddAttributeError(
-				path,
-				"Value Conversion Error",
-				"An unexpected error was encountered trying to convert from struct value. This is always an error in the provider. Please report the following to the provider developer:\n\n"+err.Error(),
-			)
-			return nil, diags
-		}
-
-		objTypes[name] = attrType.TerraformType(ctx)
 
 		tfObjVal, err := attrVal.ToTerraformValue(ctx)
 		if err != nil {
@@ -202,6 +232,7 @@ func FromStruct(ctx context.Context, typ attr.TypeWithAttributeTypes, val reflec
 		}
 
 		objValues[name] = tfObjVal
+		objTypes[name] = tfObjVal.Type()
 	}
 
 	tfVal := tftypes.NewValue(tftypes.Object{
@@ -216,8 +247,7 @@ func FromStruct(ctx context.Context, typ attr.TypeWithAttributeTypes, val reflec
 		}
 	}
 
-	retType := typ.WithAttributeTypes(attrTypes)
-	ret, err := retType.ValueFromTerraform(ctx, tfVal)
+	ret, err := typ.ValueFromTerraform(ctx, tfVal)
 	if err != nil {
 		return nil, append(diags, valueFromTerraformErrorDiag(err, path))
 	}


### PR DESCRIPTION
Closes #566

Previously in a provider where a `types.Object` zero value was used in `(tfsdk.State).Set()`:

```
panic: AttributeName("single_nested_attribute"): can't use tftypes.Object[] as tftypes.Object["nested_attribute":tftypes.String]

goroutine 448 [running]:
github.com/hashicorp/terraform-plugin-go/tftypes.NewValue(...)
	/Users/bflad/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.14.3/tftypes/value.go:273
github.com/hashicorp/terraform-plugin-framework/internal/reflect.FromStruct({0x1035b3e40, 0x140001fa870}, {0x1035b86f8?, 0x140001faae0?}, {0x103504480?, 0x140001ff400?, 0x10b4975c8?}, {{0x103b8fc60?, 0x50?, 0x1400006c900?}})
	/Users/bflad/go/pkg/mod/github.com/hashicorp/terraform-plugin-framework@v1.2.0/internal/reflect/struct.go:207 +0x73c
github.com/hashicorp/terraform-plugin-framework/internal/reflect.FromValue({0x1035b3e40, 0x140001fa870}, {0x1035b6d80?, 0x140001faae0}, {0x103504480, 0x140001ff400}, {{0x103b8fc60?, 0x0?, 0x14000462f28?}})
	/Users/bflad/go/pkg/mod/github.com/hashicorp/terraform-plugin-framework@v1.2.0/internal/reflect/outof.go:54 +0x6c0
github.com/hashicorp/terraform-plugin-framework/internal/reflect.FromPointer({0x1035b3e40, 0x140001fa870}, {0x1035b6d80?, 0x140001faae0?}, {0x10342a1e0?, 0x140001ff360?, 0x0?}, {{0x103b8fc60?, 0x0?, 0xffffffffffffffff?}})
	/Users/bflad/go/pkg/mod/github.com/hashicorp/terraform-plugin-framework@v1.2.0/internal/reflect/pointer.go:115 +0x198
github.com/hashicorp/terraform-plugin-framework/internal/reflect.FromValue({0x1035b3e40, 0x140001fa870}, {0x1035b6d80?, 0x140001faae0}, {0x10342a1e0, 0x140001ff360}, {{0x103b8fc60?, 0x0?, 0x10329f143?}})
	/Users/bflad/go/pkg/mod/github.com/hashicorp/terraform-plugin-framework@v1.2.0/internal/reflect/outof.go:82 +0x518
github.com/hashicorp/terraform-plugin-framework/internal/fwschemadata.(*Data).Set(0x1400009d2d8, {0x1035b3e40, 0x140001fa870}, {0x10342a1e0, 0x140001ff360})
	/Users/bflad/go/pkg/mod/github.com/hashicorp/terraform-plugin-framework@v1.2.0/internal/fwschemadata/data_set.go:15 +0x74
github.com/hashicorp/terraform-plugin-framework/tfsdk.(*State).Set(0x140001ff328, {0x1035b3e40?, 0x140001fa870?}, {0x10342a1e0?, 0x140001ff360?})
	/Users/bflad/go/pkg/mod/github.com/hashicorp/terraform-plugin-framework@v1.2.0/tfsdk/state.go:61 +0xd0
github.com/bflad/terraform-provider-framework/internal/provider.ExampleResource.ImportState({}, {0x1035b3e40, 0x140001fa870}, {{0x140003c8340?, 0x0?}}, 0x140001ff310)
	/Users/bflad/src/github.com/bflad/terraform-provider-framework/internal/provider/example_resource.go:116 +0xc0
github.com/hashicorp/terraform-plugin-framework/internal/fwserver.(*Server).ImportResourceState(0x14000396000, {0x1035b3e40, 0x140001fa870}, 0x14000589860, 0x1400009d5e8)
	/Users/bflad/go/pkg/mod/github.com/hashicorp/terraform-plugin-framework@v1.2.0/internal/fwserver/server_importresourcestate.go:104 +0x360
github.com/hashicorp/terraform-plugin-framework/internal/proto6server.(*Server).ImportResourceState(0x14000396000, {0x1035b3e40?, 0x140001fa750?}, 0x140000a8480)
	/Users/bflad/go/pkg/mod/github.com/hashicorp/terraform-plugin-framework@v1.2.0/internal/proto6server/server_importresourcestate.go:44 +0x268
github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server.(*server).ImportResourceState(0x140003b4820, {0x1035b3e40?, 0x140003cbda0?}, 0x140001ff0e0)
	/Users/bflad/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.14.3/tfprotov6/tf6server/server.go:846 +0x19c
github.com/hashicorp/terraform-plugin-go/tfprotov6/internal/tfplugin6._Provider_ImportResourceState_Handler({0x103578f40?, 0x140003b4820}, {0x1035b3e40, 0x140003cbda0}, 0x140002001c0, 0x0)
	/Users/bflad/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.14.3/tfprotov6/internal/tfplugin6/tfplugin6_grpc.pb.go:403 +0x164
google.golang.org/grpc.(*Server).processUnaryRPC(0x140000c7a40, {0x1035b8b38, 0x140006284e0}, 0x14000569680, 0x140003165a0, 0x103b4c898, 0x0)
	/Users/bflad/go/pkg/mod/google.golang.org/grpc@v1.51.0/server.go:1340 +0xb38
google.golang.org/grpc.(*Server).handleStream(0x140000c7a40, {0x1035b8b38, 0x140006284e0}, 0x14000569680, 0x0)
	/Users/bflad/go/pkg/mod/google.golang.org/grpc@v1.51.0/server.go:1713 +0x80c
google.golang.org/grpc.(*Server).serveStreams.func1.2()
	/Users/bflad/go/pkg/mod/google.golang.org/grpc@v1.51.0/server.go:965 +0x84
created by google.golang.org/grpc.(*Server).serveStreams.func1
	/Users/bflad/go/pkg/mod/google.golang.org/grpc@v1.51.0/server.go:963 +0x278
FAIL	github.com/bflad/terraform-provider-framework/internal/provider	1.384s
```

Now:

```
--- FAIL: TestExampleResource_basic (1.04s)
    /Users/bflad/src/github.com/bflad/terraform-provider-framework/internal/provider/example_resource_test.go:10: Step 2/3 error running import: exit status 1

        Error: Value Conversion Error

        An unexpected error was encountered while verifying an attribute value
        matched its expected type to prevent unexpected behavior or panics. This is
        always an error in the provider. Please report the following to the provider
        developer:

        Expected type: types.ObjectType["nested_attribute":basetypes.StringType]
        Value type: types.ObjectType[]
        Path: single_nested_attribute
```

Previously in the new unit testing:

```
--- FAIL: TestFromStruct_errors (0.00s)
    --- FAIL: TestFromStruct_errors/object-zero-value (0.00s)
panic: AttributeName("object"): can't use tftypes.Object[] as tftypes.Object["test":tftypes.String] [recovered]
	panic: AttributeName("object"): can't use tftypes.Object[] as tftypes.Object["test":tftypes.String]

goroutine 21 [running]:
testing.tRunner.func1.2({0x100823c80, 0x14000182078})
	/opt/homebrew/Cellar/go/1.20.2/libexec/src/testing/testing.go:1526 +0x1c8
testing.tRunner.func1()
	/opt/homebrew/Cellar/go/1.20.2/libexec/src/testing/testing.go:1529 +0x364
panic({0x100823c80, 0x14000182078})
	/opt/homebrew/Cellar/go/1.20.2/libexec/src/runtime/panic.go:884 +0x1f4
github.com/hashicorp/terraform-plugin-go/tftypes.NewValue(...)
	/Users/bflad/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.15.0/tftypes/value.go:273
github.com/hashicorp/terraform-plugin-framework/internal/reflect.FromStruct({0x100846110, 0x140000a4008}, {0x100847e00?, 0x1400009a930?}, {0x1008042c0?, 0x140000ac198?, 0x1008640c0?}, {{0x14000180030?, 0x100898a8e?, 0x3d?}})
	/Users/bflad/src/github.com/hashicorp/terraform-plugin-framework/internal/reflect/struct.go:208 +0x73c
github.com/hashicorp/terraform-plugin-framework/internal/reflect_test.TestFromStruct_errors.func1(0x14000083520)
	/Users/bflad/src/github.com/hashicorp/terraform-plugin-framework/internal/reflect/struct_test.go:926 +0xc0
testing.tRunner(0x14000083520, 0x140000a0480)
	/opt/homebrew/Cellar/go/1.20.2/libexec/src/testing/testing.go:1576 +0x104
created by testing.(*T).Run
	/opt/homebrew/Cellar/go/1.20.2/libexec/src/testing/testing.go:1629 +0x370
FAIL	github.com/hashicorp/terraform-plugin-framework/internal/reflect	0.748s
FAIL
```