### PR TITLE
resource/schema: Implement MatchElementStateForUnknown plan modifier

### DIFF
--- a/internal/fwplanmodifier/doc.go
+++ b/internal/fwplanmodifier/doc.go
@@ -1,0 +1,5 @@
+// Package fwplanmodifier contains shared implementation details for framework-
+// defined plan modifiers. The framework should only ever contain critical and
+// generic plan modifiers that are applicable in all providers to implement core
+// Terraform planning functionality.
+package fwplanmodifier

--- a/internal/fwplanmodifier/framework_implementation_error_diagnostics.go
+++ b/internal/fwplanmodifier/framework_implementation_error_diagnostics.go
@@ -1,0 +1,35 @@
+package fwplanmodifier
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+)
+
+// FrameworkImplementationErrorDiag returns an error diagnostic intended for
+// when a framework-defined schema plan modifier reached an unexpected
+// implementation issue.
+func FrameworkImplementationErrorDiag(p path.Path, details string) diag.Diagnostic {
+	return diag.NewAttributeErrorDiagnostic(
+		p,
+		"Framework Plan Modifier Implementation Error",
+		"A framework-defined plan modifier encountered an unexpected implementation issue which could cause unexpected behavior or panics. "+
+			"This is always an issue with terraform-plugin-framework and should be reported to the provider developers.\n\n"+
+			fmt.Sprintf("Path: %s\n", p)+
+			"Details: "+details,
+	)
+}
+
+// PlanValueTypeAssertionDiag returns an error diagnostic intended for when a
+// schema plan modifier with a shared implementation did not return the expected
+// type in the response for the typed response.
+func PlanValueTypeAssertionDiag(p path.Path, requestType attr.Value, responseType attr.Value) diag.Diagnostic {
+	return FrameworkImplementationErrorDiag(
+		p,
+		"The shared implementation responded with an unexpected type.\n"+
+			fmt.Sprintf("Expected Type: %T\n", requestType)+
+			fmt.Sprintf("Response Type: %T", responseType),
+	)
+}

