### PR TITLE
Shortcut logging when the level isn't active

### DIFF
--- a/internal/logging/context.go
+++ b/internal/logging/context.go
@@ -3,7 +3,17 @@ package logging
 import (
 	"context"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/terraform-plugin-log/tfsdklog"
+)
+
+// Cache the log level so that we can shortcut calling into the tfsdklog package, as on
+// very large terraform resources/projects the logging can become the majority of the
+// runtime when building a plan.
+//
+// https://github.com/hashicorp/terraform-plugin-framework/issues/721
+var (
+	level hclog.Level
 )
 
 // InitContext creates SDK logger contexts. The incoming context will
@@ -17,6 +27,11 @@ func InitContext(ctx context.Context) context.Context {
 		// Propagate tf_req_id, tf_rpc, etc. fields
 		tfsdklog.WithRootFields(),
 	)
+
+	level = hclog.LevelFromString(EnvTfLogSdkFramework)
+	if level == hclog.NoLevel {
+		level = hclog.DefaultLevel
+	}
 
 	return ctx
 }

--- a/internal/logging/framework.go
+++ b/internal/logging/framework.go
@@ -3,6 +3,7 @@ package logging
 import (
 	"context"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/terraform-plugin-log/tfsdklog"
 )
 
@@ -13,22 +14,30 @@ const (
 
 // FrameworkDebug emits a framework subsystem log at DEBUG level.
 func FrameworkDebug(ctx context.Context, msg string, additionalFields ...map[string]interface{}) {
-	tfsdklog.SubsystemDebug(ctx, SubsystemFramework, msg, additionalFields...)
+	if level <= hclog.Debug {
+		tfsdklog.SubsystemDebug(ctx, SubsystemFramework, msg, additionalFields...)
+	}
 }
 
 // FrameworkError emits a framework subsystem log at ERROR level.
 func FrameworkError(ctx context.Context, msg string, additionalFields ...map[string]interface{}) {
-	tfsdklog.SubsystemError(ctx, SubsystemFramework, msg, additionalFields...)
+	if level <= hclog.Error {
+		tfsdklog.SubsystemError(ctx, SubsystemFramework, msg, additionalFields...)
+	}
 }
 
 // FrameworkTrace emits a framework subsystem log at TRACE level.
 func FrameworkTrace(ctx context.Context, msg string, additionalFields ...map[string]interface{}) {
-	tfsdklog.SubsystemTrace(ctx, SubsystemFramework, msg, additionalFields...)
+	if level <= hclog.Trace {
+		tfsdklog.SubsystemTrace(ctx, SubsystemFramework, msg, additionalFields...)
+	}
 }
 
 // FrameworkWarn emits a framework subsystem log at WARN level.
 func FrameworkWarn(ctx context.Context, msg string, additionalFields ...map[string]interface{}) {
-	tfsdklog.SubsystemWarn(ctx, SubsystemFramework, msg, additionalFields...)
+	if level <= hclog.Warn {
+		tfsdklog.SubsystemWarn(ctx, SubsystemFramework, msg, additionalFields...)
+	}
 }
 
 // FrameworkWithAttributePath returns a new Context with KeyAttributePath set.


### PR DESCRIPTION
This commit addresses this issue:
https://github.com/hashicorp/terraform-plugin-framework/issues/721

When working with large terraform resource attributes, logging can become the primary cost to running plan/apply. This is because the context logger used by tfsdklog is very expensive, the SDK framework itself is very verbose, and even the log level means Debug/Trace logs won't be emitted we still build the log.

As we log via the internal logging package anyway, we can avoid this performance issue by maintaining a package-local log-level which is initialised at the same time as we init the contextual logger. Then our logging package can avoid calling into the tfsdklog (which is where we pay the performance penalty) unless it believes the level is active, which in most cases avoids 99% of the log cost.