### PR TITLE
Correct broken URLs describing attributes+blocks

### DIFF
--- a/website/docs/plugin/framework/migrating/schema/index.mdx
+++ b/website/docs/plugin/framework/migrating/schema/index.mdx
@@ -133,8 +133,8 @@ provider and each resource and data type have a `Schema` method that returns the
 - In SDKv2, schema structs have a `Set` field which can be populated with a `SchemaSetFunc` which is used for hashing.
 In the Framework, this is not required and does not need to be migrated.
 - The `schema.Schema` struct includes fields that you use to define
-[attributes](/terraform/plugin/framework/migrating/attributes-and-blocks/attribute-schema) and
-[blocks](/terraform/plugin/framework/migrating/attributes-and-blocks/blocks) for your provider and each resource
+[attributes](/terraform/plugin/framework/migrating/attributes-blocks/attribute-schema) and
+[blocks](/terraform/plugin/framework/migrating/attributes-blocks/blocks) for your provider and each resource
 and data source.
 - When you populate the `Version` field in `schema.Schema` for a resource in the Framework, copy the `Version`
 field in `schema.Schema` from the SDKv2 version of that resource.


### PR DESCRIPTION
👋 Hi there,

I was browsing the docs and found these two broken links

Old links that 404:

- [https://developer.hashicorp.com/terraform/plugin/framework/migrating/attributes-**and**-blocks/attribute-schema](https://developer.hashicorp.com/terraform/plugin/framework/migrating/attributes-and-blocks/attribute-schema)
- [https://developer.hashicorp.com/terraform/plugin/framework/migrating/attributes-**and**-blocks/blocks](https://developer.hashicorp.com/terraform/plugin/framework/migrating/attributes-and-blocks/blocks)

New links:
- https://developer.hashicorp.com/terraform/plugin/framework/migrating/attributes-blocks/attribute-schema
- https://developer.hashicorp.com/terraform/plugin/framework/migrating/attributes-blocks/blocks