--- a/internal/fwplanmodifier/framework_implementation_error_diagnostics_test.go
+++ b/internal/fwplanmodifier/framework_implementation_error_diagnostics_test.go
@@ -1,0 +1,90 @@
+package fwplanmodifier_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+func TestFrameworkImplementationErrorDiag(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		path     path.Path
+		details  string
+		expected diag.Diagnostic
+	}{
+		"test": {
+			path:    path.Root("test"),
+			details: "Test details.",
+			expected: diag.NewAttributeErrorDiagnostic(
+				path.Root("test"),
+				"Framework Plan Modifier Implementation Error",
+				"A framework-defined plan modifier encountered an unexpected implementation issue which could cause unexpected behavior or panics. "+
+					"This is always an issue with terraform-plugin-framework and should be reported to the provider developers.\n\n"+
+					"Path: test\n"+
+					"Details: Test details.",
+			),
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := fwplanmodifier.FrameworkImplementationErrorDiag(testCase.path, testCase.details)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestPlanValueTypeAssertionDiag(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		path         path.Path
+		requestType  attr.Value
+		responseType attr.Value
+		expected     diag.Diagnostic
+	}{
+		"test": {
+			path:         path.Root("test"),
+			requestType:  basetypes.NewStringNull(),
+			responseType: basetypes.NewBoolNull(),
+			expected: diag.NewAttributeErrorDiagnostic(
+				path.Root("test"),
+				"Framework Plan Modifier Implementation Error",
+				"A framework-defined plan modifier encountered an unexpected implementation issue which could cause unexpected behavior or panics. "+
+					"This is always an issue with terraform-plugin-framework and should be reported to the provider developers.\n\n"+
+					"Path: test\n"+
+					"Details: The shared implementation responded with an unexpected type.\n"+
+					"Expected Type: basetypes.StringValue\n"+
+					"Response Type: basetypes.BoolValue",
+			),
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := fwplanmodifier.PlanValueTypeAssertionDiag(testCase.path, testCase.requestType, testCase.responseType)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}

--- a/internal/fwplanmodifier/match_element_state_for_unknown.go
+++ b/internal/fwplanmodifier/match_element_state_for_unknown.go
@@ -1,0 +1,656 @@
+package fwplanmodifier
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/internal/parentpath"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+var (
+	_ planmodifier.Bool    = MatchElementStateForUnknownModifier{}
+	_ planmodifier.Float64 = MatchElementStateForUnknownModifier{}
+	_ planmodifier.Int64   = MatchElementStateForUnknownModifier{}
+	_ planmodifier.List    = MatchElementStateForUnknownModifier{}
+	_ planmodifier.Map     = MatchElementStateForUnknownModifier{}
+	_ planmodifier.Number  = MatchElementStateForUnknownModifier{}
+	_ planmodifier.Object  = MatchElementStateForUnknownModifier{}
+	_ planmodifier.Set     = MatchElementStateForUnknownModifier{}
+	_ planmodifier.String  = MatchElementStateForUnknownModifier{}
+)
+
+// MatchElementStateForUnknownModifier implements the plan modifier.
+type MatchElementStateForUnknownModifier struct {
+	Expressions path.Expressions
+}
+
+// Description returns a human-readable description of the plan modifier.
+func (m MatchElementStateForUnknownModifier) Description(_ context.Context) string {
+	return "Once set, the value of this attribute in state will not change."
+}
+
+// MarkdownDescription returns a markdown description of the plan modifier.
+func (m MatchElementStateForUnknownModifier) MarkdownDescription(_ context.Context) string {
+	return "Once set, the value of this attribute in state will not change."
+}
+
+// PlanModify implements the shared plan modification logic. This logic is
+// currently written with the expectation that a valid setup of this plan
+// modifier is when the request path is:
+//
+//   - Zero or more preceding path steps
+//   - AttributeName path step representing a list/set nested attribute/block
+//   - ElementKeyInt/ElementKeyValue path step of nested object elements
+//   - AttributeName path step representing a computed attribute on which the
+//     plan modifier is implemented.
+//
+// The given expressions are similarly expected to represent another attribute
+// within the same nested object as where the plan modifier is implemented. This
+// introduces the following validation rules for expressions:
+//
+//   - They must resolve to the same number of path steps as the request path.
+//     For relative expressions, this generally means
+//     path.MatchRelative().AtParent().AtName() so it is an another attribute
+//     within the same nested object as where the plan modifier is implemented.
+//   - They must be relative to properly match the current element's identifying
+//     values. A root based path would never be possible beyond a single element
+//     list/set because it would either need to be hardcoded to the first
+//     element or introduce an "any" element path step (such as AtAnyListIndex()
+//     or AtAnySetValue()), which could return multiple values.
+//   - They must not resolve above or outside the list/set nested
+//     attribute/block as this introduces another order of complexity.
+//
+// The logic is written with validation based on these expectations. The inputs
+// are generic path expressions, so if the logic can safely handle other
+// assumptions, theoretically developer-facing changes are not required for that
+// type of enhancement. Otherwise, if breaking changes would be necessary,
+// another plan modifier could be introduced to handle more complex, but
+// common and generically verifiable use cases.
+//
+// Beyond the validation logic, the general algorithm of this is:
+//
+//   - For each expression, fetch the plan data using the expression. This
+//     validates that the expression is actually valid for the schema beyond the
+//     initial validation and will yield the identifying values that later will
+//     be checked against all elements in the prior state for element alignment.
+//   - If any fetched plan data is unknown, return early.
+//   - If the request state value is null, return early.
+//   - If the request plan value is known already, return early.
+//   - If the request configuration value is unknown, return early to prevent
+//     unexpected behavior.
+//   - For all list/set elements under the parent of the request path, check all
+//     identifying values. If there is an element where they all match, set the
+//     response plan value to the prior state value from the matching element.
+func (m MatchElementStateForUnknownModifier) PlanModify(ctx context.Context, req MatchElementStateForUnknownRequest, resp *MatchElementStateForUnknownResponse) {
+	// Verify this plan modifier is only being used beneath a list or set.
+	if !parentpath.HasListOrSet(req.Path) {
+		resp.Diagnostics.Append(MatchElementStateForUnknownOutsideListOrSetDiag(req.Path))
+
+		return
+	}
+
+	// Verify at least one expression was given.
+	if len(m.Expressions) == 0 {
+		resp.Diagnostics.Append(MatchElementStateForUnknownMissingExpressionsDiag(req.Path))
+
+		return
+	}
+
+	// Collect any initial expression validation issues.
+	for _, expression := range m.Expressions {
+		if expression.IsRoot() {
+			resp.Diagnostics.Append(MatchElementStateForUnknownRootExpressionDiag(req.Path, expression))
+
+			continue
+		}
+
+		expressionSteps := expression.Steps()
+
+		if len(expressionSteps) != 2 {
+			resp.Diagnostics.Append(MatchElementStateForUnknownInvalidExpressionDiag(req.Path, expression))
+
+			continue
+		}
+
+		if _, ok := expressionSteps[0].(path.ExpressionStepParent); !ok {
+			resp.Diagnostics.Append(MatchElementStateForUnknownInvalidExpressionDiag(req.Path, expression))
+
+			continue
+		}
+
+		if _, ok := expressionSteps[1].(path.ExpressionStepAttributeNameExact); !ok {
+			resp.Diagnostics.Append(MatchElementStateForUnknownInvalidExpressionDiag(req.Path, expression))
+
+			continue
+		}
+	}
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Merge the request path expression with each given expression and begin
+	// the process of saving any identifying values into a mapping of attribute
+	// name to value.
+	identifyingValues := make(map[string]attr.Value, len(m.Expressions))
+
+	for _, expression := range req.PathExpression.MergeExpressions(m.Expressions...) {
+		// Verify expression is not a self-reference.
+		if expression.Matches(req.Path) {
+			resp.Diagnostics.Append(MatchElementStateForUnknownInvalidExpressionDiag(req.Path, expression))
+
+			continue
+		}
+
+		// Verify expression points to an actual path and is not a Computed-only
+		// attribute. Only configurable attributes are valid for this plan
+		// modifier, otherwise the value at the path will always be unknown.
+		matchedPaths, diags := req.Plan.PathMatches(ctx, expression)
+
+		resp.Diagnostics.Append(diags...)
+
+		// Collect all errors
+		if diags.HasError() {
+			continue
+		}
+
+		// Verify at least one matched path was returned. Each expression should
+		// always have plan data, which is necessary for identifying the element
+		// alignment.
+		if len(matchedPaths) == 0 {
+			resp.Diagnostics.Append(MatchElementStateForUnknownInvalidExpressionDiag(req.Path, expression))
+
+			continue
+		}
+
+		// Verify there are not multiple matching paths. If so, the logic would
+		// not have a single set of identifying values. This is defensive logic
+		// in case prior validation did not already catch the case of an
+		// expression step which might cause multiple matches. This cannot be
+		// unit tested while proper validation is in place.
+		if len(matchedPaths) > 1 {
+			resp.Diagnostics.Append(
+				FrameworkImplementationErrorDiag(
+					req.Path,
+					"MatchElementStateForUnknown received multiple matching paths for an expression.\n"+
+						fmt.Sprintf("Expression: %s", expression),
+				),
+			)
+
+			return
+		}
+
+		// There should only be one matched path per expression at this point.
+		matchedPath := matchedPaths[0]
+
+		var matchedPathValue attr.Value
+
+		diags = req.Plan.GetAttribute(ctx, matchedPath, &matchedPathValue)
+
+		resp.Diagnostics.Append(diags...)
+
+		// Collect all errors
+		if diags.HasError() {
+			continue
+		}
+
+		// Last step represents the attribute name of the identifying value.
+		lastStep, _ := matchedPath.Steps().LastStep()
+		attributeNameStep, ok := lastStep.(path.PathStepAttributeName)
+
+		if !ok {
+			resp.Diagnostics.Append(
+				FrameworkImplementationErrorDiag(
+					req.Path,
+					"MatchElementStateForUnknown matched path last step was not AttributeName.\n"+
+						fmt.Sprintf("Expression: %s", expression),
+				),
+			)
+
+			return
+		}
+
+		identifyingValues[string(attributeNameStep)] = matchedPathValue
+	}
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Delay plan modification until all identifying attributes have a
+	// known value.
+	for _, identifyingValue := range identifyingValues {
+		if identifyingValue.IsUnknown() {
+			return
+		}
+	}
+
+	// Do nothing if there is a known planned value.
+	if !req.PlanValue.IsUnknown() {
+		return
+	}
+
+	// Do nothing if there is an unknown configuration value, otherwise
+	// interpolation gets messed up.
+	if req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	// Get the list/set attribute path to fetch the prior state and all its
+	// elements.
+	collectionPath := req.Path.ParentPath().ParentPath()
+
+	// Prior state should only ever contain null or known values. The elements
+	// will always be objects per the prior validation.
+	var priorStateObjects []basetypes.ObjectValue
+
+	resp.Diagnostics.Append(req.State.GetAttribute(ctx, collectionPath, &priorStateObjects)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var matchedPriorStateValue attr.Value
+
+	// Loop through all prior state elements to find one which matches all
+	// identifying values.
+	for _, priorStateObject := range priorStateObjects {
+		objectAttributes := priorStateObject.Attributes()
+
+		// Loop through all identifying values to check each against this
+		// element. All values must exist and be equal.
+		var matching bool
+
+		for attributeName, identifyingValue := range identifyingValues {
+			objectAttributeValue, ok := objectAttributes[attributeName]
+
+			// Allow non-existent prior state attributes, rather than raise an
+			// error, because the schema may have had new nested object
+			// attributes added that are considered identifying, but not yet in
+			// the prior state.
+			if !ok {
+				matching = false
+
+				break
+			}
+
+			if !objectAttributeValue.Equal(identifyingValue) {
+				matching = false
+
+				break
+			}
+
+			matching = true
+		}
+
+		if matching {
+			// Last step represents the attribute name of the attribute with the
+			// plan modifier.
+			lastStep, _ := req.Path.Steps().LastStep()
+			attributeNameStep, ok := lastStep.(path.PathStepAttributeName)
+
+			if !ok {
+				resp.Diagnostics.Append(
+					FrameworkImplementationErrorDiag(
+						req.Path,
+						"MatchElementStateForUnknown request path last step was not AttributeName.",
+					),
+				)
+
+				return
+			}
+
+			objectAttributeValue, ok := objectAttributes[string(attributeNameStep)]
+
+			if ok {
+				matchedPriorStateValue = objectAttributeValue
+			}
+
+			break
+		}
+	}
+
+	// Do nothing if there is no prior state value or it is null.
+	if matchedPriorStateValue == nil || matchedPriorStateValue.IsNull() {
+		return
+	}
+
+	resp.PlanValue = matchedPriorStateValue
+}
+
+// PlanModifyBool implements the Bool plan modification logic.
+func (m MatchElementStateForUnknownModifier) PlanModifyBool(ctx context.Context, req planmodifier.BoolRequest, resp *planmodifier.BoolResponse) {
+	genericReq := MatchElementStateForUnknownRequest{
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+		Plan:           req.Plan,
+		PlanValue:      req.PlanValue,
+		State:          req.State,
+	}
+	genericResp := &MatchElementStateForUnknownResponse{
+		PlanValue: req.PlanValue,
+	}
+
+	m.PlanModify(ctx, genericReq, genericResp)
+
+	resp.Diagnostics = genericResp.Diagnostics
+
+	planValue, ok := genericResp.PlanValue.(basetypes.BoolValue)
+
+	if !ok {
+		resp.Diagnostics.Append(PlanValueTypeAssertionDiag(req.Path, req.PlanValue, genericResp.PlanValue))
+	}
+
+	resp.PlanValue = planValue
+}
+
+// PlanModifyFloat64 implements the Float64 plan modification logic.
+func (m MatchElementStateForUnknownModifier) PlanModifyFloat64(ctx context.Context, req planmodifier.Float64Request, resp *planmodifier.Float64Response) {
+	genericReq := MatchElementStateForUnknownRequest{
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+		Plan:           req.Plan,
+		PlanValue:      req.PlanValue,
+		State:          req.State,
+	}
+	genericResp := &MatchElementStateForUnknownResponse{
+		PlanValue: req.PlanValue,
+	}
+
+	m.PlanModify(ctx, genericReq, genericResp)
+
+	resp.Diagnostics = genericResp.Diagnostics
+
+	planValue, ok := genericResp.PlanValue.(basetypes.Float64Value)
+
+	if !ok {
+		resp.Diagnostics.Append(PlanValueTypeAssertionDiag(req.Path, req.PlanValue, genericResp.PlanValue))
+	}
+
+	resp.PlanValue = planValue
+}
+
+// PlanModifyInt64 implements the Int64 plan modification logic.
+func (m MatchElementStateForUnknownModifier) PlanModifyInt64(ctx context.Context, req planmodifier.Int64Request, resp *planmodifier.Int64Response) {
+	genericReq := MatchElementStateForUnknownRequest{
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+		Plan:           req.Plan,
+		PlanValue:      req.PlanValue,
+		State:          req.State,
+	}
+	genericResp := &MatchElementStateForUnknownResponse{
+		PlanValue: req.PlanValue,
+	}
+
+	m.PlanModify(ctx, genericReq, genericResp)
+
+	resp.Diagnostics = genericResp.Diagnostics
+
+	planValue, ok := genericResp.PlanValue.(basetypes.Int64Value)
+
+	if !ok {
+		resp.Diagnostics.Append(PlanValueTypeAssertionDiag(req.Path, req.PlanValue, genericResp.PlanValue))
+	}
+
+	resp.PlanValue = planValue
+}
+
+// PlanModifyList implements the List plan modification logic.
+func (m MatchElementStateForUnknownModifier) PlanModifyList(ctx context.Context, req planmodifier.ListRequest, resp *planmodifier.ListResponse) {
+	genericReq := MatchElementStateForUnknownRequest{
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+		Plan:           req.Plan,
+		PlanValue:      req.PlanValue,
+		State:          req.State,
+	}
+	genericResp := &MatchElementStateForUnknownResponse{
+		PlanValue: req.PlanValue,
+	}
+
+	m.PlanModify(ctx, genericReq, genericResp)
+
+	resp.Diagnostics = genericResp.Diagnostics
+
+	planValue, ok := genericResp.PlanValue.(basetypes.ListValue)
+
+	if !ok {
+		resp.Diagnostics.Append(PlanValueTypeAssertionDiag(req.Path, req.PlanValue, genericResp.PlanValue))
+	}
+
+	resp.PlanValue = planValue
+}
+
+// PlanModifyMap implements the Map plan modification logic.
+func (m MatchElementStateForUnknownModifier) PlanModifyMap(ctx context.Context, req planmodifier.MapRequest, resp *planmodifier.MapResponse) {
+	genericReq := MatchElementStateForUnknownRequest{
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+		Plan:           req.Plan,
+		PlanValue:      req.PlanValue,
+		State:          req.State,
+	}
+	genericResp := &MatchElementStateForUnknownResponse{
+		PlanValue: req.PlanValue,
+	}
+
+	m.PlanModify(ctx, genericReq, genericResp)
+
+	resp.Diagnostics = genericResp.Diagnostics
+
+	planValue, ok := genericResp.PlanValue.(basetypes.MapValue)
+
+	if !ok {
+		resp.Diagnostics.Append(PlanValueTypeAssertionDiag(req.Path, req.PlanValue, genericResp.PlanValue))
+	}
+
+	resp.PlanValue = planValue
+}
+
+// PlanModifyNumber implements the Number plan modification logic.
+func (m MatchElementStateForUnknownModifier) PlanModifyNumber(ctx context.Context, req planmodifier.NumberRequest, resp *planmodifier.NumberResponse) {
+	genericReq := MatchElementStateForUnknownRequest{
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+		Plan:           req.Plan,
+		PlanValue:      req.PlanValue,
+		State:          req.State,
+	}
+	genericResp := &MatchElementStateForUnknownResponse{
+		PlanValue: req.PlanValue,
+	}
+
+	m.PlanModify(ctx, genericReq, genericResp)
+
+	resp.Diagnostics = genericResp.Diagnostics
+
+	planValue, ok := genericResp.PlanValue.(basetypes.NumberValue)
+
+	if !ok {
+		resp.Diagnostics.Append(PlanValueTypeAssertionDiag(req.Path, req.PlanValue, genericResp.PlanValue))
+	}
+
+	resp.PlanValue = planValue
+}
+
+// PlanModifyObject implements the Object plan modification logic.
+func (m MatchElementStateForUnknownModifier) PlanModifyObject(ctx context.Context, req planmodifier.ObjectRequest, resp *planmodifier.ObjectResponse) {
+	genericReq := MatchElementStateForUnknownRequest{
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+		Plan:           req.Plan,
+		PlanValue:      req.PlanValue,
+		State:          req.State,
+	}
+	genericResp := &MatchElementStateForUnknownResponse{
+		PlanValue: req.PlanValue,
+	}
+
+	m.PlanModify(ctx, genericReq, genericResp)
+
+	resp.Diagnostics = genericResp.Diagnostics
+
+	planValue, ok := genericResp.PlanValue.(basetypes.ObjectValue)
+
+	if !ok {
+		resp.Diagnostics.Append(PlanValueTypeAssertionDiag(req.Path, req.PlanValue, genericResp.PlanValue))
+	}
+
+	resp.PlanValue = planValue
+}
+
+// PlanModifySet implements the Set plan modification logic.
+func (m MatchElementStateForUnknownModifier) PlanModifySet(ctx context.Context, req planmodifier.SetRequest, resp *planmodifier.SetResponse) {
+	genericReq := MatchElementStateForUnknownRequest{
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+		Plan:           req.Plan,
+		PlanValue:      req.PlanValue,
+		State:          req.State,
+	}
+	genericResp := &MatchElementStateForUnknownResponse{
+		PlanValue: req.PlanValue,
+	}
+
+	m.PlanModify(ctx, genericReq, genericResp)
+
+	resp.Diagnostics = genericResp.Diagnostics
+
+	planValue, ok := genericResp.PlanValue.(basetypes.SetValue)
+
+	if !ok {
+		resp.Diagnostics.Append(PlanValueTypeAssertionDiag(req.Path, req.PlanValue, genericResp.PlanValue))
+	}
+
+	resp.PlanValue = planValue
+}
+
+// PlanModifyString implements the String plan modification logic.
+func (m MatchElementStateForUnknownModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	genericReq := MatchElementStateForUnknownRequest{
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+		Plan:           req.Plan,
+		PlanValue:      req.PlanValue,
+		State:          req.State,
+	}
+	genericResp := &MatchElementStateForUnknownResponse{
+		PlanValue: req.PlanValue,
+	}
+
+	m.PlanModify(ctx, genericReq, genericResp)
+
+	resp.Diagnostics = genericResp.Diagnostics
+
+	planValue, ok := genericResp.PlanValue.(basetypes.StringValue)
+
+	if !ok {
+		resp.Diagnostics.Append(PlanValueTypeAssertionDiag(req.Path, req.PlanValue, genericResp.PlanValue))
+	}
+
+	resp.PlanValue = planValue
+}
+
+// MatchElementStateForUnknownRequest is the shared request type for
+// the plan modification logic.
+type MatchElementStateForUnknownRequest struct {
+	ConfigValue    attr.Value
+	Path           path.Path
+	PathExpression path.Expression
+	Plan           tfsdk.Plan
+	PlanValue      attr.Value
+	State          tfsdk.State
+}
+
+// MatchElementStateForUnknownResponse is the shared response type for
+// the plan modification logic.
+type MatchElementStateForUnknownResponse struct {
+	Diagnostics diag.Diagnostics
+	PlanValue   attr.Value
+}
+
+// MatchElementStateForUnknownMissingExpressionsDiag returns an error diagnostic
+// when the MatchElementStateForUnknown schema plan modifier was passed zero
+// expressions.
+func MatchElementStateForUnknownMissingExpressionsDiag(p path.Path) diag.Diagnostic {
+	return diag.NewAttributeErrorDiagnostic(
+		p,
+		"Invalid Attribute Schema",
+		"The MatchElementStateForUnknown() plan modifier has no path expressions. "+
+			"At least one path expression must be given for matching the prior state. "+
+			"For example:\n\n"+
+			"MatchElementStateForUnknown(\n"+
+			"  path.MatchRelative().AtParent().AtName(\"another_element_attribute\"),\n"+
+			"),\n\n"+
+			"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+			fmt.Sprintf("Path: %s", p),
+	)
+}
+
+// MatchElementStateForUnknownOutsideListOrSetDiag returns an error diagnostic
+// intended for when the MatchElementStateForUnknown schema plan modifier is not
+// under a list or set.
+func MatchElementStateForUnknownOutsideListOrSetDiag(p path.Path) diag.Diagnostic {
+	return diag.NewAttributeErrorDiagnostic(
+		p,
+		"Invalid Attribute Schema",
+		"The MatchElementStateForUnknown() plan modifier is only intended for nested object attributes under a list or set. "+
+			"Use the UseStateForUnknown() plan modifier instead. "+
+			"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+			fmt.Sprintf("Path: %s", p),
+	)
+}
+
+// MatchElementStateForUnknownInvalidExpressionDiag returns an error diagnostic when
+// the MatchElementStateForUnknown schema plan modifier was passed an expression
+// that would match data outside the list or set of the current path.
+func MatchElementStateForUnknownInvalidExpressionDiag(p path.Path, e path.Expression) diag.Diagnostic {
+	return diag.NewAttributeErrorDiagnostic(
+		p,
+		"Invalid Attribute Schema",
+		"The MatchElementStateForUnknown() plan modifier was given an invalid path expression. "+
+			"Expressions should be relative and match a different, identifying, and configurable attribute within the same nested object. "+
+			"For example:\n\n"+
+			"MatchElementStateForUnknown(\n"+
+			"  path.MatchRelative().AtParent().AtName(\"another_element_attribute\"),\n"+
+			"),\n\n"+
+			"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+			fmt.Sprintf("Path: %s\n", p)+
+			fmt.Sprintf("Given Expression: %s", e),
+	)
+}
+
+// MatchElementStateForUnknownRootExpressionDiag returns an error diagnostic
+// when the MatchElementStateForUnknown schema plan modifier was passed a root
+// expression.
+func MatchElementStateForUnknownRootExpressionDiag(p path.Path, e path.Expression) diag.Diagnostic {
+	return diag.NewAttributeErrorDiagnostic(
+		p,
+		"Invalid Attribute Schema",
+		"The MatchElementStateForUnknown() plan modifier was given a root path expression. "+
+			"Expressions should only be relative and reference attributes at the same level. "+
+			"For example:\n\n"+
+			"MatchElementStateForUnknown(\n"+
+			"  path.MatchRelative().AtParent().AtName(\"another_element_attribute\"),\n"+
+			"),\n\n"+
+			"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+			fmt.Sprintf("Path: %s\n", p)+
+			fmt.Sprintf("Given Expression: %s", e),
+	)
+}

--- a/internal/fwplanmodifier/match_element_state_for_unknown_test.go
+++ b/internal/fwplanmodifier/match_element_state_for_unknown_test.go
@@ -1,0 +1,2020 @@
+package fwplanmodifier_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func TestMatchElementStateForUnknownModifierPlanModify(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		request     fwplanmodifier.MatchElementStateForUnknownRequest
+		expressions path.Expressions
+		expected    *fwplanmodifier.MatchElementStateForUnknownResponse
+	}{
+		"path-root": {
+			request: fwplanmodifier.MatchElementStateForUnknownRequest{
+				Path:      path.Root("test"),
+				PlanValue: types.StringUnknown(),
+			},
+			expected: &fwplanmodifier.MatchElementStateForUnknownResponse{
+				Diagnostics: diag.Diagnostics{
+					fwplanmodifier.MatchElementStateForUnknownOutsideListOrSetDiag(
+						path.Root("test"),
+					),
+				},
+				PlanValue: types.StringUnknown(),
+			},
+		},
+		"path-map": {
+			request: fwplanmodifier.MatchElementStateForUnknownRequest{
+				Path:      path.Root("test").AtMapKey("testkey").AtName("nested_test"),
+				PlanValue: types.StringUnknown(),
+			},
+			expected: &fwplanmodifier.MatchElementStateForUnknownResponse{
+				Diagnostics: diag.Diagnostics{
+					fwplanmodifier.MatchElementStateForUnknownOutsideListOrSetDiag(
+						path.Root("test").AtMapKey("testkey").AtName("nested_test"),
+					),
+				},
+				PlanValue: types.StringUnknown(),
+			},
+		},
+		"path-object": {
+			request: fwplanmodifier.MatchElementStateForUnknownRequest{
+				Path:      path.Root("test").AtName("nested_test"),
+				PlanValue: types.StringUnknown(),
+			},
+			expected: &fwplanmodifier.MatchElementStateForUnknownResponse{
+				Diagnostics: diag.Diagnostics{
+					fwplanmodifier.MatchElementStateForUnknownOutsideListOrSetDiag(
+						path.Root("test").AtName("nested_test"),
+					),
+				},
+				PlanValue: types.StringUnknown(),
+			},
+		},
+		"path-list-no-expressions": {
+			request: fwplanmodifier.MatchElementStateForUnknownRequest{
+				Path:      path.Root("test").AtListIndex(0).AtName("nested_test"),
+				PlanValue: types.StringUnknown(),
+			},
+			expected: &fwplanmodifier.MatchElementStateForUnknownResponse{
+				Diagnostics: diag.Diagnostics{
+					fwplanmodifier.MatchElementStateForUnknownMissingExpressionsDiag(
+						path.Root("test").AtListIndex(0).AtName("nested_test"),
+					),
+				},
+				PlanValue: types.StringUnknown(),
+			},
+		},
+		"path-set-no-expressions": {
+			request: fwplanmodifier.MatchElementStateForUnknownRequest{
+				Path: path.Root("test").AtSetValue(
+					types.SetValueMust(
+						types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"nested_test": types.StringType,
+							},
+						},
+						[]attr.Value{
+							types.ObjectValueMust(
+								map[string]attr.Type{
+									"nested_test": types.StringType,
+								},
+								map[string]attr.Value{
+									"nested_test": types.StringUnknown(),
+								},
+							),
+						},
+					),
+				).AtName("nested_test"),
+				PlanValue: types.StringUnknown(),
+			},
+			expected: &fwplanmodifier.MatchElementStateForUnknownResponse{
+				Diagnostics: diag.Diagnostics{
+					fwplanmodifier.MatchElementStateForUnknownMissingExpressionsDiag(
+						path.Root("test").AtSetValue(
+							types.SetValueMust(
+								types.ObjectType{
+									AttrTypes: map[string]attr.Type{
+										"nested_test": types.StringType,
+									},
+								},
+								[]attr.Value{
+									types.ObjectValueMust(
+										map[string]attr.Type{
+											"nested_test": types.StringType,
+										},
+										map[string]attr.Value{
+											"nested_test": types.StringUnknown(),
+										},
+									),
+								},
+							),
+						).AtName("nested_test"),
+					),
+				},
+				PlanValue: types.StringUnknown(),
+			},
+		},
+		"expressions-root": {
+			request: fwplanmodifier.MatchElementStateForUnknownRequest{
+				Path:           path.Root("test").AtListIndex(0).AtName("nested_test"),
+				PathExpression: path.MatchRoot("test").AtListIndex(0).AtName("nested_test"),
+				PlanValue:      types.StringUnknown(),
+			},
+			expressions: path.Expressions{
+				// not valid for multiple elements
+				path.MatchRoot("test").AtListIndex(0).AtName("nested_other"),
+			},
+			expected: &fwplanmodifier.MatchElementStateForUnknownResponse{
+				Diagnostics: diag.Diagnostics{
+					fwplanmodifier.MatchElementStateForUnknownRootExpressionDiag(
+						path.Root("test").AtListIndex(0).AtName("nested_test"),
+						path.MatchRoot("test").AtListIndex(0).AtName("nested_other"),
+					),
+				},
+				PlanValue: types.StringUnknown(),
+			},
+		},
+		"expressions-invalid-step-length": {
+			request: fwplanmodifier.MatchElementStateForUnknownRequest{
+				Path:           path.Root("test").AtListIndex(0).AtName("nested_test"),
+				PathExpression: path.MatchRoot("test").AtListIndex(0).AtName("nested_test"),
+				PlanValue:      types.StringUnknown(),
+			},
+			expressions: path.Expressions{
+				path.MatchRelative().AtParent().AtName("nested_other").AtName("oops"),
+			},
+			expected: &fwplanmodifier.MatchElementStateForUnknownResponse{
+				Diagnostics: diag.Diagnostics{
+					fwplanmodifier.MatchElementStateForUnknownInvalidExpressionDiag(
+						path.Root("test").AtListIndex(0).AtName("nested_test"),
+						path.MatchRelative().AtParent().AtName("nested_other").AtName("oops"),
+					),
+				},
+				PlanValue: types.StringUnknown(),
+			},
+		},
+		"expressions-invalid-step-0": {
+			request: fwplanmodifier.MatchElementStateForUnknownRequest{
+				Path:           path.Root("test").AtListIndex(0).AtName("nested_test"),
+				PathExpression: path.MatchRoot("test").AtListIndex(0).AtName("nested_test"),
+				PlanValue:      types.StringUnknown(),
+			},
+			expressions: path.Expressions{
+				path.MatchRelative().AtName("nested_other"),
+			},
+			expected: &fwplanmodifier.MatchElementStateForUnknownResponse{
+				Diagnostics: diag.Diagnostics{
+					fwplanmodifier.MatchElementStateForUnknownInvalidExpressionDiag(
+						path.Root("test").AtListIndex(0).AtName("nested_test"),
+						path.MatchRelative().AtName("nested_other"),
+					),
+				},
+				PlanValue: types.StringUnknown(),
+			},
+		},
+		"expressions-invalid-step-1": {
+			request: fwplanmodifier.MatchElementStateForUnknownRequest{
+				Path:           path.Root("test").AtListIndex(0).AtName("nested_test"),
+				PathExpression: path.MatchRoot("test").AtListIndex(0).AtName("nested_test"),
+				PlanValue:      types.StringUnknown(),
+			},
+			expressions: path.Expressions{
+				path.MatchRelative().AtParent().AtParent(),
+			},
+			expected: &fwplanmodifier.MatchElementStateForUnknownResponse{
+				Diagnostics: diag.Diagnostics{
+					fwplanmodifier.MatchElementStateForUnknownInvalidExpressionDiag(
+						path.Root("test").AtListIndex(0).AtName("nested_test"),
+						path.MatchRelative().AtParent().AtParent(),
+					),
+				},
+				PlanValue: types.StringUnknown(),
+			},
+		},
+		"expressions-self-reference": {
+			request: fwplanmodifier.MatchElementStateForUnknownRequest{
+				Path:           path.Root("test").AtListIndex(0).AtName("nested_test"),
+				PathExpression: path.MatchRoot("test").AtListIndex(0).AtName("nested_test"),
+				Plan: tfsdk.Plan{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_test": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_test": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_test": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_test": tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+										},
+									),
+								},
+							),
+						},
+					),
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.NestedAttribute{
+								NestedObject: testschema.NestedAttributeObject{
+									Attributes: map[string]fwschema.Attribute{
+										"nested_test": testschema.AttributeWithStringPlanModifiers{
+											Computed: true,
+											PlanModifiers: []planmodifier.String{
+												fwplanmodifier.MatchElementStateForUnknownModifier{
+													Expressions: path.Expressions{
+														path.MatchRelative().AtParent().AtName("nested_test"),
+													},
+												},
+											},
+										},
+									},
+								},
+								NestingMode: fwschema.NestingModeList,
+							},
+						},
+					},
+				},
+				PlanValue: types.StringUnknown(),
+			},
+			expressions: path.Expressions{
+				path.MatchRelative().AtParent().AtName("nested_test"),
+			},
+			expected: &fwplanmodifier.MatchElementStateForUnknownResponse{
+				Diagnostics: diag.Diagnostics{
+					fwplanmodifier.MatchElementStateForUnknownInvalidExpressionDiag(
+						path.Root("test").AtListIndex(0).AtName("nested_test"),
+						path.MatchRoot("test").AtListIndex(0).AtName("nested_test").AtParent().AtName("nested_test"),
+					),
+				},
+				PlanValue: types.StringUnknown(),
+			},
+		},
+		"expressions-no-matched-path": {
+			request: fwplanmodifier.MatchElementStateForUnknownRequest{
+				Path:           path.Root("test").AtListIndex(0).AtName("nested_test"),
+				PathExpression: path.MatchRoot("test").AtListIndex(0).AtName("nested_test"),
+				Plan: tfsdk.Plan{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											// intentionally missing nested_other
+											"nested_test": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											// intentionally missing nested_other
+											"nested_test": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												// intentionally missing nested_other
+												"nested_test": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_test": tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+										},
+									),
+								},
+							),
+						},
+					),
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.NestedAttribute{
+								NestedObject: testschema.NestedAttributeObject{
+									Attributes: map[string]fwschema.Attribute{
+										// intentionally missing nested_other
+										"nested_test": testschema.AttributeWithStringPlanModifiers{
+											Computed: true,
+											PlanModifiers: []planmodifier.String{
+												fwplanmodifier.MatchElementStateForUnknownModifier{
+													Expressions: path.Expressions{
+														path.MatchRelative().AtParent().AtName("nested_other"),
+													},
+												},
+											},
+										},
+									},
+								},
+								NestingMode: fwschema.NestingModeList,
+							},
+						},
+					},
+				},
+				PlanValue: types.StringUnknown(),
+			},
+			expressions: path.Expressions{
+				path.MatchRelative().AtParent().AtName("nested_other"),
+			},
+			expected: &fwplanmodifier.MatchElementStateForUnknownResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic(
+						"Invalid Path Expression for Schema",
+						"The Terraform Provider unexpectedly provided a path expression that does not match the current schema. "+
+							"This can happen if the path expression does not correctly follow the schema in structure or types. "+
+							"Please report this to the provider developers.\n\n"+
+							"Path Expression: test[0].nested_test.<.nested_other",
+					),
+				},
+				PlanValue: types.StringUnknown(),
+			},
+		},
+		"unknown-identifying-value": {
+			request: fwplanmodifier.MatchElementStateForUnknownRequest{
+				ConfigValue:    types.StringNull(),
+				Path:           path.Root("test").AtListIndex(0).AtName("nested_test"),
+				PathExpression: path.MatchRoot("test").AtListIndex(0).AtName("nested_test"),
+				Plan: tfsdk.Plan{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_other": tftypes.String,
+											"nested_test":  tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_other": tftypes.String,
+											"nested_test":  tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_other": tftypes.String,
+												"nested_test":  tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_other": tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+											"nested_test":  tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+										},
+									),
+								},
+							),
+						},
+					),
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.NestedAttribute{
+								NestedObject: testschema.NestedAttributeObject{
+									Attributes: map[string]fwschema.Attribute{
+										"nested_other": testschema.AttributeWithStringPlanModifiers{
+											Required: true,
+										},
+										"nested_test": testschema.AttributeWithStringPlanModifiers{
+											Computed: true,
+											PlanModifiers: []planmodifier.String{
+												fwplanmodifier.MatchElementStateForUnknownModifier{
+													Expressions: path.Expressions{
+														path.MatchRelative().AtParent().AtName("nested_other"),
+													},
+												},
+											},
+										},
+									},
+								},
+								NestingMode: fwschema.NestingModeList,
+							},
+						},
+					},
+				},
+				PlanValue: types.StringUnknown(),
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_other": tftypes.String,
+											"nested_test":  tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_other": tftypes.String,
+											"nested_test":  tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_other": tftypes.String,
+												"nested_test":  tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_other": tftypes.NewValue(tftypes.String, "otherstatevalue"),
+											"nested_test":  tftypes.NewValue(tftypes.String, "teststatevalue"),
+										},
+									),
+								},
+							),
+						},
+					),
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.NestedAttribute{
+								NestedObject: testschema.NestedAttributeObject{
+									Attributes: map[string]fwschema.Attribute{
+										"nested_other": testschema.AttributeWithStringPlanModifiers{
+											Required: true,
+										},
+										"nested_test": testschema.AttributeWithStringPlanModifiers{
+											Computed: true,
+											PlanModifiers: []planmodifier.String{
+												fwplanmodifier.MatchElementStateForUnknownModifier{
+													Expressions: path.Expressions{
+														path.MatchRelative().AtParent().AtName("nested_other"),
+													},
+												},
+											},
+										},
+									},
+								},
+								NestingMode: fwschema.NestingModeList,
+							},
+						},
+					},
+				},
+			},
+			expressions: path.Expressions{
+				path.MatchRelative().AtParent().AtName("nested_other"),
+			},
+			expected: &fwplanmodifier.MatchElementStateForUnknownResponse{
+				PlanValue: types.StringUnknown(),
+			},
+		},
+		"known-plan-value": {
+			request: fwplanmodifier.MatchElementStateForUnknownRequest{
+				ConfigValue:    types.StringNull(),
+				Path:           path.Root("test").AtListIndex(0).AtName("nested_test"),
+				PathExpression: path.MatchRoot("test").AtListIndex(0).AtName("nested_test"),
+				Plan: tfsdk.Plan{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_other": tftypes.String,
+											"nested_test":  tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_other": tftypes.String,
+											"nested_test":  tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_other": tftypes.String,
+												"nested_test":  tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_other": tftypes.NewValue(tftypes.String, "otherstatevalue"),
+											"nested_test":  tftypes.NewValue(tftypes.String, "knownplanvalue"),
+										},
+									),
+								},
+							),
+						},
+					),
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.NestedAttribute{
+								NestedObject: testschema.NestedAttributeObject{
+									Attributes: map[string]fwschema.Attribute{
+										"nested_other": testschema.AttributeWithStringPlanModifiers{
+											Required: true,
+										},
+										"nested_test": testschema.AttributeWithStringPlanModifiers{
+											Computed: true,
+											PlanModifiers: []planmodifier.String{
+												fwplanmodifier.MatchElementStateForUnknownModifier{
+													Expressions: path.Expressions{
+														path.MatchRelative().AtParent().AtName("nested_other"),
+													},
+												},
+											},
+										},
+									},
+								},
+								NestingMode: fwschema.NestingModeList,
+							},
+						},
+					},
+				},
+				PlanValue: types.StringValue("knownplanvalue"),
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_other": tftypes.String,
+											"nested_test":  tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_other": tftypes.String,
+											"nested_test":  tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_other": tftypes.String,
+												"nested_test":  tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_other": tftypes.NewValue(tftypes.String, "otherstatevalue"),
+											"nested_test":  tftypes.NewValue(tftypes.String, "teststatevalue"),
+										},
+									),
+								},
+							),
+						},
+					),
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.NestedAttribute{
+								NestedObject: testschema.NestedAttributeObject{
+									Attributes: map[string]fwschema.Attribute{
+										"nested_other": testschema.AttributeWithStringPlanModifiers{
+											Required: true,
+										},
+										"nested_test": testschema.AttributeWithStringPlanModifiers{
+											Computed: true,
+											PlanModifiers: []planmodifier.String{
+												fwplanmodifier.MatchElementStateForUnknownModifier{
+													Expressions: path.Expressions{
+														path.MatchRelative().AtParent().AtName("nested_other"),
+													},
+												},
+											},
+										},
+									},
+								},
+								NestingMode: fwschema.NestingModeList,
+							},
+						},
+					},
+				},
+			},
+			expressions: path.Expressions{
+				path.MatchRelative().AtParent().AtName("nested_other"),
+			},
+			expected: &fwplanmodifier.MatchElementStateForUnknownResponse{
+				PlanValue: types.StringValue("knownplanvalue"),
+			},
+		},
+		"unknown-config-value": {
+			request: fwplanmodifier.MatchElementStateForUnknownRequest{
+				ConfigValue:    types.StringUnknown(),
+				Path:           path.Root("test").AtListIndex(0).AtName("nested_test"),
+				PathExpression: path.MatchRoot("test").AtListIndex(0).AtName("nested_test"),
+				Plan: tfsdk.Plan{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_other": tftypes.String,
+											"nested_test":  tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_other": tftypes.String,
+											"nested_test":  tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_other": tftypes.String,
+												"nested_test":  tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_other": tftypes.NewValue(tftypes.String, "otherstatevalue"),
+											"nested_test":  tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+										},
+									),
+								},
+							),
+						},
+					),
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.NestedAttribute{
+								NestedObject: testschema.NestedAttributeObject{
+									Attributes: map[string]fwschema.Attribute{
+										"nested_other": testschema.AttributeWithStringPlanModifiers{
+											Required: true,
+										},
+										"nested_test": testschema.AttributeWithStringPlanModifiers{
+											Optional: true,
+											Computed: true,
+											PlanModifiers: []planmodifier.String{
+												fwplanmodifier.MatchElementStateForUnknownModifier{
+													Expressions: path.Expressions{
+														path.MatchRelative().AtParent().AtName("nested_other"),
+													},
+												},
+											},
+										},
+									},
+								},
+								NestingMode: fwschema.NestingModeList,
+							},
+						},
+					},
+				},
+				PlanValue: types.StringUnknown(),
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_other": tftypes.String,
+											"nested_test":  tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_other": tftypes.String,
+											"nested_test":  tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_other": tftypes.String,
+												"nested_test":  tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_other": tftypes.NewValue(tftypes.String, "otherstatevalue"),
+											"nested_test":  tftypes.NewValue(tftypes.String, "teststatevalue"),
+										},
+									),
+								},
+							),
+						},
+					),
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.NestedAttribute{
+								NestedObject: testschema.NestedAttributeObject{
+									Attributes: map[string]fwschema.Attribute{
+										"nested_other": testschema.AttributeWithStringPlanModifiers{
+											Required: true,
+										},
+										"nested_test": testschema.AttributeWithStringPlanModifiers{
+											Computed: true,
+											PlanModifiers: []planmodifier.String{
+												fwplanmodifier.MatchElementStateForUnknownModifier{
+													Expressions: path.Expressions{
+														path.MatchRelative().AtParent().AtName("nested_other"),
+													},
+												},
+											},
+										},
+									},
+								},
+								NestingMode: fwschema.NestingModeList,
+							},
+						},
+					},
+				},
+			},
+			expressions: path.Expressions{
+				path.MatchRelative().AtParent().AtName("nested_other"),
+			},
+			expected: &fwplanmodifier.MatchElementStateForUnknownResponse{
+				PlanValue: types.StringUnknown(),
+			},
+		},
+		"null-matching-prior-state-value": {
+			request: fwplanmodifier.MatchElementStateForUnknownRequest{
+				ConfigValue:    types.StringNull(),
+				Path:           path.Root("test").AtListIndex(0).AtName("nested_test"),
+				PathExpression: path.MatchRoot("test").AtListIndex(0).AtName("nested_test"),
+				Plan: tfsdk.Plan{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_other": tftypes.String,
+											"nested_test":  tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_other": tftypes.String,
+											"nested_test":  tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_other": tftypes.String,
+												"nested_test":  tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_other": tftypes.NewValue(tftypes.String, "otherstatevalue"),
+											"nested_test":  tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+										},
+									),
+								},
+							),
+						},
+					),
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.NestedAttribute{
+								NestedObject: testschema.NestedAttributeObject{
+									Attributes: map[string]fwschema.Attribute{
+										"nested_other": testschema.AttributeWithStringPlanModifiers{
+											Required: true,
+										},
+										"nested_test": testschema.AttributeWithStringPlanModifiers{
+											Computed: true,
+											PlanModifiers: []planmodifier.String{
+												fwplanmodifier.MatchElementStateForUnknownModifier{
+													Expressions: path.Expressions{
+														path.MatchRelative().AtParent().AtName("nested_other"),
+													},
+												},
+											},
+										},
+									},
+								},
+								NestingMode: fwschema.NestingModeList,
+							},
+						},
+					},
+				},
+				PlanValue: types.StringUnknown(),
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_other": tftypes.String,
+											"nested_test":  tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_other": tftypes.String,
+											"nested_test":  tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_other": tftypes.String,
+												"nested_test":  tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_other": tftypes.NewValue(tftypes.String, "otherstatevalue"),
+											"nested_test":  tftypes.NewValue(tftypes.String, nil),
+										},
+									),
+								},
+							),
+						},
+					),
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.NestedAttribute{
+								NestedObject: testschema.NestedAttributeObject{
+									Attributes: map[string]fwschema.Attribute{
+										"nested_other": testschema.AttributeWithStringPlanModifiers{
+											Required: true,
+										},
+										"nested_test": testschema.AttributeWithStringPlanModifiers{
+											Computed: true,
+											PlanModifiers: []planmodifier.String{
+												fwplanmodifier.MatchElementStateForUnknownModifier{
+													Expressions: path.Expressions{
+														path.MatchRelative().AtParent().AtName("nested_other"),
+													},
+												},
+											},
+										},
+									},
+								},
+								NestingMode: fwschema.NestingModeList,
+							},
+						},
+					},
+				},
+			},
+			expressions: path.Expressions{
+				path.MatchRelative().AtParent().AtName("nested_other"),
+			},
+			expected: &fwplanmodifier.MatchElementStateForUnknownResponse{
+				PlanValue: types.StringUnknown(),
+			},
+		},
+		"null-state": { // resource creation
+			request: fwplanmodifier.MatchElementStateForUnknownRequest{
+				ConfigValue:    types.StringNull(),
+				Path:           path.Root("test").AtListIndex(0).AtName("nested_test"),
+				PathExpression: path.MatchRoot("test").AtListIndex(0).AtName("nested_test"),
+				Plan: tfsdk.Plan{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_other": tftypes.String,
+											"nested_test":  tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_other": tftypes.String,
+											"nested_test":  tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_other": tftypes.String,
+												"nested_test":  tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_other": tftypes.NewValue(tftypes.String, "otherstatevalue"),
+											"nested_test":  tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+										},
+									),
+								},
+							),
+						},
+					),
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.NestedAttribute{
+								NestedObject: testschema.NestedAttributeObject{
+									Attributes: map[string]fwschema.Attribute{
+										"nested_other": testschema.AttributeWithStringPlanModifiers{
+											Required: true,
+										},
+										"nested_test": testschema.AttributeWithStringPlanModifiers{
+											Computed: true,
+											PlanModifiers: []planmodifier.String{
+												fwplanmodifier.MatchElementStateForUnknownModifier{
+													Expressions: path.Expressions{
+														path.MatchRelative().AtParent().AtName("nested_other"),
+													},
+												},
+											},
+										},
+									},
+								},
+								NestingMode: fwschema.NestingModeList,
+							},
+						},
+					},
+				},
+				PlanValue: types.StringUnknown(),
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_other": tftypes.String,
+											"nested_test":  tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						nil,
+					),
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.NestedAttribute{
+								NestedObject: testschema.NestedAttributeObject{
+									Attributes: map[string]fwschema.Attribute{
+										"nested_other": testschema.AttributeWithStringPlanModifiers{
+											Required: true,
+										},
+										"nested_test": testschema.AttributeWithStringPlanModifiers{
+											Computed: true,
+											PlanModifiers: []planmodifier.String{
+												fwplanmodifier.MatchElementStateForUnknownModifier{
+													Expressions: path.Expressions{
+														path.MatchRelative().AtParent().AtName("nested_other"),
+													},
+												},
+											},
+										},
+									},
+								},
+								NestingMode: fwschema.NestingModeList,
+							},
+						},
+					},
+				},
+			},
+			expressions: path.Expressions{
+				path.MatchRelative().AtParent().AtName("nested_other"),
+			},
+			expected: &fwplanmodifier.MatchElementStateForUnknownResponse{
+				PlanValue: types.StringUnknown(),
+			},
+		},
+		"list-matching-prior-state-value": {
+			request: fwplanmodifier.MatchElementStateForUnknownRequest{
+				ConfigValue:    types.StringNull(),
+				Path:           path.Root("test").AtListIndex(0).AtName("nested_test"),
+				PathExpression: path.MatchRoot("test").AtListIndex(0).AtName("nested_test"),
+				Plan: tfsdk.Plan{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_other": tftypes.String,
+											"nested_test":  tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_other": tftypes.String,
+											"nested_test":  tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_other": tftypes.String,
+												"nested_test":  tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_other": tftypes.NewValue(tftypes.String, "otherstatevalue"),
+											"nested_test":  tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+										},
+									),
+								},
+							),
+						},
+					),
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.NestedAttribute{
+								NestedObject: testschema.NestedAttributeObject{
+									Attributes: map[string]fwschema.Attribute{
+										"nested_other": testschema.AttributeWithStringPlanModifiers{
+											Required: true,
+										},
+										"nested_test": testschema.AttributeWithStringPlanModifiers{
+											Computed: true,
+											PlanModifiers: []planmodifier.String{
+												fwplanmodifier.MatchElementStateForUnknownModifier{
+													Expressions: path.Expressions{
+														path.MatchRelative().AtParent().AtName("nested_other"),
+													},
+												},
+											},
+										},
+									},
+								},
+								NestingMode: fwschema.NestingModeList,
+							},
+						},
+					},
+				},
+				PlanValue: types.StringUnknown(),
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_other": tftypes.String,
+											"nested_test":  tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_other": tftypes.String,
+											"nested_test":  tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_other": tftypes.String,
+												"nested_test":  tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_other": tftypes.NewValue(tftypes.String, "otherstatevalue"),
+											"nested_test":  tftypes.NewValue(tftypes.String, "teststatevalue"),
+										},
+									),
+								},
+							),
+						},
+					),
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.NestedAttribute{
+								NestedObject: testschema.NestedAttributeObject{
+									Attributes: map[string]fwschema.Attribute{
+										"nested_other": testschema.AttributeWithStringPlanModifiers{
+											Required: true,
+										},
+										"nested_test": testschema.AttributeWithStringPlanModifiers{
+											Computed: true,
+											PlanModifiers: []planmodifier.String{
+												fwplanmodifier.MatchElementStateForUnknownModifier{
+													Expressions: path.Expressions{
+														path.MatchRelative().AtParent().AtName("nested_other"),
+													},
+												},
+											},
+										},
+									},
+								},
+								NestingMode: fwschema.NestingModeList,
+							},
+						},
+					},
+				},
+			},
+			expressions: path.Expressions{
+				path.MatchRelative().AtParent().AtName("nested_other"),
+			},
+			expected: &fwplanmodifier.MatchElementStateForUnknownResponse{
+				PlanValue: types.StringValue("teststatevalue"),
+			},
+		},
+		"list-rearranged": {
+			request: fwplanmodifier.MatchElementStateForUnknownRequest{
+				ConfigValue:    types.StringNull(),
+				Path:           path.Root("test").AtListIndex(0).AtName("nested_computed1"),
+				PathExpression: path.MatchRoot("test").AtListIndex(0).AtName("nested_computed1"),
+				Plan: tfsdk.Plan{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed1":   tftypes.String,
+											"nested_computed2":   tftypes.String,
+											"nested_configured1": tftypes.String,
+											"nested_configured2": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed1":   tftypes.String,
+											"nested_computed2":   tftypes.String,
+											"nested_configured1": tftypes.String,
+											"nested_configured2": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed1":   tftypes.String,
+												"nested_computed2":   tftypes.String,
+												"nested_configured1": tftypes.String,
+												"nested_configured2": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_configured1": tftypes.NewValue(tftypes.String, "element2-configured1"),
+											"nested_configured2": tftypes.NewValue(tftypes.String, "element2-configured2"),
+											"nested_computed1":   tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+											"nested_computed2":   tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+										},
+									),
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed1":   tftypes.String,
+												"nested_computed2":   tftypes.String,
+												"nested_configured1": tftypes.String,
+												"nested_configured2": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_configured1": tftypes.NewValue(tftypes.String, "element1-configured1"),
+											"nested_configured2": tftypes.NewValue(tftypes.String, "element1-configured2"),
+											"nested_computed1":   tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+											"nested_computed2":   tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+										},
+									),
+								},
+							),
+						},
+					),
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.NestedAttribute{
+								NestedObject: testschema.NestedAttributeObject{
+									Attributes: map[string]fwschema.Attribute{
+										"nested_computed1": testschema.AttributeWithStringPlanModifiers{
+											Computed: true,
+											PlanModifiers: []planmodifier.String{
+												fwplanmodifier.MatchElementStateForUnknownModifier{
+													Expressions: path.Expressions{
+														path.MatchRelative().AtParent().AtName("nested_configured1"),
+														path.MatchRelative().AtParent().AtName("nested_configured2"),
+													},
+												},
+											},
+										},
+										"nested_computed2": testschema.AttributeWithStringPlanModifiers{
+											Computed: true,
+										},
+										"nested_configured1": testschema.AttributeWithStringPlanModifiers{
+											Required: true,
+										},
+										"nested_configured2": testschema.AttributeWithStringPlanModifiers{
+											Required: true,
+										},
+									},
+								},
+								NestingMode: fwschema.NestingModeList,
+							},
+						},
+					},
+				},
+				PlanValue: types.StringUnknown(),
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed1":   tftypes.String,
+											"nested_computed2":   tftypes.String,
+											"nested_configured1": tftypes.String,
+											"nested_configured2": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed1":   tftypes.String,
+											"nested_computed2":   tftypes.String,
+											"nested_configured1": tftypes.String,
+											"nested_configured2": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed1":   tftypes.String,
+												"nested_computed2":   tftypes.String,
+												"nested_configured1": tftypes.String,
+												"nested_configured2": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_configured1": tftypes.NewValue(tftypes.String, "element1-configured1"),
+											"nested_configured2": tftypes.NewValue(tftypes.String, "element1-configured2"),
+											"nested_computed1":   tftypes.NewValue(tftypes.String, "element1-computed1"),
+											"nested_computed2":   tftypes.NewValue(tftypes.String, "element1-computed2"),
+										},
+									),
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed1":   tftypes.String,
+												"nested_computed2":   tftypes.String,
+												"nested_configured1": tftypes.String,
+												"nested_configured2": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_configured1": tftypes.NewValue(tftypes.String, "element2-configured1"),
+											"nested_configured2": tftypes.NewValue(tftypes.String, "element2-configured2"),
+											"nested_computed1":   tftypes.NewValue(tftypes.String, "element2-computed1"),
+											"nested_computed2":   tftypes.NewValue(tftypes.String, "element2-computed2"),
+										},
+									),
+								},
+							),
+						},
+					),
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.NestedAttribute{
+								NestedObject: testschema.NestedAttributeObject{
+									Attributes: map[string]fwschema.Attribute{
+										"nested_computed1": testschema.AttributeWithStringPlanModifiers{
+											Computed: true,
+											PlanModifiers: []planmodifier.String{
+												fwplanmodifier.MatchElementStateForUnknownModifier{
+													Expressions: path.Expressions{
+														path.MatchRelative().AtParent().AtName("nested_configured1"),
+														path.MatchRelative().AtParent().AtName("nested_configured2"),
+													},
+												},
+											},
+										},
+										"nested_computed2": testschema.AttributeWithStringPlanModifiers{
+											Computed: true,
+										},
+										"nested_configured1": testschema.AttributeWithStringPlanModifiers{
+											Required: true,
+										},
+										"nested_configured2": testschema.AttributeWithStringPlanModifiers{
+											Required: true,
+										},
+									},
+								},
+								NestingMode: fwschema.NestingModeList,
+							},
+						},
+					},
+				},
+			},
+			expressions: path.Expressions{
+				path.MatchRelative().AtParent().AtName("nested_configured1"),
+				path.MatchRelative().AtParent().AtName("nested_configured2"),
+			},
+			expected: &fwplanmodifier.MatchElementStateForUnknownResponse{
+				PlanValue: types.StringValue("element2-computed1"),
+			},
+		},
+		"set-matching-prior-state-value": {
+			request: fwplanmodifier.MatchElementStateForUnknownRequest{
+				ConfigValue: types.StringNull(),
+				Path: path.Root("test").AtSetValue(
+					types.ObjectValueMust(
+						map[string]attr.Type{
+							"nested_other": types.StringType,
+							"nested_test":  types.StringType,
+						},
+						map[string]attr.Value{
+							"nested_other": types.StringValue("otherstatevalue"),
+							"nested_test":  types.StringUnknown(),
+						},
+					),
+				).AtName("nested_test"),
+				PathExpression: path.MatchRoot("test").AtSetValue(
+					types.ObjectValueMust(
+						map[string]attr.Type{
+							"nested_other": types.StringType,
+							"nested_test":  types.StringType,
+						},
+						map[string]attr.Value{
+							"nested_other": types.StringValue("otherstatevalue"),
+							"nested_test":  types.StringUnknown(),
+						},
+					),
+				).AtName("nested_test"),
+				Plan: tfsdk.Plan{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_other": tftypes.String,
+											"nested_test":  tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_other": tftypes.String,
+											"nested_test":  tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_other": tftypes.String,
+												"nested_test":  tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_other": tftypes.NewValue(tftypes.String, "otherstatevalue"),
+											"nested_test":  tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+										},
+									),
+								},
+							),
+						},
+					),
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.NestedAttribute{
+								NestedObject: testschema.NestedAttributeObject{
+									Attributes: map[string]fwschema.Attribute{
+										"nested_other": testschema.AttributeWithStringPlanModifiers{
+											Required: true,
+										},
+										"nested_test": testschema.AttributeWithStringPlanModifiers{
+											Computed: true,
+											PlanModifiers: []planmodifier.String{
+												fwplanmodifier.MatchElementStateForUnknownModifier{
+													Expressions: path.Expressions{
+														path.MatchRelative().AtParent().AtName("nested_other"),
+													},
+												},
+											},
+										},
+									},
+								},
+								NestingMode: fwschema.NestingModeSet,
+							},
+						},
+					},
+				},
+				PlanValue: types.StringUnknown(),
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_other": tftypes.String,
+											"nested_test":  tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_other": tftypes.String,
+											"nested_test":  tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_other": tftypes.String,
+												"nested_test":  tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_other": tftypes.NewValue(tftypes.String, "otherstatevalue"),
+											"nested_test":  tftypes.NewValue(tftypes.String, "teststatevalue"),
+										},
+									),
+								},
+							),
+						},
+					),
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.NestedAttribute{
+								NestedObject: testschema.NestedAttributeObject{
+									Attributes: map[string]fwschema.Attribute{
+										"nested_other": testschema.AttributeWithStringPlanModifiers{
+											Required: true,
+										},
+										"nested_test": testschema.AttributeWithStringPlanModifiers{
+											Computed: true,
+											PlanModifiers: []planmodifier.String{
+												fwplanmodifier.MatchElementStateForUnknownModifier{
+													Expressions: path.Expressions{
+														path.MatchRelative().AtParent().AtName("nested_other"),
+													},
+												},
+											},
+										},
+									},
+								},
+								NestingMode: fwschema.NestingModeSet,
+							},
+						},
+					},
+				},
+			},
+			expressions: path.Expressions{
+				path.MatchRelative().AtParent().AtName("nested_other"),
+			},
+			expected: &fwplanmodifier.MatchElementStateForUnknownResponse{
+				PlanValue: types.StringValue("teststatevalue"),
+			},
+		},
+		"set-rearranged": {
+			request: fwplanmodifier.MatchElementStateForUnknownRequest{
+				ConfigValue: types.StringNull(),
+				Path: path.Root("test").AtSetValue(
+					types.ObjectValueMust(
+						map[string]attr.Type{
+							"nested_computed1":   types.StringType,
+							"nested_computed2":   types.StringType,
+							"nested_configured1": types.StringType,
+							"nested_configured2": types.StringType,
+						},
+						map[string]attr.Value{
+							"nested_computed1":   types.StringUnknown(),
+							"nested_computed2":   types.StringUnknown(),
+							"nested_configured1": types.StringValue("element2-configured1"),
+							"nested_configured2": types.StringValue("element2-configured2"),
+						},
+					),
+				).AtName("nested_computed1"),
+				PathExpression: path.MatchRoot("test").AtSetValue(
+					types.ObjectValueMust(
+						map[string]attr.Type{
+							"nested_computed1":   types.StringType,
+							"nested_computed2":   types.StringType,
+							"nested_configured1": types.StringType,
+							"nested_configured2": types.StringType,
+						},
+						map[string]attr.Value{
+							"nested_computed1":   types.StringUnknown(),
+							"nested_computed2":   types.StringUnknown(),
+							"nested_configured1": types.StringValue("element2-configured1"),
+							"nested_configured2": types.StringValue("element2-configured2"),
+						},
+					),
+				).AtName("nested_computed1"),
+				Plan: tfsdk.Plan{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed1":   tftypes.String,
+											"nested_computed2":   tftypes.String,
+											"nested_configured1": tftypes.String,
+											"nested_configured2": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed1":   tftypes.String,
+											"nested_computed2":   tftypes.String,
+											"nested_configured1": tftypes.String,
+											"nested_configured2": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed1":   tftypes.String,
+												"nested_computed2":   tftypes.String,
+												"nested_configured1": tftypes.String,
+												"nested_configured2": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_configured1": tftypes.NewValue(tftypes.String, "element2-configured1"),
+											"nested_configured2": tftypes.NewValue(tftypes.String, "element2-configured2"),
+											"nested_computed1":   tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+											"nested_computed2":   tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+										},
+									),
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed1":   tftypes.String,
+												"nested_computed2":   tftypes.String,
+												"nested_configured1": tftypes.String,
+												"nested_configured2": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_configured1": tftypes.NewValue(tftypes.String, "element1-configured1"),
+											"nested_configured2": tftypes.NewValue(tftypes.String, "element1-configured2"),
+											"nested_computed1":   tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+											"nested_computed2":   tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+										},
+									),
+								},
+							),
+						},
+					),
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.NestedAttribute{
+								NestedObject: testschema.NestedAttributeObject{
+									Attributes: map[string]fwschema.Attribute{
+										"nested_computed1": testschema.AttributeWithStringPlanModifiers{
+											Computed: true,
+											PlanModifiers: []planmodifier.String{
+												fwplanmodifier.MatchElementStateForUnknownModifier{
+													Expressions: path.Expressions{
+														path.MatchRelative().AtParent().AtName("nested_configured1"),
+														path.MatchRelative().AtParent().AtName("nested_configured2"),
+													},
+												},
+											},
+										},
+										"nested_computed2": testschema.AttributeWithStringPlanModifiers{
+											Computed: true,
+										},
+										"nested_configured1": testschema.AttributeWithStringPlanModifiers{
+											Required: true,
+										},
+										"nested_configured2": testschema.AttributeWithStringPlanModifiers{
+											Required: true,
+										},
+									},
+								},
+								NestingMode: fwschema.NestingModeSet,
+							},
+						},
+					},
+				},
+				PlanValue: types.StringUnknown(),
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed1":   tftypes.String,
+											"nested_computed2":   tftypes.String,
+											"nested_configured1": tftypes.String,
+											"nested_configured2": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed1":   tftypes.String,
+											"nested_computed2":   tftypes.String,
+											"nested_configured1": tftypes.String,
+											"nested_configured2": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed1":   tftypes.String,
+												"nested_computed2":   tftypes.String,
+												"nested_configured1": tftypes.String,
+												"nested_configured2": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_configured1": tftypes.NewValue(tftypes.String, "element1-configured1"),
+											"nested_configured2": tftypes.NewValue(tftypes.String, "element1-configured2"),
+											"nested_computed1":   tftypes.NewValue(tftypes.String, "element1-computed1"),
+											"nested_computed2":   tftypes.NewValue(tftypes.String, "element1-computed2"),
+										},
+									),
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed1":   tftypes.String,
+												"nested_computed2":   tftypes.String,
+												"nested_configured1": tftypes.String,
+												"nested_configured2": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_configured1": tftypes.NewValue(tftypes.String, "element2-configured1"),
+											"nested_configured2": tftypes.NewValue(tftypes.String, "element2-configured2"),
+											"nested_computed1":   tftypes.NewValue(tftypes.String, "element2-computed1"),
+											"nested_computed2":   tftypes.NewValue(tftypes.String, "element2-computed2"),
+										},
+									),
+								},
+							),
+						},
+					),
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.NestedAttribute{
+								NestedObject: testschema.NestedAttributeObject{
+									Attributes: map[string]fwschema.Attribute{
+										"nested_computed1": testschema.AttributeWithStringPlanModifiers{
+											Computed: true,
+											PlanModifiers: []planmodifier.String{
+												fwplanmodifier.MatchElementStateForUnknownModifier{
+													Expressions: path.Expressions{
+														path.MatchRelative().AtParent().AtName("nested_configured1"),
+														path.MatchRelative().AtParent().AtName("nested_configured2"),
+													},
+												},
+											},
+										},
+										"nested_computed2": testschema.AttributeWithStringPlanModifiers{
+											Computed: true,
+										},
+										"nested_configured1": testschema.AttributeWithStringPlanModifiers{
+											Required: true,
+										},
+										"nested_configured2": testschema.AttributeWithStringPlanModifiers{
+											Required: true,
+										},
+									},
+								},
+								NestingMode: fwschema.NestingModeSet,
+							},
+						},
+					},
+				},
+			},
+			expressions: path.Expressions{
+				path.MatchRelative().AtParent().AtName("nested_configured1"),
+				path.MatchRelative().AtParent().AtName("nested_configured2"),
+			},
+			expected: &fwplanmodifier.MatchElementStateForUnknownResponse{
+				PlanValue: types.StringValue("element2-computed1"),
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			resp := &fwplanmodifier.MatchElementStateForUnknownResponse{
+				PlanValue: testCase.request.PlanValue,
+			}
+			fwplanmodifier.MatchElementStateForUnknownModifier{
+				Expressions: testCase.expressions,
+			}.PlanModify(context.Background(), testCase.request, resp)
+
+			if diff := cmp.Diff(testCase.expected, resp); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestMatchElementStateForUnknownMissingExpressionsDiag(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		path     path.Path
+		expected diag.Diagnostic
+	}{
+		"test": {
+			path: path.Root("test").AtListIndex(0).AtName("nested_test"),
+			expected: diag.NewAttributeErrorDiagnostic(
+				path.Root("test").AtListIndex(0).AtName("nested_test"),
+				"Invalid Attribute Schema",
+				"The MatchElementStateForUnknown() plan modifier has no path expressions. "+
+					"At least one path expression must be given for matching the prior state. "+
+					"For example:\n\n"+
+					"MatchElementStateForUnknown(\n"+
+					"  path.MatchRelative().AtParent().AtName(\"another_element_attribute\"),\n"+
+					"),\n\n"+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					"Path: test[0].nested_test",
+			),
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := fwplanmodifier.MatchElementStateForUnknownMissingExpressionsDiag(testCase.path)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestMatchElementStateForUnknownOutsideListOrSetDiag(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		path     path.Path
+		expected diag.Diagnostic
+	}{
+		"test": {
+			path: path.Root("test").AtMapKey("testkey").AtName("nested_test"),
+			expected: diag.NewAttributeErrorDiagnostic(
+				path.Root("test").AtMapKey("testkey").AtName("nested_test"),
+				"Invalid Attribute Schema",
+				"The MatchElementStateForUnknown() plan modifier is only intended for nested object attributes under a list or set. "+
+					"Use the UseStateForUnknown() plan modifier instead. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					"Path: test[\"testkey\"].nested_test",
+			),
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := fwplanmodifier.MatchElementStateForUnknownOutsideListOrSetDiag(testCase.path)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestMatchElementStateForUnknownInvalidExpressionDiag(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		path       path.Path
+		expression path.Expression
+		expected   diag.Diagnostic
+	}{
+		"test": {
+			path:       path.Root("test").AtListIndex(0).AtName("nested_test"),
+			expression: path.MatchRelative().AtParent().AtParent().AtName("not_test"),
+			expected: diag.NewAttributeErrorDiagnostic(
+				path.Root("test").AtListIndex(0).AtName("nested_test"),
+				"Invalid Attribute Schema",
+				"The MatchElementStateForUnknown() plan modifier was given an invalid path expression. "+
+					"Expressions should be relative and match a different, identifying, and configurable attribute within the same nested object. "+
+					"For example:\n\n"+
+					"MatchElementStateForUnknown(\n"+
+					"  path.MatchRelative().AtParent().AtName(\"another_element_attribute\"),\n"+
+					"),\n\n"+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					"Path: test[0].nested_test\n"+
+					"Given Expression: <.<.not_test",
+			),
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := fwplanmodifier.MatchElementStateForUnknownInvalidExpressionDiag(testCase.path, testCase.expression)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestMatchElementStateForUnknownRootExpressionDiag(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		path       path.Path
+		expression path.Expression
+		expected   diag.Diagnostic
+	}{
+		"test": {
+			path:       path.Root("test").AtListIndex(0).AtName("nested_test"),
+			expression: path.MatchRoot("test").AtListIndex(0).AtName("not_nested_test"), // not valid for multiple elements
+			expected: diag.NewAttributeErrorDiagnostic(
+				path.Root("test").AtListIndex(0).AtName("nested_test"),
+				"Invalid Attribute Schema",
+				"The MatchElementStateForUnknown() plan modifier was given a root path expression. "+
+					"Expressions should only be relative and reference attributes at the same level. "+
+					"For example:\n\n"+
+					"MatchElementStateForUnknown(\n"+
+					"  path.MatchRelative().AtParent().AtName(\"another_element_attribute\"),\n"+
+					"),\n\n"+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					"Path: test[0].nested_test\n"+
+					"Given Expression: test[0].not_nested_test",
+			),
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := fwplanmodifier.MatchElementStateForUnknownRootExpressionDiag(testCase.path, testCase.expression)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}

--- a/internal/planmodifierdiag/use_state_for_unknown.go
+++ b/internal/planmodifierdiag/use_state_for_unknown.go
@@ -14,9 +14,7 @@ func UseStateForUnknownUnderListOrSet(p path.Path) diag.Diagnostic {
 		p,
 		"Invalid Attribute Schema",
 		"Attributes under a list or set cannot use the UseStateForUnknown() plan modifier. "+
-			// TODO: Implement MatchElementStateForUnknown plan modifiers.
-			// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/717
-			// "Use the MatchElementStateForUnknown() plan modifier instead. "+
+			"Use the MatchElementStateForUnknown() plan modifier instead. "+
 			"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
 			fmt.Sprintf("Path: %s\n", p),
 	)

--- a/internal/planmodifierdiag/use_state_for_unknown_test.go
+++ b/internal/planmodifierdiag/use_state_for_unknown_test.go
@@ -22,9 +22,7 @@ func TestUseStateForUnknownUnderListOrSet(t *testing.T) {
 				path.Root("test"),
 				"Invalid Attribute Schema",
 				"Attributes under a list or set cannot use the UseStateForUnknown() plan modifier. "+
-					// TODO: Implement MatchElementStateForUnknown plan modifiers.
-					// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/717
-					// "Use the MatchElementStateForUnknown() plan modifier instead. "+
+					"Use the MatchElementStateForUnknown() plan modifier instead. "+
 					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
 					"Path: test\n",
 			),

--- a/path/expression.go
+++ b/path/expression.go
@@ -45,7 +45,7 @@ import (
 type Expression struct {
 	// root stores whether an expression was intentionally created to start
 	// from the root of the data. This is used with Merge to overwrite steps
-	// instead of appending steps.
+	// instead of appending steps and can be checked with IsRoot.
 	root bool
 
 	// steps is the transversals included with the expression. In general,
@@ -165,6 +165,11 @@ func (e Expression) Equal(o Expression) bool {
 	return true
 }
 
+// IsRoot returns true if the expression is a root expression and not relative.
+func (e Expression) IsRoot() bool {
+	return e.root
+}
+
 // Matches returns true if the given Path is valid for the Expression. Any
 // relative expression steps, such as ExpressionStepParent, are automatically
 // resolved before matching.
@@ -191,7 +196,7 @@ func (e Expression) MatchesParent(path Path) bool {
 // method explicitly if a resolved expression without any ExpressionStepParent
 // is desired.
 func (e Expression) Merge(other Expression) Expression {
-	if other.root {
+	if other.IsRoot() {
 		return other.Copy()
 	}
 

--- a/resource/schema/boolplanmodifier/match_element_state_for_unknown.go
+++ b/resource/schema/boolplanmodifier/match_element_state_for_unknown.go
@@ -1,0 +1,42 @@
+package boolplanmodifier
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// MatchElementStateForUnknown returns a plan modifier that copies a known prior
+// state value into the planned value based on list or set element identifying
+// paths. Use this when it is known that an unconfigured value under a list or
+// set nested attribute or block will remain the same after a resource update.
+//
+// Identifying path expression(s) should be in the form:
+//
+//	path.MatchRelative().AtParent().AtName("another_configurable_attribute")
+//
+// To prevent Terraform errors, the framework automatically sets unconfigured
+// and Computed attributes to an unknown value "(known after apply)" on update.
+// Using this plan modifier will instead display the prior state value from the
+// matching element in the plan, unless a prior plan modifier set the value to
+// null or a known value.
+//
+// To prevent errant implementations, this plan modifier will raise an error
+// diagnostic if:
+//
+//   - Implemented on an attribute which is not beneath a list or set. Use the
+//     UseStateForUnknown plan modifier instead.
+//   - Zero path expressions are given.
+//   - A given path expression is not relative.
+//   - A given path expression is not a parent step, then a name step.
+//   - A given path expression self-references the attribute where the plan
+//     modifier is implemented.
+//   - A given path expression references a path to a Computed-only attribute.
+//     Only configurable attributes are valid for this plan modifier, otherwise
+//     the value at the path will always be unknown and plan modifier will never
+//     return an expected value.
+func MatchElementStateForUnknown(expressions ...path.Expression) planmodifier.Bool {
+	return fwplanmodifier.MatchElementStateForUnknownModifier{
+		Expressions: expressions,
+	}
+}

--- a/resource/schema/boolplanmodifier/match_element_state_for_unknown_example_test.go
+++ b/resource/schema/boolplanmodifier/match_element_state_for_unknown_example_test.go
@@ -1,0 +1,37 @@
+package boolplanmodifier_test
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+func ExampleMatchElementStateForUnknown() {
+	// Used within a Schema method of a Resource
+	_ = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"example_attr": schema.SetNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"computed_attr": schema.BoolAttribute{
+							Computed: true,
+							PlanModifiers: []planmodifier.Bool{
+								// Preseve this computed value during updates.
+								boolplanmodifier.MatchElementStateForUnknown(
+									// Identify matching prior state value based on configurable_attr
+									path.MatchRelative().AtParent().AtName("configurable_attr"),
+									// ... potentially others ...
+								),
+							},
+						},
+						"configurable_attr": schema.StringAttribute{
+							Required: true,
+						},
+					},
+				},
+				Optional: true,
+			},
+		},
+	}
+}

--- a/resource/schema/boolplanmodifier/use_state_for_unknown.go
+++ b/resource/schema/boolplanmodifier/use_state_for_unknown.go
@@ -20,7 +20,7 @@ import (
 // To prevent data issues and Terraform errors, this plan modifier cannot be
 // implemented on attribute values beneath lists or sets. An implementation
 // error diagnostic is raised if the plan modifier logic detects a list or set
-// in the request path.
+// in the request path. Use MatchElementStateForUnknown in that situation.
 func UseStateForUnknown() planmodifier.Bool {
 	return useStateForUnknownModifier{}
 }

--- a/resource/schema/float64planmodifier/match_element_state_for_unknown.go
+++ b/resource/schema/float64planmodifier/match_element_state_for_unknown.go
@@ -1,0 +1,42 @@
+package float64planmodifier
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// MatchElementStateForUnknown returns a plan modifier that copies a known prior
+// state value into the planned value based on list or set element identifying
+// paths. Use this when it is known that an unconfigured value under a list or
+// set nested attribute or block will remain the same after a resource update.
+//
+// Identifying path expression(s) should be in the form:
+//
+//	path.MatchRelative().AtParent().AtName("another_configurable_attribute")
+//
+// To prevent Terraform errors, the framework automatically sets unconfigured
+// and Computed attributes to an unknown value "(known after apply)" on update.
+// Using this plan modifier will instead display the prior state value from the
+// matching element in the plan, unless a prior plan modifier set the value to
+// null or a known value.
+//
+// To prevent errant implementations, this plan modifier will raise an error
+// diagnostic if:
+//
+//   - Implemented on an attribute which is not beneath a list or set. Use the
+//     UseStateForUnknown plan modifier instead.
+//   - Zero path expressions are given.
+//   - A given path expression is not relative.
+//   - A given path expression is not a parent step, then a name step.
+//   - A given path expression self-references the attribute where the plan
+//     modifier is implemented.
+//   - A given path expression references a path to a Computed-only attribute.
+//     Only configurable attributes are valid for this plan modifier, otherwise
+//     the value at the path will always be unknown and plan modifier will never
+//     return an expected value.
+func MatchElementStateForUnknown(expressions ...path.Expression) planmodifier.Float64 {
+	return fwplanmodifier.MatchElementStateForUnknownModifier{
+		Expressions: expressions,
+	}
+}

--- a/resource/schema/float64planmodifier/match_element_state_for_unknown_example_test.go
+++ b/resource/schema/float64planmodifier/match_element_state_for_unknown_example_test.go
@@ -1,0 +1,37 @@
+package float64planmodifier_test
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/float64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+func ExampleMatchElementStateForUnknown() {
+	// Used within a Schema method of a Resource
+	_ = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"example_attr": schema.SetNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"computed_attr": schema.Float64Attribute{
+							Computed: true,
+							PlanModifiers: []planmodifier.Float64{
+								// Preseve this computed value during updates.
+								float64planmodifier.MatchElementStateForUnknown(
+									// Identify matching prior state value based on configurable_attr
+									path.MatchRelative().AtParent().AtName("configurable_attr"),
+									// ... potentially others ...
+								),
+							},
+						},
+						"configurable_attr": schema.StringAttribute{
+							Required: true,
+						},
+					},
+				},
+				Optional: true,
+			},
+		},
+	}
+}

--- a/resource/schema/float64planmodifier/use_state_for_unknown.go
+++ b/resource/schema/float64planmodifier/use_state_for_unknown.go
@@ -20,7 +20,7 @@ import (
 // To prevent data issues and Terraform errors, this plan modifier cannot be
 // implemented on attribute values beneath lists or sets. An implementation
 // error diagnostic is raised if the plan modifier logic detects a list or set
-// in the request path.
+// in the request path. Use MatchElementStateForUnknown in that situation.
 func UseStateForUnknown() planmodifier.Float64 {
 	return useStateForUnknownModifier{}
 }

--- a/resource/schema/int64planmodifier/match_element_state_for_unknown.go
+++ b/resource/schema/int64planmodifier/match_element_state_for_unknown.go
@@ -1,0 +1,42 @@
+package int64planmodifier
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// MatchElementStateForUnknown returns a plan modifier that copies a known prior
+// state value into the planned value based on list or set element identifying
+// paths. Use this when it is known that an unconfigured value under a list or
+// set nested attribute or block will remain the same after a resource update.
+//
+// Identifying path expression(s) should be in the form:
+//
+//	path.MatchRelative().AtParent().AtName("another_configurable_attribute")
+//
+// To prevent Terraform errors, the framework automatically sets unconfigured
+// and Computed attributes to an unknown value "(known after apply)" on update.
+// Using this plan modifier will instead display the prior state value from the
+// matching element in the plan, unless a prior plan modifier set the value to
+// null or a known value.
+//
+// To prevent errant implementations, this plan modifier will raise an error
+// diagnostic if:
+//
+//   - Implemented on an attribute which is not beneath a list or set. Use the
+//     UseStateForUnknown plan modifier instead.
+//   - Zero path expressions are given.
+//   - A given path expression is not relative.
+//   - A given path expression is not a parent step, then a name step.
+//   - A given path expression self-references the attribute where the plan
+//     modifier is implemented.
+//   - A given path expression references a path to a Computed-only attribute.
+//     Only configurable attributes are valid for this plan modifier, otherwise
+//     the value at the path will always be unknown and plan modifier will never
+//     return an expected value.
+func MatchElementStateForUnknown(expressions ...path.Expression) planmodifier.Int64 {
+	return fwplanmodifier.MatchElementStateForUnknownModifier{
+		Expressions: expressions,
+	}
+}

--- a/resource/schema/int64planmodifier/match_element_state_for_unknown_example_test.go
+++ b/resource/schema/int64planmodifier/match_element_state_for_unknown_example_test.go
@@ -1,0 +1,37 @@
+package int64planmodifier_test
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+func ExampleMatchElementStateForUnknown() {
+	// Used within a Schema method of a Resource
+	_ = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"example_attr": schema.SetNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"computed_attr": schema.Int64Attribute{
+							Computed: true,
+							PlanModifiers: []planmodifier.Int64{
+								// Preseve this computed value during updates.
+								int64planmodifier.MatchElementStateForUnknown(
+									// Identify matching prior state value based on configurable_attr
+									path.MatchRelative().AtParent().AtName("configurable_attr"),
+									// ... potentially others ...
+								),
+							},
+						},
+						"configurable_attr": schema.StringAttribute{
+							Required: true,
+						},
+					},
+				},
+				Optional: true,
+			},
+		},
+	}
+}

--- a/resource/schema/int64planmodifier/use_state_for_unknown.go
+++ b/resource/schema/int64planmodifier/use_state_for_unknown.go
@@ -20,7 +20,7 @@ import (
 // To prevent data issues and Terraform errors, this plan modifier cannot be
 // implemented on attribute values beneath lists or sets. An implementation
 // error diagnostic is raised if the plan modifier logic detects a list or set
-// in the request path.
+// in the request path. Use MatchElementStateForUnknown in that situation.
 func UseStateForUnknown() planmodifier.Int64 {
 	return useStateForUnknownModifier{}
 }

--- a/resource/schema/listplanmodifier/match_element_state_for_unknown.go
+++ b/resource/schema/listplanmodifier/match_element_state_for_unknown.go
@@ -1,0 +1,42 @@
+package listplanmodifier
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// MatchElementStateForUnknown returns a plan modifier that copies a known prior
+// state value into the planned value based on list or set element identifying
+// paths. Use this when it is known that an unconfigured value under a list or
+// set nested attribute or block will remain the same after a resource update.
+//
+// Identifying path expression(s) should be in the form:
+//
+//	path.MatchRelative().AtParent().AtName("another_configurable_attribute")
+//
+// To prevent Terraform errors, the framework automatically sets unconfigured
+// and Computed attributes to an unknown value "(known after apply)" on update.
+// Using this plan modifier will instead display the prior state value from the
+// matching element in the plan, unless a prior plan modifier set the value to
+// null or a known value.
+//
+// To prevent errant implementations, this plan modifier will raise an error
+// diagnostic if:
+//
+//   - Implemented on an attribute which is not beneath a list or set. Use the
+//     UseStateForUnknown plan modifier instead.
+//   - Zero path expressions are given.
+//   - A given path expression is not relative.
+//   - A given path expression is not a parent step, then a name step.
+//   - A given path expression self-references the attribute where the plan
+//     modifier is implemented.
+//   - A given path expression references a path to a Computed-only attribute.
+//     Only configurable attributes are valid for this plan modifier, otherwise
+//     the value at the path will always be unknown and plan modifier will never
+//     return an expected value.
+func MatchElementStateForUnknown(expressions ...path.Expression) planmodifier.List {
+	return fwplanmodifier.MatchElementStateForUnknownModifier{
+		Expressions: expressions,
+	}
+}

--- a/resource/schema/listplanmodifier/match_element_state_for_unknown_example_test.go
+++ b/resource/schema/listplanmodifier/match_element_state_for_unknown_example_test.go
@@ -1,0 +1,39 @@
+package listplanmodifier_test
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func ExampleMatchElementStateForUnknown() {
+	// Used within a Schema method of a Resource
+	_ = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"example_attr": schema.SetNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"computed_attr": schema.ListAttribute{
+							Computed:    true,
+							ElementType: types.StringType,
+							PlanModifiers: []planmodifier.List{
+								// Preseve this computed value during updates.
+								listplanmodifier.MatchElementStateForUnknown(
+									// Identify matching prior state value based on configurable_attr
+									path.MatchRelative().AtParent().AtName("configurable_attr"),
+									// ... potentially others ...
+								),
+							},
+						},
+						"configurable_attr": schema.StringAttribute{
+							Required: true,
+						},
+					},
+				},
+				Optional: true,
+			},
+		},
+	}
+}

--- a/resource/schema/listplanmodifier/use_state_for_unknown.go
+++ b/resource/schema/listplanmodifier/use_state_for_unknown.go
@@ -20,7 +20,7 @@ import (
 // To prevent data issues and Terraform errors, this plan modifier cannot be
 // implemented on attribute values beneath lists or sets. An implementation
 // error diagnostic is raised if the plan modifier logic detects a list or set
-// in the request path.
+// in the request path. Use MatchElementStateForUnknown in that situation.
 func UseStateForUnknown() planmodifier.List {
 	return useStateForUnknownModifier{}
 }

--- a/resource/schema/mapplanmodifier/match_element_state_for_unknown.go
+++ b/resource/schema/mapplanmodifier/match_element_state_for_unknown.go
@@ -1,0 +1,42 @@
+package mapplanmodifier
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// MatchElementStateForUnknown returns a plan modifier that copies a known prior
+// state value into the planned value based on list or set element identifying
+// paths. Use this when it is known that an unconfigured value under a list or
+// set nested attribute or block will remain the same after a resource update.
+//
+// Identifying path expression(s) should be in the form:
+//
+//	path.MatchRelative().AtParent().AtName("another_configurable_attribute")
+//
+// To prevent Terraform errors, the framework automatically sets unconfigured
+// and Computed attributes to an unknown value "(known after apply)" on update.
+// Using this plan modifier will instead display the prior state value from the
+// matching element in the plan, unless a prior plan modifier set the value to
+// null or a known value.
+//
+// To prevent errant implementations, this plan modifier will raise an error
+// diagnostic if:
+//
+//   - Implemented on an attribute which is not beneath a list or set. Use the
+//     UseStateForUnknown plan modifier instead.
+//   - Zero path expressions are given.
+//   - A given path expression is not relative.
+//   - A given path expression is not a parent step, then a name step.
+//   - A given path expression self-references the attribute where the plan
+//     modifier is implemented.
+//   - A given path expression references a path to a Computed-only attribute.
+//     Only configurable attributes are valid for this plan modifier, otherwise
+//     the value at the path will always be unknown and plan modifier will never
+//     return an expected value.
+func MatchElementStateForUnknown(expressions ...path.Expression) planmodifier.Map {
+	return fwplanmodifier.MatchElementStateForUnknownModifier{
+		Expressions: expressions,
+	}
+}

--- a/resource/schema/mapplanmodifier/match_element_state_for_unknown_example_test.go
+++ b/resource/schema/mapplanmodifier/match_element_state_for_unknown_example_test.go
@@ -1,0 +1,39 @@
+package mapplanmodifier_test
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func ExampleMatchElementStateForUnknown() {
+	// Used within a Schema method of a Resource
+	_ = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"example_attr": schema.SetNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"computed_attr": schema.MapAttribute{
+							Computed:    true,
+							ElementType: types.StringType,
+							PlanModifiers: []planmodifier.Map{
+								// Preseve this computed value during updates.
+								mapplanmodifier.MatchElementStateForUnknown(
+									// Identify matching prior state value based on configurable_attr
+									path.MatchRelative().AtParent().AtName("configurable_attr"),
+									// ... potentially others ...
+								),
+							},
+						},
+						"configurable_attr": schema.StringAttribute{
+							Required: true,
+						},
+					},
+				},
+				Optional: true,
+			},
+		},
+	}
+}

--- a/resource/schema/mapplanmodifier/use_state_for_unknown.go
+++ b/resource/schema/mapplanmodifier/use_state_for_unknown.go
@@ -20,7 +20,7 @@ import (
 // To prevent data issues and Terraform errors, this plan modifier cannot be
 // implemented on attribute values beneath lists or sets. An implementation
 // error diagnostic is raised if the plan modifier logic detects a list or set
-// in the request path.
+// in the request path. Use MatchElementStateForUnknown in that situation.
 func UseStateForUnknown() planmodifier.Map {
 	return useStateForUnknownModifier{}
 }

--- a/resource/schema/numberplanmodifier/match_element_state_for_unknown.go
+++ b/resource/schema/numberplanmodifier/match_element_state_for_unknown.go
@@ -1,0 +1,42 @@
+package numberplanmodifier
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// MatchElementStateForUnknown returns a plan modifier that copies a known prior
+// state value into the planned value based on list or set element identifying
+// paths. Use this when it is known that an unconfigured value under a list or
+// set nested attribute or block will remain the same after a resource update.
+//
+// Identifying path expression(s) should be in the form:
+//
+//	path.MatchRelative().AtParent().AtName("another_configurable_attribute")
+//
+// To prevent Terraform errors, the framework automatically sets unconfigured
+// and Computed attributes to an unknown value "(known after apply)" on update.
+// Using this plan modifier will instead display the prior state value from the
+// matching element in the plan, unless a prior plan modifier set the value to
+// null or a known value.
+//
+// To prevent errant implementations, this plan modifier will raise an error
+// diagnostic if:
+//
+//   - Implemented on an attribute which is not beneath a list or set. Use the
+//     UseStateForUnknown plan modifier instead.
+//   - Zero path expressions are given.
+//   - A given path expression is not relative.
+//   - A given path expression is not a parent step, then a name step.
+//   - A given path expression self-references the attribute where the plan
+//     modifier is implemented.
+//   - A given path expression references a path to a Computed-only attribute.
+//     Only configurable attributes are valid for this plan modifier, otherwise
+//     the value at the path will always be unknown and plan modifier will never
+//     return an expected value.
+func MatchElementStateForUnknown(expressions ...path.Expression) planmodifier.Number {
+	return fwplanmodifier.MatchElementStateForUnknownModifier{
+		Expressions: expressions,
+	}
+}

--- a/resource/schema/numberplanmodifier/match_element_state_for_unknown_example_test.go
+++ b/resource/schema/numberplanmodifier/match_element_state_for_unknown_example_test.go
@@ -1,0 +1,37 @@
+package numberplanmodifier_test
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/numberplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+func ExampleMatchElementStateForUnknown() {
+	// Used within a Schema method of a Resource
+	_ = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"example_attr": schema.SetNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"computed_attr": schema.NumberAttribute{
+							Computed: true,
+							PlanModifiers: []planmodifier.Number{
+								// Preseve this computed value during updates.
+								numberplanmodifier.MatchElementStateForUnknown(
+									// Identify matching prior state value based on configurable_attr
+									path.MatchRelative().AtParent().AtName("configurable_attr"),
+									// ... potentially others ...
+								),
+							},
+						},
+						"configurable_attr": schema.StringAttribute{
+							Required: true,
+						},
+					},
+				},
+				Optional: true,
+			},
+		},
+	}
+}

--- a/resource/schema/numberplanmodifier/use_state_for_unknown.go
+++ b/resource/schema/numberplanmodifier/use_state_for_unknown.go
@@ -20,7 +20,7 @@ import (
 // To prevent data issues and Terraform errors, this plan modifier cannot be
 // implemented on attribute values beneath lists or sets. An implementation
 // error diagnostic is raised if the plan modifier logic detects a list or set
-// in the request path.
+// in the request path. Use MatchElementStateForUnknown in that situation.
 func UseStateForUnknown() planmodifier.Number {
 	return useStateForUnknownModifier{}
 }

--- a/resource/schema/objectplanmodifier/match_element_state_for_unknown.go
+++ b/resource/schema/objectplanmodifier/match_element_state_for_unknown.go
@@ -1,0 +1,42 @@
+package objectplanmodifier
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// MatchElementStateForUnknown returns a plan modifier that copies a known prior
+// state value into the planned value based on list or set element identifying
+// paths. Use this when it is known that an unconfigured value under a list or
+// set nested attribute or block will remain the same after a resource update.
+//
+// Identifying path expression(s) should be in the form:
+//
+//	path.MatchRelative().AtParent().AtName("another_configurable_attribute")
+//
+// To prevent Terraform errors, the framework automatically sets unconfigured
+// and Computed attributes to an unknown value "(known after apply)" on update.
+// Using this plan modifier will instead display the prior state value from the
+// matching element in the plan, unless a prior plan modifier set the value to
+// null or a known value.
+//
+// To prevent errant implementations, this plan modifier will raise an error
+// diagnostic if:
+//
+//   - Implemented on an attribute which is not beneath a list or set. Use the
+//     UseStateForUnknown plan modifier instead.
+//   - Zero path expressions are given.
+//   - A given path expression is not relative.
+//   - A given path expression is not a parent step, then a name step.
+//   - A given path expression self-references the attribute where the plan
+//     modifier is implemented.
+//   - A given path expression references a path to a Computed-only attribute.
+//     Only configurable attributes are valid for this plan modifier, otherwise
+//     the value at the path will always be unknown and plan modifier will never
+//     return an expected value.
+func MatchElementStateForUnknown(expressions ...path.Expression) planmodifier.Object {
+	return fwplanmodifier.MatchElementStateForUnknownModifier{
+		Expressions: expressions,
+	}
+}

--- a/resource/schema/objectplanmodifier/match_element_state_for_unknown_example_test.go
+++ b/resource/schema/objectplanmodifier/match_element_state_for_unknown_example_test.go
@@ -1,0 +1,42 @@
+package objectplanmodifier_test
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+func ExampleMatchElementStateForUnknown() {
+	// Used within a Schema method of a Resource
+	_ = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"example_attr": schema.SetNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"computed_attr": schema.SingleNestedAttribute{
+							Attributes: map[string]schema.Attribute{
+								"nested_computed_attr": schema.StringAttribute{
+									Computed: true,
+								},
+							},
+							Computed: true,
+							PlanModifiers: []planmodifier.Object{
+								// Preseve this computed value during updates.
+								objectplanmodifier.MatchElementStateForUnknown(
+									// Identify matching prior state value based on configurable_attr
+									path.MatchRelative().AtParent().AtName("configurable_attr"),
+									// ... potentially others ...
+								),
+							},
+						},
+						"configurable_attr": schema.StringAttribute{
+							Required: true,
+						},
+					},
+				},
+				Optional: true,
+			},
+		},
+	}
+}

--- a/resource/schema/objectplanmodifier/use_state_for_unknown.go
+++ b/resource/schema/objectplanmodifier/use_state_for_unknown.go
@@ -20,7 +20,7 @@ import (
 // To prevent data issues and Terraform errors, this plan modifier cannot be
 // implemented on attribute values beneath lists or sets. An implementation
 // error diagnostic is raised if the plan modifier logic detects a list or set
-// in the request path.
+// in the request path. Use MatchElementStateForUnknown in that situation.
 func UseStateForUnknown() planmodifier.Object {
 	return useStateForUnknownModifier{}
 }

--- a/resource/schema/setplanmodifier/match_element_state_for_unknown.go
+++ b/resource/schema/setplanmodifier/match_element_state_for_unknown.go
@@ -1,0 +1,42 @@
+package setplanmodifier
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// MatchElementStateForUnknown returns a plan modifier that copies a known prior
+// state value into the planned value based on list or set element identifying
+// paths. Use this when it is known that an unconfigured value under a list or
+// set nested attribute or block will remain the same after a resource update.
+//
+// Identifying path expression(s) should be in the form:
+//
+//	path.MatchRelative().AtParent().AtName("another_configurable_attribute")
+//
+// To prevent Terraform errors, the framework automatically sets unconfigured
+// and Computed attributes to an unknown value "(known after apply)" on update.
+// Using this plan modifier will instead display the prior state value from the
+// matching element in the plan, unless a prior plan modifier set the value to
+// null or a known value.
+//
+// To prevent errant implementations, this plan modifier will raise an error
+// diagnostic if:
+//
+//   - Implemented on an attribute which is not beneath a list or set. Use the
+//     UseStateForUnknown plan modifier instead.
+//   - Zero path expressions are given.
+//   - A given path expression is not relative.
+//   - A given path expression is not a parent step, then a name step.
+//   - A given path expression self-references the attribute where the plan
+//     modifier is implemented.
+//   - A given path expression references a path to a Computed-only attribute.
+//     Only configurable attributes are valid for this plan modifier, otherwise
+//     the value at the path will always be unknown and plan modifier will never
+//     return an expected value.
+func MatchElementStateForUnknown(expressions ...path.Expression) planmodifier.Set {
+	return fwplanmodifier.MatchElementStateForUnknownModifier{
+		Expressions: expressions,
+	}
+}

--- a/resource/schema/setplanmodifier/match_element_state_for_unknown_example_test.go
+++ b/resource/schema/setplanmodifier/match_element_state_for_unknown_example_test.go
@@ -1,0 +1,39 @@
+package setplanmodifier_test
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func ExampleMatchElementStateForUnknown() {
+	// Used within a Schema method of a Resource
+	_ = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"example_attr": schema.SetNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"computed_attr": schema.SetAttribute{
+							Computed:    true,
+							ElementType: types.StringType,
+							PlanModifiers: []planmodifier.Set{
+								// Preseve this computed value during updates.
+								setplanmodifier.MatchElementStateForUnknown(
+									// Identify matching prior state value based on configurable_attr
+									path.MatchRelative().AtParent().AtName("configurable_attr"),
+									// ... potentially others ...
+								),
+							},
+						},
+						"configurable_attr": schema.StringAttribute{
+							Required: true,
+						},
+					},
+				},
+				Optional: true,
+			},
+		},
+	}
+}

--- a/resource/schema/setplanmodifier/use_state_for_unknown.go
+++ b/resource/schema/setplanmodifier/use_state_for_unknown.go
@@ -20,7 +20,7 @@ import (
 // To prevent data issues and Terraform errors, this plan modifier cannot be
 // implemented on attribute values beneath lists or sets. An implementation
 // error diagnostic is raised if the plan modifier logic detects a list or set
-// in the request path.
+// in the request path. Use MatchElementStateForUnknown in that situation.
 func UseStateForUnknown() planmodifier.Set {
 	return useStateForUnknownModifier{}
 }

--- a/resource/schema/stringplanmodifier/match_element_state_for_unknown.go
+++ b/resource/schema/stringplanmodifier/match_element_state_for_unknown.go
@@ -1,0 +1,42 @@
+package stringplanmodifier
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// MatchElementStateForUnknown returns a plan modifier that copies a known prior
+// state value into the planned value based on list or set element identifying
+// paths. Use this when it is known that an unconfigured value under a list or
+// set nested attribute or block will remain the same after a resource update.
+//
+// Identifying path expression(s) should be in the form:
+//
+//	path.MatchRelative().AtParent().AtName("another_configurable_attribute")
+//
+// To prevent Terraform errors, the framework automatically sets unconfigured
+// and Computed attributes to an unknown value "(known after apply)" on update.
+// Using this plan modifier will instead display the prior state value from the
+// matching element in the plan, unless a prior plan modifier set the value to
+// null or a known value.
+//
+// To prevent errant implementations, this plan modifier will raise an error
+// diagnostic if:
+//
+//   - Implemented on an attribute which is not beneath a list or set. Use the
+//     UseStateForUnknown plan modifier instead.
+//   - Zero path expressions are given.
+//   - A given path expression is not relative.
+//   - A given path expression is not a parent step, then a name step.
+//   - A given path expression self-references the attribute where the plan
+//     modifier is implemented.
+//   - A given path expression references a path to a Computed-only attribute.
+//     Only configurable attributes are valid for this plan modifier, otherwise
+//     the value at the path will always be unknown and plan modifier will never
+//     return an expected value.
+func MatchElementStateForUnknown(expressions ...path.Expression) planmodifier.String {
+	return fwplanmodifier.MatchElementStateForUnknownModifier{
+		Expressions: expressions,
+	}
+}

--- a/resource/schema/stringplanmodifier/match_element_state_for_unknown_example_test.go
+++ b/resource/schema/stringplanmodifier/match_element_state_for_unknown_example_test.go
@@ -1,0 +1,37 @@
+package stringplanmodifier_test
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+)
+
+func ExampleMatchElementStateForUnknown() {
+	// Used within a Schema method of a Resource
+	_ = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"example_attr": schema.SetNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"computed_attr": schema.StringAttribute{
+							Computed: true,
+							PlanModifiers: []planmodifier.String{
+								// Preseve this computed value during updates.
+								stringplanmodifier.MatchElementStateForUnknown(
+									// Identify matching prior state value based on configurable_attr
+									path.MatchRelative().AtParent().AtName("configurable_attr"),
+									// ... potentially others ...
+								),
+							},
+						},
+						"configurable_attr": schema.StringAttribute{
+							Required: true,
+						},
+					},
+				},
+				Optional: true,
+			},
+		},
+	}
+}

--- a/resource/schema/stringplanmodifier/use_state_for_unknown.go
+++ b/resource/schema/stringplanmodifier/use_state_for_unknown.go
@@ -20,7 +20,7 @@ import (
 // To prevent data issues and Terraform errors, this plan modifier cannot be
 // implemented on attribute values beneath lists or sets. An implementation
 // error diagnostic is raised if the plan modifier logic detects a list or set
-// in the request path.
+// in the request path. Use MatchElementStateForUnknown in that situation.
 func UseStateForUnknown() planmodifier.String {
 	return useStateForUnknownModifier{}
 }

--- a/website/docs/plugin/framework/resources/plan-modification.mdx
+++ b/website/docs/plugin/framework/resources/plan-modification.mdx
@@ -53,10 +53,11 @@ If defined, plan modifiers are applied to the current attribute. If any nested a
 
 The framework implements some common use case modifiers in the typed packages under `resource/schema/`, such as `resource/schema/stringplanmodifier`:
 
+- `MatchElementStateForUnknown()`: For attributes under list or set nested attributes or blocks, copies the prior state value, if not null. This is useful for reducing `(known after apply)` plan outputs for computed attributes which are known to not change over time. Use `UseStateForUnknown()` for attributes not under list or set nested attributes or blocks.
 - `RequiresReplace()`: If the value of the attribute changes, in-place update is not possible and instead the resource should be replaced for the change to occur. Refer to the Go documentation for full details on its behavior.
 - `RequiresReplaceIf()`: Similar to `resource.RequiresReplace()`, however it also accepts provider-defined conditional logic. Refer to the Go documentation for full details on its behavior.
 - `RequiresReplaceIfConfigured()`: Similar to `resource.RequiresReplace()`, however it also will only trigger if the practitioner has configured a value. Refer to the Go documentation for full details on its behavior.
-- `UseStateForUnknown()`: Copies the prior state value, if not null. This is useful for reducing `(known after apply)` plan outputs for computed attributes which are known to not change over time.
+- `UseStateForUnknown()`: For attributes not under list or set nested attributes or blocks, copies the prior state value, if not null. This is useful for reducing `(known after apply)` plan outputs for computed attributes which are known to not change over time. Use `MatchElementStateForUnknown()` for attributes under list or set nested attributes or blocks.
 
 ### Creating Attribute Plan Modifiers
 


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform-plugin-framework/pull/711
Closes #717

This change implements a new plan modifier to cover cases where `UseStateForUnknown` will now raise an implementation error when under a list or set nested attribute or block. Provider developers can supply all configurable and identifying nested object attributes which can be used to align and preserve prior state data for this attribute.

An example schema implementation:

```go
schema.SetNestedAttribute{
	NestedObject: schema.NestedAttributeObject{
		Attributes: map[string]schema.Attribute{
			"computed_attr": schema.StringAttribute{
				Computed: true,
				PlanModifiers: []planmodifier.String{
					// Preseve this computed value during updates.
					stringplanmodifier.MatchElementStateForUnknown(
						// Identify matching prior state value based on configurable_attr
						path.MatchRelative().AtParent().AtName("configurable_attr"),
						// ... potentially others ...
					),
				},
			},
			"configurable_attr": schema.StringAttribute{
				Required: true,
			},
		},
	},
	Optional: true,
}
```