### PR TITLE
Type-Based Semantic Equality

### DIFF
--- a/internal/fwschemadata/value_semantic_equality.go
+++ b/internal/fwschemadata/value_semantic_equality.go
@@ -1,0 +1,84 @@
+package fwschemadata
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/internal/logging"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+// ValueSemanticEqualityRequest represents a request for the provider to
+// perform semantic equality logic on a value.
+type ValueSemanticEqualityRequest struct {
+	// Path is the schema-based path of the value.
+	Path path.Path
+
+	// PriorValue is the prior value.
+	PriorValue attr.Value
+
+	// ProposedNewValue is the proposed new value. NewValue in the response
+	// contains the results of semantic equality logic.
+	ProposedNewValue attr.Value
+}
+
+// ValueSemanticEqualityResponse represents a response to a
+// ValueSemanticEqualityRequest.
+type ValueSemanticEqualityResponse struct {
+	// NewValue contains the new value based on the semantic equality logic.
+	NewValue attr.Value
+
+	// Diagnostics contains any errors and warnings for the logic.
+	Diagnostics diag.Diagnostics
+}
+
+// ValueSemanticEquality runs all semantic equality logic for a value, including
+// recursive checking against collection and structural types.
+func ValueSemanticEquality(ctx context.Context, req ValueSemanticEqualityRequest, resp *ValueSemanticEqualityResponse) {
+	ctx = logging.FrameworkWithAttributePath(ctx, req.Path.String())
+
+	// Ensure the response NewValue always starts with the proposed new value.
+	// This is purely defensive coding to prevent subtle data handling bugs.
+	resp.NewValue = req.ProposedNewValue
+
+	// If the prior value is null or unknown, no need to check semantic equality
+	// as the proposed new value is always correct. There is also no need to
+	// descend further into any nesting.
+	if req.PriorValue.IsNull() || req.PriorValue.IsUnknown() {
+		return
+	}
+
+	// If the proposed new value is null or unknown, no need to check semantic
+	// equality as it should never be changed back to the prior value. There is
+	// also no need to descend further into any nesting.
+	if req.ProposedNewValue.IsNull() || req.ProposedNewValue.IsUnknown() {
+		return
+	}
+
+	switch req.ProposedNewValue.(type) {
+	case basetypes.BoolValuable:
+		ValueSemanticEqualityBool(ctx, req, resp)
+	case basetypes.Float64Valuable:
+		ValueSemanticEqualityFloat64(ctx, req, resp)
+	case basetypes.Int64Valuable:
+		ValueSemanticEqualityInt64(ctx, req, resp)
+	case basetypes.ListValuable:
+		ValueSemanticEqualityList(ctx, req, resp)
+	case basetypes.MapValuable:
+		ValueSemanticEqualityMap(ctx, req, resp)
+	case basetypes.NumberValuable:
+		ValueSemanticEqualityNumber(ctx, req, resp)
+	case basetypes.ObjectValuable:
+		ValueSemanticEqualityObject(ctx, req, resp)
+	case basetypes.SetValuable:
+		ValueSemanticEqualitySet(ctx, req, resp)
+	case basetypes.StringValuable:
+		ValueSemanticEqualityString(ctx, req, resp)
+	}
+
+	if resp.NewValue.Equal(req.PriorValue) {
+		logging.FrameworkDebug(ctx, "Value switched to prior value due to semantic equality logic")
+	}
+}

--- a/internal/fwschemadata/value_semantic_equality_bool.go
+++ b/internal/fwschemadata/value_semantic_equality_bool.go
@@ -1,0 +1,51 @@
+package fwschemadata
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/internal/logging"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+// ValueSemanticEqualityBool performs bool type semantic equality.
+func ValueSemanticEqualityBool(ctx context.Context, req ValueSemanticEqualityRequest, resp *ValueSemanticEqualityResponse) {
+	priorValuable, ok := req.PriorValue.(basetypes.BoolValuableWithSemanticEquals)
+
+	// No changes required if the interface is not implemented.
+	if !ok {
+		return
+	}
+
+	proposedNewValuable, ok := req.ProposedNewValue.(basetypes.BoolValuableWithSemanticEquals)
+
+	// No changes required if the interface is not implemented.
+	if !ok {
+		return
+	}
+
+	logging.FrameworkTrace(
+		ctx,
+		"Calling provider defined type-based SemanticEquals",
+		map[string]interface{}{
+			logging.KeyValueType: proposedNewValuable.String(),
+		},
+	)
+
+	usePriorValue, diags := proposedNewValuable.BoolSemanticEquals(ctx, priorValuable)
+
+	logging.FrameworkTrace(
+		ctx,
+		"Called provider defined type-based SemanticEquals",
+		map[string]interface{}{
+			logging.KeyValueType: proposedNewValuable.String(),
+		},
+	)
+
+	resp.Diagnostics.Append(diags...)
+
+	if !usePriorValue {
+		return
+	}
+
+	resp.NewValue = priorValuable
+}

--- a/internal/fwschemadata/value_semantic_equality_bool_test.go
+++ b/internal/fwschemadata/value_semantic_equality_bool_test.go
@@ -1,0 +1,124 @@
+package fwschemadata_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschemadata"
+	testtypes "github.com/hashicorp/terraform-plugin-framework/internal/testing/types"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestValueSemanticEqualityBool(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		request  fwschemadata.ValueSemanticEqualityRequest
+		expected *fwschemadata.ValueSemanticEqualityResponse
+	}{
+		"BoolValue": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path:             path.Root("test"),
+				PriorValue:       types.BoolValue(false),
+				ProposedNewValue: types.BoolValue(true),
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: types.BoolValue(true),
+			},
+		},
+		"BoolValuableWithSemanticEquals-true": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: testtypes.BoolValueWithSemanticEquals{
+					BoolValue:      types.BoolValue(false),
+					SemanticEquals: true,
+				},
+				ProposedNewValue: testtypes.BoolValueWithSemanticEquals{
+					BoolValue:      types.BoolValue(true),
+					SemanticEquals: true,
+				},
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testtypes.BoolValueWithSemanticEquals{
+					BoolValue:      types.BoolValue(false),
+					SemanticEquals: true,
+				},
+			},
+		},
+		"BoolValuableWithSemanticEquals-false": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: testtypes.BoolValueWithSemanticEquals{
+					BoolValue:      types.BoolValue(false),
+					SemanticEquals: false,
+				},
+				ProposedNewValue: testtypes.BoolValueWithSemanticEquals{
+					BoolValue:      types.BoolValue(true),
+					SemanticEquals: false,
+				},
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testtypes.BoolValueWithSemanticEquals{
+					BoolValue:      types.BoolValue(true),
+					SemanticEquals: false,
+				},
+			},
+		},
+		"BoolValuableWithSemanticEquals-diagnostics": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: testtypes.BoolValueWithSemanticEquals{
+					BoolValue:      types.BoolValue(false),
+					SemanticEquals: false,
+					SemanticEqualsDiagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+						diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+					},
+				},
+				ProposedNewValue: testtypes.BoolValueWithSemanticEquals{
+					BoolValue:      types.BoolValue(true),
+					SemanticEquals: false,
+					SemanticEqualsDiagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+						diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+					},
+				},
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testtypes.BoolValueWithSemanticEquals{
+					BoolValue:      types.BoolValue(true),
+					SemanticEquals: false,
+					SemanticEqualsDiagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+						diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+					},
+				},
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+					diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testCase.request.ProposedNewValue,
+			}
+
+			fwschemadata.ValueSemanticEqualityBool(context.Background(), testCase.request, got)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}

--- a/internal/fwschemadata/value_semantic_equality_float64.go
+++ b/internal/fwschemadata/value_semantic_equality_float64.go
@@ -1,0 +1,51 @@
+package fwschemadata
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/internal/logging"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+// ValueSemanticEqualityFloat64 performs float64 type semantic equality.
+func ValueSemanticEqualityFloat64(ctx context.Context, req ValueSemanticEqualityRequest, resp *ValueSemanticEqualityResponse) {
+	priorValuable, ok := req.PriorValue.(basetypes.Float64ValuableWithSemanticEquals)
+
+	// No changes required if the interface is not implemented.
+	if !ok {
+		return
+	}
+
+	proposedNewValuable, ok := req.ProposedNewValue.(basetypes.Float64ValuableWithSemanticEquals)
+
+	// No changes required if the interface is not implemented.
+	if !ok {
+		return
+	}
+
+	logging.FrameworkTrace(
+		ctx,
+		"Calling provider defined type-based SemanticEquals",
+		map[string]interface{}{
+			logging.KeyValueType: proposedNewValuable.String(),
+		},
+	)
+
+	usePriorValue, diags := proposedNewValuable.Float64SemanticEquals(ctx, priorValuable)
+
+	logging.FrameworkTrace(
+		ctx,
+		"Called provider defined type-based SemanticEquals",
+		map[string]interface{}{
+			logging.KeyValueType: proposedNewValuable.String(),
+		},
+	)
+
+	resp.Diagnostics.Append(diags...)
+
+	if !usePriorValue {
+		return
+	}
+
+	resp.NewValue = priorValuable
+}

--- a/internal/fwschemadata/value_semantic_equality_float64_test.go
+++ b/internal/fwschemadata/value_semantic_equality_float64_test.go
@@ -1,0 +1,124 @@
+package fwschemadata_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschemadata"
+	testtypes "github.com/hashicorp/terraform-plugin-framework/internal/testing/types"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestValueSemanticEqualityFloat64(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		request  fwschemadata.ValueSemanticEqualityRequest
+		expected *fwschemadata.ValueSemanticEqualityResponse
+	}{
+		"Float64Value": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path:             path.Root("test"),
+				PriorValue:       types.Float64Value(1.2),
+				ProposedNewValue: types.Float64Value(2.4),
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: types.Float64Value(2.4),
+			},
+		},
+		"Float64ValuableWithSemanticEquals-true": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: testtypes.Float64ValueWithSemanticEquals{
+					Float64Value:   types.Float64Value(1.2),
+					SemanticEquals: true,
+				},
+				ProposedNewValue: testtypes.Float64ValueWithSemanticEquals{
+					Float64Value:   types.Float64Value(2.4),
+					SemanticEquals: true,
+				},
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testtypes.Float64ValueWithSemanticEquals{
+					Float64Value:   types.Float64Value(1.2),
+					SemanticEquals: true,
+				},
+			},
+		},
+		"Float64ValuableWithSemanticEquals-false": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: testtypes.Float64ValueWithSemanticEquals{
+					Float64Value:   types.Float64Value(1.2),
+					SemanticEquals: false,
+				},
+				ProposedNewValue: testtypes.Float64ValueWithSemanticEquals{
+					Float64Value:   types.Float64Value(2.4),
+					SemanticEquals: false,
+				},
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testtypes.Float64ValueWithSemanticEquals{
+					Float64Value:   types.Float64Value(2.4),
+					SemanticEquals: false,
+				},
+			},
+		},
+		"Float64ValuableWithSemanticEquals-diagnostics": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: testtypes.Float64ValueWithSemanticEquals{
+					Float64Value:   types.Float64Value(1.2),
+					SemanticEquals: false,
+					SemanticEqualsDiagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+						diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+					},
+				},
+				ProposedNewValue: testtypes.Float64ValueWithSemanticEquals{
+					Float64Value:   types.Float64Value(2.4),
+					SemanticEquals: false,
+					SemanticEqualsDiagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+						diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+					},
+				},
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testtypes.Float64ValueWithSemanticEquals{
+					Float64Value:   types.Float64Value(2.4),
+					SemanticEquals: false,
+					SemanticEqualsDiagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+						diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+					},
+				},
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+					diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testCase.request.ProposedNewValue,
+			}
+
+			fwschemadata.ValueSemanticEqualityFloat64(context.Background(), testCase.request, got)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}

--- a/internal/fwschemadata/value_semantic_equality_int64.go
+++ b/internal/fwschemadata/value_semantic_equality_int64.go
@@ -1,0 +1,51 @@
+package fwschemadata
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/internal/logging"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+// ValueSemanticEqualityInt64 performs int64 type semantic equality.
+func ValueSemanticEqualityInt64(ctx context.Context, req ValueSemanticEqualityRequest, resp *ValueSemanticEqualityResponse) {
+	priorValuable, ok := req.PriorValue.(basetypes.Int64ValuableWithSemanticEquals)
+
+	// No changes required if the interface is not implemented.
+	if !ok {
+		return
+	}
+
+	proposedNewValuable, ok := req.ProposedNewValue.(basetypes.Int64ValuableWithSemanticEquals)
+
+	// No changes required if the interface is not implemented.
+	if !ok {
+		return
+	}
+
+	logging.FrameworkTrace(
+		ctx,
+		"Calling provider defined type-based SemanticEquals",
+		map[string]interface{}{
+			logging.KeyValueType: proposedNewValuable.String(),
+		},
+	)
+
+	usePriorValue, diags := proposedNewValuable.Int64SemanticEquals(ctx, priorValuable)
+
+	logging.FrameworkTrace(
+		ctx,
+		"Called provider defined type-based SemanticEquals",
+		map[string]interface{}{
+			logging.KeyValueType: proposedNewValuable.String(),
+		},
+	)
+
+	resp.Diagnostics.Append(diags...)
+
+	if !usePriorValue {
+		return
+	}
+
+	resp.NewValue = priorValuable
+}

--- a/internal/fwschemadata/value_semantic_equality_int64_test.go
+++ b/internal/fwschemadata/value_semantic_equality_int64_test.go
@@ -1,0 +1,124 @@
+package fwschemadata_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschemadata"
+	testtypes "github.com/hashicorp/terraform-plugin-framework/internal/testing/types"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestValueSemanticEqualityInt64(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		request  fwschemadata.ValueSemanticEqualityRequest
+		expected *fwschemadata.ValueSemanticEqualityResponse
+	}{
+		"Int64Value": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path:             path.Root("test"),
+				PriorValue:       types.Int64Value(12),
+				ProposedNewValue: types.Int64Value(24),
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: types.Int64Value(24),
+			},
+		},
+		"Int64ValuableWithSemanticEquals-true": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: testtypes.Int64ValueWithSemanticEquals{
+					Int64Value:     types.Int64Value(12),
+					SemanticEquals: true,
+				},
+				ProposedNewValue: testtypes.Int64ValueWithSemanticEquals{
+					Int64Value:     types.Int64Value(24),
+					SemanticEquals: true,
+				},
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testtypes.Int64ValueWithSemanticEquals{
+					Int64Value:     types.Int64Value(12),
+					SemanticEquals: true,
+				},
+			},
+		},
+		"Int64ValuableWithSemanticEquals-false": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: testtypes.Int64ValueWithSemanticEquals{
+					Int64Value:     types.Int64Value(12),
+					SemanticEquals: false,
+				},
+				ProposedNewValue: testtypes.Int64ValueWithSemanticEquals{
+					Int64Value:     types.Int64Value(24),
+					SemanticEquals: false,
+				},
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testtypes.Int64ValueWithSemanticEquals{
+					Int64Value:     types.Int64Value(24),
+					SemanticEquals: false,
+				},
+			},
+		},
+		"Int64ValuableWithSemanticEquals-diagnostics": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: testtypes.Int64ValueWithSemanticEquals{
+					Int64Value:     types.Int64Value(12),
+					SemanticEquals: false,
+					SemanticEqualsDiagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+						diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+					},
+				},
+				ProposedNewValue: testtypes.Int64ValueWithSemanticEquals{
+					Int64Value:     types.Int64Value(24),
+					SemanticEquals: false,
+					SemanticEqualsDiagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+						diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+					},
+				},
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testtypes.Int64ValueWithSemanticEquals{
+					Int64Value:     types.Int64Value(24),
+					SemanticEquals: false,
+					SemanticEqualsDiagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+						diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+					},
+				},
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+					diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testCase.request.ProposedNewValue,
+			}
+
+			fwschemadata.ValueSemanticEqualityInt64(context.Background(), testCase.request, got)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}

--- a/internal/fwschemadata/value_semantic_equality_list.go
+++ b/internal/fwschemadata/value_semantic_equality_list.go
@@ -1,0 +1,207 @@
+package fwschemadata
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/internal/logging"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+// ValueSemanticEqualityList performs list type semantic equality.
+//
+// This will perform semantic equality checking on elements, regardless of
+// whether the collection type implements the expected interface, since it
+// cannot be assumed that the collection type implementation runs all possible
+// element implementations.
+func ValueSemanticEqualityList(ctx context.Context, req ValueSemanticEqualityRequest, resp *ValueSemanticEqualityResponse) {
+	priorValuable, ok := req.PriorValue.(basetypes.ListValuableWithSemanticEquals)
+
+	// While the collection type itself does not implement the interface,
+	// underlying elements might. Check elements automatically, if possible.
+	if !ok {
+		ValueSemanticEqualityListElements(ctx, req, resp)
+
+		return
+	}
+
+	proposedNewValuable, ok := req.ProposedNewValue.(basetypes.ListValuableWithSemanticEquals)
+
+	// While the collection type itself does not implement the interface,
+	// underlying elements might. Check elements automatically, if possible.
+	if !ok {
+		ValueSemanticEqualityListElements(ctx, req, resp)
+
+		return
+	}
+
+	logging.FrameworkTrace(
+		ctx,
+		"Calling provider defined type-based SemanticEquals",
+		map[string]interface{}{
+			logging.KeyValueType: proposedNewValuable.String(),
+		},
+	)
+
+	usePriorValue, diags := proposedNewValuable.ListSemanticEquals(ctx, priorValuable)
+
+	logging.FrameworkTrace(
+		ctx,
+		"Called provider defined type-based SemanticEquals",
+		map[string]interface{}{
+			logging.KeyValueType: proposedNewValuable.String(),
+		},
+	)
+
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// If the collection type signaled semantic equality, respect the
+	// determination to use the whole prior value and return early since
+	// checking elements is not necessary.
+	if usePriorValue {
+		resp.NewValue = priorValuable
+
+		return
+	}
+
+	// While the collection type itself did not signal semantic equality,
+	// underlying elements might, which should still modify the collection.
+	// Check elements automatically, if possible.
+	//
+	// This logic pessimistically assumes that collection type semantic equality
+	// implementations may be missing proper element type handling. While
+	// correct implementations receive a small performance penalty of
+	// being re-checked, this ensures that less-correct implementations do not
+	// cause inconsistent data handling behaviors for developers.
+	ValueSemanticEqualityListElements(ctx, req, resp)
+}
+
+// ValueSemanticEqualityListElements performs list type semantic equality
+// on elements, returning a modified list as necessary.
+func ValueSemanticEqualityListElements(ctx context.Context, req ValueSemanticEqualityRequest, resp *ValueSemanticEqualityResponse) {
+	priorValuable, ok := req.PriorValue.(basetypes.ListValuable)
+
+	// No changes required if the elements cannot be extracted.
+	if !ok {
+		return
+	}
+
+	priorValue, diags := priorValuable.ToListValue(ctx)
+
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	priorValueElements := priorValue.Elements()
+
+	proposedNewValuable, ok := req.ProposedNewValue.(basetypes.ListValuable)
+
+	// No changes required if the elements cannot be extracted.
+	if !ok {
+		return
+	}
+
+	proposedNewValue, diags := proposedNewValuable.ToListValue(ctx)
+
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	proposedNewValueElements := proposedNewValue.Elements()
+
+	// Create a new element value slice, which will be used to create the final
+	// collection value after each element is evaluated.
+	newValueElements := make([]attr.Value, len(proposedNewValueElements))
+
+	// Short circuit flag
+	updatedElements := false
+
+	// Loop through proposed elements by delegating to the recursive semantic
+	// equality logic. This ensures that recursion will catch a further
+	// underlying element type has its semantic equality logic checked, even if
+	// the current element type does not implement the interface.
+	for idx, proposedNewValueElement := range proposedNewValueElements {
+		// Ensure new value always contains all of proposed new value
+		newValueElements[idx] = proposedNewValueElement
+
+		if idx > len(priorValueElements) {
+			continue
+		}
+
+		elementReq := ValueSemanticEqualityRequest{
+			Path:             req.Path.AtListIndex(idx),
+			PriorValue:       priorValueElements[idx],
+			ProposedNewValue: proposedNewValueElement,
+		}
+		elementResp := &ValueSemanticEqualityResponse{
+			NewValue: elementReq.ProposedNewValue,
+		}
+
+		ValueSemanticEquality(ctx, elementReq, elementResp)
+
+		resp.Diagnostics.Append(elementResp.Diagnostics...)
+
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		if elementResp.NewValue.Equal(elementReq.ProposedNewValue) {
+			continue
+		}
+
+		updatedElements = true
+		newValueElements[idx] = elementResp.NewValue
+	}
+
+	// No changes required if the elements were not updated.
+	if !updatedElements {
+		return
+	}
+
+	newValue, diags := basetypes.NewListValue(proposedNewValue.ElementType(ctx), newValueElements)
+
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Convert the new value to the original ListValuable type to ensure
+	// downstream logic has the correct value type for the defined schema type.
+	newTypable, ok := proposedNewValuable.Type(ctx).(basetypes.ListTypable)
+
+	// This should be a requirement of having a ListValuable, but defensively
+	// checking just in case.
+	if !ok {
+		resp.Diagnostics.AddAttributeError(
+			req.Path,
+			"Value Semantic Equality Type Error",
+			"An unexpected error occurred while performing value semantic equality logic. "+
+				"This is either an error in terraform-plugin-framework or a provider custom type implementation. "+
+				"Please report this to the provider developers.\n\n"+
+				"Error: Expected basetypes.ListTypable type for value type: "+fmt.Sprintf("%T", proposedNewValuable)+"\n"+
+				"Path: "+req.Path.String(),
+		)
+
+		return
+	}
+
+	newValuable, diags := newTypable.ValueFromList(ctx, newValue)
+
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.NewValue = newValuable
+}

--- a/internal/fwschemadata/value_semantic_equality_list_test.go
+++ b/internal/fwschemadata/value_semantic_equality_list_test.go
@@ -1,0 +1,578 @@
+package fwschemadata_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschemadata"
+	testtypes "github.com/hashicorp/terraform-plugin-framework/internal/testing/types"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestValueSemanticEqualityList(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		request  fwschemadata.ValueSemanticEqualityRequest
+		expected *fwschemadata.ValueSemanticEqualityResponse
+	}{
+		// Type and ElementType without semantic equality
+		"ListValue": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: types.ListValueMust(
+					types.StringType,
+					[]attr.Value{
+						types.StringValue("prior"),
+					},
+				),
+				ProposedNewValue: types.ListValueMust(
+					types.StringType,
+					[]attr.Value{
+						types.StringValue("new"),
+					},
+				),
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: types.ListValueMust(
+					types.StringType,
+					[]attr.Value{
+						types.StringValue("new"),
+					},
+				),
+			},
+		},
+		// ElementType with semantic equality
+		"ListValue-StringValuableWithSemanticEquals-true": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: types.ListValueMust(
+					testtypes.StringTypeWithSemanticEquals{
+						SemanticEquals: true,
+					},
+					[]attr.Value{
+						testtypes.StringValueWithSemanticEquals{
+							StringValue:    types.StringValue("prior"),
+							SemanticEquals: true,
+						},
+					},
+				),
+				ProposedNewValue: types.ListValueMust(
+					testtypes.StringTypeWithSemanticEquals{
+						SemanticEquals: true,
+					},
+					[]attr.Value{
+						testtypes.StringValueWithSemanticEquals{
+							StringValue:    types.StringValue("new"),
+							SemanticEquals: true,
+						},
+					},
+				),
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: types.ListValueMust(
+					testtypes.StringTypeWithSemanticEquals{
+						SemanticEquals: true,
+					},
+					[]attr.Value{
+						testtypes.StringValueWithSemanticEquals{
+							StringValue:    types.StringValue("prior"),
+							SemanticEquals: true,
+						},
+					},
+				),
+			},
+		},
+		"ListValue-StringValuableWithSemanticEquals-false": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: types.ListValueMust(
+					testtypes.StringTypeWithSemanticEquals{
+						SemanticEquals: false,
+					},
+					[]attr.Value{
+						testtypes.StringValueWithSemanticEquals{
+							StringValue:    types.StringValue("prior"),
+							SemanticEquals: false,
+						},
+					},
+				),
+				ProposedNewValue: types.ListValueMust(
+					testtypes.StringTypeWithSemanticEquals{
+						SemanticEquals: false,
+					},
+					[]attr.Value{
+						testtypes.StringValueWithSemanticEquals{
+							StringValue:    types.StringValue("new"),
+							SemanticEquals: false,
+						},
+					},
+				),
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: types.ListValueMust(
+					testtypes.StringTypeWithSemanticEquals{
+						SemanticEquals: false,
+					},
+					[]attr.Value{
+						testtypes.StringValueWithSemanticEquals{
+							StringValue:    types.StringValue("new"),
+							SemanticEquals: false,
+						},
+					},
+				),
+			},
+		},
+		"ListValue-StringValuableWithSemanticEquals-diagnostics": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: types.ListValueMust(
+					testtypes.StringTypeWithSemanticEquals{
+						SemanticEquals: true,
+						SemanticEqualsDiagnostics: diag.Diagnostics{
+							diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+							diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+						},
+					},
+					[]attr.Value{
+						testtypes.StringValueWithSemanticEquals{
+							StringValue:    types.StringValue("prior"),
+							SemanticEquals: true,
+							SemanticEqualsDiagnostics: diag.Diagnostics{
+								diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+								diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+							},
+						},
+					},
+				),
+				ProposedNewValue: types.ListValueMust(
+					testtypes.StringTypeWithSemanticEquals{
+						SemanticEquals: true,
+						SemanticEqualsDiagnostics: diag.Diagnostics{
+							diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+							diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+						},
+					},
+					[]attr.Value{
+						testtypes.StringValueWithSemanticEquals{
+							StringValue:    types.StringValue("new"),
+							SemanticEquals: true,
+							SemanticEqualsDiagnostics: diag.Diagnostics{
+								diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+								diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+							},
+						},
+					},
+				),
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: types.ListValueMust(
+					testtypes.StringTypeWithSemanticEquals{
+						SemanticEquals: true,
+						SemanticEqualsDiagnostics: diag.Diagnostics{
+							diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+							diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+						},
+					},
+					[]attr.Value{
+						testtypes.StringValueWithSemanticEquals{
+							StringValue:    types.StringValue("new"),
+							SemanticEquals: true,
+							SemanticEqualsDiagnostics: diag.Diagnostics{
+								diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+								diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+							},
+						},
+					},
+				),
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+					diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+				},
+			},
+		},
+		// Nested ElementType with semantic equality
+		"ListValue-ListValue-StringValuableWithSemanticEquals-true": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: types.ListValueMust(
+					types.ListType{
+						ElemType: testtypes.StringTypeWithSemanticEquals{
+							SemanticEquals: true,
+						},
+					},
+					[]attr.Value{
+						types.ListValueMust(
+							testtypes.StringTypeWithSemanticEquals{
+								SemanticEquals: true,
+							},
+							[]attr.Value{
+								testtypes.StringValueWithSemanticEquals{
+									StringValue:    types.StringValue("prior"),
+									SemanticEquals: true,
+								},
+							},
+						),
+					},
+				),
+				ProposedNewValue: types.ListValueMust(
+					types.ListType{
+						ElemType: testtypes.StringTypeWithSemanticEquals{
+							SemanticEquals: true,
+						},
+					},
+					[]attr.Value{
+						types.ListValueMust(
+							testtypes.StringTypeWithSemanticEquals{
+								SemanticEquals: true,
+							},
+							[]attr.Value{
+								testtypes.StringValueWithSemanticEquals{
+									StringValue:    types.StringValue("new"),
+									SemanticEquals: true,
+								},
+							},
+						),
+					},
+				),
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: types.ListValueMust(
+					types.ListType{
+						ElemType: testtypes.StringTypeWithSemanticEquals{
+							SemanticEquals: true,
+						},
+					},
+					[]attr.Value{
+						types.ListValueMust(
+							testtypes.StringTypeWithSemanticEquals{
+								SemanticEquals: true,
+							},
+							[]attr.Value{
+								testtypes.StringValueWithSemanticEquals{
+									StringValue:    types.StringValue("prior"),
+									SemanticEquals: true,
+								},
+							},
+						),
+					},
+				),
+			},
+		},
+		"ListValue-ListValue-StringValuableWithSemanticEquals-false": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: types.ListValueMust(
+					types.ListType{
+						ElemType: testtypes.StringTypeWithSemanticEquals{
+							SemanticEquals: false,
+						},
+					},
+					[]attr.Value{
+						types.ListValueMust(
+							testtypes.StringTypeWithSemanticEquals{
+								SemanticEquals: false,
+							},
+							[]attr.Value{
+								testtypes.StringValueWithSemanticEquals{
+									StringValue:    types.StringValue("prior"),
+									SemanticEquals: false,
+								},
+							},
+						),
+					},
+				),
+				ProposedNewValue: types.ListValueMust(
+					types.ListType{
+						ElemType: testtypes.StringTypeWithSemanticEquals{
+							SemanticEquals: false,
+						},
+					},
+					[]attr.Value{
+						types.ListValueMust(
+							testtypes.StringTypeWithSemanticEquals{
+								SemanticEquals: false,
+							},
+							[]attr.Value{
+								testtypes.StringValueWithSemanticEquals{
+									StringValue:    types.StringValue("new"),
+									SemanticEquals: false,
+								},
+							},
+						),
+					},
+				),
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: types.ListValueMust(
+					types.ListType{
+						ElemType: testtypes.StringTypeWithSemanticEquals{
+							SemanticEquals: false,
+						},
+					},
+					[]attr.Value{
+						types.ListValueMust(
+							testtypes.StringTypeWithSemanticEquals{
+								SemanticEquals: false,
+							},
+							[]attr.Value{
+								testtypes.StringValueWithSemanticEquals{
+									StringValue:    types.StringValue("new"),
+									SemanticEquals: false,
+								},
+							},
+						),
+					},
+				),
+			},
+		},
+		"ListValue-ListValue-StringValuableWithSemanticEquals-diagnostics": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: types.ListValueMust(
+					types.ListType{
+						ElemType: testtypes.StringTypeWithSemanticEquals{
+							SemanticEquals: true,
+							SemanticEqualsDiagnostics: diag.Diagnostics{
+								diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+								diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+							},
+						},
+					},
+					[]attr.Value{
+						types.ListValueMust(
+							testtypes.StringTypeWithSemanticEquals{
+								SemanticEquals: true,
+								SemanticEqualsDiagnostics: diag.Diagnostics{
+									diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+									diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+								},
+							},
+							[]attr.Value{
+								testtypes.StringValueWithSemanticEquals{
+									StringValue:    types.StringValue("prior"),
+									SemanticEquals: true,
+									SemanticEqualsDiagnostics: diag.Diagnostics{
+										diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+										diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+									},
+								},
+							},
+						),
+					},
+				),
+				ProposedNewValue: types.ListValueMust(
+					types.ListType{
+						ElemType: testtypes.StringTypeWithSemanticEquals{
+							SemanticEquals: true,
+							SemanticEqualsDiagnostics: diag.Diagnostics{
+								diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+								diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+							},
+						},
+					},
+					[]attr.Value{
+						types.ListValueMust(
+							testtypes.StringTypeWithSemanticEquals{
+								SemanticEquals: true,
+								SemanticEqualsDiagnostics: diag.Diagnostics{
+									diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+									diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+								},
+							},
+							[]attr.Value{
+								testtypes.StringValueWithSemanticEquals{
+									StringValue:    types.StringValue("new"),
+									SemanticEquals: true,
+									SemanticEqualsDiagnostics: diag.Diagnostics{
+										diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+										diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+									},
+								},
+							},
+						),
+					},
+				),
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: types.ListValueMust(
+					types.ListType{
+						ElemType: testtypes.StringTypeWithSemanticEquals{
+							SemanticEquals: true,
+							SemanticEqualsDiagnostics: diag.Diagnostics{
+								diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+								diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+							},
+						},
+					},
+					[]attr.Value{
+						types.ListValueMust(
+							testtypes.StringTypeWithSemanticEquals{
+								SemanticEquals: true,
+								SemanticEqualsDiagnostics: diag.Diagnostics{
+									diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+									diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+								},
+							},
+							[]attr.Value{
+								testtypes.StringValueWithSemanticEquals{
+									StringValue:    types.StringValue("new"),
+									SemanticEquals: true,
+									SemanticEqualsDiagnostics: diag.Diagnostics{
+										diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+										diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+									},
+								},
+							},
+						),
+					},
+				),
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+					diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+				},
+			},
+		},
+		// Type with semantic equality
+		"ListValuableWithSemanticEquals-true": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: testtypes.ListValueWithSemanticEquals{
+					ListValue: types.ListValueMust(
+						types.StringType,
+						[]attr.Value{
+							types.StringValue("prior"),
+						},
+					),
+					SemanticEquals: true,
+				},
+				ProposedNewValue: testtypes.ListValueWithSemanticEquals{
+					ListValue: types.ListValueMust(
+						types.StringType,
+						[]attr.Value{
+							types.StringValue("new"),
+						},
+					),
+					SemanticEquals: true,
+				},
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testtypes.ListValueWithSemanticEquals{
+					ListValue: types.ListValueMust(
+						types.StringType,
+						[]attr.Value{
+							types.StringValue("prior"),
+						},
+					),
+					SemanticEquals: true,
+				},
+			},
+		},
+		"ListValuableWithSemanticEquals-false": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: testtypes.ListValueWithSemanticEquals{
+					ListValue: types.ListValueMust(
+						types.StringType,
+						[]attr.Value{
+							types.StringValue("prior"),
+						},
+					),
+					SemanticEquals: false,
+				},
+				ProposedNewValue: testtypes.ListValueWithSemanticEquals{
+					ListValue: types.ListValueMust(
+						types.StringType,
+						[]attr.Value{
+							types.StringValue("new"),
+						},
+					),
+					SemanticEquals: false,
+				},
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testtypes.ListValueWithSemanticEquals{
+					ListValue: types.ListValueMust(
+						types.StringType,
+						[]attr.Value{
+							types.StringValue("new"),
+						},
+					),
+					SemanticEquals: false,
+				},
+			},
+		},
+		"ListValuableWithSemanticEquals-diagnostics": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: testtypes.ListValueWithSemanticEquals{
+					ListValue: types.ListValueMust(
+						types.StringType,
+						[]attr.Value{
+							types.StringValue("prior"),
+						},
+					),
+					SemanticEquals: false,
+					SemanticEqualsDiagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+						diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+					},
+				},
+				ProposedNewValue: testtypes.ListValueWithSemanticEquals{
+					ListValue: types.ListValueMust(
+						types.StringType,
+						[]attr.Value{
+							types.StringValue("new"),
+						},
+					),
+					SemanticEquals: false,
+					SemanticEqualsDiagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+						diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+					},
+				},
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testtypes.ListValueWithSemanticEquals{
+					ListValue: types.ListValueMust(
+						types.StringType,
+						[]attr.Value{
+							types.StringValue("new"),
+						},
+					),
+					SemanticEquals: false,
+					SemanticEqualsDiagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+						diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+					},
+				},
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+					diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testCase.request.ProposedNewValue,
+			}
+
+			fwschemadata.ValueSemanticEqualityList(context.Background(), testCase.request, got)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}

--- a/internal/fwschemadata/value_semantic_equality_map.go
+++ b/internal/fwschemadata/value_semantic_equality_map.go
@@ -1,0 +1,209 @@
+package fwschemadata
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/internal/logging"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+// ValueSemanticEqualityMap performs map type semantic equality.
+//
+// This will perform semantic equality checking on elements, regardless of
+// whether the collection type implements the expected interface, since it
+// cannot be assumed that the collection type implementation runs all possible
+// element implementations.
+func ValueSemanticEqualityMap(ctx context.Context, req ValueSemanticEqualityRequest, resp *ValueSemanticEqualityResponse) {
+	priorValuable, ok := req.PriorValue.(basetypes.MapValuableWithSemanticEquals)
+
+	// While the collection type itself does not implement the interface,
+	// underlying elements might. Check elements automatically, if possible.
+	if !ok {
+		ValueSemanticEqualityMapElements(ctx, req, resp)
+
+		return
+	}
+
+	proposedNewValuable, ok := req.ProposedNewValue.(basetypes.MapValuableWithSemanticEquals)
+
+	// While the collection type itself does not implement the interface,
+	// underlying elements might. Check elements automatically, if possible.
+	if !ok {
+		ValueSemanticEqualityMapElements(ctx, req, resp)
+
+		return
+	}
+
+	logging.FrameworkTrace(
+		ctx,
+		"Calling provider defined type-based SemanticEquals",
+		map[string]interface{}{
+			logging.KeyValueType: proposedNewValuable.String(),
+		},
+	)
+
+	usePriorValue, diags := proposedNewValuable.MapSemanticEquals(ctx, priorValuable)
+
+	logging.FrameworkTrace(
+		ctx,
+		"Called provider defined type-based SemanticEquals",
+		map[string]interface{}{
+			logging.KeyValueType: proposedNewValuable.String(),
+		},
+	)
+
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// If the collection type signaled semantic equality, respect the
+	// determination to use the whole prior value and return early since
+	// checking elements is not necessary.
+	if usePriorValue {
+		resp.NewValue = priorValuable
+
+		return
+	}
+
+	// While the collection type itself did not signal semantic equality,
+	// underlying elements might, which should still modify the collection.
+	// Check elements automatically, if possible.
+	//
+	// This logic pessimistically assumes that collection type semantic equality
+	// implementations may be missing proper element type handling. While
+	// correct implementations receive a small performance penalty of
+	// being re-checked, this ensures that less-correct implementations do not
+	// cause inconsistent data handling behaviors for developers.
+	ValueSemanticEqualityMapElements(ctx, req, resp)
+}
+
+// ValueSemanticEqualityMapElements performs list type semantic equality
+// on elements, returning a modified list as necessary.
+func ValueSemanticEqualityMapElements(ctx context.Context, req ValueSemanticEqualityRequest, resp *ValueSemanticEqualityResponse) {
+	priorValuable, ok := req.PriorValue.(basetypes.MapValuable)
+
+	// No changes required if the elements cannot be extracted.
+	if !ok {
+		return
+	}
+
+	priorValue, diags := priorValuable.ToMapValue(ctx)
+
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	priorValueElements := priorValue.Elements()
+
+	proposedNewValuable, ok := req.ProposedNewValue.(basetypes.MapValuable)
+
+	// No changes required if the elements cannot be extracted.
+	if !ok {
+		return
+	}
+
+	proposedNewValue, diags := proposedNewValuable.ToMapValue(ctx)
+
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	proposedNewValueElements := proposedNewValue.Elements()
+
+	// Create a new element value map, which will be used to create the final
+	// collection value after each element is evaluated.
+	newValueElements := make(map[string]attr.Value, len(proposedNewValueElements))
+
+	// Short circuit flag
+	updatedElements := false
+
+	// Loop through proposed elements by delegating to the recursive semantic
+	// equality logic. This ensures that recursion will catch a further
+	// underlying element type has its semantic equality logic checked, even if
+	// the current element type does not implement the interface.
+	for key, proposedNewValueElement := range proposedNewValueElements {
+		// Ensure new value always contains all of proposed new value
+		newValueElements[key] = proposedNewValueElement
+
+		priorValueElement, ok := priorValueElements[key]
+
+		if !ok {
+			continue
+		}
+
+		elementReq := ValueSemanticEqualityRequest{
+			Path:             req.Path.AtMapKey(key),
+			PriorValue:       priorValueElement,
+			ProposedNewValue: proposedNewValueElement,
+		}
+		elementResp := &ValueSemanticEqualityResponse{
+			NewValue: elementReq.ProposedNewValue,
+		}
+
+		ValueSemanticEquality(ctx, elementReq, elementResp)
+
+		resp.Diagnostics.Append(elementResp.Diagnostics...)
+
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		if elementResp.NewValue.Equal(elementReq.ProposedNewValue) {
+			continue
+		}
+
+		updatedElements = true
+		newValueElements[key] = elementResp.NewValue
+	}
+
+	// No changes required if the elements were not updated.
+	if !updatedElements {
+		return
+	}
+
+	newValue, diags := basetypes.NewMapValue(proposedNewValue.ElementType(ctx), newValueElements)
+
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Convert the new value to the original MapValuable type to ensure
+	// downstream logic has the correct value type for the defined schema type.
+	newTypable, ok := proposedNewValuable.Type(ctx).(basetypes.MapTypable)
+
+	// This should be a requirement of having a MapValuable, but defensively
+	// checking just in case.
+	if !ok {
+		resp.Diagnostics.AddAttributeError(
+			req.Path,
+			"Value Semantic Equality Type Error",
+			"An unexpected error occurred while performing value semantic equality logic. "+
+				"This is either an error in terraform-plugin-framework or a provider custom type implementation. "+
+				"Please report this to the provider developers.\n\n"+
+				"Error: Expected basetypes.MapTypable type for value type: "+fmt.Sprintf("%T", proposedNewValuable)+"\n"+
+				"Path: "+req.Path.String(),
+		)
+
+		return
+	}
+
+	newValuable, diags := newTypable.ValueFromMap(ctx, newValue)
+
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.NewValue = newValuable
+}

--- a/internal/fwschemadata/value_semantic_equality_map_test.go
+++ b/internal/fwschemadata/value_semantic_equality_map_test.go
@@ -1,0 +1,578 @@
+package fwschemadata_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschemadata"
+	testtypes "github.com/hashicorp/terraform-plugin-framework/internal/testing/types"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestValueSemanticEqualityMap(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		request  fwschemadata.ValueSemanticEqualityRequest
+		expected *fwschemadata.ValueSemanticEqualityResponse
+	}{
+		// Type and ElementType without semantic equality
+		"MapValue": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: types.MapValueMust(
+					types.StringType,
+					map[string]attr.Value{
+						"testkey": types.StringValue("prior"),
+					},
+				),
+				ProposedNewValue: types.MapValueMust(
+					types.StringType,
+					map[string]attr.Value{
+						"testkey": types.StringValue("new"),
+					},
+				),
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: types.MapValueMust(
+					types.StringType,
+					map[string]attr.Value{
+						"testkey": types.StringValue("new"),
+					},
+				),
+			},
+		},
+		// ElementType with semantic equality
+		"MapValue-StringValuableWithSemanticEquals-true": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: types.MapValueMust(
+					testtypes.StringTypeWithSemanticEquals{
+						SemanticEquals: true,
+					},
+					map[string]attr.Value{
+						"testkey": testtypes.StringValueWithSemanticEquals{
+							StringValue:    types.StringValue("prior"),
+							SemanticEquals: true,
+						},
+					},
+				),
+				ProposedNewValue: types.MapValueMust(
+					testtypes.StringTypeWithSemanticEquals{
+						SemanticEquals: true,
+					},
+					map[string]attr.Value{
+						"testkey": testtypes.StringValueWithSemanticEquals{
+							StringValue:    types.StringValue("new"),
+							SemanticEquals: true,
+						},
+					},
+				),
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: types.MapValueMust(
+					testtypes.StringTypeWithSemanticEquals{
+						SemanticEquals: true,
+					},
+					map[string]attr.Value{
+						"testkey": testtypes.StringValueWithSemanticEquals{
+							StringValue:    types.StringValue("prior"),
+							SemanticEquals: true,
+						},
+					},
+				),
+			},
+		},
+		"MapValue-StringValuableWithSemanticEquals-false": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: types.MapValueMust(
+					testtypes.StringTypeWithSemanticEquals{
+						SemanticEquals: false,
+					},
+					map[string]attr.Value{
+						"testkey": testtypes.StringValueWithSemanticEquals{
+							StringValue:    types.StringValue("prior"),
+							SemanticEquals: false,
+						},
+					},
+				),
+				ProposedNewValue: types.MapValueMust(
+					testtypes.StringTypeWithSemanticEquals{
+						SemanticEquals: false,
+					},
+					map[string]attr.Value{
+						"testkey": testtypes.StringValueWithSemanticEquals{
+							StringValue:    types.StringValue("new"),
+							SemanticEquals: false,
+						},
+					},
+				),
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: types.MapValueMust(
+					testtypes.StringTypeWithSemanticEquals{
+						SemanticEquals: false,
+					},
+					map[string]attr.Value{
+						"testkey": testtypes.StringValueWithSemanticEquals{
+							StringValue:    types.StringValue("new"),
+							SemanticEquals: false,
+						},
+					},
+				),
+			},
+		},
+		"MapValue-StringValuableWithSemanticEquals-diagnostics": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: types.MapValueMust(
+					testtypes.StringTypeWithSemanticEquals{
+						SemanticEquals: true,
+						SemanticEqualsDiagnostics: diag.Diagnostics{
+							diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+							diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+						},
+					},
+					map[string]attr.Value{
+						"testkey": testtypes.StringValueWithSemanticEquals{
+							StringValue:    types.StringValue("prior"),
+							SemanticEquals: true,
+							SemanticEqualsDiagnostics: diag.Diagnostics{
+								diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+								diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+							},
+						},
+					},
+				),
+				ProposedNewValue: types.MapValueMust(
+					testtypes.StringTypeWithSemanticEquals{
+						SemanticEquals: true,
+						SemanticEqualsDiagnostics: diag.Diagnostics{
+							diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+							diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+						},
+					},
+					map[string]attr.Value{
+						"testkey": testtypes.StringValueWithSemanticEquals{
+							StringValue:    types.StringValue("new"),
+							SemanticEquals: true,
+							SemanticEqualsDiagnostics: diag.Diagnostics{
+								diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+								diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+							},
+						},
+					},
+				),
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: types.MapValueMust(
+					testtypes.StringTypeWithSemanticEquals{
+						SemanticEquals: true,
+						SemanticEqualsDiagnostics: diag.Diagnostics{
+							diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+							diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+						},
+					},
+					map[string]attr.Value{
+						"testkey": testtypes.StringValueWithSemanticEquals{
+							StringValue:    types.StringValue("new"),
+							SemanticEquals: true,
+							SemanticEqualsDiagnostics: diag.Diagnostics{
+								diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+								diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+							},
+						},
+					},
+				),
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+					diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+				},
+			},
+		},
+		// Nested ElementType with semantic equality
+		"MapValue-MapValue-StringValuableWithSemanticEquals-true": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: types.MapValueMust(
+					types.MapType{
+						ElemType: testtypes.StringTypeWithSemanticEquals{
+							SemanticEquals: true,
+						},
+					},
+					map[string]attr.Value{
+						"testkey": types.MapValueMust(
+							testtypes.StringTypeWithSemanticEquals{
+								SemanticEquals: true,
+							},
+							map[string]attr.Value{
+								"testkey": testtypes.StringValueWithSemanticEquals{
+									StringValue:    types.StringValue("prior"),
+									SemanticEquals: true,
+								},
+							},
+						),
+					},
+				),
+				ProposedNewValue: types.MapValueMust(
+					types.MapType{
+						ElemType: testtypes.StringTypeWithSemanticEquals{
+							SemanticEquals: true,
+						},
+					},
+					map[string]attr.Value{
+						"testkey": types.MapValueMust(
+							testtypes.StringTypeWithSemanticEquals{
+								SemanticEquals: true,
+							},
+							map[string]attr.Value{
+								"testkey": testtypes.StringValueWithSemanticEquals{
+									StringValue:    types.StringValue("new"),
+									SemanticEquals: true,
+								},
+							},
+						),
+					},
+				),
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: types.MapValueMust(
+					types.MapType{
+						ElemType: testtypes.StringTypeWithSemanticEquals{
+							SemanticEquals: true,
+						},
+					},
+					map[string]attr.Value{
+						"testkey": types.MapValueMust(
+							testtypes.StringTypeWithSemanticEquals{
+								SemanticEquals: true,
+							},
+							map[string]attr.Value{
+								"testkey": testtypes.StringValueWithSemanticEquals{
+									StringValue:    types.StringValue("prior"),
+									SemanticEquals: true,
+								},
+							},
+						),
+					},
+				),
+			},
+		},
+		"MapValue-MapValue-StringValuableWithSemanticEquals-false": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: types.MapValueMust(
+					types.MapType{
+						ElemType: testtypes.StringTypeWithSemanticEquals{
+							SemanticEquals: false,
+						},
+					},
+					map[string]attr.Value{
+						"testkey": types.MapValueMust(
+							testtypes.StringTypeWithSemanticEquals{
+								SemanticEquals: false,
+							},
+							map[string]attr.Value{
+								"testkey": testtypes.StringValueWithSemanticEquals{
+									StringValue:    types.StringValue("prior"),
+									SemanticEquals: false,
+								},
+							},
+						),
+					},
+				),
+				ProposedNewValue: types.MapValueMust(
+					types.MapType{
+						ElemType: testtypes.StringTypeWithSemanticEquals{
+							SemanticEquals: false,
+						},
+					},
+					map[string]attr.Value{
+						"testkey": types.MapValueMust(
+							testtypes.StringTypeWithSemanticEquals{
+								SemanticEquals: false,
+							},
+							map[string]attr.Value{
+								"testkey": testtypes.StringValueWithSemanticEquals{
+									StringValue:    types.StringValue("new"),
+									SemanticEquals: false,
+								},
+							},
+						),
+					},
+				),
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: types.MapValueMust(
+					types.MapType{
+						ElemType: testtypes.StringTypeWithSemanticEquals{
+							SemanticEquals: false,
+						},
+					},
+					map[string]attr.Value{
+						"testkey": types.MapValueMust(
+							testtypes.StringTypeWithSemanticEquals{
+								SemanticEquals: false,
+							},
+							map[string]attr.Value{
+								"testkey": testtypes.StringValueWithSemanticEquals{
+									StringValue:    types.StringValue("new"),
+									SemanticEquals: false,
+								},
+							},
+						),
+					},
+				),
+			},
+		},
+		"MapValue-MapValue-StringValuableWithSemanticEquals-diagnostics": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: types.MapValueMust(
+					types.MapType{
+						ElemType: testtypes.StringTypeWithSemanticEquals{
+							SemanticEquals: true,
+							SemanticEqualsDiagnostics: diag.Diagnostics{
+								diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+								diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+							},
+						},
+					},
+					map[string]attr.Value{
+						"testkey": types.MapValueMust(
+							testtypes.StringTypeWithSemanticEquals{
+								SemanticEquals: true,
+								SemanticEqualsDiagnostics: diag.Diagnostics{
+									diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+									diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+								},
+							},
+							map[string]attr.Value{
+								"testkey": testtypes.StringValueWithSemanticEquals{
+									StringValue:    types.StringValue("prior"),
+									SemanticEquals: true,
+									SemanticEqualsDiagnostics: diag.Diagnostics{
+										diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+										diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+									},
+								},
+							},
+						),
+					},
+				),
+				ProposedNewValue: types.MapValueMust(
+					types.MapType{
+						ElemType: testtypes.StringTypeWithSemanticEquals{
+							SemanticEquals: true,
+							SemanticEqualsDiagnostics: diag.Diagnostics{
+								diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+								diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+							},
+						},
+					},
+					map[string]attr.Value{
+						"testkey": types.MapValueMust(
+							testtypes.StringTypeWithSemanticEquals{
+								SemanticEquals: true,
+								SemanticEqualsDiagnostics: diag.Diagnostics{
+									diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+									diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+								},
+							},
+							map[string]attr.Value{
+								"testkey": testtypes.StringValueWithSemanticEquals{
+									StringValue:    types.StringValue("new"),
+									SemanticEquals: true,
+									SemanticEqualsDiagnostics: diag.Diagnostics{
+										diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+										diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+									},
+								},
+							},
+						),
+					},
+				),
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: types.MapValueMust(
+					types.MapType{
+						ElemType: testtypes.StringTypeWithSemanticEquals{
+							SemanticEquals: true,
+							SemanticEqualsDiagnostics: diag.Diagnostics{
+								diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+								diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+							},
+						},
+					},
+					map[string]attr.Value{
+						"testkey": types.MapValueMust(
+							testtypes.StringTypeWithSemanticEquals{
+								SemanticEquals: true,
+								SemanticEqualsDiagnostics: diag.Diagnostics{
+									diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+									diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+								},
+							},
+							map[string]attr.Value{
+								"testkey": testtypes.StringValueWithSemanticEquals{
+									StringValue:    types.StringValue("new"),
+									SemanticEquals: true,
+									SemanticEqualsDiagnostics: diag.Diagnostics{
+										diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+										diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+									},
+								},
+							},
+						),
+					},
+				),
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+					diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+				},
+			},
+		},
+		// Type with semantic equality
+		"MapValuableWithSemanticEquals-true": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: testtypes.MapValueWithSemanticEquals{
+					MapValue: types.MapValueMust(
+						types.StringType,
+						map[string]attr.Value{
+							"testkey": types.StringValue("prior"),
+						},
+					),
+					SemanticEquals: true,
+				},
+				ProposedNewValue: testtypes.MapValueWithSemanticEquals{
+					MapValue: types.MapValueMust(
+						types.StringType,
+						map[string]attr.Value{
+							"testkey": types.StringValue("new"),
+						},
+					),
+					SemanticEquals: true,
+				},
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testtypes.MapValueWithSemanticEquals{
+					MapValue: types.MapValueMust(
+						types.StringType,
+						map[string]attr.Value{
+							"testkey": types.StringValue("prior"),
+						},
+					),
+					SemanticEquals: true,
+				},
+			},
+		},
+		"MapValuableWithSemanticEquals-false": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: testtypes.MapValueWithSemanticEquals{
+					MapValue: types.MapValueMust(
+						types.StringType,
+						map[string]attr.Value{
+							"testkey": types.StringValue("prior"),
+						},
+					),
+					SemanticEquals: false,
+				},
+				ProposedNewValue: testtypes.MapValueWithSemanticEquals{
+					MapValue: types.MapValueMust(
+						types.StringType,
+						map[string]attr.Value{
+							"testkey": types.StringValue("new"),
+						},
+					),
+					SemanticEquals: false,
+				},
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testtypes.MapValueWithSemanticEquals{
+					MapValue: types.MapValueMust(
+						types.StringType,
+						map[string]attr.Value{
+							"testkey": types.StringValue("new"),
+						},
+					),
+					SemanticEquals: false,
+				},
+			},
+		},
+		"MapValuableWithSemanticEquals-diagnostics": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: testtypes.MapValueWithSemanticEquals{
+					MapValue: types.MapValueMust(
+						types.StringType,
+						map[string]attr.Value{
+							"testkey": types.StringValue("prior"),
+						},
+					),
+					SemanticEquals: false,
+					SemanticEqualsDiagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+						diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+					},
+				},
+				ProposedNewValue: testtypes.MapValueWithSemanticEquals{
+					MapValue: types.MapValueMust(
+						types.StringType,
+						map[string]attr.Value{
+							"testkey": types.StringValue("new"),
+						},
+					),
+					SemanticEquals: false,
+					SemanticEqualsDiagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+						diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+					},
+				},
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testtypes.MapValueWithSemanticEquals{
+					MapValue: types.MapValueMust(
+						types.StringType,
+						map[string]attr.Value{
+							"testkey": types.StringValue("new"),
+						},
+					),
+					SemanticEquals: false,
+					SemanticEqualsDiagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+						diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+					},
+				},
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+					diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testCase.request.ProposedNewValue,
+			}
+
+			fwschemadata.ValueSemanticEqualityMap(context.Background(), testCase.request, got)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}

--- a/internal/fwschemadata/value_semantic_equality_number.go
+++ b/internal/fwschemadata/value_semantic_equality_number.go
@@ -1,0 +1,51 @@
+package fwschemadata
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/internal/logging"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+// ValueSemanticEqualityNumber performs number type semantic equality.
+func ValueSemanticEqualityNumber(ctx context.Context, req ValueSemanticEqualityRequest, resp *ValueSemanticEqualityResponse) {
+	priorValuable, ok := req.PriorValue.(basetypes.NumberValuableWithSemanticEquals)
+
+	// No changes required if the interface is not implemented.
+	if !ok {
+		return
+	}
+
+	proposedNewValuable, ok := req.ProposedNewValue.(basetypes.NumberValuableWithSemanticEquals)
+
+	// No changes required if the interface is not implemented.
+	if !ok {
+		return
+	}
+
+	logging.FrameworkTrace(
+		ctx,
+		"Calling provider defined type-based SemanticEquals",
+		map[string]interface{}{
+			logging.KeyValueType: proposedNewValuable.String(),
+		},
+	)
+
+	usePriorValue, diags := proposedNewValuable.NumberSemanticEquals(ctx, priorValuable)
+
+	logging.FrameworkTrace(
+		ctx,
+		"Called provider defined type-based SemanticEquals",
+		map[string]interface{}{
+			logging.KeyValueType: proposedNewValuable.String(),
+		},
+	)
+
+	resp.Diagnostics.Append(diags...)
+
+	if !usePriorValue {
+		return
+	}
+
+	resp.NewValue = priorValuable
+}

--- a/internal/fwschemadata/value_semantic_equality_number_test.go
+++ b/internal/fwschemadata/value_semantic_equality_number_test.go
@@ -1,0 +1,125 @@
+package fwschemadata_test
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschemadata"
+	testtypes "github.com/hashicorp/terraform-plugin-framework/internal/testing/types"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestValueSemanticEqualityNumber(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		request  fwschemadata.ValueSemanticEqualityRequest
+		expected *fwschemadata.ValueSemanticEqualityResponse
+	}{
+		"NumberValue": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path:             path.Root("test"),
+				PriorValue:       types.NumberValue(big.NewFloat(1.2)),
+				ProposedNewValue: types.NumberValue(big.NewFloat(2.4)),
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: types.NumberValue(big.NewFloat(2.4)),
+			},
+		},
+		"NumberValuableWithSemanticEquals-true": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: testtypes.NumberValueWithSemanticEquals{
+					NumberValue:    types.NumberValue(big.NewFloat(1.2)),
+					SemanticEquals: true,
+				},
+				ProposedNewValue: testtypes.NumberValueWithSemanticEquals{
+					NumberValue:    types.NumberValue(big.NewFloat(2.4)),
+					SemanticEquals: true,
+				},
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testtypes.NumberValueWithSemanticEquals{
+					NumberValue:    types.NumberValue(big.NewFloat(1.2)),
+					SemanticEquals: true,
+				},
+			},
+		},
+		"NumberValuableWithSemanticEquals-false": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: testtypes.NumberValueWithSemanticEquals{
+					NumberValue:    types.NumberValue(big.NewFloat(1.2)),
+					SemanticEquals: false,
+				},
+				ProposedNewValue: testtypes.NumberValueWithSemanticEquals{
+					NumberValue:    types.NumberValue(big.NewFloat(2.4)),
+					SemanticEquals: false,
+				},
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testtypes.NumberValueWithSemanticEquals{
+					NumberValue:    types.NumberValue(big.NewFloat(2.4)),
+					SemanticEquals: false,
+				},
+			},
+		},
+		"NumberValuableWithSemanticEquals-diagnostics": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: testtypes.NumberValueWithSemanticEquals{
+					NumberValue:    types.NumberValue(big.NewFloat(1.2)),
+					SemanticEquals: false,
+					SemanticEqualsDiagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+						diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+					},
+				},
+				ProposedNewValue: testtypes.NumberValueWithSemanticEquals{
+					NumberValue:    types.NumberValue(big.NewFloat(2.4)),
+					SemanticEquals: false,
+					SemanticEqualsDiagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+						diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+					},
+				},
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testtypes.NumberValueWithSemanticEquals{
+					NumberValue:    types.NumberValue(big.NewFloat(2.4)),
+					SemanticEquals: false,
+					SemanticEqualsDiagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+						diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+					},
+				},
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+					diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testCase.request.ProposedNewValue,
+			}
+
+			fwschemadata.ValueSemanticEqualityNumber(context.Background(), testCase.request, got)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}

--- a/internal/fwschemadata/value_semantic_equality_object.go
+++ b/internal/fwschemadata/value_semantic_equality_object.go
@@ -1,0 +1,209 @@
+package fwschemadata
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/internal/logging"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+// ValueSemanticEqualityObject performs object type semantic equality.
+//
+// This will perform semantic equality checking on attributes, regardless of
+// whether the structural type implements the expected interface, since it
+// cannot be assumed that the structural type implementation runs all possible
+// attribute implementations.
+func ValueSemanticEqualityObject(ctx context.Context, req ValueSemanticEqualityRequest, resp *ValueSemanticEqualityResponse) {
+	priorValuable, ok := req.PriorValue.(basetypes.ObjectValuableWithSemanticEquals)
+
+	// While the structural type itself does not implement the interface,
+	// underlying attributes might. Check attributes automatically, if possible.
+	if !ok {
+		ValueSemanticEqualityObjectAttributes(ctx, req, resp)
+
+		return
+	}
+
+	proposedNewValuable, ok := req.ProposedNewValue.(basetypes.ObjectValuableWithSemanticEquals)
+
+	// While the structural type itself does not implement the interface,
+	// underlying attributes might. Check attributes automatically, if possible.
+	if !ok {
+		ValueSemanticEqualityObjectAttributes(ctx, req, resp)
+
+		return
+	}
+
+	logging.FrameworkTrace(
+		ctx,
+		"Calling provider defined type-based SemanticEquals",
+		map[string]interface{}{
+			logging.KeyValueType: proposedNewValuable.String(),
+		},
+	)
+
+	usePriorValue, diags := proposedNewValuable.ObjectSemanticEquals(ctx, priorValuable)
+
+	logging.FrameworkTrace(
+		ctx,
+		"Called provider defined type-based SemanticEquals",
+		map[string]interface{}{
+			logging.KeyValueType: proposedNewValuable.String(),
+		},
+	)
+
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// If the structural type signaled semantic equality, respect the
+	// determination to use the whole prior value and return early since
+	// checking attributes is not necessary.
+	if usePriorValue {
+		resp.NewValue = priorValuable
+
+		return
+	}
+
+	// While the structural type itself did not signal semantic equality,
+	// underlying attributes might, which should still modify the structural.
+	// Check attributes automatically, if possible.
+	//
+	// This logic pessimistically assumes that structural type semantic equality
+	// implementations may be missing proper attribute type handling. While
+	// correct implementations receive a small performance penalty of
+	// being re-checked, this ensures that less-correct implementations do not
+	// cause inconsistent data handling behaviors for developers.
+	ValueSemanticEqualityObjectAttributes(ctx, req, resp)
+}
+
+// ValueSemanticEqualityObjectAttributes performs object type semantic equality
+// on attributes, returning a modified object as necessary.
+func ValueSemanticEqualityObjectAttributes(ctx context.Context, req ValueSemanticEqualityRequest, resp *ValueSemanticEqualityResponse) {
+	priorValuable, ok := req.PriorValue.(basetypes.ObjectValuable)
+
+	// No changes required if the attributes cannot be extracted.
+	if !ok {
+		return
+	}
+
+	priorValue, diags := priorValuable.ToObjectValue(ctx)
+
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	priorValueAttributes := priorValue.Attributes()
+
+	proposedNewValuable, ok := req.ProposedNewValue.(basetypes.ObjectValuable)
+
+	// No changes required if the attributes cannot be extracted.
+	if !ok {
+		return
+	}
+
+	proposedNewValue, diags := proposedNewValuable.ToObjectValue(ctx)
+
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	proposedNewValueAttributes := proposedNewValue.Attributes()
+
+	// Create a new element value map, which will be used to create the final
+	// collection value after each element is evaluated.
+	newValueAttributes := make(map[string]attr.Value, len(proposedNewValueAttributes))
+
+	// Short circuit flag
+	updatedAttributes := false
+
+	// Loop through proposed attributes by delegating to the recursive semantic
+	// equality logic. This ensures that recursion will catch a further
+	// underlying element type has its semantic equality logic checked, even if
+	// the current element type does not implement the interface.
+	for name, proposedNewValueElement := range proposedNewValueAttributes {
+		// Ensure new value always contains all of proposed new value
+		newValueAttributes[name] = proposedNewValueElement
+
+		priorValueElement, ok := priorValueAttributes[name]
+
+		if !ok {
+			continue
+		}
+
+		elementReq := ValueSemanticEqualityRequest{
+			Path:             req.Path.AtName(name),
+			PriorValue:       priorValueElement,
+			ProposedNewValue: proposedNewValueElement,
+		}
+		elementResp := &ValueSemanticEqualityResponse{
+			NewValue: elementReq.ProposedNewValue,
+		}
+
+		ValueSemanticEquality(ctx, elementReq, elementResp)
+
+		resp.Diagnostics.Append(elementResp.Diagnostics...)
+
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		if elementResp.NewValue.Equal(elementReq.ProposedNewValue) {
+			continue
+		}
+
+		updatedAttributes = true
+		newValueAttributes[name] = elementResp.NewValue
+	}
+
+	// No changes required if the attributes were not updated.
+	if !updatedAttributes {
+		return
+	}
+
+	newValue, diags := basetypes.NewObjectValue(proposedNewValue.AttributeTypes(ctx), newValueAttributes)
+
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Convert the new value to the original ObjectValuable type to ensure
+	// downstream logic has the correct value type for the defined schema type.
+	newTypable, ok := proposedNewValuable.Type(ctx).(basetypes.ObjectTypable)
+
+	// This should be a requirement of having a ObjectValuable, but defensively
+	// checking just in case.
+	if !ok {
+		resp.Diagnostics.AddAttributeError(
+			req.Path,
+			"Value Semantic Equality Type Error",
+			"An unexpected error occurred while performing value semantic equality logic. "+
+				"This is either an error in terraform-plugin-framework or a provider custom type implementation. "+
+				"Please report this to the provider developers.\n\n"+
+				"Error: Expected basetypes.ObjectTypable type for value type: "+fmt.Sprintf("%T", proposedNewValuable)+"\n"+
+				"Path: "+req.Path.String(),
+		)
+
+		return
+	}
+
+	newValuable, diags := newTypable.ValueFromObject(ctx, newValue)
+
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.NewValue = newValuable
+}

--- a/internal/fwschemadata/value_semantic_equality_object_test.go
+++ b/internal/fwschemadata/value_semantic_equality_object_test.go
@@ -1,0 +1,674 @@
+package fwschemadata_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschemadata"
+	testtypes "github.com/hashicorp/terraform-plugin-framework/internal/testing/types"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestValueSemanticEqualityObject(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		request  fwschemadata.ValueSemanticEqualityRequest
+		expected *fwschemadata.ValueSemanticEqualityResponse
+	}{
+		// Type and AttributeTypes without semantic equality
+		"ObjectValue": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: types.ObjectValueMust(
+					map[string]attr.Type{
+						"test_attr": types.StringType,
+					},
+					map[string]attr.Value{
+						"test_attr": types.StringValue("prior"),
+					},
+				),
+				ProposedNewValue: types.ObjectValueMust(
+					map[string]attr.Type{
+						"test_attr": types.StringType,
+					},
+					map[string]attr.Value{
+						"test_attr": types.StringValue("new"),
+					},
+				),
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: types.ObjectValueMust(
+					map[string]attr.Type{
+						"test_attr": types.StringType,
+					},
+					map[string]attr.Value{
+						"test_attr": types.StringValue("new"),
+					},
+				),
+			},
+		},
+		// AttributeTypes with semantic equality
+		"ObjectValue-StringValuableWithSemanticEquals-true": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: types.ObjectValueMust(
+					map[string]attr.Type{
+						"test_attr": testtypes.StringTypeWithSemanticEquals{
+							SemanticEquals: true,
+						},
+					},
+					map[string]attr.Value{
+						"test_attr": testtypes.StringValueWithSemanticEquals{
+							StringValue:    types.StringValue("prior"),
+							SemanticEquals: true,
+						},
+					},
+				),
+				ProposedNewValue: types.ObjectValueMust(
+					map[string]attr.Type{
+						"test_attr": testtypes.StringTypeWithSemanticEquals{
+							SemanticEquals: true,
+						},
+					},
+					map[string]attr.Value{
+						"test_attr": testtypes.StringValueWithSemanticEquals{
+							StringValue:    types.StringValue("new"),
+							SemanticEquals: true,
+						},
+					},
+				),
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: types.ObjectValueMust(
+					map[string]attr.Type{
+						"test_attr": testtypes.StringTypeWithSemanticEquals{
+							SemanticEquals: true,
+						},
+					},
+					map[string]attr.Value{
+						"test_attr": testtypes.StringValueWithSemanticEquals{
+							StringValue:    types.StringValue("prior"),
+							SemanticEquals: true,
+						},
+					},
+				),
+			},
+		},
+		"ObjectValue-StringValuableWithSemanticEquals-false": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: types.ObjectValueMust(
+					map[string]attr.Type{
+						"test_attr": testtypes.StringTypeWithSemanticEquals{
+							SemanticEquals: false,
+						},
+					},
+					map[string]attr.Value{
+						"test_attr": testtypes.StringValueWithSemanticEquals{
+							StringValue:    types.StringValue("prior"),
+							SemanticEquals: false,
+						},
+					},
+				),
+				ProposedNewValue: types.ObjectValueMust(
+					map[string]attr.Type{
+						"test_attr": testtypes.StringTypeWithSemanticEquals{
+							SemanticEquals: false,
+						},
+					},
+					map[string]attr.Value{
+						"test_attr": testtypes.StringValueWithSemanticEquals{
+							StringValue:    types.StringValue("new"),
+							SemanticEquals: false,
+						},
+					},
+				),
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: types.ObjectValueMust(
+					map[string]attr.Type{
+						"test_attr": testtypes.StringTypeWithSemanticEquals{
+							SemanticEquals: false,
+						},
+					},
+					map[string]attr.Value{
+						"test_attr": testtypes.StringValueWithSemanticEquals{
+							StringValue:    types.StringValue("new"),
+							SemanticEquals: false,
+						},
+					},
+				),
+			},
+		},
+		"ObjectValue-StringValuableWithSemanticEquals-diagnostics": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: types.ObjectValueMust(
+					map[string]attr.Type{
+						"test_attr": testtypes.StringTypeWithSemanticEquals{
+							SemanticEquals: true,
+							SemanticEqualsDiagnostics: diag.Diagnostics{
+								diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+								diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+							},
+						},
+					},
+					map[string]attr.Value{
+						"test_attr": testtypes.StringValueWithSemanticEquals{
+							StringValue:    types.StringValue("prior"),
+							SemanticEquals: true,
+							SemanticEqualsDiagnostics: diag.Diagnostics{
+								diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+								diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+							},
+						},
+					},
+				),
+				ProposedNewValue: types.ObjectValueMust(
+					map[string]attr.Type{
+						"test_attr": testtypes.StringTypeWithSemanticEquals{
+							SemanticEquals: true,
+							SemanticEqualsDiagnostics: diag.Diagnostics{
+								diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+								diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+							},
+						},
+					},
+					map[string]attr.Value{
+						"test_attr": testtypes.StringValueWithSemanticEquals{
+							StringValue:    types.StringValue("new"),
+							SemanticEquals: true,
+							SemanticEqualsDiagnostics: diag.Diagnostics{
+								diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+								diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+							},
+						},
+					},
+				),
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: types.ObjectValueMust(
+					map[string]attr.Type{
+						"test_attr": testtypes.StringTypeWithSemanticEquals{
+							SemanticEquals: true,
+							SemanticEqualsDiagnostics: diag.Diagnostics{
+								diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+								diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+							},
+						},
+					},
+					map[string]attr.Value{
+						"test_attr": testtypes.StringValueWithSemanticEquals{
+							StringValue:    types.StringValue("new"),
+							SemanticEquals: true,
+							SemanticEqualsDiagnostics: diag.Diagnostics{
+								diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+								diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+							},
+						},
+					},
+				),
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+					diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+				},
+			},
+		},
+		// Nested AttributeTypes with semantic equality
+		"ObjectValue-ObjectValue-StringValuableWithSemanticEquals-true": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: types.ObjectValueMust(
+					map[string]attr.Type{
+						"test_attr": types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"test_attr": testtypes.StringTypeWithSemanticEquals{
+									SemanticEquals: true,
+								},
+							},
+						},
+					},
+					map[string]attr.Value{
+						"test_attr": types.ObjectValueMust(
+							map[string]attr.Type{
+								"test_attr": testtypes.StringTypeWithSemanticEquals{
+									SemanticEquals: true,
+								},
+							},
+							map[string]attr.Value{
+								"test_attr": testtypes.StringValueWithSemanticEquals{
+									StringValue:    types.StringValue("prior"),
+									SemanticEquals: true,
+								},
+							},
+						),
+					},
+				),
+				ProposedNewValue: types.ObjectValueMust(
+					map[string]attr.Type{
+						"test_attr": types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"test_attr": testtypes.StringTypeWithSemanticEquals{
+									SemanticEquals: true,
+								},
+							},
+						},
+					},
+					map[string]attr.Value{
+						"test_attr": types.ObjectValueMust(
+							map[string]attr.Type{
+								"test_attr": testtypes.StringTypeWithSemanticEquals{
+									SemanticEquals: true,
+								},
+							},
+							map[string]attr.Value{
+								"test_attr": testtypes.StringValueWithSemanticEquals{
+									StringValue:    types.StringValue("new"),
+									SemanticEquals: true,
+								},
+							},
+						),
+					},
+				),
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: types.ObjectValueMust(
+					map[string]attr.Type{
+						"test_attr": types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"test_attr": testtypes.StringTypeWithSemanticEquals{
+									SemanticEquals: true,
+								},
+							},
+						},
+					},
+					map[string]attr.Value{
+						"test_attr": types.ObjectValueMust(
+							map[string]attr.Type{
+								"test_attr": testtypes.StringTypeWithSemanticEquals{
+									SemanticEquals: true,
+								},
+							},
+							map[string]attr.Value{
+								"test_attr": testtypes.StringValueWithSemanticEquals{
+									StringValue:    types.StringValue("prior"),
+									SemanticEquals: true,
+								},
+							},
+						),
+					},
+				),
+			},
+		},
+		"ObjectValue-ObjectValue-StringValuableWithSemanticEquals-false": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: types.ObjectValueMust(
+					map[string]attr.Type{
+						"test_attr": types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"test_attr": testtypes.StringTypeWithSemanticEquals{
+									SemanticEquals: false,
+								},
+							},
+						},
+					},
+					map[string]attr.Value{
+						"test_attr": types.ObjectValueMust(
+							map[string]attr.Type{
+								"test_attr": testtypes.StringTypeWithSemanticEquals{
+									SemanticEquals: false,
+								},
+							},
+							map[string]attr.Value{
+								"test_attr": testtypes.StringValueWithSemanticEquals{
+									StringValue:    types.StringValue("prior"),
+									SemanticEquals: false,
+								},
+							},
+						),
+					},
+				),
+				ProposedNewValue: types.ObjectValueMust(
+					map[string]attr.Type{
+						"test_attr": types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"test_attr": testtypes.StringTypeWithSemanticEquals{
+									SemanticEquals: false,
+								},
+							},
+						},
+					},
+					map[string]attr.Value{
+						"test_attr": types.ObjectValueMust(
+							map[string]attr.Type{
+								"test_attr": testtypes.StringTypeWithSemanticEquals{
+									SemanticEquals: false,
+								},
+							},
+							map[string]attr.Value{
+								"test_attr": testtypes.StringValueWithSemanticEquals{
+									StringValue:    types.StringValue("new"),
+									SemanticEquals: false,
+								},
+							},
+						),
+					},
+				),
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: types.ObjectValueMust(
+					map[string]attr.Type{
+						"test_attr": types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"test_attr": testtypes.StringTypeWithSemanticEquals{
+									SemanticEquals: false,
+								},
+							},
+						},
+					},
+					map[string]attr.Value{
+						"test_attr": types.ObjectValueMust(
+							map[string]attr.Type{
+								"test_attr": testtypes.StringTypeWithSemanticEquals{
+									SemanticEquals: false,
+								},
+							},
+							map[string]attr.Value{
+								"test_attr": testtypes.StringValueWithSemanticEquals{
+									StringValue:    types.StringValue("new"),
+									SemanticEquals: false,
+								},
+							},
+						),
+					},
+				),
+			},
+		},
+		"ObjectValue-ObjectValue-StringValuableWithSemanticEquals-diagnostics": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: types.ObjectValueMust(
+					map[string]attr.Type{
+						"test_attr": types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"test_attr": testtypes.StringTypeWithSemanticEquals{
+									SemanticEquals: true,
+									SemanticEqualsDiagnostics: diag.Diagnostics{
+										diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+										diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+									},
+								},
+							},
+						},
+					},
+					map[string]attr.Value{
+						"test_attr": types.ObjectValueMust(
+							map[string]attr.Type{
+								"test_attr": testtypes.StringTypeWithSemanticEquals{
+									SemanticEquals: true,
+									SemanticEqualsDiagnostics: diag.Diagnostics{
+										diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+										diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+									},
+								},
+							},
+							map[string]attr.Value{
+								"test_attr": testtypes.StringValueWithSemanticEquals{
+									StringValue:    types.StringValue("prior"),
+									SemanticEquals: true,
+									SemanticEqualsDiagnostics: diag.Diagnostics{
+										diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+										diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+									},
+								},
+							},
+						),
+					},
+				),
+				ProposedNewValue: types.ObjectValueMust(
+					map[string]attr.Type{
+						"test_attr": types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"test_attr": testtypes.StringTypeWithSemanticEquals{
+									SemanticEquals: true,
+									SemanticEqualsDiagnostics: diag.Diagnostics{
+										diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+										diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+									},
+								},
+							},
+						},
+					},
+					map[string]attr.Value{
+						"test_attr": types.ObjectValueMust(
+							map[string]attr.Type{
+								"test_attr": testtypes.StringTypeWithSemanticEquals{
+									SemanticEquals: true,
+									SemanticEqualsDiagnostics: diag.Diagnostics{
+										diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+										diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+									},
+								},
+							},
+							map[string]attr.Value{
+								"test_attr": testtypes.StringValueWithSemanticEquals{
+									StringValue:    types.StringValue("new"),
+									SemanticEquals: true,
+									SemanticEqualsDiagnostics: diag.Diagnostics{
+										diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+										diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+									},
+								},
+							},
+						),
+					},
+				),
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: types.ObjectValueMust(
+					map[string]attr.Type{
+						"test_attr": types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"test_attr": testtypes.StringTypeWithSemanticEquals{
+									SemanticEquals: true,
+									SemanticEqualsDiagnostics: diag.Diagnostics{
+										diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+										diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+									},
+								},
+							},
+						},
+					},
+					map[string]attr.Value{
+						"test_attr": types.ObjectValueMust(
+							map[string]attr.Type{
+								"test_attr": testtypes.StringTypeWithSemanticEquals{
+									SemanticEquals: true,
+									SemanticEqualsDiagnostics: diag.Diagnostics{
+										diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+										diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+									},
+								},
+							},
+							map[string]attr.Value{
+								"test_attr": testtypes.StringValueWithSemanticEquals{
+									StringValue:    types.StringValue("new"),
+									SemanticEquals: true,
+									SemanticEqualsDiagnostics: diag.Diagnostics{
+										diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+										diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+									},
+								},
+							},
+						),
+					},
+				),
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+					diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+				},
+			},
+		},
+		// Type with semantic equality
+		"ObjectValuableWithSemanticEquals-true": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: testtypes.ObjectValueWithSemanticEquals{
+					ObjectValue: types.ObjectValueMust(
+						map[string]attr.Type{
+							"test_attr": types.StringType,
+						},
+						map[string]attr.Value{
+							"test_attr": types.StringValue("prior"),
+						},
+					),
+					SemanticEquals: true,
+				},
+				ProposedNewValue: testtypes.ObjectValueWithSemanticEquals{
+					ObjectValue: types.ObjectValueMust(
+						map[string]attr.Type{
+							"test_attr": types.StringType,
+						},
+						map[string]attr.Value{
+							"test_attr": types.StringValue("new"),
+						},
+					),
+					SemanticEquals: true,
+				},
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testtypes.ObjectValueWithSemanticEquals{
+					ObjectValue: types.ObjectValueMust(
+						map[string]attr.Type{
+							"test_attr": types.StringType,
+						},
+						map[string]attr.Value{
+							"test_attr": types.StringValue("prior"),
+						},
+					),
+					SemanticEquals: true,
+				},
+			},
+		},
+		"ObjectValuableWithSemanticEquals-false": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: testtypes.ObjectValueWithSemanticEquals{
+					ObjectValue: types.ObjectValueMust(
+						map[string]attr.Type{
+							"test_attr": types.StringType,
+						},
+						map[string]attr.Value{
+							"test_attr": types.StringValue("prior"),
+						},
+					),
+					SemanticEquals: false,
+				},
+				ProposedNewValue: testtypes.ObjectValueWithSemanticEquals{
+					ObjectValue: types.ObjectValueMust(
+						map[string]attr.Type{
+							"test_attr": types.StringType,
+						},
+						map[string]attr.Value{
+							"test_attr": types.StringValue("new"),
+						},
+					),
+					SemanticEquals: false,
+				},
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testtypes.ObjectValueWithSemanticEquals{
+					ObjectValue: types.ObjectValueMust(
+						map[string]attr.Type{
+							"test_attr": types.StringType,
+						},
+						map[string]attr.Value{
+							"test_attr": types.StringValue("new"),
+						},
+					),
+					SemanticEquals: false,
+				},
+			},
+		},
+		"ObjectValuableWithSemanticEquals-diagnostics": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: testtypes.ObjectValueWithSemanticEquals{
+					ObjectValue: types.ObjectValueMust(
+						map[string]attr.Type{
+							"test_attr": types.StringType,
+						},
+						map[string]attr.Value{
+							"test_attr": types.StringValue("prior"),
+						},
+					),
+					SemanticEquals: false,
+					SemanticEqualsDiagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+						diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+					},
+				},
+				ProposedNewValue: testtypes.ObjectValueWithSemanticEquals{
+					ObjectValue: types.ObjectValueMust(
+						map[string]attr.Type{
+							"test_attr": types.StringType,
+						},
+						map[string]attr.Value{
+							"test_attr": types.StringValue("new"),
+						},
+					),
+					SemanticEquals: false,
+					SemanticEqualsDiagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+						diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+					},
+				},
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testtypes.ObjectValueWithSemanticEquals{
+					ObjectValue: types.ObjectValueMust(
+						map[string]attr.Type{
+							"test_attr": types.StringType,
+						},
+						map[string]attr.Value{
+							"test_attr": types.StringValue("new"),
+						},
+					),
+					SemanticEquals: false,
+					SemanticEqualsDiagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+						diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+					},
+				},
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+					diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testCase.request.ProposedNewValue,
+			}
+
+			fwschemadata.ValueSemanticEqualityObject(context.Background(), testCase.request, got)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}

--- a/internal/fwschemadata/value_semantic_equality_set.go
+++ b/internal/fwschemadata/value_semantic_equality_set.go
@@ -1,0 +1,207 @@
+package fwschemadata
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/internal/logging"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+// ValueSemanticEqualitySet performs set type semantic equality.
+//
+// This will perform semantic equality checking on elements, regardless of
+// whether the collection type implements the expected interface, since it
+// cannot be assumed that the collection type implementation runs all possible
+// element implementations.
+func ValueSemanticEqualitySet(ctx context.Context, req ValueSemanticEqualityRequest, resp *ValueSemanticEqualityResponse) {
+	priorValuable, ok := req.PriorValue.(basetypes.SetValuableWithSemanticEquals)
+
+	// While the collection type itself does not implement the interface,
+	// underlying elements might. Check elements automatically, if possible.
+	if !ok {
+		ValueSemanticEqualitySetElements(ctx, req, resp)
+
+		return
+	}
+
+	proposedNewValuable, ok := req.ProposedNewValue.(basetypes.SetValuableWithSemanticEquals)
+
+	// While the collection type itself does not implement the interface,
+	// underlying elements might. Check elements automatically, if possible.
+	if !ok {
+		ValueSemanticEqualitySetElements(ctx, req, resp)
+
+		return
+	}
+
+	logging.FrameworkTrace(
+		ctx,
+		"Calling provider defined type-based SemanticEquals",
+		map[string]interface{}{
+			logging.KeyValueType: proposedNewValuable.String(),
+		},
+	)
+
+	usePriorValue, diags := proposedNewValuable.SetSemanticEquals(ctx, priorValuable)
+
+	logging.FrameworkTrace(
+		ctx,
+		"Called provider defined type-based SemanticEquals",
+		map[string]interface{}{
+			logging.KeyValueType: proposedNewValuable.String(),
+		},
+	)
+
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// If the collection type signaled semantic equality, respect the
+	// determination to use the whole prior value and return early since
+	// checking elements is not necessary.
+	if usePriorValue {
+		resp.NewValue = priorValuable
+
+		return
+	}
+
+	// While the collection type itself did not signal semantic equality,
+	// underlying elements might, which should still modify the collection.
+	// Check elements automatically, if possible.
+	//
+	// This logic pessimistically assumes that collection type semantic equality
+	// implementations may be missing proper element type handling. While
+	// correct implementations receive a small performance penalty of
+	// being re-checked, this ensures that less-correct implementations do not
+	// cause inconsistent data handling behaviors for developers.
+	ValueSemanticEqualitySetElements(ctx, req, resp)
+}
+
+// ValueSemanticEqualitySetElements performs list type semantic equality
+// on elements, returning a modified list as necessary.
+func ValueSemanticEqualitySetElements(ctx context.Context, req ValueSemanticEqualityRequest, resp *ValueSemanticEqualityResponse) {
+	priorValuable, ok := req.PriorValue.(basetypes.SetValuable)
+
+	// No changes required if the elements cannot be extracted.
+	if !ok {
+		return
+	}
+
+	priorValue, diags := priorValuable.ToSetValue(ctx)
+
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	priorValueElements := priorValue.Elements()
+
+	proposedNewValuable, ok := req.ProposedNewValue.(basetypes.SetValuable)
+
+	// No changes required if the elements cannot be extracted.
+	if !ok {
+		return
+	}
+
+	proposedNewValue, diags := proposedNewValuable.ToSetValue(ctx)
+
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	proposedNewValueElements := proposedNewValue.Elements()
+
+	// Create a new element value slice, which will be used to create the final
+	// collection value after each element is evaluated.
+	newValueElements := make([]attr.Value, len(proposedNewValueElements))
+
+	// Short circuit flag
+	updatedElements := false
+
+	// Loop through proposed elements by delegating to the recursive semantic
+	// equality logic. This ensures that recursion will catch a further
+	// underlying element type has its semantic equality logic checked, even if
+	// the current element type does not implement the interface.
+	for idx, proposedNewValueElement := range proposedNewValueElements {
+		// Ensure new value always contains all of proposed new value
+		newValueElements[idx] = proposedNewValueElement
+
+		if idx > len(priorValueElements) {
+			continue
+		}
+
+		elementReq := ValueSemanticEqualityRequest{
+			Path:             req.Path.AtSetValue(proposedNewValueElement),
+			PriorValue:       priorValueElements[idx],
+			ProposedNewValue: proposedNewValueElement,
+		}
+		elementResp := &ValueSemanticEqualityResponse{
+			NewValue: elementReq.ProposedNewValue,
+		}
+
+		ValueSemanticEquality(ctx, elementReq, elementResp)
+
+		resp.Diagnostics.Append(elementResp.Diagnostics...)
+
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		if elementResp.NewValue.Equal(elementReq.ProposedNewValue) {
+			continue
+		}
+
+		updatedElements = true
+		newValueElements[idx] = elementResp.NewValue
+	}
+
+	// No changes required if the elements were not updated.
+	if !updatedElements {
+		return
+	}
+
+	newValue, diags := basetypes.NewSetValue(proposedNewValue.ElementType(ctx), newValueElements)
+
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Convert the new value to the original SetValuable type to ensure
+	// downstream logic has the correct value type for the defined schema type.
+	newTypable, ok := proposedNewValuable.Type(ctx).(basetypes.SetTypable)
+
+	// This should be a requirement of having a SetValuable, but defensively
+	// checking just in case.
+	if !ok {
+		resp.Diagnostics.AddAttributeError(
+			req.Path,
+			"Value Semantic Equality Type Error",
+			"An unexpected error occurred while performing value semantic equality logic. "+
+				"This is either an error in terraform-plugin-framework or a provider custom type implementation. "+
+				"Please report this to the provider developers.\n\n"+
+				"Error: Expected basetypes.SetTypable type for value type: "+fmt.Sprintf("%T", proposedNewValuable)+"\n"+
+				"Path: "+req.Path.String(),
+		)
+
+		return
+	}
+
+	newValuable, diags := newTypable.ValueFromSet(ctx, newValue)
+
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.NewValue = newValuable
+}

--- a/internal/fwschemadata/value_semantic_equality_set_test.go
+++ b/internal/fwschemadata/value_semantic_equality_set_test.go
@@ -1,0 +1,578 @@
+package fwschemadata_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschemadata"
+	testtypes "github.com/hashicorp/terraform-plugin-framework/internal/testing/types"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestValueSemanticEqualitySet(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		request  fwschemadata.ValueSemanticEqualityRequest
+		expected *fwschemadata.ValueSemanticEqualityResponse
+	}{
+		// Type and ElementType without semantic equality
+		"SetValue": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: types.SetValueMust(
+					types.StringType,
+					[]attr.Value{
+						types.StringValue("prior"),
+					},
+				),
+				ProposedNewValue: types.SetValueMust(
+					types.StringType,
+					[]attr.Value{
+						types.StringValue("new"),
+					},
+				),
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: types.SetValueMust(
+					types.StringType,
+					[]attr.Value{
+						types.StringValue("new"),
+					},
+				),
+			},
+		},
+		// ElementType with semantic equality
+		"SetValue-StringValuableWithSemanticEquals-true": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: types.SetValueMust(
+					testtypes.StringTypeWithSemanticEquals{
+						SemanticEquals: true,
+					},
+					[]attr.Value{
+						testtypes.StringValueWithSemanticEquals{
+							StringValue:    types.StringValue("prior"),
+							SemanticEquals: true,
+						},
+					},
+				),
+				ProposedNewValue: types.SetValueMust(
+					testtypes.StringTypeWithSemanticEquals{
+						SemanticEquals: true,
+					},
+					[]attr.Value{
+						testtypes.StringValueWithSemanticEquals{
+							StringValue:    types.StringValue("new"),
+							SemanticEquals: true,
+						},
+					},
+				),
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: types.SetValueMust(
+					testtypes.StringTypeWithSemanticEquals{
+						SemanticEquals: true,
+					},
+					[]attr.Value{
+						testtypes.StringValueWithSemanticEquals{
+							StringValue:    types.StringValue("prior"),
+							SemanticEquals: true,
+						},
+					},
+				),
+			},
+		},
+		"SetValue-StringValuableWithSemanticEquals-false": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: types.SetValueMust(
+					testtypes.StringTypeWithSemanticEquals{
+						SemanticEquals: false,
+					},
+					[]attr.Value{
+						testtypes.StringValueWithSemanticEquals{
+							StringValue:    types.StringValue("prior"),
+							SemanticEquals: false,
+						},
+					},
+				),
+				ProposedNewValue: types.SetValueMust(
+					testtypes.StringTypeWithSemanticEquals{
+						SemanticEquals: false,
+					},
+					[]attr.Value{
+						testtypes.StringValueWithSemanticEquals{
+							StringValue:    types.StringValue("new"),
+							SemanticEquals: false,
+						},
+					},
+				),
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: types.SetValueMust(
+					testtypes.StringTypeWithSemanticEquals{
+						SemanticEquals: false,
+					},
+					[]attr.Value{
+						testtypes.StringValueWithSemanticEquals{
+							StringValue:    types.StringValue("new"),
+							SemanticEquals: false,
+						},
+					},
+				),
+			},
+		},
+		"SetValue-StringValuableWithSemanticEquals-diagnostics": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: types.SetValueMust(
+					testtypes.StringTypeWithSemanticEquals{
+						SemanticEquals: true,
+						SemanticEqualsDiagnostics: diag.Diagnostics{
+							diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+							diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+						},
+					},
+					[]attr.Value{
+						testtypes.StringValueWithSemanticEquals{
+							StringValue:    types.StringValue("prior"),
+							SemanticEquals: true,
+							SemanticEqualsDiagnostics: diag.Diagnostics{
+								diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+								diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+							},
+						},
+					},
+				),
+				ProposedNewValue: types.SetValueMust(
+					testtypes.StringTypeWithSemanticEquals{
+						SemanticEquals: true,
+						SemanticEqualsDiagnostics: diag.Diagnostics{
+							diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+							diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+						},
+					},
+					[]attr.Value{
+						testtypes.StringValueWithSemanticEquals{
+							StringValue:    types.StringValue("new"),
+							SemanticEquals: true,
+							SemanticEqualsDiagnostics: diag.Diagnostics{
+								diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+								diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+							},
+						},
+					},
+				),
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: types.SetValueMust(
+					testtypes.StringTypeWithSemanticEquals{
+						SemanticEquals: true,
+						SemanticEqualsDiagnostics: diag.Diagnostics{
+							diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+							diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+						},
+					},
+					[]attr.Value{
+						testtypes.StringValueWithSemanticEquals{
+							StringValue:    types.StringValue("new"),
+							SemanticEquals: true,
+							SemanticEqualsDiagnostics: diag.Diagnostics{
+								diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+								diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+							},
+						},
+					},
+				),
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+					diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+				},
+			},
+		},
+		// Nested ElementType with semantic equality
+		"SetValue-SetValue-StringValuableWithSemanticEquals-true": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: types.SetValueMust(
+					types.SetType{
+						ElemType: testtypes.StringTypeWithSemanticEquals{
+							SemanticEquals: true,
+						},
+					},
+					[]attr.Value{
+						types.SetValueMust(
+							testtypes.StringTypeWithSemanticEquals{
+								SemanticEquals: true,
+							},
+							[]attr.Value{
+								testtypes.StringValueWithSemanticEquals{
+									StringValue:    types.StringValue("prior"),
+									SemanticEquals: true,
+								},
+							},
+						),
+					},
+				),
+				ProposedNewValue: types.SetValueMust(
+					types.SetType{
+						ElemType: testtypes.StringTypeWithSemanticEquals{
+							SemanticEquals: true,
+						},
+					},
+					[]attr.Value{
+						types.SetValueMust(
+							testtypes.StringTypeWithSemanticEquals{
+								SemanticEquals: true,
+							},
+							[]attr.Value{
+								testtypes.StringValueWithSemanticEquals{
+									StringValue:    types.StringValue("new"),
+									SemanticEquals: true,
+								},
+							},
+						),
+					},
+				),
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: types.SetValueMust(
+					types.SetType{
+						ElemType: testtypes.StringTypeWithSemanticEquals{
+							SemanticEquals: true,
+						},
+					},
+					[]attr.Value{
+						types.SetValueMust(
+							testtypes.StringTypeWithSemanticEquals{
+								SemanticEquals: true,
+							},
+							[]attr.Value{
+								testtypes.StringValueWithSemanticEquals{
+									StringValue:    types.StringValue("prior"),
+									SemanticEquals: true,
+								},
+							},
+						),
+					},
+				),
+			},
+		},
+		"SetValue-SetValue-StringValuableWithSemanticEquals-false": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: types.SetValueMust(
+					types.SetType{
+						ElemType: testtypes.StringTypeWithSemanticEquals{
+							SemanticEquals: false,
+						},
+					},
+					[]attr.Value{
+						types.SetValueMust(
+							testtypes.StringTypeWithSemanticEquals{
+								SemanticEquals: false,
+							},
+							[]attr.Value{
+								testtypes.StringValueWithSemanticEquals{
+									StringValue:    types.StringValue("prior"),
+									SemanticEquals: false,
+								},
+							},
+						),
+					},
+				),
+				ProposedNewValue: types.SetValueMust(
+					types.SetType{
+						ElemType: testtypes.StringTypeWithSemanticEquals{
+							SemanticEquals: false,
+						},
+					},
+					[]attr.Value{
+						types.SetValueMust(
+							testtypes.StringTypeWithSemanticEquals{
+								SemanticEquals: false,
+							},
+							[]attr.Value{
+								testtypes.StringValueWithSemanticEquals{
+									StringValue:    types.StringValue("new"),
+									SemanticEquals: false,
+								},
+							},
+						),
+					},
+				),
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: types.SetValueMust(
+					types.SetType{
+						ElemType: testtypes.StringTypeWithSemanticEquals{
+							SemanticEquals: false,
+						},
+					},
+					[]attr.Value{
+						types.SetValueMust(
+							testtypes.StringTypeWithSemanticEquals{
+								SemanticEquals: false,
+							},
+							[]attr.Value{
+								testtypes.StringValueWithSemanticEquals{
+									StringValue:    types.StringValue("new"),
+									SemanticEquals: false,
+								},
+							},
+						),
+					},
+				),
+			},
+		},
+		"SetValue-SetValue-StringValuableWithSemanticEquals-diagnostics": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: types.SetValueMust(
+					types.SetType{
+						ElemType: testtypes.StringTypeWithSemanticEquals{
+							SemanticEquals: true,
+							SemanticEqualsDiagnostics: diag.Diagnostics{
+								diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+								diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+							},
+						},
+					},
+					[]attr.Value{
+						types.SetValueMust(
+							testtypes.StringTypeWithSemanticEquals{
+								SemanticEquals: true,
+								SemanticEqualsDiagnostics: diag.Diagnostics{
+									diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+									diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+								},
+							},
+							[]attr.Value{
+								testtypes.StringValueWithSemanticEquals{
+									StringValue:    types.StringValue("prior"),
+									SemanticEquals: true,
+									SemanticEqualsDiagnostics: diag.Diagnostics{
+										diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+										diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+									},
+								},
+							},
+						),
+					},
+				),
+				ProposedNewValue: types.SetValueMust(
+					types.SetType{
+						ElemType: testtypes.StringTypeWithSemanticEquals{
+							SemanticEquals: true,
+							SemanticEqualsDiagnostics: diag.Diagnostics{
+								diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+								diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+							},
+						},
+					},
+					[]attr.Value{
+						types.SetValueMust(
+							testtypes.StringTypeWithSemanticEquals{
+								SemanticEquals: true,
+								SemanticEqualsDiagnostics: diag.Diagnostics{
+									diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+									diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+								},
+							},
+							[]attr.Value{
+								testtypes.StringValueWithSemanticEquals{
+									StringValue:    types.StringValue("new"),
+									SemanticEquals: true,
+									SemanticEqualsDiagnostics: diag.Diagnostics{
+										diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+										diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+									},
+								},
+							},
+						),
+					},
+				),
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: types.SetValueMust(
+					types.SetType{
+						ElemType: testtypes.StringTypeWithSemanticEquals{
+							SemanticEquals: true,
+							SemanticEqualsDiagnostics: diag.Diagnostics{
+								diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+								diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+							},
+						},
+					},
+					[]attr.Value{
+						types.SetValueMust(
+							testtypes.StringTypeWithSemanticEquals{
+								SemanticEquals: true,
+								SemanticEqualsDiagnostics: diag.Diagnostics{
+									diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+									diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+								},
+							},
+							[]attr.Value{
+								testtypes.StringValueWithSemanticEquals{
+									StringValue:    types.StringValue("new"),
+									SemanticEquals: true,
+									SemanticEqualsDiagnostics: diag.Diagnostics{
+										diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+										diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+									},
+								},
+							},
+						),
+					},
+				),
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+					diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+				},
+			},
+		},
+		// Type with semantic equality
+		"SetValuableWithSemanticEquals-true": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: testtypes.SetValueWithSemanticEquals{
+					SetValue: types.SetValueMust(
+						types.StringType,
+						[]attr.Value{
+							types.StringValue("prior"),
+						},
+					),
+					SemanticEquals: true,
+				},
+				ProposedNewValue: testtypes.SetValueWithSemanticEquals{
+					SetValue: types.SetValueMust(
+						types.StringType,
+						[]attr.Value{
+							types.StringValue("new"),
+						},
+					),
+					SemanticEquals: true,
+				},
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testtypes.SetValueWithSemanticEquals{
+					SetValue: types.SetValueMust(
+						types.StringType,
+						[]attr.Value{
+							types.StringValue("prior"),
+						},
+					),
+					SemanticEquals: true,
+				},
+			},
+		},
+		"SetValuableWithSemanticEquals-false": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: testtypes.SetValueWithSemanticEquals{
+					SetValue: types.SetValueMust(
+						types.StringType,
+						[]attr.Value{
+							types.StringValue("prior"),
+						},
+					),
+					SemanticEquals: false,
+				},
+				ProposedNewValue: testtypes.SetValueWithSemanticEquals{
+					SetValue: types.SetValueMust(
+						types.StringType,
+						[]attr.Value{
+							types.StringValue("new"),
+						},
+					),
+					SemanticEquals: false,
+				},
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testtypes.SetValueWithSemanticEquals{
+					SetValue: types.SetValueMust(
+						types.StringType,
+						[]attr.Value{
+							types.StringValue("new"),
+						},
+					),
+					SemanticEquals: false,
+				},
+			},
+		},
+		"SetValuableWithSemanticEquals-diagnostics": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: testtypes.SetValueWithSemanticEquals{
+					SetValue: types.SetValueMust(
+						types.StringType,
+						[]attr.Value{
+							types.StringValue("prior"),
+						},
+					),
+					SemanticEquals: false,
+					SemanticEqualsDiagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+						diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+					},
+				},
+				ProposedNewValue: testtypes.SetValueWithSemanticEquals{
+					SetValue: types.SetValueMust(
+						types.StringType,
+						[]attr.Value{
+							types.StringValue("new"),
+						},
+					),
+					SemanticEquals: false,
+					SemanticEqualsDiagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+						diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+					},
+				},
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testtypes.SetValueWithSemanticEquals{
+					SetValue: types.SetValueMust(
+						types.StringType,
+						[]attr.Value{
+							types.StringValue("new"),
+						},
+					),
+					SemanticEquals: false,
+					SemanticEqualsDiagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+						diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+					},
+				},
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+					diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testCase.request.ProposedNewValue,
+			}
+
+			fwschemadata.ValueSemanticEqualitySet(context.Background(), testCase.request, got)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}

--- a/internal/fwschemadata/value_semantic_equality_string.go
+++ b/internal/fwschemadata/value_semantic_equality_string.go
@@ -1,0 +1,51 @@
+package fwschemadata
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/internal/logging"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+// ValueSemanticEqualityString performs string type semantic equality.
+func ValueSemanticEqualityString(ctx context.Context, req ValueSemanticEqualityRequest, resp *ValueSemanticEqualityResponse) {
+	priorValuable, ok := req.PriorValue.(basetypes.StringValuableWithSemanticEquals)
+
+	// No changes required if the interface is not implemented.
+	if !ok {
+		return
+	}
+
+	proposedNewValuable, ok := req.ProposedNewValue.(basetypes.StringValuableWithSemanticEquals)
+
+	// No changes required if the interface is not implemented.
+	if !ok {
+		return
+	}
+
+	logging.FrameworkTrace(
+		ctx,
+		"Calling provider defined type-based SemanticEquals",
+		map[string]interface{}{
+			logging.KeyValueType: proposedNewValuable.String(),
+		},
+	)
+
+	usePriorValue, diags := proposedNewValuable.StringSemanticEquals(ctx, priorValuable)
+
+	logging.FrameworkTrace(
+		ctx,
+		"Called provider defined type-based SemanticEquals",
+		map[string]interface{}{
+			logging.KeyValueType: proposedNewValuable.String(),
+		},
+	)
+
+	resp.Diagnostics.Append(diags...)
+
+	if !usePriorValue {
+		return
+	}
+
+	resp.NewValue = priorValuable
+}

--- a/internal/fwschemadata/value_semantic_equality_string_test.go
+++ b/internal/fwschemadata/value_semantic_equality_string_test.go
@@ -1,0 +1,124 @@
+package fwschemadata_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschemadata"
+	testtypes "github.com/hashicorp/terraform-plugin-framework/internal/testing/types"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestValueSemanticEqualityString(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		request  fwschemadata.ValueSemanticEqualityRequest
+		expected *fwschemadata.ValueSemanticEqualityResponse
+	}{
+		"StringValue": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path:             path.Root("test"),
+				PriorValue:       types.StringValue("prior"),
+				ProposedNewValue: types.StringValue("new"),
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: types.StringValue("new"),
+			},
+		},
+		"StringValuableWithSemanticEquals-true": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: testtypes.StringValueWithSemanticEquals{
+					StringValue:    types.StringValue("prior"),
+					SemanticEquals: true,
+				},
+				ProposedNewValue: testtypes.StringValueWithSemanticEquals{
+					StringValue:    types.StringValue("new"),
+					SemanticEquals: true,
+				},
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testtypes.StringValueWithSemanticEquals{
+					StringValue:    types.StringValue("prior"),
+					SemanticEquals: true,
+				},
+			},
+		},
+		"StringValuableWithSemanticEquals-false": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: testtypes.StringValueWithSemanticEquals{
+					StringValue:    types.StringValue("prior"),
+					SemanticEquals: false,
+				},
+				ProposedNewValue: testtypes.StringValueWithSemanticEquals{
+					StringValue:    types.StringValue("new"),
+					SemanticEquals: false,
+				},
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testtypes.StringValueWithSemanticEquals{
+					StringValue:    types.StringValue("new"),
+					SemanticEquals: false,
+				},
+			},
+		},
+		"StringValuableWithSemanticEquals-diagnostics": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: testtypes.StringValueWithSemanticEquals{
+					StringValue:    types.StringValue("prior"),
+					SemanticEquals: false,
+					SemanticEqualsDiagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+						diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+					},
+				},
+				ProposedNewValue: testtypes.StringValueWithSemanticEquals{
+					StringValue:    types.StringValue("new"),
+					SemanticEquals: false,
+					SemanticEqualsDiagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+						diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+					},
+				},
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testtypes.StringValueWithSemanticEquals{
+					StringValue:    types.StringValue("new"),
+					SemanticEquals: false,
+					SemanticEqualsDiagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+						diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+					},
+				},
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+					diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testCase.request.ProposedNewValue,
+			}
+
+			fwschemadata.ValueSemanticEqualityString(context.Background(), testCase.request, got)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}

--- a/internal/fwschemadata/value_semantic_equality_test.go
+++ b/internal/fwschemadata/value_semantic_equality_test.go
@@ -1,0 +1,1054 @@
+package fwschemadata_test
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschemadata"
+	testtypes "github.com/hashicorp/terraform-plugin-framework/internal/testing/types"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestValueSemanticEquality(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		request  fwschemadata.ValueSemanticEqualityRequest
+		expected *fwschemadata.ValueSemanticEqualityResponse
+	}{
+		"BoolValue": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path:             path.Root("test"),
+				PriorValue:       types.BoolValue(false),
+				ProposedNewValue: types.BoolValue(true),
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: types.BoolValue(true),
+			},
+		},
+		"BoolValuableWithSemanticEquals-true": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: testtypes.BoolValueWithSemanticEquals{
+					BoolValue:      types.BoolValue(false),
+					SemanticEquals: true,
+				},
+				ProposedNewValue: testtypes.BoolValueWithSemanticEquals{
+					BoolValue:      types.BoolValue(true),
+					SemanticEquals: true,
+				},
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testtypes.BoolValueWithSemanticEquals{
+					BoolValue:      types.BoolValue(false),
+					SemanticEquals: true,
+				},
+			},
+		},
+		"BoolValuableWithSemanticEquals-false": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: testtypes.BoolValueWithSemanticEquals{
+					BoolValue:      types.BoolValue(false),
+					SemanticEquals: false,
+				},
+				ProposedNewValue: testtypes.BoolValueWithSemanticEquals{
+					BoolValue:      types.BoolValue(true),
+					SemanticEquals: false,
+				},
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testtypes.BoolValueWithSemanticEquals{
+					BoolValue:      types.BoolValue(true),
+					SemanticEquals: false,
+				},
+			},
+		},
+		"BoolValuableWithSemanticEquals-diagnostics": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: testtypes.BoolValueWithSemanticEquals{
+					BoolValue:      types.BoolValue(false),
+					SemanticEquals: false,
+					SemanticEqualsDiagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+						diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+					},
+				},
+				ProposedNewValue: testtypes.BoolValueWithSemanticEquals{
+					BoolValue:      types.BoolValue(true),
+					SemanticEquals: false,
+					SemanticEqualsDiagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+						diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+					},
+				},
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testtypes.BoolValueWithSemanticEquals{
+					BoolValue:      types.BoolValue(true),
+					SemanticEquals: false,
+					SemanticEqualsDiagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+						diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+					},
+				},
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+					diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+				},
+			},
+		},
+		"Float64Value": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path:             path.Root("test"),
+				PriorValue:       types.Float64Value(1.2),
+				ProposedNewValue: types.Float64Value(2.4),
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: types.Float64Value(2.4),
+			},
+		},
+		"Float64ValuableWithSemanticEquals-true": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: testtypes.Float64ValueWithSemanticEquals{
+					Float64Value:   types.Float64Value(1.2),
+					SemanticEquals: true,
+				},
+				ProposedNewValue: testtypes.Float64ValueWithSemanticEquals{
+					Float64Value:   types.Float64Value(2.4),
+					SemanticEquals: true,
+				},
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testtypes.Float64ValueWithSemanticEquals{
+					Float64Value:   types.Float64Value(1.2),
+					SemanticEquals: true,
+				},
+			},
+		},
+		"Float64ValuableWithSemanticEquals-false": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: testtypes.Float64ValueWithSemanticEquals{
+					Float64Value:   types.Float64Value(1.2),
+					SemanticEquals: false,
+				},
+				ProposedNewValue: testtypes.Float64ValueWithSemanticEquals{
+					Float64Value:   types.Float64Value(2.4),
+					SemanticEquals: false,
+				},
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testtypes.Float64ValueWithSemanticEquals{
+					Float64Value:   types.Float64Value(2.4),
+					SemanticEquals: false,
+				},
+			},
+		},
+		"Float64ValuableWithSemanticEquals-diagnostics": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: testtypes.Float64ValueWithSemanticEquals{
+					Float64Value:   types.Float64Value(1.2),
+					SemanticEquals: false,
+					SemanticEqualsDiagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+						diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+					},
+				},
+				ProposedNewValue: testtypes.Float64ValueWithSemanticEquals{
+					Float64Value:   types.Float64Value(2.4),
+					SemanticEquals: false,
+					SemanticEqualsDiagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+						diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+					},
+				},
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testtypes.Float64ValueWithSemanticEquals{
+					Float64Value:   types.Float64Value(2.4),
+					SemanticEquals: false,
+					SemanticEqualsDiagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+						diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+					},
+				},
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+					diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+				},
+			},
+		},
+		"Int64Value": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path:             path.Root("test"),
+				PriorValue:       types.Int64Value(12),
+				ProposedNewValue: types.Int64Value(24),
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: types.Int64Value(24),
+			},
+		},
+		"Int64ValuableWithSemanticEquals-true": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: testtypes.Int64ValueWithSemanticEquals{
+					Int64Value:     types.Int64Value(12),
+					SemanticEquals: true,
+				},
+				ProposedNewValue: testtypes.Int64ValueWithSemanticEquals{
+					Int64Value:     types.Int64Value(24),
+					SemanticEquals: true,
+				},
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testtypes.Int64ValueWithSemanticEquals{
+					Int64Value:     types.Int64Value(12),
+					SemanticEquals: true,
+				},
+			},
+		},
+		"Int64ValuableWithSemanticEquals-false": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: testtypes.Int64ValueWithSemanticEquals{
+					Int64Value:     types.Int64Value(12),
+					SemanticEquals: false,
+				},
+				ProposedNewValue: testtypes.Int64ValueWithSemanticEquals{
+					Int64Value:     types.Int64Value(24),
+					SemanticEquals: false,
+				},
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testtypes.Int64ValueWithSemanticEquals{
+					Int64Value:     types.Int64Value(24),
+					SemanticEquals: false,
+				},
+			},
+		},
+		"Int64ValuableWithSemanticEquals-diagnostics": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: testtypes.Int64ValueWithSemanticEquals{
+					Int64Value:     types.Int64Value(12),
+					SemanticEquals: false,
+					SemanticEqualsDiagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+						diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+					},
+				},
+				ProposedNewValue: testtypes.Int64ValueWithSemanticEquals{
+					Int64Value:     types.Int64Value(24),
+					SemanticEquals: false,
+					SemanticEqualsDiagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+						diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+					},
+				},
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testtypes.Int64ValueWithSemanticEquals{
+					Int64Value:     types.Int64Value(24),
+					SemanticEquals: false,
+					SemanticEqualsDiagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+						diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+					},
+				},
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+					diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+				},
+			},
+		},
+		"ListValue": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: types.ListValueMust(
+					types.StringType,
+					[]attr.Value{
+						types.StringValue("prior"),
+					},
+				),
+				ProposedNewValue: types.ListValueMust(
+					types.StringType,
+					[]attr.Value{
+						types.StringValue("new"),
+					},
+				),
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: types.ListValueMust(
+					types.StringType,
+					[]attr.Value{
+						types.StringValue("new"),
+					},
+				),
+			},
+		},
+		"ListValuableWithSemanticEquals-true": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: testtypes.ListValueWithSemanticEquals{
+					ListValue: types.ListValueMust(
+						types.StringType,
+						[]attr.Value{
+							types.StringValue("prior"),
+						},
+					),
+					SemanticEquals: true,
+				},
+				ProposedNewValue: testtypes.ListValueWithSemanticEquals{
+					ListValue: types.ListValueMust(
+						types.StringType,
+						[]attr.Value{
+							types.StringValue("new"),
+						},
+					),
+					SemanticEquals: true,
+				},
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testtypes.ListValueWithSemanticEquals{
+					ListValue: types.ListValueMust(
+						types.StringType,
+						[]attr.Value{
+							types.StringValue("prior"),
+						},
+					),
+					SemanticEquals: true,
+				},
+			},
+		},
+		"ListValuableWithSemanticEquals-false": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: testtypes.ListValueWithSemanticEquals{
+					ListValue: types.ListValueMust(
+						types.StringType,
+						[]attr.Value{
+							types.StringValue("prior"),
+						},
+					),
+					SemanticEquals: false,
+				},
+				ProposedNewValue: testtypes.ListValueWithSemanticEquals{
+					ListValue: types.ListValueMust(
+						types.StringType,
+						[]attr.Value{
+							types.StringValue("new"),
+						},
+					),
+					SemanticEquals: false,
+				},
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testtypes.ListValueWithSemanticEquals{
+					ListValue: types.ListValueMust(
+						types.StringType,
+						[]attr.Value{
+							types.StringValue("new"),
+						},
+					),
+					SemanticEquals: false,
+				},
+			},
+		},
+		"ListValuableWithSemanticEquals-diagnostics": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: testtypes.ListValueWithSemanticEquals{
+					ListValue: types.ListValueMust(
+						types.StringType,
+						[]attr.Value{
+							types.StringValue("prior"),
+						},
+					),
+					SemanticEquals: false,
+					SemanticEqualsDiagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+						diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+					},
+				},
+				ProposedNewValue: testtypes.ListValueWithSemanticEquals{
+					ListValue: types.ListValueMust(
+						types.StringType,
+						[]attr.Value{
+							types.StringValue("new"),
+						},
+					),
+					SemanticEquals: false,
+					SemanticEqualsDiagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+						diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+					},
+				},
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testtypes.ListValueWithSemanticEquals{
+					ListValue: types.ListValueMust(
+						types.StringType,
+						[]attr.Value{
+							types.StringValue("new"),
+						},
+					),
+					SemanticEquals: false,
+					SemanticEqualsDiagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+						diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+					},
+				},
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+					diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+				},
+			},
+		},
+		"MapValue": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: types.MapValueMust(
+					types.StringType,
+					map[string]attr.Value{
+						"testkey": types.StringValue("prior"),
+					},
+				),
+				ProposedNewValue: types.MapValueMust(
+					types.StringType,
+					map[string]attr.Value{
+						"testkey": types.StringValue("new"),
+					},
+				),
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: types.MapValueMust(
+					types.StringType,
+					map[string]attr.Value{
+						"testkey": types.StringValue("new"),
+					},
+				),
+			},
+		},
+		"MapValuableWithSemanticEquals-true": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: testtypes.MapValueWithSemanticEquals{
+					MapValue: types.MapValueMust(
+						types.StringType,
+						map[string]attr.Value{
+							"testkey": types.StringValue("prior"),
+						},
+					),
+					SemanticEquals: true,
+				},
+				ProposedNewValue: testtypes.MapValueWithSemanticEquals{
+					MapValue: types.MapValueMust(
+						types.StringType,
+						map[string]attr.Value{
+							"testkey": types.StringValue("new"),
+						},
+					),
+					SemanticEquals: true,
+				},
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testtypes.MapValueWithSemanticEquals{
+					MapValue: types.MapValueMust(
+						types.StringType,
+						map[string]attr.Value{
+							"testkey": types.StringValue("prior"),
+						},
+					),
+					SemanticEquals: true,
+				},
+			},
+		},
+		"MapValuableWithSemanticEquals-false": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: testtypes.MapValueWithSemanticEquals{
+					MapValue: types.MapValueMust(
+						types.StringType,
+						map[string]attr.Value{
+							"testkey": types.StringValue("prior"),
+						},
+					),
+					SemanticEquals: false,
+				},
+				ProposedNewValue: testtypes.MapValueWithSemanticEquals{
+					MapValue: types.MapValueMust(
+						types.StringType,
+						map[string]attr.Value{
+							"testkey": types.StringValue("new"),
+						},
+					),
+					SemanticEquals: false,
+				},
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testtypes.MapValueWithSemanticEquals{
+					MapValue: types.MapValueMust(
+						types.StringType,
+						map[string]attr.Value{
+							"testkey": types.StringValue("new"),
+						},
+					),
+					SemanticEquals: false,
+				},
+			},
+		},
+		"MapValuableWithSemanticEquals-diagnostics": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: testtypes.MapValueWithSemanticEquals{
+					MapValue: types.MapValueMust(
+						types.StringType,
+						map[string]attr.Value{
+							"testkey": types.StringValue("prior"),
+						},
+					),
+					SemanticEquals: false,
+					SemanticEqualsDiagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+						diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+					},
+				},
+				ProposedNewValue: testtypes.MapValueWithSemanticEquals{
+					MapValue: types.MapValueMust(
+						types.StringType,
+						map[string]attr.Value{
+							"testkey": types.StringValue("new"),
+						},
+					),
+					SemanticEquals: false,
+					SemanticEqualsDiagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+						diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+					},
+				},
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testtypes.MapValueWithSemanticEquals{
+					MapValue: types.MapValueMust(
+						types.StringType,
+						map[string]attr.Value{
+							"testkey": types.StringValue("new"),
+						},
+					),
+					SemanticEquals: false,
+					SemanticEqualsDiagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+						diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+					},
+				},
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+					diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+				},
+			},
+		},
+		"NumberValue": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path:             path.Root("test"),
+				PriorValue:       types.NumberValue(big.NewFloat(1.2)),
+				ProposedNewValue: types.NumberValue(big.NewFloat(2.4)),
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: types.NumberValue(big.NewFloat(2.4)),
+			},
+		},
+		"NumberValuableWithSemanticEquals-true": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: testtypes.NumberValueWithSemanticEquals{
+					NumberValue:    types.NumberValue(big.NewFloat(1.2)),
+					SemanticEquals: true,
+				},
+				ProposedNewValue: testtypes.NumberValueWithSemanticEquals{
+					NumberValue:    types.NumberValue(big.NewFloat(2.4)),
+					SemanticEquals: true,
+				},
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testtypes.NumberValueWithSemanticEquals{
+					NumberValue:    types.NumberValue(big.NewFloat(1.2)),
+					SemanticEquals: true,
+				},
+			},
+		},
+		"NumberValuableWithSemanticEquals-false": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: testtypes.NumberValueWithSemanticEquals{
+					NumberValue:    types.NumberValue(big.NewFloat(1.2)),
+					SemanticEquals: false,
+				},
+				ProposedNewValue: testtypes.NumberValueWithSemanticEquals{
+					NumberValue:    types.NumberValue(big.NewFloat(2.4)),
+					SemanticEquals: false,
+				},
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testtypes.NumberValueWithSemanticEquals{
+					NumberValue:    types.NumberValue(big.NewFloat(2.4)),
+					SemanticEquals: false,
+				},
+			},
+		},
+		"NumberValuableWithSemanticEquals-diagnostics": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: testtypes.NumberValueWithSemanticEquals{
+					NumberValue:    types.NumberValue(big.NewFloat(1.2)),
+					SemanticEquals: false,
+					SemanticEqualsDiagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+						diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+					},
+				},
+				ProposedNewValue: testtypes.NumberValueWithSemanticEquals{
+					NumberValue:    types.NumberValue(big.NewFloat(2.4)),
+					SemanticEquals: false,
+					SemanticEqualsDiagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+						diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+					},
+				},
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testtypes.NumberValueWithSemanticEquals{
+					NumberValue:    types.NumberValue(big.NewFloat(2.4)),
+					SemanticEquals: false,
+					SemanticEqualsDiagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+						diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+					},
+				},
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+					diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+				},
+			},
+		},
+		"ObjectValue": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: types.ObjectValueMust(
+					map[string]attr.Type{
+						"test_attr": types.StringType,
+					},
+					map[string]attr.Value{
+						"test_attr": types.StringValue("prior"),
+					},
+				),
+				ProposedNewValue: types.ObjectValueMust(
+					map[string]attr.Type{
+						"test_attr": types.StringType,
+					},
+					map[string]attr.Value{
+						"test_attr": types.StringValue("new"),
+					},
+				),
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: types.ObjectValueMust(
+					map[string]attr.Type{
+						"test_attr": types.StringType,
+					},
+					map[string]attr.Value{
+						"test_attr": types.StringValue("new"),
+					},
+				),
+			},
+		},
+		"ObjectValuableWithSemanticEquals-true": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: testtypes.ObjectValueWithSemanticEquals{
+					ObjectValue: types.ObjectValueMust(
+						map[string]attr.Type{
+							"test_attr": types.StringType,
+						},
+						map[string]attr.Value{
+							"test_attr": types.StringValue("prior"),
+						},
+					),
+					SemanticEquals: true,
+				},
+				ProposedNewValue: testtypes.ObjectValueWithSemanticEquals{
+					ObjectValue: types.ObjectValueMust(
+						map[string]attr.Type{
+							"test_attr": types.StringType,
+						},
+						map[string]attr.Value{
+							"test_attr": types.StringValue("new"),
+						},
+					),
+					SemanticEquals: true,
+				},
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testtypes.ObjectValueWithSemanticEquals{
+					ObjectValue: types.ObjectValueMust(
+						map[string]attr.Type{
+							"test_attr": types.StringType,
+						},
+						map[string]attr.Value{
+							"test_attr": types.StringValue("prior"),
+						},
+					),
+					SemanticEquals: true,
+				},
+			},
+		},
+		"ObjectValuableWithSemanticEquals-false": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: testtypes.ObjectValueWithSemanticEquals{
+					ObjectValue: types.ObjectValueMust(
+						map[string]attr.Type{
+							"test_attr": types.StringType,
+						},
+						map[string]attr.Value{
+							"test_attr": types.StringValue("prior"),
+						},
+					),
+					SemanticEquals: false,
+				},
+				ProposedNewValue: testtypes.ObjectValueWithSemanticEquals{
+					ObjectValue: types.ObjectValueMust(
+						map[string]attr.Type{
+							"test_attr": types.StringType,
+						},
+						map[string]attr.Value{
+							"test_attr": types.StringValue("new"),
+						},
+					),
+					SemanticEquals: false,
+				},
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testtypes.ObjectValueWithSemanticEquals{
+					ObjectValue: types.ObjectValueMust(
+						map[string]attr.Type{
+							"test_attr": types.StringType,
+						},
+						map[string]attr.Value{
+							"test_attr": types.StringValue("new"),
+						},
+					),
+					SemanticEquals: false,
+				},
+			},
+		},
+		"ObjectValuableWithSemanticEquals-diagnostics": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: testtypes.ObjectValueWithSemanticEquals{
+					ObjectValue: types.ObjectValueMust(
+						map[string]attr.Type{
+							"test_attr": types.StringType,
+						},
+						map[string]attr.Value{
+							"test_attr": types.StringValue("prior"),
+						},
+					),
+					SemanticEquals: false,
+					SemanticEqualsDiagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+						diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+					},
+				},
+				ProposedNewValue: testtypes.ObjectValueWithSemanticEquals{
+					ObjectValue: types.ObjectValueMust(
+						map[string]attr.Type{
+							"test_attr": types.StringType,
+						},
+						map[string]attr.Value{
+							"test_attr": types.StringValue("new"),
+						},
+					),
+					SemanticEquals: false,
+					SemanticEqualsDiagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+						diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+					},
+				},
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testtypes.ObjectValueWithSemanticEquals{
+					ObjectValue: types.ObjectValueMust(
+						map[string]attr.Type{
+							"test_attr": types.StringType,
+						},
+						map[string]attr.Value{
+							"test_attr": types.StringValue("new"),
+						},
+					),
+					SemanticEquals: false,
+					SemanticEqualsDiagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+						diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+					},
+				},
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+					diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+				},
+			},
+		},
+		"SetValue": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: types.SetValueMust(
+					types.StringType,
+					[]attr.Value{
+						types.StringValue("prior"),
+					},
+				),
+				ProposedNewValue: types.SetValueMust(
+					types.StringType,
+					[]attr.Value{
+						types.StringValue("new"),
+					},
+				),
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: types.SetValueMust(
+					types.StringType,
+					[]attr.Value{
+						types.StringValue("new"),
+					},
+				),
+			},
+		},
+		"SetValuableWithSemanticEquals-true": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: testtypes.SetValueWithSemanticEquals{
+					SetValue: types.SetValueMust(
+						types.StringType,
+						[]attr.Value{
+							types.StringValue("prior"),
+						},
+					),
+					SemanticEquals: true,
+				},
+				ProposedNewValue: testtypes.SetValueWithSemanticEquals{
+					SetValue: types.SetValueMust(
+						types.StringType,
+						[]attr.Value{
+							types.StringValue("new"),
+						},
+					),
+					SemanticEquals: true,
+				},
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testtypes.SetValueWithSemanticEquals{
+					SetValue: types.SetValueMust(
+						types.StringType,
+						[]attr.Value{
+							types.StringValue("prior"),
+						},
+					),
+					SemanticEquals: true,
+				},
+			},
+		},
+		"SetValuableWithSemanticEquals-false": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: testtypes.SetValueWithSemanticEquals{
+					SetValue: types.SetValueMust(
+						types.StringType,
+						[]attr.Value{
+							types.StringValue("prior"),
+						},
+					),
+					SemanticEquals: false,
+				},
+				ProposedNewValue: testtypes.SetValueWithSemanticEquals{
+					SetValue: types.SetValueMust(
+						types.StringType,
+						[]attr.Value{
+							types.StringValue("new"),
+						},
+					),
+					SemanticEquals: false,
+				},
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testtypes.SetValueWithSemanticEquals{
+					SetValue: types.SetValueMust(
+						types.StringType,
+						[]attr.Value{
+							types.StringValue("new"),
+						},
+					),
+					SemanticEquals: false,
+				},
+			},
+		},
+		"SetValuableWithSemanticEquals-diagnostics": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: testtypes.SetValueWithSemanticEquals{
+					SetValue: types.SetValueMust(
+						types.StringType,
+						[]attr.Value{
+							types.StringValue("prior"),
+						},
+					),
+					SemanticEquals: false,
+					SemanticEqualsDiagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+						diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+					},
+				},
+				ProposedNewValue: testtypes.SetValueWithSemanticEquals{
+					SetValue: types.SetValueMust(
+						types.StringType,
+						[]attr.Value{
+							types.StringValue("new"),
+						},
+					),
+					SemanticEquals: false,
+					SemanticEqualsDiagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+						diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+					},
+				},
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testtypes.SetValueWithSemanticEquals{
+					SetValue: types.SetValueMust(
+						types.StringType,
+						[]attr.Value{
+							types.StringValue("new"),
+						},
+					),
+					SemanticEquals: false,
+					SemanticEqualsDiagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+						diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+					},
+				},
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+					diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+				},
+			},
+		},
+		"StringValue": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path:             path.Root("test"),
+				PriorValue:       types.StringValue("prior"),
+				ProposedNewValue: types.StringValue("new"),
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: types.StringValue("new"),
+			},
+		},
+		"StringValuableWithSemanticEquals-true": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: testtypes.StringValueWithSemanticEquals{
+					StringValue:    types.StringValue("prior"),
+					SemanticEquals: true,
+				},
+				ProposedNewValue: testtypes.StringValueWithSemanticEquals{
+					StringValue:    types.StringValue("new"),
+					SemanticEquals: true,
+				},
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testtypes.StringValueWithSemanticEquals{
+					StringValue:    types.StringValue("prior"),
+					SemanticEquals: true,
+				},
+			},
+		},
+		"StringValuableWithSemanticEquals-false": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: testtypes.StringValueWithSemanticEquals{
+					StringValue:    types.StringValue("prior"),
+					SemanticEquals: false,
+				},
+				ProposedNewValue: testtypes.StringValueWithSemanticEquals{
+					StringValue:    types.StringValue("new"),
+					SemanticEquals: false,
+				},
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testtypes.StringValueWithSemanticEquals{
+					StringValue:    types.StringValue("new"),
+					SemanticEquals: false,
+				},
+			},
+		},
+		"StringValuableWithSemanticEquals-diagnostics": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: testtypes.StringValueWithSemanticEquals{
+					StringValue:    types.StringValue("prior"),
+					SemanticEquals: false,
+					SemanticEqualsDiagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+						diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+					},
+				},
+				ProposedNewValue: testtypes.StringValueWithSemanticEquals{
+					StringValue:    types.StringValue("new"),
+					SemanticEquals: false,
+					SemanticEqualsDiagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+						diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+					},
+				},
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testtypes.StringValueWithSemanticEquals{
+					StringValue:    types.StringValue("new"),
+					SemanticEquals: false,
+					SemanticEqualsDiagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+						diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+					},
+				},
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+					diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: testCase.request.ProposedNewValue,
+			}
+
+			fwschemadata.ValueSemanticEquality(context.Background(), testCase.request, got)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}

--- a/internal/fwserver/attr_value.go
+++ b/internal/fwserver/attr_value.go
@@ -18,7 +18,7 @@ func coerceListValue(ctx context.Context, schemaPath path.Path, value attr.Value
 
 	if !ok {
 		return types.ListNull(nil), diag.Diagnostics{
-			attributePlanModificationWalkError(schemaPath, value),
+			schemaDataWalkError(schemaPath, value),
 		}
 	}
 
@@ -30,7 +30,7 @@ func coerceMapValue(ctx context.Context, schemaPath path.Path, value attr.Value)
 
 	if !ok {
 		return types.MapNull(nil), diag.Diagnostics{
-			attributePlanModificationWalkError(schemaPath, value),
+			schemaDataWalkError(schemaPath, value),
 		}
 	}
 
@@ -42,7 +42,7 @@ func coerceObjectValue(ctx context.Context, schemaPath path.Path, value attr.Val
 
 	if !ok {
 		return types.ObjectNull(nil), diag.Diagnostics{
-			attributePlanModificationWalkError(schemaPath, value),
+			schemaDataWalkError(schemaPath, value),
 		}
 	}
 
@@ -54,7 +54,7 @@ func coerceSetValue(ctx context.Context, schemaPath path.Path, value attr.Value)
 
 	if !ok {
 		return types.SetNull(nil), diag.Diagnostics{
-			attributePlanModificationWalkError(schemaPath, value),
+			schemaDataWalkError(schemaPath, value),
 		}
 	}
 
@@ -83,7 +83,7 @@ func listElemObjectFromTerraformValue(ctx context.Context, schemaPath path.Path,
 
 	if err != nil {
 		return types.ObjectNull(nil), diag.Diagnostics{
-			attributePlanModificationValueError(ctx, list, description, err),
+			schemaDataValueError(ctx, list, description, err),
 		}
 	}
 
@@ -114,7 +114,7 @@ func mapElemObjectFromTerraformValue(ctx context.Context, schemaPath path.Path, 
 
 	if err != nil {
 		return types.ObjectNull(nil), diag.Diagnostics{
-			attributePlanModificationValueError(ctx, m, description, err),
+			schemaDataValueError(ctx, m, description, err),
 		}
 	}
 
@@ -144,7 +144,7 @@ func objectAttributeValueFromTerraformValue(ctx context.Context, object types.Ob
 
 	if err != nil {
 		return nil, diag.Diagnostics{
-			attributePlanModificationValueError(ctx, object, description, err),
+			schemaDataValueError(ctx, object, description, err),
 		}
 	}
 
@@ -173,7 +173,7 @@ func setElemObjectFromTerraformValue(ctx context.Context, schemaPath path.Path, 
 
 	if err != nil {
 		return types.ObjectNull(nil), diag.Diagnostics{
-			attributePlanModificationValueError(ctx, set, description, err),
+			schemaDataValueError(ctx, set, description, err),
 		}
 	}
 

--- a/internal/fwserver/attribute_plan_modification.go
+++ b/internal/fwserver/attribute_plan_modification.go
@@ -1765,22 +1765,3 @@ func NestedAttributeObjectPlanModify(ctx context.Context, o fwschema.NestedAttri
 
 	resp.AttributePlan = newPlanValue
 }
-
-func attributePlanModificationValueError(ctx context.Context, value attr.Value, description fwschemadata.DataDescription, err error) diag.Diagnostic {
-	return diag.NewErrorDiagnostic(
-		"Attribute Plan Modification "+description.Title()+" Value Error",
-		"An unexpected error occurred while fetching a "+value.Type(ctx).String()+" element value in the "+description.String()+". "+
-			"This is an issue with the provider and should be reported to the provider developers.\n\n"+
-			"Original Error: "+err.Error(),
-	)
-}
-
-func attributePlanModificationWalkError(schemaPath path.Path, value attr.Value) diag.Diagnostic {
-	return diag.NewAttributeErrorDiagnostic(
-		schemaPath,
-		"Attribute Plan Modification Walk Error",
-		"An unexpected error occurred while walking the schema for attribute plan modification. "+
-			"This is an issue with terraform-plugin-framework and should be reported to the provider developers.\n\n"+
-			fmt.Sprintf("unknown attribute value type (%T) at path: %s", value, schemaPath),
-	)
-}

--- a/internal/fwserver/diagnostics.go
+++ b/internal/fwserver/diagnostics.go
@@ -1,0 +1,30 @@
+package fwserver
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschemadata"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+)
+
+func schemaDataValueError(ctx context.Context, value attr.Value, description fwschemadata.DataDescription, err error) diag.Diagnostic {
+	return diag.NewErrorDiagnostic(
+		description.Title()+" Value Error",
+		"An unexpected error occurred while fetching a "+value.Type(ctx).String()+" element value in the "+description.String()+". "+
+			"This is an issue with the provider and should be reported to the provider developers.\n\n"+
+			"Original Error: "+err.Error(),
+	)
+}
+
+func schemaDataWalkError(schemaPath path.Path, value attr.Value) diag.Diagnostic {
+	return diag.NewAttributeErrorDiagnostic(
+		schemaPath,
+		"Schema Data Walk Error",
+		"An unexpected error occurred while walking the schema for data modification. "+
+			"This is an issue with terraform-plugin-framework and should be reported to the provider developers.\n\n"+
+			fmt.Sprintf("unknown attribute value type (%T) at path: %s", value, schemaPath),
+	)
+}

--- a/internal/fwserver/schema_semantic_equality.go
+++ b/internal/fwserver/schema_semantic_equality.go
@@ -1,0 +1,143 @@
+package fwserver
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschemadata"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+)
+
+// SchemaSemanticEqualityRequest represents a request for a schema to run all
+// semantic equality logic.
+type SchemaSemanticEqualityRequest struct {
+	// PriorData is the prior schema-based data.
+	PriorData fwschemadata.Data
+
+	// ProposedNewData is the proposed new schema-based data. The response
+	// NewData contains the results of any modifications.
+	ProposedNewData fwschemadata.Data
+}
+
+// SchemaSemanticEqualityResponse represents a response to a
+// SchemaSemanticEqualityRequest.
+type SchemaSemanticEqualityResponse struct {
+	// NewData is the new schema-based data after any modifications.
+	NewData fwschemadata.Data
+
+	// Diagnostics report errors or warnings related to running all attribute
+	// plan modifiers. Returning an empty slice indicates a successful
+	// plan modification with no warnings or errors generated.
+	Diagnostics diag.Diagnostics
+}
+
+// SchemaSemanticEquality runs semantic equality logic for all schema attributes
+// and blocks.
+//
+// MAINTAINER NOTE: Since semantic equality is purely value based, where
+// attributes and blocks cannot currently introduce semantic equality logic
+// based on those schema concepts, this logic immediately delegates to value
+// based handling. On the off chance that the framework is enhanced with
+// attribute and block level semantic equality support (not recommended since
+// value types should really be the correct provider developer abstraction,
+// rather than potentially causing confusing or duplicated provider logic), this
+// logic will need to be redesigned similar to the plan modification and
+// validation logic which walks the schema. That schema walk may interfere with
+// the value based recursion for collection and structural types, so additional
+// design may be necessary so that provider developer data handling intentions
+// are kept based on both the value based logic and schema based logic.
+func SchemaSemanticEquality(ctx context.Context, req SchemaSemanticEqualityRequest, resp *SchemaSemanticEqualityResponse) {
+	var diags diag.Diagnostics
+
+	for name := range req.ProposedNewData.Schema.GetAttributes() {
+		valueReq := fwschemadata.ValueSemanticEqualityRequest{
+			Path: path.Root(name),
+		}
+
+		valueReq.PriorValue, diags = req.PriorData.ValueAtPath(ctx, valueReq.Path)
+
+		resp.Diagnostics.Append(diags...)
+
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		valueReq.ProposedNewValue, diags = req.ProposedNewData.ValueAtPath(ctx, valueReq.Path)
+
+		resp.Diagnostics.Append(diags...)
+
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		valueResp := &fwschemadata.ValueSemanticEqualityResponse{
+			NewValue: valueReq.ProposedNewValue,
+		}
+
+		fwschemadata.ValueSemanticEquality(ctx, valueReq, valueResp)
+
+		resp.Diagnostics.Append(valueResp.Diagnostics...)
+
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		// If the response value equals the original proposed new value, move
+		// to next attribute.
+		if valueResp.NewValue.Equal(valueReq.ProposedNewValue) {
+			continue
+		}
+
+		resp.Diagnostics.Append(resp.NewData.SetAtPath(ctx, valueReq.Path, valueResp.NewValue)...)
+
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
+	for name := range req.ProposedNewData.Schema.GetBlocks() {
+		valueReq := fwschemadata.ValueSemanticEqualityRequest{
+			Path: path.Root(name),
+		}
+
+		valueReq.PriorValue, diags = req.PriorData.ValueAtPath(ctx, valueReq.Path)
+
+		resp.Diagnostics.Append(diags...)
+
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		valueReq.ProposedNewValue, diags = req.ProposedNewData.ValueAtPath(ctx, valueReq.Path)
+
+		resp.Diagnostics.Append(diags...)
+
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		valueResp := &fwschemadata.ValueSemanticEqualityResponse{
+			NewValue: valueReq.ProposedNewValue,
+		}
+
+		fwschemadata.ValueSemanticEquality(ctx, valueReq, valueResp)
+
+		resp.Diagnostics.Append(valueResp.Diagnostics...)
+
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		// If the response value equals the original proposed new value, move
+		// to next block.
+		if valueResp.NewValue.Equal(valueReq.ProposedNewValue) {
+			continue
+		}
+
+		resp.Diagnostics.Append(resp.NewData.SetAtPath(ctx, valueReq.Path, valueResp.NewValue)...)
+
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+}

--- a/internal/fwserver/schema_semantic_equality_test.go
+++ b/internal/fwserver/schema_semantic_equality_test.go
@@ -1,0 +1,2316 @@
+package fwserver_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschemadata"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
+	testtypes "github.com/hashicorp/terraform-plugin-framework/internal/testing/types"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func TestSchemaSemanticEquality(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		request  fwserver.SchemaSemanticEqualityRequest
+		expected *fwserver.SchemaSemanticEqualityResponse
+	}{
+		"Attribute-Valuable": {
+			request: fwserver.SchemaSemanticEqualityRequest{
+				PriorData: fwschemadata.Data{
+					Description: fwschemadata.DataDescriptionState,
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.Attribute{
+								Optional: true,
+								Type:     types.StringType,
+							},
+						},
+					},
+					TerraformValue: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.String,
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(tftypes.String, "prior"),
+						},
+					),
+				},
+				ProposedNewData: fwschemadata.Data{
+					Description: fwschemadata.DataDescriptionPlan,
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.Attribute{
+								Optional: true,
+								Type:     types.StringType,
+							},
+						},
+					},
+					TerraformValue: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.String,
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(tftypes.String, "new"),
+						},
+					),
+				},
+			},
+			expected: &fwserver.SchemaSemanticEqualityResponse{
+				NewData: fwschemadata.Data{
+					Description: fwschemadata.DataDescriptionPlan,
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.Attribute{
+								Optional: true,
+								Type:     types.StringType,
+							},
+						},
+					},
+					TerraformValue: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.String,
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(tftypes.String, "new"),
+						},
+					),
+				},
+			},
+		},
+		"Attribute-ValuableWithSemanticEquals-true": {
+			request: fwserver.SchemaSemanticEqualityRequest{
+				PriorData: fwschemadata.Data{
+					Description: fwschemadata.DataDescriptionState,
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.Attribute{
+								Optional: true,
+								Type: testtypes.StringTypeWithSemanticEquals{
+									SemanticEquals: true,
+								},
+							},
+						},
+					},
+					TerraformValue: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.String,
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(tftypes.String, "prior"),
+						},
+					),
+				},
+				ProposedNewData: fwschemadata.Data{
+					Description: fwschemadata.DataDescriptionPlan,
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.Attribute{
+								Optional: true,
+								Type: testtypes.StringTypeWithSemanticEquals{
+									SemanticEquals: true,
+								},
+							},
+						},
+					},
+					TerraformValue: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.String,
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(tftypes.String, "new"),
+						},
+					),
+				},
+			},
+			expected: &fwserver.SchemaSemanticEqualityResponse{
+				NewData: fwschemadata.Data{
+					Description: fwschemadata.DataDescriptionPlan,
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.Attribute{
+								Optional: true,
+								Type: testtypes.StringTypeWithSemanticEquals{
+									SemanticEquals: true,
+								},
+							},
+						},
+					},
+					TerraformValue: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.String,
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(tftypes.String, "prior"),
+						},
+					),
+				},
+			},
+		},
+		"Attribute-ValuableWithSemanticEquals-false": {
+			request: fwserver.SchemaSemanticEqualityRequest{
+				PriorData: fwschemadata.Data{
+					Description: fwschemadata.DataDescriptionState,
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.Attribute{
+								Optional: true,
+								Type: testtypes.StringTypeWithSemanticEquals{
+									SemanticEquals: false,
+								},
+							},
+						},
+					},
+					TerraformValue: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.String,
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(tftypes.String, "prior"),
+						},
+					),
+				},
+				ProposedNewData: fwschemadata.Data{
+					Description: fwschemadata.DataDescriptionPlan,
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.Attribute{
+								Optional: true,
+								Type: testtypes.StringTypeWithSemanticEquals{
+									SemanticEquals: false,
+								},
+							},
+						},
+					},
+					TerraformValue: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.String,
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(tftypes.String, "new"),
+						},
+					),
+				},
+			},
+			expected: &fwserver.SchemaSemanticEqualityResponse{
+				NewData: fwschemadata.Data{
+					Description: fwschemadata.DataDescriptionPlan,
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.Attribute{
+								Optional: true,
+								Type: testtypes.StringTypeWithSemanticEquals{
+									SemanticEquals: false,
+								},
+							},
+						},
+					},
+					TerraformValue: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.String,
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(tftypes.String, "new"),
+						},
+					),
+				},
+			},
+		},
+		"Attribute-ValuableWithSemanticEquals-diagnostics": {
+			request: fwserver.SchemaSemanticEqualityRequest{
+				PriorData: fwschemadata.Data{
+					Description: fwschemadata.DataDescriptionState,
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.Attribute{
+								Optional: true,
+								Type: testtypes.StringTypeWithSemanticEquals{
+									SemanticEquals: false,
+									SemanticEqualsDiagnostics: diag.Diagnostics{
+										diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+										diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+									},
+								},
+							},
+						},
+					},
+					TerraformValue: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.String,
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(tftypes.String, "prior"),
+						},
+					),
+				},
+				ProposedNewData: fwschemadata.Data{
+					Description: fwschemadata.DataDescriptionPlan,
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.Attribute{
+								Optional: true,
+								Type: testtypes.StringTypeWithSemanticEquals{
+									SemanticEquals: false,
+									SemanticEqualsDiagnostics: diag.Diagnostics{
+										diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+										diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+									},
+								},
+							},
+						},
+					},
+					TerraformValue: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.String,
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(tftypes.String, "new"),
+						},
+					),
+				},
+			},
+			expected: &fwserver.SchemaSemanticEqualityResponse{
+				NewData: fwschemadata.Data{
+					Description: fwschemadata.DataDescriptionPlan,
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"test": testschema.Attribute{
+								Optional: true,
+								Type: testtypes.StringTypeWithSemanticEquals{
+									SemanticEquals: false,
+									SemanticEqualsDiagnostics: diag.Diagnostics{
+										diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+										diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+									},
+								},
+							},
+						},
+					},
+					TerraformValue: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.String,
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(tftypes.String, "new"),
+						},
+					),
+				},
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+					diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+				},
+			},
+		},
+		"Block-List-Valuable": {
+			request: fwserver.SchemaSemanticEqualityRequest{
+				PriorData: fwschemadata.Data{
+					Description: fwschemadata.DataDescriptionState,
+					Schema: testschema.Schema{
+						Blocks: map[string]fwschema.Block{
+							"test": testschema.Block{
+								NestedObject: testschema.NestedBlockObject{
+									Attributes: map[string]fwschema.Attribute{
+										"test": testschema.Attribute{
+											Optional: true,
+											Type:     types.StringType,
+										},
+									},
+								},
+								NestingMode: fwschema.BlockNestingModeList,
+							},
+						},
+					},
+					TerraformValue: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"test": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"test": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"test": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"test": tftypes.NewValue(tftypes.String, "prior"),
+										},
+									),
+								},
+							),
+						},
+					),
+				},
+				ProposedNewData: fwschemadata.Data{
+					Description: fwschemadata.DataDescriptionPlan,
+					Schema: testschema.Schema{
+						Blocks: map[string]fwschema.Block{
+							"test": testschema.Block{
+								NestedObject: testschema.NestedBlockObject{
+									Attributes: map[string]fwschema.Attribute{
+										"test": testschema.Attribute{
+											Optional: true,
+											Type:     types.StringType,
+										},
+									},
+								},
+								NestingMode: fwschema.BlockNestingModeList,
+							},
+						},
+					},
+					TerraformValue: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"test": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"test": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"test": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"test": tftypes.NewValue(tftypes.String, "new"),
+										},
+									),
+								},
+							),
+						},
+					),
+				},
+			},
+			expected: &fwserver.SchemaSemanticEqualityResponse{
+				NewData: fwschemadata.Data{
+					Description: fwschemadata.DataDescriptionPlan,
+					Schema: testschema.Schema{
+						Blocks: map[string]fwschema.Block{
+							"test": testschema.Block{
+								NestedObject: testschema.NestedBlockObject{
+									Attributes: map[string]fwschema.Attribute{
+										"test": testschema.Attribute{
+											Optional: true,
+											Type:     types.StringType,
+										},
+									},
+								},
+								NestingMode: fwschema.BlockNestingModeList,
+							},
+						},
+					},
+					TerraformValue: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"test": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"test": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"test": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"test": tftypes.NewValue(tftypes.String, "new"),
+										},
+									),
+								},
+							),
+						},
+					),
+				},
+			},
+		},
+		"Block-List-ValuableWithSemanticEquals-true": {
+			request: fwserver.SchemaSemanticEqualityRequest{
+				PriorData: fwschemadata.Data{
+					Description: fwschemadata.DataDescriptionState,
+					Schema: testschema.Schema{
+						Blocks: map[string]fwschema.Block{
+							"test": testschema.Block{
+								NestedObject: testschema.NestedBlockObject{
+									Attributes: map[string]fwschema.Attribute{
+										"test": testschema.Attribute{
+											Optional: true,
+											Type: testtypes.StringTypeWithSemanticEquals{
+												SemanticEquals: true,
+											},
+										},
+									},
+								},
+								NestingMode: fwschema.BlockNestingModeList,
+							},
+						},
+					},
+					TerraformValue: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"test": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"test": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"test": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"test": tftypes.NewValue(tftypes.String, "prior"),
+										},
+									),
+								},
+							),
+						},
+					),
+				},
+				ProposedNewData: fwschemadata.Data{
+					Description: fwschemadata.DataDescriptionPlan,
+					Schema: testschema.Schema{
+						Blocks: map[string]fwschema.Block{
+							"test": testschema.Block{
+								NestedObject: testschema.NestedBlockObject{
+									Attributes: map[string]fwschema.Attribute{
+										"test": testschema.Attribute{
+											Optional: true,
+											Type: testtypes.StringTypeWithSemanticEquals{
+												SemanticEquals: true,
+											},
+										},
+									},
+								},
+								NestingMode: fwschema.BlockNestingModeList,
+							},
+						},
+					},
+					TerraformValue: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"test": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"test": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"test": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"test": tftypes.NewValue(tftypes.String, "new"),
+										},
+									),
+								},
+							),
+						},
+					),
+				},
+			},
+			expected: &fwserver.SchemaSemanticEqualityResponse{
+				NewData: fwschemadata.Data{
+					Description: fwschemadata.DataDescriptionPlan,
+					Schema: testschema.Schema{
+						Blocks: map[string]fwschema.Block{
+							"test": testschema.Block{
+								NestedObject: testschema.NestedBlockObject{
+									Attributes: map[string]fwschema.Attribute{
+										"test": testschema.Attribute{
+											Optional: true,
+											Type: testtypes.StringTypeWithSemanticEquals{
+												SemanticEquals: true,
+											},
+										},
+									},
+								},
+								NestingMode: fwschema.BlockNestingModeList,
+							},
+						},
+					},
+					TerraformValue: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"test": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"test": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"test": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"test": tftypes.NewValue(tftypes.String, "prior"),
+										},
+									),
+								},
+							),
+						},
+					),
+				},
+			},
+		},
+		"Block-List-ValuableWithSemanticEquals-false": {
+			request: fwserver.SchemaSemanticEqualityRequest{
+				PriorData: fwschemadata.Data{
+					Description: fwschemadata.DataDescriptionState,
+					Schema: testschema.Schema{
+						Blocks: map[string]fwschema.Block{
+							"test": testschema.Block{
+								NestedObject: testschema.NestedBlockObject{
+									Attributes: map[string]fwschema.Attribute{
+										"test": testschema.Attribute{
+											Optional: true,
+											Type: testtypes.StringTypeWithSemanticEquals{
+												SemanticEquals: false,
+											},
+										},
+									},
+								},
+								NestingMode: fwschema.BlockNestingModeList,
+							},
+						},
+					},
+					TerraformValue: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"test": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"test": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"test": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"test": tftypes.NewValue(tftypes.String, "prior"),
+										},
+									),
+								},
+							),
+						},
+					),
+				},
+				ProposedNewData: fwschemadata.Data{
+					Description: fwschemadata.DataDescriptionPlan,
+					Schema: testschema.Schema{
+						Blocks: map[string]fwschema.Block{
+							"test": testschema.Block{
+								NestedObject: testschema.NestedBlockObject{
+									Attributes: map[string]fwschema.Attribute{
+										"test": testschema.Attribute{
+											Optional: true,
+											Type: testtypes.StringTypeWithSemanticEquals{
+												SemanticEquals: false,
+											},
+										},
+									},
+								},
+								NestingMode: fwschema.BlockNestingModeList,
+							},
+						},
+					},
+					TerraformValue: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"test": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"test": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"test": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"test": tftypes.NewValue(tftypes.String, "new"),
+										},
+									),
+								},
+							),
+						},
+					),
+				},
+			},
+			expected: &fwserver.SchemaSemanticEqualityResponse{
+				NewData: fwschemadata.Data{
+					Description: fwschemadata.DataDescriptionPlan,
+					Schema: testschema.Schema{
+						Blocks: map[string]fwschema.Block{
+							"test": testschema.Block{
+								NestedObject: testschema.NestedBlockObject{
+									Attributes: map[string]fwschema.Attribute{
+										"test": testschema.Attribute{
+											Optional: true,
+											Type: testtypes.StringTypeWithSemanticEquals{
+												SemanticEquals: false,
+											},
+										},
+									},
+								},
+								NestingMode: fwschema.BlockNestingModeList,
+							},
+						},
+					},
+					TerraformValue: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"test": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"test": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"test": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"test": tftypes.NewValue(tftypes.String, "new"),
+										},
+									),
+								},
+							),
+						},
+					),
+				},
+			},
+		},
+		"Block-List-ValuableWithSemanticEquals-diagnostics": {
+			request: fwserver.SchemaSemanticEqualityRequest{
+				PriorData: fwschemadata.Data{
+					Description: fwschemadata.DataDescriptionState,
+					Schema: testschema.Schema{
+						Blocks: map[string]fwschema.Block{
+							"test": testschema.Block{
+								NestedObject: testschema.NestedBlockObject{
+									Attributes: map[string]fwschema.Attribute{
+										"test": testschema.Attribute{
+											Optional: true,
+											Type: testtypes.StringTypeWithSemanticEquals{
+												SemanticEquals: false,
+												SemanticEqualsDiagnostics: diag.Diagnostics{
+													diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+													diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+												},
+											},
+										},
+									},
+								},
+								NestingMode: fwschema.BlockNestingModeList,
+							},
+						},
+					},
+					TerraformValue: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"test": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"test": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"test": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"test": tftypes.NewValue(tftypes.String, "prior"),
+										},
+									),
+								},
+							),
+						},
+					),
+				},
+				ProposedNewData: fwschemadata.Data{
+					Description: fwschemadata.DataDescriptionPlan,
+					Schema: testschema.Schema{
+						Blocks: map[string]fwschema.Block{
+							"test": testschema.Block{
+								NestedObject: testschema.NestedBlockObject{
+									Attributes: map[string]fwschema.Attribute{
+										"test": testschema.Attribute{
+											Optional: true,
+											Type: testtypes.StringTypeWithSemanticEquals{
+												SemanticEquals: false,
+												SemanticEqualsDiagnostics: diag.Diagnostics{
+													diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+													diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+												},
+											},
+										},
+									},
+								},
+								NestingMode: fwschema.BlockNestingModeList,
+							},
+						},
+					},
+					TerraformValue: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"test": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"test": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"test": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"test": tftypes.NewValue(tftypes.String, "new"),
+										},
+									),
+								},
+							),
+						},
+					),
+				},
+			},
+			expected: &fwserver.SchemaSemanticEqualityResponse{
+				NewData: fwschemadata.Data{
+					Description: fwschemadata.DataDescriptionPlan,
+					Schema: testschema.Schema{
+						Blocks: map[string]fwschema.Block{
+							"test": testschema.Block{
+								NestedObject: testschema.NestedBlockObject{
+									Attributes: map[string]fwschema.Attribute{
+										"test": testschema.Attribute{
+											Optional: true,
+											Type: testtypes.StringTypeWithSemanticEquals{
+												SemanticEquals: false,
+												SemanticEqualsDiagnostics: diag.Diagnostics{
+													diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+													diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+												},
+											},
+										},
+									},
+								},
+								NestingMode: fwschema.BlockNestingModeList,
+							},
+						},
+					},
+					TerraformValue: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"test": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"test": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"test": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"test": tftypes.NewValue(tftypes.String, "new"),
+										},
+									),
+								},
+							),
+						},
+					),
+				},
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+					diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+				},
+			},
+		},
+		"Block-Set-Valuable": {
+			request: fwserver.SchemaSemanticEqualityRequest{
+				PriorData: fwschemadata.Data{
+					Description: fwschemadata.DataDescriptionState,
+					Schema: testschema.Schema{
+						Blocks: map[string]fwschema.Block{
+							"test": testschema.Block{
+								NestedObject: testschema.NestedBlockObject{
+									Attributes: map[string]fwschema.Attribute{
+										"test": testschema.Attribute{
+											Optional: true,
+											Type:     types.StringType,
+										},
+									},
+								},
+								NestingMode: fwschema.BlockNestingModeSet,
+							},
+						},
+					},
+					TerraformValue: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"test": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"test": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"test": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"test": tftypes.NewValue(tftypes.String, "prior"),
+										},
+									),
+								},
+							),
+						},
+					),
+				},
+				ProposedNewData: fwschemadata.Data{
+					Description: fwschemadata.DataDescriptionPlan,
+					Schema: testschema.Schema{
+						Blocks: map[string]fwschema.Block{
+							"test": testschema.Block{
+								NestedObject: testschema.NestedBlockObject{
+									Attributes: map[string]fwschema.Attribute{
+										"test": testschema.Attribute{
+											Optional: true,
+											Type:     types.StringType,
+										},
+									},
+								},
+								NestingMode: fwschema.BlockNestingModeSet,
+							},
+						},
+					},
+					TerraformValue: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"test": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"test": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"test": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"test": tftypes.NewValue(tftypes.String, "new"),
+										},
+									),
+								},
+							),
+						},
+					),
+				},
+			},
+			expected: &fwserver.SchemaSemanticEqualityResponse{
+				NewData: fwschemadata.Data{
+					Description: fwschemadata.DataDescriptionPlan,
+					Schema: testschema.Schema{
+						Blocks: map[string]fwschema.Block{
+							"test": testschema.Block{
+								NestedObject: testschema.NestedBlockObject{
+									Attributes: map[string]fwschema.Attribute{
+										"test": testschema.Attribute{
+											Optional: true,
+											Type:     types.StringType,
+										},
+									},
+								},
+								NestingMode: fwschema.BlockNestingModeSet,
+							},
+						},
+					},
+					TerraformValue: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"test": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"test": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"test": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"test": tftypes.NewValue(tftypes.String, "new"),
+										},
+									),
+								},
+							),
+						},
+					),
+				},
+			},
+		},
+		"Block-Set-ValuableWithSemanticEquals-true": {
+			request: fwserver.SchemaSemanticEqualityRequest{
+				PriorData: fwschemadata.Data{
+					Description: fwschemadata.DataDescriptionState,
+					Schema: testschema.Schema{
+						Blocks: map[string]fwschema.Block{
+							"test": testschema.Block{
+								NestedObject: testschema.NestedBlockObject{
+									Attributes: map[string]fwschema.Attribute{
+										"test": testschema.Attribute{
+											Optional: true,
+											Type: testtypes.StringTypeWithSemanticEquals{
+												SemanticEquals: true,
+											},
+										},
+									},
+								},
+								NestingMode: fwschema.BlockNestingModeSet,
+							},
+						},
+					},
+					TerraformValue: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"test": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"test": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"test": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"test": tftypes.NewValue(tftypes.String, "prior"),
+										},
+									),
+								},
+							),
+						},
+					),
+				},
+				ProposedNewData: fwschemadata.Data{
+					Description: fwschemadata.DataDescriptionPlan,
+					Schema: testschema.Schema{
+						Blocks: map[string]fwschema.Block{
+							"test": testschema.Block{
+								NestedObject: testschema.NestedBlockObject{
+									Attributes: map[string]fwschema.Attribute{
+										"test": testschema.Attribute{
+											Optional: true,
+											Type: testtypes.StringTypeWithSemanticEquals{
+												SemanticEquals: true,
+											},
+										},
+									},
+								},
+								NestingMode: fwschema.BlockNestingModeSet,
+							},
+						},
+					},
+					TerraformValue: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"test": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"test": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"test": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"test": tftypes.NewValue(tftypes.String, "new"),
+										},
+									),
+								},
+							),
+						},
+					),
+				},
+			},
+			expected: &fwserver.SchemaSemanticEqualityResponse{
+				NewData: fwschemadata.Data{
+					Description: fwschemadata.DataDescriptionPlan,
+					Schema: testschema.Schema{
+						Blocks: map[string]fwschema.Block{
+							"test": testschema.Block{
+								NestedObject: testschema.NestedBlockObject{
+									Attributes: map[string]fwschema.Attribute{
+										"test": testschema.Attribute{
+											Optional: true,
+											Type: testtypes.StringTypeWithSemanticEquals{
+												SemanticEquals: true,
+											},
+										},
+									},
+								},
+								NestingMode: fwschema.BlockNestingModeSet,
+							},
+						},
+					},
+					TerraformValue: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"test": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"test": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"test": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"test": tftypes.NewValue(tftypes.String, "prior"),
+										},
+									),
+								},
+							),
+						},
+					),
+				},
+			},
+		},
+		"Block-Set-ValuableWithSemanticEquals-false": {
+			request: fwserver.SchemaSemanticEqualityRequest{
+				PriorData: fwschemadata.Data{
+					Description: fwschemadata.DataDescriptionState,
+					Schema: testschema.Schema{
+						Blocks: map[string]fwschema.Block{
+							"test": testschema.Block{
+								NestedObject: testschema.NestedBlockObject{
+									Attributes: map[string]fwschema.Attribute{
+										"test": testschema.Attribute{
+											Optional: true,
+											Type: testtypes.StringTypeWithSemanticEquals{
+												SemanticEquals: false,
+											},
+										},
+									},
+								},
+								NestingMode: fwschema.BlockNestingModeSet,
+							},
+						},
+					},
+					TerraformValue: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"test": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"test": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"test": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"test": tftypes.NewValue(tftypes.String, "prior"),
+										},
+									),
+								},
+							),
+						},
+					),
+				},
+				ProposedNewData: fwschemadata.Data{
+					Description: fwschemadata.DataDescriptionPlan,
+					Schema: testschema.Schema{
+						Blocks: map[string]fwschema.Block{
+							"test": testschema.Block{
+								NestedObject: testschema.NestedBlockObject{
+									Attributes: map[string]fwschema.Attribute{
+										"test": testschema.Attribute{
+											Optional: true,
+											Type: testtypes.StringTypeWithSemanticEquals{
+												SemanticEquals: false,
+											},
+										},
+									},
+								},
+								NestingMode: fwschema.BlockNestingModeSet,
+							},
+						},
+					},
+					TerraformValue: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"test": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"test": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"test": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"test": tftypes.NewValue(tftypes.String, "new"),
+										},
+									),
+								},
+							),
+						},
+					),
+				},
+			},
+			expected: &fwserver.SchemaSemanticEqualityResponse{
+				NewData: fwschemadata.Data{
+					Description: fwschemadata.DataDescriptionPlan,
+					Schema: testschema.Schema{
+						Blocks: map[string]fwschema.Block{
+							"test": testschema.Block{
+								NestedObject: testschema.NestedBlockObject{
+									Attributes: map[string]fwschema.Attribute{
+										"test": testschema.Attribute{
+											Optional: true,
+											Type: testtypes.StringTypeWithSemanticEquals{
+												SemanticEquals: false,
+											},
+										},
+									},
+								},
+								NestingMode: fwschema.BlockNestingModeSet,
+							},
+						},
+					},
+					TerraformValue: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"test": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"test": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"test": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"test": tftypes.NewValue(tftypes.String, "new"),
+										},
+									),
+								},
+							),
+						},
+					),
+				},
+			},
+		},
+		"Block-Set-ValuableWithSemanticEquals-diagnostics": {
+			request: fwserver.SchemaSemanticEqualityRequest{
+				PriorData: fwschemadata.Data{
+					Description: fwschemadata.DataDescriptionState,
+					Schema: testschema.Schema{
+						Blocks: map[string]fwschema.Block{
+							"test": testschema.Block{
+								NestedObject: testschema.NestedBlockObject{
+									Attributes: map[string]fwschema.Attribute{
+										"test": testschema.Attribute{
+											Optional: true,
+											Type: testtypes.StringTypeWithSemanticEquals{
+												SemanticEquals: false,
+												SemanticEqualsDiagnostics: diag.Diagnostics{
+													diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+													diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+												},
+											},
+										},
+									},
+								},
+								NestingMode: fwschema.BlockNestingModeSet,
+							},
+						},
+					},
+					TerraformValue: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"test": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"test": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"test": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"test": tftypes.NewValue(tftypes.String, "prior"),
+										},
+									),
+								},
+							),
+						},
+					),
+				},
+				ProposedNewData: fwschemadata.Data{
+					Description: fwschemadata.DataDescriptionPlan,
+					Schema: testschema.Schema{
+						Blocks: map[string]fwschema.Block{
+							"test": testschema.Block{
+								NestedObject: testschema.NestedBlockObject{
+									Attributes: map[string]fwschema.Attribute{
+										"test": testschema.Attribute{
+											Optional: true,
+											Type: testtypes.StringTypeWithSemanticEquals{
+												SemanticEquals: false,
+												SemanticEqualsDiagnostics: diag.Diagnostics{
+													diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+													diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+												},
+											},
+										},
+									},
+								},
+								NestingMode: fwschema.BlockNestingModeSet,
+							},
+						},
+					},
+					TerraformValue: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"test": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"test": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"test": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"test": tftypes.NewValue(tftypes.String, "new"),
+										},
+									),
+								},
+							),
+						},
+					),
+				},
+			},
+			expected: &fwserver.SchemaSemanticEqualityResponse{
+				NewData: fwschemadata.Data{
+					Description: fwschemadata.DataDescriptionPlan,
+					Schema: testschema.Schema{
+						Blocks: map[string]fwschema.Block{
+							"test": testschema.Block{
+								NestedObject: testschema.NestedBlockObject{
+									Attributes: map[string]fwschema.Attribute{
+										"test": testschema.Attribute{
+											Optional: true,
+											Type: testtypes.StringTypeWithSemanticEquals{
+												SemanticEquals: false,
+												SemanticEqualsDiagnostics: diag.Diagnostics{
+													diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+													diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+												},
+											},
+										},
+									},
+								},
+								NestingMode: fwschema.BlockNestingModeSet,
+							},
+						},
+					},
+					TerraformValue: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"test": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"test": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"test": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"test": tftypes.NewValue(tftypes.String, "new"),
+										},
+									),
+								},
+							),
+						},
+					),
+				},
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+					diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+				},
+			},
+		},
+		"Block-Single-Valuable": {
+			request: fwserver.SchemaSemanticEqualityRequest{
+				PriorData: fwschemadata.Data{
+					Description: fwschemadata.DataDescriptionState,
+					Schema: testschema.Schema{
+						Blocks: map[string]fwschema.Block{
+							"test": testschema.Block{
+								NestedObject: testschema.NestedBlockObject{
+									Attributes: map[string]fwschema.Attribute{
+										"test": testschema.Attribute{
+											Optional: true,
+											Type:     types.StringType,
+										},
+									},
+								},
+								NestingMode: fwschema.BlockNestingModeSingle,
+							},
+						},
+					},
+					TerraformValue: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"test": tftypes.String,
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"test": tftypes.String,
+									},
+								},
+								map[string]tftypes.Value{
+									"test": tftypes.NewValue(tftypes.String, "prior"),
+								},
+							),
+						},
+					),
+				},
+				ProposedNewData: fwschemadata.Data{
+					Description: fwschemadata.DataDescriptionPlan,
+					Schema: testschema.Schema{
+						Blocks: map[string]fwschema.Block{
+							"test": testschema.Block{
+								NestedObject: testschema.NestedBlockObject{
+									Attributes: map[string]fwschema.Attribute{
+										"test": testschema.Attribute{
+											Optional: true,
+											Type:     types.StringType,
+										},
+									},
+								},
+								NestingMode: fwschema.BlockNestingModeSingle,
+							},
+						},
+					},
+					TerraformValue: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"test": tftypes.String,
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"test": tftypes.String,
+									},
+								},
+								map[string]tftypes.Value{
+									"test": tftypes.NewValue(tftypes.String, "new"),
+								},
+							),
+						},
+					),
+				},
+			},
+			expected: &fwserver.SchemaSemanticEqualityResponse{
+				NewData: fwschemadata.Data{
+					Description: fwschemadata.DataDescriptionPlan,
+					Schema: testschema.Schema{
+						Blocks: map[string]fwschema.Block{
+							"test": testschema.Block{
+								NestedObject: testschema.NestedBlockObject{
+									Attributes: map[string]fwschema.Attribute{
+										"test": testschema.Attribute{
+											Optional: true,
+											Type:     types.StringType,
+										},
+									},
+								},
+								NestingMode: fwschema.BlockNestingModeSingle,
+							},
+						},
+					},
+					TerraformValue: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"test": tftypes.String,
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"test": tftypes.String,
+									},
+								},
+								map[string]tftypes.Value{
+									"test": tftypes.NewValue(tftypes.String, "new"),
+								},
+							),
+						},
+					),
+				},
+			},
+		},
+		"Block-Single-ValuableWithSemanticEquals-true": {
+			request: fwserver.SchemaSemanticEqualityRequest{
+				PriorData: fwschemadata.Data{
+					Description: fwschemadata.DataDescriptionState,
+					Schema: testschema.Schema{
+						Blocks: map[string]fwschema.Block{
+							"test": testschema.Block{
+								NestedObject: testschema.NestedBlockObject{
+									Attributes: map[string]fwschema.Attribute{
+										"test": testschema.Attribute{
+											Optional: true,
+											Type: testtypes.StringTypeWithSemanticEquals{
+												SemanticEquals: true,
+											},
+										},
+									},
+								},
+								NestingMode: fwschema.BlockNestingModeSingle,
+							},
+						},
+					},
+					TerraformValue: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"test": tftypes.String,
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"test": tftypes.String,
+									},
+								},
+								map[string]tftypes.Value{
+									"test": tftypes.NewValue(tftypes.String, "prior"),
+								},
+							),
+						},
+					),
+				},
+				ProposedNewData: fwschemadata.Data{
+					Description: fwschemadata.DataDescriptionPlan,
+					Schema: testschema.Schema{
+						Blocks: map[string]fwschema.Block{
+							"test": testschema.Block{
+								NestedObject: testschema.NestedBlockObject{
+									Attributes: map[string]fwschema.Attribute{
+										"test": testschema.Attribute{
+											Optional: true,
+											Type: testtypes.StringTypeWithSemanticEquals{
+												SemanticEquals: true,
+											},
+										},
+									},
+								},
+								NestingMode: fwschema.BlockNestingModeSingle,
+							},
+						},
+					},
+					TerraformValue: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"test": tftypes.String,
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"test": tftypes.String,
+									},
+								},
+								map[string]tftypes.Value{
+									"test": tftypes.NewValue(tftypes.String, "new"),
+								},
+							),
+						},
+					),
+				},
+			},
+			expected: &fwserver.SchemaSemanticEqualityResponse{
+				NewData: fwschemadata.Data{
+					Description: fwschemadata.DataDescriptionPlan,
+					Schema: testschema.Schema{
+						Blocks: map[string]fwschema.Block{
+							"test": testschema.Block{
+								NestedObject: testschema.NestedBlockObject{
+									Attributes: map[string]fwschema.Attribute{
+										"test": testschema.Attribute{
+											Optional: true,
+											Type: testtypes.StringTypeWithSemanticEquals{
+												SemanticEquals: true,
+											},
+										},
+									},
+								},
+								NestingMode: fwschema.BlockNestingModeSingle,
+							},
+						},
+					},
+					TerraformValue: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"test": tftypes.String,
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"test": tftypes.String,
+									},
+								},
+								map[string]tftypes.Value{
+									"test": tftypes.NewValue(tftypes.String, "prior"),
+								},
+							),
+						},
+					),
+				},
+			},
+		},
+		"Block-Single-ValuableWithSemanticEquals-false": {
+			request: fwserver.SchemaSemanticEqualityRequest{
+				PriorData: fwschemadata.Data{
+					Description: fwschemadata.DataDescriptionState,
+					Schema: testschema.Schema{
+						Blocks: map[string]fwschema.Block{
+							"test": testschema.Block{
+								NestedObject: testschema.NestedBlockObject{
+									Attributes: map[string]fwschema.Attribute{
+										"test": testschema.Attribute{
+											Optional: true,
+											Type: testtypes.StringTypeWithSemanticEquals{
+												SemanticEquals: false,
+											},
+										},
+									},
+								},
+								NestingMode: fwschema.BlockNestingModeSingle,
+							},
+						},
+					},
+					TerraformValue: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"test": tftypes.String,
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"test": tftypes.String,
+									},
+								},
+								map[string]tftypes.Value{
+									"test": tftypes.NewValue(tftypes.String, "prior"),
+								},
+							),
+						},
+					),
+				},
+				ProposedNewData: fwschemadata.Data{
+					Description: fwschemadata.DataDescriptionPlan,
+					Schema: testschema.Schema{
+						Blocks: map[string]fwschema.Block{
+							"test": testschema.Block{
+								NestedObject: testschema.NestedBlockObject{
+									Attributes: map[string]fwschema.Attribute{
+										"test": testschema.Attribute{
+											Optional: true,
+											Type: testtypes.StringTypeWithSemanticEquals{
+												SemanticEquals: false,
+											},
+										},
+									},
+								},
+								NestingMode: fwschema.BlockNestingModeSingle,
+							},
+						},
+					},
+					TerraformValue: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"test": tftypes.String,
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"test": tftypes.String,
+									},
+								},
+								map[string]tftypes.Value{
+									"test": tftypes.NewValue(tftypes.String, "new"),
+								},
+							),
+						},
+					),
+				},
+			},
+			expected: &fwserver.SchemaSemanticEqualityResponse{
+				NewData: fwschemadata.Data{
+					Description: fwschemadata.DataDescriptionPlan,
+					Schema: testschema.Schema{
+						Blocks: map[string]fwschema.Block{
+							"test": testschema.Block{
+								NestedObject: testschema.NestedBlockObject{
+									Attributes: map[string]fwschema.Attribute{
+										"test": testschema.Attribute{
+											Optional: true,
+											Type: testtypes.StringTypeWithSemanticEquals{
+												SemanticEquals: false,
+											},
+										},
+									},
+								},
+								NestingMode: fwschema.BlockNestingModeSingle,
+							},
+						},
+					},
+					TerraformValue: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"test": tftypes.String,
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"test": tftypes.String,
+									},
+								},
+								map[string]tftypes.Value{
+									"test": tftypes.NewValue(tftypes.String, "new"),
+								},
+							),
+						},
+					),
+				},
+			},
+		},
+		"Block-Single-ValuableWithSemanticEquals-diagnostics": {
+			request: fwserver.SchemaSemanticEqualityRequest{
+				PriorData: fwschemadata.Data{
+					Description: fwschemadata.DataDescriptionState,
+					Schema: testschema.Schema{
+						Blocks: map[string]fwschema.Block{
+							"test": testschema.Block{
+								NestedObject: testschema.NestedBlockObject{
+									Attributes: map[string]fwschema.Attribute{
+										"test": testschema.Attribute{
+											Optional: true,
+											Type: testtypes.StringTypeWithSemanticEquals{
+												SemanticEquals: false,
+												SemanticEqualsDiagnostics: diag.Diagnostics{
+													diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+													diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+												},
+											},
+										},
+									},
+								},
+								NestingMode: fwschema.BlockNestingModeSingle,
+							},
+						},
+					},
+					TerraformValue: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"test": tftypes.String,
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"test": tftypes.String,
+									},
+								},
+								map[string]tftypes.Value{
+									"test": tftypes.NewValue(tftypes.String, "prior"),
+								},
+							),
+						},
+					),
+				},
+				ProposedNewData: fwschemadata.Data{
+					Description: fwschemadata.DataDescriptionPlan,
+					Schema: testschema.Schema{
+						Blocks: map[string]fwschema.Block{
+							"test": testschema.Block{
+								NestedObject: testschema.NestedBlockObject{
+									Attributes: map[string]fwschema.Attribute{
+										"test": testschema.Attribute{
+											Optional: true,
+											Type: testtypes.StringTypeWithSemanticEquals{
+												SemanticEquals: false,
+												SemanticEqualsDiagnostics: diag.Diagnostics{
+													diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+													diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+												},
+											},
+										},
+									},
+								},
+								NestingMode: fwschema.BlockNestingModeSingle,
+							},
+						},
+					},
+					TerraformValue: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"test": tftypes.String,
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"test": tftypes.String,
+									},
+								},
+								map[string]tftypes.Value{
+									"test": tftypes.NewValue(tftypes.String, "new"),
+								},
+							),
+						},
+					),
+				},
+			},
+			expected: &fwserver.SchemaSemanticEqualityResponse{
+				NewData: fwschemadata.Data{
+					Description: fwschemadata.DataDescriptionPlan,
+					Schema: testschema.Schema{
+						Blocks: map[string]fwschema.Block{
+							"test": testschema.Block{
+								NestedObject: testschema.NestedBlockObject{
+									Attributes: map[string]fwschema.Attribute{
+										"test": testschema.Attribute{
+											Optional: true,
+											Type: testtypes.StringTypeWithSemanticEquals{
+												SemanticEquals: false,
+												SemanticEqualsDiagnostics: diag.Diagnostics{
+													diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+													diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+												},
+											},
+										},
+									},
+								},
+								NestingMode: fwschema.BlockNestingModeSingle,
+							},
+						},
+					},
+					TerraformValue: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"test": tftypes.String,
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"test": tftypes.String,
+									},
+								},
+								map[string]tftypes.Value{
+									"test": tftypes.NewValue(tftypes.String, "new"),
+								},
+							),
+						},
+					),
+				},
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+					diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := &fwserver.SchemaSemanticEqualityResponse{
+				NewData: testCase.request.ProposedNewData,
+			}
+
+			fwserver.SchemaSemanticEquality(context.Background(), testCase.request, got)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}

--- a/internal/fwserver/server_applyresourcechange_test.go
+++ b/internal/fwserver/server_applyresourcechange_test.go
@@ -129,6 +129,13 @@ func TestServerApplyResourceChange(t *testing.T) {
 					}),
 					Schema: testSchema,
 				},
+				PlannedState: &tfsdk.Plan{
+					Raw: tftypes.NewValue(testSchemaType, map[string]tftypes.Value{
+						"test_computed": tftypes.NewValue(tftypes.String, nil),
+						"test_required": tftypes.NewValue(tftypes.String, "test-config-value"),
+					}),
+					Schema: testSchema,
+				},
 				PriorState:     testEmptyState,
 				ResourceSchema: testSchema,
 				Resource: &testprovider.Resource{
@@ -393,6 +400,7 @@ func TestServerApplyResourceChange(t *testing.T) {
 				Provider: &testprovider.Provider{},
 			},
 			request: &fwserver.ApplyResourceChangeRequest{
+				PlannedState:   testEmptyPlan,
 				PriorState:     testEmptyState,
 				ResourceSchema: testSchema,
 				Resource: &testprovider.Resource{

--- a/internal/fwserver/server_readdatasource_test.go
+++ b/internal/fwserver/server_readdatasource_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
 	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testprovider"
+	testtypes "github.com/hashicorp/terraform-plugin-framework/internal/testing/types"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
@@ -42,6 +43,38 @@ func TestServerReadDataSource(t *testing.T) {
 				Computed: true,
 			},
 			"test_required": schema.StringAttribute{
+				Required: true,
+			},
+		},
+	}
+
+	testSchemaWithSemanticEquals := schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"test_computed": schema.StringAttribute{
+				Computed: true,
+			},
+			"test_required": schema.StringAttribute{
+				CustomType: testtypes.StringTypeWithSemanticEquals{
+					SemanticEquals: true,
+				},
+				Required: true,
+			},
+		},
+	}
+
+	testSchemaWithSemanticEqualsDiagnostics := schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"test_computed": schema.StringAttribute{
+				Computed: true,
+			},
+			"test_required": schema.StringAttribute{
+				CustomType: testtypes.StringTypeWithSemanticEquals{
+					SemanticEquals: true,
+					SemanticEqualsDiagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+						diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+					},
+				},
 				Required: true,
 			},
 		},
@@ -195,6 +228,56 @@ func TestServerReadDataSource(t *testing.T) {
 				State: testStateUnchanged,
 			},
 		},
+		"response-diagnostics-semantic-equality": {
+			server: &fwserver.Server{
+				Provider: &testprovider.Provider{},
+			},
+			request: &fwserver.ReadDataSourceRequest{
+				Config: &tfsdk.Config{
+					Raw: tftypes.NewValue(testType, map[string]tftypes.Value{
+						"test_computed": tftypes.NewValue(tftypes.String, nil),
+						"test_required": tftypes.NewValue(tftypes.String, "test-config-value"),
+					}),
+					Schema: testSchemaWithSemanticEqualsDiagnostics,
+				},
+				DataSourceSchema: testSchemaWithSemanticEqualsDiagnostics,
+				DataSource: &testprovider.DataSource{
+					ReadMethod: func(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+						var data struct {
+							TestComputed types.String                            `tfsdk:"test_computed"`
+							TestRequired testtypes.StringValueWithSemanticEquals `tfsdk:"test_required"`
+						}
+
+						resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+
+						data.TestRequired = testtypes.StringValueWithSemanticEquals{
+							SemanticEquals: true,
+							SemanticEqualsDiagnostics: diag.Diagnostics{
+								diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+								diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+							},
+							StringValue: types.StringValue("test-semantic-equal-value"),
+						}
+
+						resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+					},
+				},
+			},
+			expectedResponse: &fwserver.ReadDataSourceResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic("test summary 1", "test detail 1"),
+					diag.NewErrorDiagnostic("test summary 2", "test detail 2"),
+				},
+				State: &tfsdk.State{
+					Raw: tftypes.NewValue(testType, map[string]tftypes.Value{
+						"test_computed": tftypes.NewValue(tftypes.String, nil),
+						// The response state is intentionally not updated when there are diagnostics
+						"test_required": tftypes.NewValue(tftypes.String, "test-semantic-equal-value"),
+					}),
+					Schema: testSchemaWithSemanticEqualsDiagnostics,
+				},
+			},
+		},
 		"response-state": {
 			server: &fwserver.Server{
 				Provider: &testprovider.Provider{},
@@ -219,6 +302,48 @@ func TestServerReadDataSource(t *testing.T) {
 			},
 			expectedResponse: &fwserver.ReadDataSourceResponse{
 				State: testState,
+			},
+		},
+		"response-state-semantic-equality": {
+			server: &fwserver.Server{
+				Provider: &testprovider.Provider{},
+			},
+			request: &fwserver.ReadDataSourceRequest{
+				Config: &tfsdk.Config{
+					Raw: tftypes.NewValue(testType, map[string]tftypes.Value{
+						"test_computed": tftypes.NewValue(tftypes.String, nil),
+						"test_required": tftypes.NewValue(tftypes.String, "test-config-value"),
+					}),
+					Schema: testSchemaWithSemanticEquals,
+				},
+				DataSourceSchema: testSchemaWithSemanticEquals,
+				DataSource: &testprovider.DataSource{
+					ReadMethod: func(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+						var data struct {
+							TestComputed types.String                            `tfsdk:"test_computed"`
+							TestRequired testtypes.StringValueWithSemanticEquals `tfsdk:"test_required"`
+						}
+
+						resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+
+						// This value should be overwritten back to the config value.
+						data.TestRequired = testtypes.StringValueWithSemanticEquals{
+							SemanticEquals: true,
+							StringValue:    types.StringValue("test-semantic-equal-value"),
+						}
+
+						resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+					},
+				},
+			},
+			expectedResponse: &fwserver.ReadDataSourceResponse{
+				State: &tfsdk.State{
+					Raw: tftypes.NewValue(testType, map[string]tftypes.Value{
+						"test_computed": tftypes.NewValue(tftypes.String, nil),
+						"test_required": tftypes.NewValue(tftypes.String, "test-config-value"),
+					}),
+					Schema: testSchemaWithSemanticEquals,
+				},
 			},
 		},
 	}

--- a/internal/fwserver/server_updateresource.go
+++ b/internal/fwserver/server_updateresource.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschemadata"
 	"github.com/hashicorp/terraform-plugin-framework/internal/logging"
 	"github.com/hashicorp/terraform-plugin-framework/internal/privatestate"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -136,4 +137,40 @@ func (s *Server) UpdateResource(ctx context.Context, req *UpdateResourceRequest,
 
 		resp.Private.Provider = updateResp.Private
 	}
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	semanticEqualityReq := SchemaSemanticEqualityRequest{
+		PriorData: fwschemadata.Data{
+			Description:    fwschemadata.DataDescriptionPlan,
+			Schema:         req.PlannedState.Schema,
+			TerraformValue: req.PlannedState.Raw.Copy(),
+		},
+		ProposedNewData: fwschemadata.Data{
+			Description:    fwschemadata.DataDescriptionState,
+			Schema:         resp.NewState.Schema,
+			TerraformValue: resp.NewState.Raw.Copy(),
+		},
+	}
+	semanticEqualityResp := &SchemaSemanticEqualityResponse{
+		NewData: semanticEqualityReq.ProposedNewData,
+	}
+
+	SchemaSemanticEquality(ctx, semanticEqualityReq, semanticEqualityResp)
+
+	resp.Diagnostics.Append(semanticEqualityResp.Diagnostics...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if semanticEqualityResp.NewData.TerraformValue.Equal(resp.NewState.Raw) {
+		return
+	}
+
+	logging.FrameworkDebug(ctx, "State updated due to semantic equality")
+
+	resp.NewState.Raw = semanticEqualityResp.NewData.TerraformValue
 }

--- a/internal/logging/keys.go
+++ b/internal/logging/keys.go
@@ -24,4 +24,7 @@ const (
 
 	// The type of resource being operated on, such as "random_pet"
 	KeyResourceType = "tf_resource_type"
+
+	// The type of value being operated on, such as "JSONStringValue".
+	KeyValueType = "tf_value_type"
 )

--- a/internal/proto5server/server_applyresourcechange_test.go
+++ b/internal/proto5server/server_applyresourcechange_test.go
@@ -463,6 +463,10 @@ func TestServerApplyResourceChange(t *testing.T) {
 				},
 			},
 			request: &tfprotov5.ApplyResourceChangeRequest{
+				PlannedState: testNewDynamicValue(t, testSchemaType, map[string]tftypes.Value{
+					"test_computed": tftypes.NewValue(tftypes.String, nil),
+					"test_required": tftypes.NewValue(tftypes.String, nil),
+				}),
 				TypeName: "test_resource",
 			},
 			expectedResponse: &tfprotov5.ApplyResourceChangeResponse{

--- a/internal/proto6server/server_applyresourcechange_test.go
+++ b/internal/proto6server/server_applyresourcechange_test.go
@@ -463,6 +463,10 @@ func TestServerApplyResourceChange(t *testing.T) {
 				},
 			},
 			request: &tfprotov6.ApplyResourceChangeRequest{
+				PlannedState: testNewDynamicValue(t, testSchemaType, map[string]tftypes.Value{
+					"test_computed": tftypes.NewValue(tftypes.String, nil),
+					"test_required": tftypes.NewValue(tftypes.String, nil),
+				}),
 				TypeName: "test_resource",
 			},
 			expectedResponse: &tfprotov6.ApplyResourceChangeResponse{

--- a/internal/testing/types/boolwithsemanticequals.go
+++ b/internal/testing/types/boolwithsemanticequals.go
@@ -1,0 +1,113 @@
+package types
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+var (
+	_ basetypes.BoolTypable                    = BoolTypeWithSemanticEquals{}
+	_ basetypes.BoolValuableWithSemanticEquals = BoolValueWithSemanticEquals{}
+)
+
+// BoolTypeWithSemanticEquals is a BoolType associated with
+// BoolValueWithSemanticEquals, which implements semantic equality logic that
+// returns the SemanticEquals boolean for testing.
+type BoolTypeWithSemanticEquals struct {
+	basetypes.BoolType
+
+	SemanticEquals            bool
+	SemanticEqualsDiagnostics diag.Diagnostics
+}
+
+func (t BoolTypeWithSemanticEquals) Equal(o attr.Type) bool {
+	other, ok := o.(BoolTypeWithSemanticEquals)
+
+	if !ok {
+		return false
+	}
+
+	if t.SemanticEquals != other.SemanticEquals {
+		return false
+	}
+
+	return t.BoolType.Equal(other.BoolType)
+}
+
+func (t BoolTypeWithSemanticEquals) String() string {
+	return fmt.Sprintf("BoolTypeWithSemanticEquals(%t)", t.SemanticEquals)
+}
+
+func (t BoolTypeWithSemanticEquals) ValueFromBool(ctx context.Context, in basetypes.BoolValue) (basetypes.BoolValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	value := BoolValueWithSemanticEquals{
+		BoolValue:                 in,
+		SemanticEquals:            t.SemanticEquals,
+		SemanticEqualsDiagnostics: t.SemanticEqualsDiagnostics,
+	}
+
+	return value, diags
+}
+
+func (t BoolTypeWithSemanticEquals) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	attrValue, err := t.BoolType.ValueFromTerraform(ctx, in)
+
+	if err != nil {
+		return nil, err
+	}
+
+	stringValue, ok := attrValue.(basetypes.BoolValue)
+
+	if !ok {
+		return nil, fmt.Errorf("unexpected value type of %T", attrValue)
+	}
+
+	stringValuable, diags := t.ValueFromBool(ctx, stringValue)
+
+	if diags.HasError() {
+		return nil, fmt.Errorf("unexpected error converting BoolValue to BoolValuable: %v", diags)
+	}
+
+	return stringValuable, nil
+}
+
+func (t BoolTypeWithSemanticEquals) ValueType(ctx context.Context) attr.Value {
+	return BoolValueWithSemanticEquals{
+		SemanticEquals:            t.SemanticEquals,
+		SemanticEqualsDiagnostics: t.SemanticEqualsDiagnostics,
+	}
+}
+
+type BoolValueWithSemanticEquals struct {
+	basetypes.BoolValue
+
+	SemanticEquals            bool
+	SemanticEqualsDiagnostics diag.Diagnostics
+}
+
+func (v BoolValueWithSemanticEquals) Equal(o attr.Value) bool {
+	other, ok := o.(BoolValueWithSemanticEquals)
+
+	if !ok {
+		return false
+	}
+
+	return v.BoolValue.Equal(other.BoolValue)
+}
+
+func (v BoolValueWithSemanticEquals) BoolSemanticEquals(ctx context.Context, otherV basetypes.BoolValuable) (bool, diag.Diagnostics) {
+	return v.SemanticEquals, v.SemanticEqualsDiagnostics
+}
+
+func (v BoolValueWithSemanticEquals) Type(ctx context.Context) attr.Type {
+	return BoolTypeWithSemanticEquals{
+		SemanticEquals:            v.SemanticEquals,
+		SemanticEqualsDiagnostics: v.SemanticEqualsDiagnostics,
+	}
+}

--- a/internal/testing/types/float64withsemanticequals.go
+++ b/internal/testing/types/float64withsemanticequals.go
@@ -1,0 +1,113 @@
+package types
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+var (
+	_ basetypes.Float64Typable                    = Float64TypeWithSemanticEquals{}
+	_ basetypes.Float64ValuableWithSemanticEquals = Float64ValueWithSemanticEquals{}
+)
+
+// Float64TypeWithSemanticEquals is a Float64Type associated with
+// Float64ValueWithSemanticEquals, which implements semantic equality logic that
+// returns the SemanticEquals boolean for testing.
+type Float64TypeWithSemanticEquals struct {
+	basetypes.Float64Type
+
+	SemanticEquals            bool
+	SemanticEqualsDiagnostics diag.Diagnostics
+}
+
+func (t Float64TypeWithSemanticEquals) Equal(o attr.Type) bool {
+	other, ok := o.(Float64TypeWithSemanticEquals)
+
+	if !ok {
+		return false
+	}
+
+	if t.SemanticEquals != other.SemanticEquals {
+		return false
+	}
+
+	return t.Float64Type.Equal(other.Float64Type)
+}
+
+func (t Float64TypeWithSemanticEquals) String() string {
+	return fmt.Sprintf("Float64TypeWithSemanticEquals(%t)", t.SemanticEquals)
+}
+
+func (t Float64TypeWithSemanticEquals) ValueFromFloat64(ctx context.Context, in basetypes.Float64Value) (basetypes.Float64Valuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	value := Float64ValueWithSemanticEquals{
+		Float64Value:              in,
+		SemanticEquals:            t.SemanticEquals,
+		SemanticEqualsDiagnostics: t.SemanticEqualsDiagnostics,
+	}
+
+	return value, diags
+}
+
+func (t Float64TypeWithSemanticEquals) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	attrValue, err := t.Float64Type.ValueFromTerraform(ctx, in)
+
+	if err != nil {
+		return nil, err
+	}
+
+	stringValue, ok := attrValue.(basetypes.Float64Value)
+
+	if !ok {
+		return nil, fmt.Errorf("unexpected value type of %T", attrValue)
+	}
+
+	stringValuable, diags := t.ValueFromFloat64(ctx, stringValue)
+
+	if diags.HasError() {
+		return nil, fmt.Errorf("unexpected error converting Float64Value to Float64Valuable: %v", diags)
+	}
+
+	return stringValuable, nil
+}
+
+func (t Float64TypeWithSemanticEquals) ValueType(ctx context.Context) attr.Value {
+	return Float64ValueWithSemanticEquals{
+		SemanticEquals:            t.SemanticEquals,
+		SemanticEqualsDiagnostics: t.SemanticEqualsDiagnostics,
+	}
+}
+
+type Float64ValueWithSemanticEquals struct {
+	basetypes.Float64Value
+
+	SemanticEquals            bool
+	SemanticEqualsDiagnostics diag.Diagnostics
+}
+
+func (v Float64ValueWithSemanticEquals) Equal(o attr.Value) bool {
+	other, ok := o.(Float64ValueWithSemanticEquals)
+
+	if !ok {
+		return false
+	}
+
+	return v.Float64Value.Equal(other.Float64Value)
+}
+
+func (v Float64ValueWithSemanticEquals) Float64SemanticEquals(ctx context.Context, otherV basetypes.Float64Valuable) (bool, diag.Diagnostics) {
+	return v.SemanticEquals, v.SemanticEqualsDiagnostics
+}
+
+func (v Float64ValueWithSemanticEquals) Type(ctx context.Context) attr.Type {
+	return Float64TypeWithSemanticEquals{
+		SemanticEquals:            v.SemanticEquals,
+		SemanticEqualsDiagnostics: v.SemanticEqualsDiagnostics,
+	}
+}

--- a/internal/testing/types/int64withsemanticequals.go
+++ b/internal/testing/types/int64withsemanticequals.go
@@ -1,0 +1,113 @@
+package types
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+var (
+	_ basetypes.Int64Typable                    = Int64TypeWithSemanticEquals{}
+	_ basetypes.Int64ValuableWithSemanticEquals = Int64ValueWithSemanticEquals{}
+)
+
+// Int64TypeWithSemanticEquals is a Int64Type associated with
+// Int64ValueWithSemanticEquals, which implements semantic equality logic that
+// returns the SemanticEquals boolean for testing.
+type Int64TypeWithSemanticEquals struct {
+	basetypes.Int64Type
+
+	SemanticEquals            bool
+	SemanticEqualsDiagnostics diag.Diagnostics
+}
+
+func (t Int64TypeWithSemanticEquals) Equal(o attr.Type) bool {
+	other, ok := o.(Int64TypeWithSemanticEquals)
+
+	if !ok {
+		return false
+	}
+
+	if t.SemanticEquals != other.SemanticEquals {
+		return false
+	}
+
+	return t.Int64Type.Equal(other.Int64Type)
+}
+
+func (t Int64TypeWithSemanticEquals) String() string {
+	return fmt.Sprintf("Int64TypeWithSemanticEquals(%t)", t.SemanticEquals)
+}
+
+func (t Int64TypeWithSemanticEquals) ValueFromInt64(ctx context.Context, in basetypes.Int64Value) (basetypes.Int64Valuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	value := Int64ValueWithSemanticEquals{
+		Int64Value:                in,
+		SemanticEquals:            t.SemanticEquals,
+		SemanticEqualsDiagnostics: t.SemanticEqualsDiagnostics,
+	}
+
+	return value, diags
+}
+
+func (t Int64TypeWithSemanticEquals) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	attrValue, err := t.Int64Type.ValueFromTerraform(ctx, in)
+
+	if err != nil {
+		return nil, err
+	}
+
+	stringValue, ok := attrValue.(basetypes.Int64Value)
+
+	if !ok {
+		return nil, fmt.Errorf("unexpected value type of %T", attrValue)
+	}
+
+	stringValuable, diags := t.ValueFromInt64(ctx, stringValue)
+
+	if diags.HasError() {
+		return nil, fmt.Errorf("unexpected error converting Int64Value to Int64Valuable: %v", diags)
+	}
+
+	return stringValuable, nil
+}
+
+func (t Int64TypeWithSemanticEquals) ValueType(ctx context.Context) attr.Value {
+	return Int64ValueWithSemanticEquals{
+		SemanticEquals:            t.SemanticEquals,
+		SemanticEqualsDiagnostics: t.SemanticEqualsDiagnostics,
+	}
+}
+
+type Int64ValueWithSemanticEquals struct {
+	basetypes.Int64Value
+
+	SemanticEquals            bool
+	SemanticEqualsDiagnostics diag.Diagnostics
+}
+
+func (v Int64ValueWithSemanticEquals) Equal(o attr.Value) bool {
+	other, ok := o.(Int64ValueWithSemanticEquals)
+
+	if !ok {
+		return false
+	}
+
+	return v.Int64Value.Equal(other.Int64Value)
+}
+
+func (v Int64ValueWithSemanticEquals) Int64SemanticEquals(ctx context.Context, otherV basetypes.Int64Valuable) (bool, diag.Diagnostics) {
+	return v.SemanticEquals, v.SemanticEqualsDiagnostics
+}
+
+func (v Int64ValueWithSemanticEquals) Type(ctx context.Context) attr.Type {
+	return Int64TypeWithSemanticEquals{
+		SemanticEquals:            v.SemanticEquals,
+		SemanticEqualsDiagnostics: v.SemanticEqualsDiagnostics,
+	}
+}

--- a/internal/testing/types/listwithsemanticequals.go
+++ b/internal/testing/types/listwithsemanticequals.go
@@ -1,0 +1,113 @@
+package types
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+var (
+	_ basetypes.ListTypable                    = ListTypeWithSemanticEquals{}
+	_ basetypes.ListValuableWithSemanticEquals = ListValueWithSemanticEquals{}
+)
+
+// ListTypeWithSemanticEquals is a ListType associated with
+// ListValueWithSemanticEquals, which implements semantic equality logic that
+// returns the SemanticEquals boolean for testing.
+type ListTypeWithSemanticEquals struct {
+	basetypes.ListType
+
+	SemanticEquals            bool
+	SemanticEqualsDiagnostics diag.Diagnostics
+}
+
+func (t ListTypeWithSemanticEquals) Equal(o attr.Type) bool {
+	other, ok := o.(ListTypeWithSemanticEquals)
+
+	if !ok {
+		return false
+	}
+
+	if t.SemanticEquals != other.SemanticEquals {
+		return false
+	}
+
+	return t.ListType.Equal(other.ListType)
+}
+
+func (t ListTypeWithSemanticEquals) String() string {
+	return fmt.Sprintf("ListTypeWithSemanticEquals(%t)", t.SemanticEquals)
+}
+
+func (t ListTypeWithSemanticEquals) ValueFromList(ctx context.Context, in basetypes.ListValue) (basetypes.ListValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	value := ListValueWithSemanticEquals{
+		ListValue:                 in,
+		SemanticEquals:            t.SemanticEquals,
+		SemanticEqualsDiagnostics: t.SemanticEqualsDiagnostics,
+	}
+
+	return value, diags
+}
+
+func (t ListTypeWithSemanticEquals) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	attrValue, err := t.ListType.ValueFromTerraform(ctx, in)
+
+	if err != nil {
+		return nil, err
+	}
+
+	stringValue, ok := attrValue.(basetypes.ListValue)
+
+	if !ok {
+		return nil, fmt.Errorf("unexpected value type of %T", attrValue)
+	}
+
+	stringValuable, diags := t.ValueFromList(ctx, stringValue)
+
+	if diags.HasError() {
+		return nil, fmt.Errorf("unexpected error converting ListValue to ListValuable: %v", diags)
+	}
+
+	return stringValuable, nil
+}
+
+func (t ListTypeWithSemanticEquals) ValueType(ctx context.Context) attr.Value {
+	return ListValueWithSemanticEquals{
+		SemanticEquals:            t.SemanticEquals,
+		SemanticEqualsDiagnostics: t.SemanticEqualsDiagnostics,
+	}
+}
+
+type ListValueWithSemanticEquals struct {
+	basetypes.ListValue
+
+	SemanticEquals            bool
+	SemanticEqualsDiagnostics diag.Diagnostics
+}
+
+func (v ListValueWithSemanticEquals) Equal(o attr.Value) bool {
+	other, ok := o.(ListValueWithSemanticEquals)
+
+	if !ok {
+		return false
+	}
+
+	return v.ListValue.Equal(other.ListValue)
+}
+
+func (v ListValueWithSemanticEquals) ListSemanticEquals(ctx context.Context, otherV basetypes.ListValuable) (bool, diag.Diagnostics) {
+	return v.SemanticEquals, v.SemanticEqualsDiagnostics
+}
+
+func (v ListValueWithSemanticEquals) Type(ctx context.Context) attr.Type {
+	return ListTypeWithSemanticEquals{
+		SemanticEquals:            v.SemanticEquals,
+		SemanticEqualsDiagnostics: v.SemanticEqualsDiagnostics,
+	}
+}

--- a/internal/testing/types/mapwithsemanticequals.go
+++ b/internal/testing/types/mapwithsemanticequals.go
@@ -1,0 +1,113 @@
+package types
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+var (
+	_ basetypes.MapTypable                    = MapTypeWithSemanticEquals{}
+	_ basetypes.MapValuableWithSemanticEquals = MapValueWithSemanticEquals{}
+)
+
+// MapTypeWithSemanticEquals is a MapType associated with
+// MapValueWithSemanticEquals, which implements semantic equality logic that
+// returns the SemanticEquals boolean for testing.
+type MapTypeWithSemanticEquals struct {
+	basetypes.MapType
+
+	SemanticEquals            bool
+	SemanticEqualsDiagnostics diag.Diagnostics
+}
+
+func (t MapTypeWithSemanticEquals) Equal(o attr.Type) bool {
+	other, ok := o.(MapTypeWithSemanticEquals)
+
+	if !ok {
+		return false
+	}
+
+	if t.SemanticEquals != other.SemanticEquals {
+		return false
+	}
+
+	return t.MapType.Equal(other.MapType)
+}
+
+func (t MapTypeWithSemanticEquals) String() string {
+	return fmt.Sprintf("MapTypeWithSemanticEquals(%t)", t.SemanticEquals)
+}
+
+func (t MapTypeWithSemanticEquals) ValueFromMap(ctx context.Context, in basetypes.MapValue) (basetypes.MapValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	value := MapValueWithSemanticEquals{
+		MapValue:                  in,
+		SemanticEquals:            t.SemanticEquals,
+		SemanticEqualsDiagnostics: t.SemanticEqualsDiagnostics,
+	}
+
+	return value, diags
+}
+
+func (t MapTypeWithSemanticEquals) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	attrValue, err := t.MapType.ValueFromTerraform(ctx, in)
+
+	if err != nil {
+		return nil, err
+	}
+
+	stringValue, ok := attrValue.(basetypes.MapValue)
+
+	if !ok {
+		return nil, fmt.Errorf("unexpected value type of %T", attrValue)
+	}
+
+	stringValuable, diags := t.ValueFromMap(ctx, stringValue)
+
+	if diags.HasError() {
+		return nil, fmt.Errorf("unexpected error converting MapValue to MapValuable: %v", diags)
+	}
+
+	return stringValuable, nil
+}
+
+func (t MapTypeWithSemanticEquals) ValueType(ctx context.Context) attr.Value {
+	return MapValueWithSemanticEquals{
+		SemanticEquals:            t.SemanticEquals,
+		SemanticEqualsDiagnostics: t.SemanticEqualsDiagnostics,
+	}
+}
+
+type MapValueWithSemanticEquals struct {
+	basetypes.MapValue
+
+	SemanticEquals            bool
+	SemanticEqualsDiagnostics diag.Diagnostics
+}
+
+func (v MapValueWithSemanticEquals) Equal(o attr.Value) bool {
+	other, ok := o.(MapValueWithSemanticEquals)
+
+	if !ok {
+		return false
+	}
+
+	return v.MapValue.Equal(other.MapValue)
+}
+
+func (v MapValueWithSemanticEquals) MapSemanticEquals(ctx context.Context, otherV basetypes.MapValuable) (bool, diag.Diagnostics) {
+	return v.SemanticEquals, v.SemanticEqualsDiagnostics
+}
+
+func (v MapValueWithSemanticEquals) Type(ctx context.Context) attr.Type {
+	return MapTypeWithSemanticEquals{
+		SemanticEquals:            v.SemanticEquals,
+		SemanticEqualsDiagnostics: v.SemanticEqualsDiagnostics,
+	}
+}

--- a/internal/testing/types/numberwithsemanticequals.go
+++ b/internal/testing/types/numberwithsemanticequals.go
@@ -1,0 +1,113 @@
+package types
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+var (
+	_ basetypes.NumberTypable                    = NumberTypeWithSemanticEquals{}
+	_ basetypes.NumberValuableWithSemanticEquals = NumberValueWithSemanticEquals{}
+)
+
+// NumberTypeWithSemanticEquals is a NumberType associated with
+// NumberValueWithSemanticEquals, which implements semantic equality logic that
+// returns the SemanticEquals boolean for testing.
+type NumberTypeWithSemanticEquals struct {
+	basetypes.NumberType
+
+	SemanticEquals            bool
+	SemanticEqualsDiagnostics diag.Diagnostics
+}
+
+func (t NumberTypeWithSemanticEquals) Equal(o attr.Type) bool {
+	other, ok := o.(NumberTypeWithSemanticEquals)
+
+	if !ok {
+		return false
+	}
+
+	if t.SemanticEquals != other.SemanticEquals {
+		return false
+	}
+
+	return t.NumberType.Equal(other.NumberType)
+}
+
+func (t NumberTypeWithSemanticEquals) String() string {
+	return fmt.Sprintf("NumberTypeWithSemanticEquals(%t)", t.SemanticEquals)
+}
+
+func (t NumberTypeWithSemanticEquals) ValueFromNumber(ctx context.Context, in basetypes.NumberValue) (basetypes.NumberValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	value := NumberValueWithSemanticEquals{
+		NumberValue:               in,
+		SemanticEquals:            t.SemanticEquals,
+		SemanticEqualsDiagnostics: t.SemanticEqualsDiagnostics,
+	}
+
+	return value, diags
+}
+
+func (t NumberTypeWithSemanticEquals) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	attrValue, err := t.NumberType.ValueFromTerraform(ctx, in)
+
+	if err != nil {
+		return nil, err
+	}
+
+	stringValue, ok := attrValue.(basetypes.NumberValue)
+
+	if !ok {
+		return nil, fmt.Errorf("unexpected value type of %T", attrValue)
+	}
+
+	stringValuable, diags := t.ValueFromNumber(ctx, stringValue)
+
+	if diags.HasError() {
+		return nil, fmt.Errorf("unexpected error converting NumberValue to NumberValuable: %v", diags)
+	}
+
+	return stringValuable, nil
+}
+
+func (t NumberTypeWithSemanticEquals) ValueType(ctx context.Context) attr.Value {
+	return NumberValueWithSemanticEquals{
+		SemanticEquals:            t.SemanticEquals,
+		SemanticEqualsDiagnostics: t.SemanticEqualsDiagnostics,
+	}
+}
+
+type NumberValueWithSemanticEquals struct {
+	basetypes.NumberValue
+
+	SemanticEquals            bool
+	SemanticEqualsDiagnostics diag.Diagnostics
+}
+
+func (v NumberValueWithSemanticEquals) Equal(o attr.Value) bool {
+	other, ok := o.(NumberValueWithSemanticEquals)
+
+	if !ok {
+		return false
+	}
+
+	return v.NumberValue.Equal(other.NumberValue)
+}
+
+func (v NumberValueWithSemanticEquals) NumberSemanticEquals(ctx context.Context, otherV basetypes.NumberValuable) (bool, diag.Diagnostics) {
+	return v.SemanticEquals, v.SemanticEqualsDiagnostics
+}
+
+func (v NumberValueWithSemanticEquals) Type(ctx context.Context) attr.Type {
+	return NumberTypeWithSemanticEquals{
+		SemanticEquals:            v.SemanticEquals,
+		SemanticEqualsDiagnostics: v.SemanticEqualsDiagnostics,
+	}
+}

--- a/internal/testing/types/objectwithsemanticequals.go
+++ b/internal/testing/types/objectwithsemanticequals.go
@@ -1,0 +1,113 @@
+package types
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+var (
+	_ basetypes.ObjectTypable                    = ObjectTypeWithSemanticEquals{}
+	_ basetypes.ObjectValuableWithSemanticEquals = ObjectValueWithSemanticEquals{}
+)
+
+// ObjectTypeWithSemanticEquals is a ObjectType associated with
+// ObjectValueWithSemanticEquals, which implements semantic equality logic that
+// returns the SemanticEquals boolean for testing.
+type ObjectTypeWithSemanticEquals struct {
+	basetypes.ObjectType
+
+	SemanticEquals            bool
+	SemanticEqualsDiagnostics diag.Diagnostics
+}
+
+func (t ObjectTypeWithSemanticEquals) Equal(o attr.Type) bool {
+	other, ok := o.(ObjectTypeWithSemanticEquals)
+
+	if !ok {
+		return false
+	}
+
+	if t.SemanticEquals != other.SemanticEquals {
+		return false
+	}
+
+	return t.ObjectType.Equal(other.ObjectType)
+}
+
+func (t ObjectTypeWithSemanticEquals) String() string {
+	return fmt.Sprintf("ObjectTypeWithSemanticEquals(%t)", t.SemanticEquals)
+}
+
+func (t ObjectTypeWithSemanticEquals) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	value := ObjectValueWithSemanticEquals{
+		ObjectValue:               in,
+		SemanticEquals:            t.SemanticEquals,
+		SemanticEqualsDiagnostics: t.SemanticEqualsDiagnostics,
+	}
+
+	return value, diags
+}
+
+func (t ObjectTypeWithSemanticEquals) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	attrValue, err := t.ObjectType.ValueFromTerraform(ctx, in)
+
+	if err != nil {
+		return nil, err
+	}
+
+	stringValue, ok := attrValue.(basetypes.ObjectValue)
+
+	if !ok {
+		return nil, fmt.Errorf("unexpected value type of %T", attrValue)
+	}
+
+	stringValuable, diags := t.ValueFromObject(ctx, stringValue)
+
+	if diags.HasError() {
+		return nil, fmt.Errorf("unexpected error converting ObjectValue to ObjectValuable: %v", diags)
+	}
+
+	return stringValuable, nil
+}
+
+func (t ObjectTypeWithSemanticEquals) ValueType(ctx context.Context) attr.Value {
+	return ObjectValueWithSemanticEquals{
+		SemanticEquals:            t.SemanticEquals,
+		SemanticEqualsDiagnostics: t.SemanticEqualsDiagnostics,
+	}
+}
+
+type ObjectValueWithSemanticEquals struct {
+	basetypes.ObjectValue
+
+	SemanticEquals            bool
+	SemanticEqualsDiagnostics diag.Diagnostics
+}
+
+func (v ObjectValueWithSemanticEquals) Equal(o attr.Value) bool {
+	other, ok := o.(ObjectValueWithSemanticEquals)
+
+	if !ok {
+		return false
+	}
+
+	return v.ObjectValue.Equal(other.ObjectValue)
+}
+
+func (v ObjectValueWithSemanticEquals) ObjectSemanticEquals(ctx context.Context, otherV basetypes.ObjectValuable) (bool, diag.Diagnostics) {
+	return v.SemanticEquals, v.SemanticEqualsDiagnostics
+}
+
+func (v ObjectValueWithSemanticEquals) Type(ctx context.Context) attr.Type {
+	return ObjectTypeWithSemanticEquals{
+		SemanticEquals:            v.SemanticEquals,
+		SemanticEqualsDiagnostics: v.SemanticEqualsDiagnostics,
+	}
+}

--- a/internal/testing/types/setwithsemanticequals.go
+++ b/internal/testing/types/setwithsemanticequals.go
@@ -1,0 +1,113 @@
+package types
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+var (
+	_ basetypes.SetTypable                    = SetTypeWithSemanticEquals{}
+	_ basetypes.SetValuableWithSemanticEquals = SetValueWithSemanticEquals{}
+)
+
+// SetTypeWithSemanticEquals is a SetType associated with
+// SetValueWithSemanticEquals, which implements semantic equality logic that
+// returns the SemanticEquals boolean for testing.
+type SetTypeWithSemanticEquals struct {
+	basetypes.SetType
+
+	SemanticEquals            bool
+	SemanticEqualsDiagnostics diag.Diagnostics
+}
+
+func (t SetTypeWithSemanticEquals) Equal(o attr.Type) bool {
+	other, ok := o.(SetTypeWithSemanticEquals)
+
+	if !ok {
+		return false
+	}
+
+	if t.SemanticEquals != other.SemanticEquals {
+		return false
+	}
+
+	return t.SetType.Equal(other.SetType)
+}
+
+func (t SetTypeWithSemanticEquals) String() string {
+	return fmt.Sprintf("SetTypeWithSemanticEquals(%t)", t.SemanticEquals)
+}
+
+func (t SetTypeWithSemanticEquals) ValueFromSet(ctx context.Context, in basetypes.SetValue) (basetypes.SetValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	value := SetValueWithSemanticEquals{
+		SetValue:                  in,
+		SemanticEquals:            t.SemanticEquals,
+		SemanticEqualsDiagnostics: t.SemanticEqualsDiagnostics,
+	}
+
+	return value, diags
+}
+
+func (t SetTypeWithSemanticEquals) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	attrValue, err := t.SetType.ValueFromTerraform(ctx, in)
+
+	if err != nil {
+		return nil, err
+	}
+
+	stringValue, ok := attrValue.(basetypes.SetValue)
+
+	if !ok {
+		return nil, fmt.Errorf("unexpected value type of %T", attrValue)
+	}
+
+	stringValuable, diags := t.ValueFromSet(ctx, stringValue)
+
+	if diags.HasError() {
+		return nil, fmt.Errorf("unexpected error converting SetValue to SetValuable: %v", diags)
+	}
+
+	return stringValuable, nil
+}
+
+func (t SetTypeWithSemanticEquals) ValueType(ctx context.Context) attr.Value {
+	return SetValueWithSemanticEquals{
+		SemanticEquals:            t.SemanticEquals,
+		SemanticEqualsDiagnostics: t.SemanticEqualsDiagnostics,
+	}
+}
+
+type SetValueWithSemanticEquals struct {
+	basetypes.SetValue
+
+	SemanticEquals            bool
+	SemanticEqualsDiagnostics diag.Diagnostics
+}
+
+func (v SetValueWithSemanticEquals) Equal(o attr.Value) bool {
+	other, ok := o.(SetValueWithSemanticEquals)
+
+	if !ok {
+		return false
+	}
+
+	return v.SetValue.Equal(other.SetValue)
+}
+
+func (v SetValueWithSemanticEquals) SetSemanticEquals(ctx context.Context, otherV basetypes.SetValuable) (bool, diag.Diagnostics) {
+	return v.SemanticEquals, v.SemanticEqualsDiagnostics
+}
+
+func (v SetValueWithSemanticEquals) Type(ctx context.Context) attr.Type {
+	return SetTypeWithSemanticEquals{
+		SemanticEquals:            v.SemanticEquals,
+		SemanticEqualsDiagnostics: v.SemanticEqualsDiagnostics,
+	}
+}

--- a/internal/testing/types/stringwithsemanticequals.go
+++ b/internal/testing/types/stringwithsemanticequals.go
@@ -1,0 +1,113 @@
+package types
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+var (
+	_ basetypes.StringTypable                    = StringTypeWithSemanticEquals{}
+	_ basetypes.StringValuableWithSemanticEquals = StringValueWithSemanticEquals{}
+)
+
+// StringTypeWithSemanticEquals is a StringType associated with
+// StringValueWithSemanticEquals, which implements semantic equality logic that
+// returns the SemanticEquals boolean for testing.
+type StringTypeWithSemanticEquals struct {
+	basetypes.StringType
+
+	SemanticEquals            bool
+	SemanticEqualsDiagnostics diag.Diagnostics
+}
+
+func (t StringTypeWithSemanticEquals) Equal(o attr.Type) bool {
+	other, ok := o.(StringTypeWithSemanticEquals)
+
+	if !ok {
+		return false
+	}
+
+	if t.SemanticEquals != other.SemanticEquals {
+		return false
+	}
+
+	return t.StringType.Equal(other.StringType)
+}
+
+func (t StringTypeWithSemanticEquals) String() string {
+	return fmt.Sprintf("StringTypeWithSemanticEquals(%t)", t.SemanticEquals)
+}
+
+func (t StringTypeWithSemanticEquals) ValueFromString(ctx context.Context, in basetypes.StringValue) (basetypes.StringValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	value := StringValueWithSemanticEquals{
+		StringValue:               in,
+		SemanticEquals:            t.SemanticEquals,
+		SemanticEqualsDiagnostics: t.SemanticEqualsDiagnostics,
+	}
+
+	return value, diags
+}
+
+func (t StringTypeWithSemanticEquals) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	attrValue, err := t.StringType.ValueFromTerraform(ctx, in)
+
+	if err != nil {
+		return nil, err
+	}
+
+	stringValue, ok := attrValue.(basetypes.StringValue)
+
+	if !ok {
+		return nil, fmt.Errorf("unexpected value type of %T", attrValue)
+	}
+
+	stringValuable, diags := t.ValueFromString(ctx, stringValue)
+
+	if diags.HasError() {
+		return nil, fmt.Errorf("unexpected error converting StringValue to StringValuable: %v", diags)
+	}
+
+	return stringValuable, nil
+}
+
+func (t StringTypeWithSemanticEquals) ValueType(ctx context.Context) attr.Value {
+	return StringValueWithSemanticEquals{
+		SemanticEquals:            t.SemanticEquals,
+		SemanticEqualsDiagnostics: t.SemanticEqualsDiagnostics,
+	}
+}
+
+type StringValueWithSemanticEquals struct {
+	basetypes.StringValue
+
+	SemanticEquals            bool
+	SemanticEqualsDiagnostics diag.Diagnostics
+}
+
+func (v StringValueWithSemanticEquals) Equal(o attr.Value) bool {
+	other, ok := o.(StringValueWithSemanticEquals)
+
+	if !ok {
+		return false
+	}
+
+	return v.StringValue.Equal(other.StringValue)
+}
+
+func (v StringValueWithSemanticEquals) StringSemanticEquals(ctx context.Context, otherV basetypes.StringValuable) (bool, diag.Diagnostics) {
+	return v.SemanticEquals, v.SemanticEqualsDiagnostics
+}
+
+func (v StringValueWithSemanticEquals) Type(ctx context.Context) attr.Type {
+	return StringTypeWithSemanticEquals{
+		SemanticEquals:            v.SemanticEquals,
+		SemanticEqualsDiagnostics: v.SemanticEqualsDiagnostics,
+	}
+}

--- a/types/basetypes/bool_value.go
+++ b/types/basetypes/bool_value.go
@@ -23,6 +23,21 @@ type BoolValuable interface {
 	ToBoolValue(ctx context.Context) (BoolValue, diag.Diagnostics)
 }
 
+// BoolValuableWithSemanticEquals extends BoolValuable with semantic
+// equality logic.
+type BoolValuableWithSemanticEquals interface {
+	BoolValuable
+
+	// BoolSemanticEquals should return true if the given value is
+	// semantically equal to the current value. This logic is used to prevent
+	// Terraform data consistency errors and resource drift where a value change
+	// may have inconsequential differences.
+	//
+	// Only known values are compared with this method as changing a value's
+	// state implicitly represents a different value.
+	BoolSemanticEquals(context.Context, BoolValuable) (bool, diag.Diagnostics)
+}
+
 // NewBoolNull creates a Bool with a null value. Determine whether the value is
 // null via the Bool type IsNull method.
 func NewBoolNull() BoolValue {

--- a/types/basetypes/float64_value.go
+++ b/types/basetypes/float64_value.go
@@ -23,6 +23,21 @@ type Float64Valuable interface {
 	ToFloat64Value(ctx context.Context) (Float64Value, diag.Diagnostics)
 }
 
+// Float64ValuableWithSemanticEquals extends Float64Valuable with semantic
+// equality logic.
+type Float64ValuableWithSemanticEquals interface {
+	Float64Valuable
+
+	// Float64SemanticEquals should return true if the given value is
+	// semantically equal to the current value. This logic is used to prevent
+	// Terraform data consistency errors and resource drift where a value change
+	// may have inconsequential differences, such as rounding.
+	//
+	// Only known values are compared with this method as changing a value's
+	// state implicitly represents a different value.
+	Float64SemanticEquals(context.Context, Float64Valuable) (bool, diag.Diagnostics)
+}
+
 // Float64Null creates a Float64 with a null value. Determine whether the value is
 // null via the Float64 type IsNull method.
 func NewFloat64Null() Float64Value {

--- a/types/basetypes/int64_value.go
+++ b/types/basetypes/int64_value.go
@@ -23,6 +23,21 @@ type Int64Valuable interface {
 	ToInt64Value(ctx context.Context) (Int64Value, diag.Diagnostics)
 }
 
+// Int64ValuableWithSemanticEquals extends Int64Valuable with semantic
+// equality logic.
+type Int64ValuableWithSemanticEquals interface {
+	Int64Valuable
+
+	// Int64SemanticEquals should return true if the given value is
+	// semantically equal to the current value. This logic is used to prevent
+	// Terraform data consistency errors and resource drift where a value change
+	// may have inconsequential differences, such as rounding.
+	//
+	// Only known values are compared with this method as changing a value's
+	// state implicitly represents a different value.
+	Int64SemanticEquals(context.Context, Int64Valuable) (bool, diag.Diagnostics)
+}
+
 // NewInt64Null creates a Int64 with a null value. Determine whether the value is
 // null via the Int64 type IsNull method.
 func NewInt64Null() Int64Value {

--- a/types/basetypes/list_value.go
+++ b/types/basetypes/list_value.go
@@ -24,6 +24,22 @@ type ListValuable interface {
 	ToListValue(ctx context.Context) (ListValue, diag.Diagnostics)
 }
 
+// ListValuableWithSemanticEquals extends ListValuable with semantic equality
+// logic.
+type ListValuableWithSemanticEquals interface {
+	ListValuable
+
+	// ListSemanticEquals should return true if the given value is
+	// semantically equal to the current value. This logic is used to prevent
+	// Terraform data consistency errors and resource drift where a value change
+	// may have inconsequential differences, such as computed elements added by
+	// a remote system.
+	//
+	// Only known values are compared with this method as changing a value's
+	// state implicitly represents a different value.
+	ListSemanticEquals(context.Context, ListValuable) (bool, diag.Diagnostics)
+}
+
 // NewListNull creates a List with a null value. Determine whether the value is
 // null via the List type IsNull method.
 func NewListNull(elementType attr.Type) ListValue {

--- a/types/basetypes/map_value.go
+++ b/types/basetypes/map_value.go
@@ -25,6 +25,22 @@ type MapValuable interface {
 	ToMapValue(ctx context.Context) (MapValue, diag.Diagnostics)
 }
 
+// MapValuableWithSemanticEquals extends MapValuable with semantic equality
+// logic.
+type MapValuableWithSemanticEquals interface {
+	MapValuable
+
+	// MapSemanticEquals should return true if the given value is
+	// semantically equal to the current value. This logic is used to prevent
+	// Terraform data consistency errors and resource drift where a value change
+	// may have inconsequential differences, such as computed elements added by
+	// a remote system.
+	//
+	// Only known values are compared with this method as changing a value's
+	// state implicitly represents a different value.
+	MapSemanticEquals(context.Context, MapValuable) (bool, diag.Diagnostics)
+}
+
 // NewMapNull creates a Map with a null value. Determine whether the value is
 // null via the Map type IsNull method.
 func NewMapNull(elementType attr.Type) MapValue {

--- a/types/basetypes/number_value.go
+++ b/types/basetypes/number_value.go
@@ -24,6 +24,21 @@ type NumberValuable interface {
 	ToNumberValue(ctx context.Context) (NumberValue, diag.Diagnostics)
 }
 
+// NumberValuableWithSemanticEquals extends NumberValuable with semantic
+// equality logic.
+type NumberValuableWithSemanticEquals interface {
+	NumberValuable
+
+	// NumberSemanticEquals should return true if the given value is
+	// semantically equal to the current value. This logic is used to prevent
+	// Terraform data consistency errors and resource drift where a value change
+	// may have inconsequential differences, such as rounding.
+	//
+	// Only known values are compared with this method as changing a value's
+	// state implicitly represents a different value.
+	NumberSemanticEquals(context.Context, NumberValuable) (bool, diag.Diagnostics)
+}
+
 // NewNumberNull creates a Number with a null value. Determine whether the value is
 // null via the Number type IsNull method.
 func NewNumberNull() NumberValue {

--- a/types/basetypes/object_value.go
+++ b/types/basetypes/object_value.go
@@ -25,6 +25,22 @@ type ObjectValuable interface {
 	ToObjectValue(ctx context.Context) (ObjectValue, diag.Diagnostics)
 }
 
+// ObjectValuableWithSemanticEquals extends ObjectValuable with semantic
+// equality logic.
+type ObjectValuableWithSemanticEquals interface {
+	ObjectValuable
+
+	// ObjectSemanticEquals should return true if the given value is
+	// semantically equal to the current value. This logic is used to prevent
+	// Terraform data consistency errors and resource drift where a value change
+	// may have inconsequential differences, such as computed attribute values
+	// changed by a remote system.
+	//
+	// Only known values are compared with this method as changing a value's
+	// state implicitly represents a different value.
+	ObjectSemanticEquals(context.Context, ObjectValuable) (bool, diag.Diagnostics)
+}
+
 // NewObjectNull creates a Object with a null value. Determine whether the value is
 // null via the Object type IsNull method.
 func NewObjectNull(attributeTypes map[string]attr.Type) ObjectValue {

--- a/types/basetypes/set_value.go
+++ b/types/basetypes/set_value.go
@@ -24,6 +24,22 @@ type SetValuable interface {
 	ToSetValue(ctx context.Context) (SetValue, diag.Diagnostics)
 }
 
+// SetValuableWithSemanticEquals extends SetValuable with semantic equality
+// logic.
+type SetValuableWithSemanticEquals interface {
+	SetValuable
+
+	// SetSemanticEquals should return true if the given value is
+	// semantically equal to the current value. This logic is used to prevent
+	// Terraform data consistency errors and resource drift where a value change
+	// may have inconsequential differences, such as computed elements added by
+	// a remote system.
+	//
+	// Only known values are compared with this method as changing a value's
+	// state implicitly represents a different value.
+	SetSemanticEquals(context.Context, SetValuable) (bool, diag.Diagnostics)
+}
+
 // NewSetNull creates a Set with a null value. Determine whether the value is
 // null via the Set type IsNull method.
 func NewSetNull(elementType attr.Type) SetValue {

--- a/types/basetypes/string_value.go
+++ b/types/basetypes/string_value.go
@@ -23,6 +23,22 @@ type StringValuable interface {
 	ToStringValue(ctx context.Context) (StringValue, diag.Diagnostics)
 }
 
+// StringValuableWithSemanticEquals extends StringValuable with semantic
+// equality logic.
+type StringValuableWithSemanticEquals interface {
+	StringValuable
+
+	// StringSemanticEquals should return true if the given value is
+	// semantically equal to the current value. This logic is used to prevent
+	// Terraform data consistency errors and resource drift where a value change
+	// may have inconsequential differences, such as spacing character removal
+	// in JSON formatted strings.
+	//
+	// Only known values are compared with this method as changing a value's
+	// state implicitly represents a different value.
+	StringSemanticEquals(context.Context, StringValuable) (bool, diag.Diagnostics)
+}
+
 // NewStringNull creates a String with a null value. Determine whether the value is
 // null via the String type IsNull method.
 //

--- a/website/docs/plugin/framework/handling-data/custom-types.mdx
+++ b/website/docs/plugin/framework/handling-data/custom-types.mdx
@@ -6,278 +6,337 @@ description: >-
 
 # Custom Types
 
-You can use custom types for both attributes and blocks.
+Use existing custom types or develop custom types to consistently define behaviors for a kind of value across schemas. Custom types are supported on top of any framework-defined type.
 
-~> **Important:** Specifying plan customization for attribute types is not yet
-supported, limiting their utility. Support is expected in the near future.
+Supported behaviors for custom types include:
 
-### `attr.Type` Interface
+- Semantic Equality: Keep a prior value if a new value is inconsequentially different, such as preventing drift detection of JSON strings with differing property ordering.
+- Validation: Raise warning and/or error diagnostics based on the value, such as not following a specified format or enumeration of values.
 
-Use the [`attr.Type`
-interface](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/attr#Type)
-to implement an attribute type. It tells Terraform about its constraints and tells the framework how to create new attribute values from the information Terraform supplies. `attr.Type` has the following methods.
+## Example Use Cases
 
-| Method               | Description                                                                                                                                                                                                                                                                                                                |
-|----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `TerraformType`      | Returns the [`tftypes.Type` value](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-go/tftypes#Type) that describes its type constraints. This is how Terraform will know what type of values it can accept.                                                                                                       |
-| `ValueFromTerraform` | Returns an attribute value from the [`tftypes.Value`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-go/tftypes#Value) that Terraform supplies, or to return an error if it cannot. This error should not be used for validation purposes, and is expected to indicate programmer error, not practitioner error. |
-| `Equal`              | Returns true if the attribute type is considered equal to the passed attribute type.                                                                                                                                                                                                                                       |
+- Encoded values, such as JSON or YAML string.
+- Networking values, such as an IPv4 address string.
+- Time values, such as an RFC3339 string.
+- Provider-specific values, such as an AWS ARN or AzureRM location string.
 
-### `AttributePathStepper` Interface
+## Concepts
 
-All attribute types must implement the [`tftypes.AttributePathStepper`
-interface](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-go/tftypes#AttributePathStepper),
-so the framework can access element or attribute types using attribute paths.
+Individual data value handling in the framework is performed by a pair of associated Go types:
 
-### `xattr.TypeWithValidation` Interface
+- Schema Types: Define the associated value type and logic to create a value.
+- Value Types: Define behaviors associated with the value, data storage of the value, and data storage of the value state (null, unknown, or known).
 
-If validation for type values is desired, use the [`xattr.TypeWithValidation` interface](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/attr/xattr#TypeWithValidation) to include validation logic for type values. The framework will call this functionality when validating all values based on the schema.
+The framework defines a standard set these associated Go types referred to by the "base type" terminology. Extending these base types is referred to by the "custom type" terminology.
 
-| Method     | Description                                                   |
-|------------|---------------------------------------------------------------|
-| `Validate` | Returns any warning or error diagnostics for the given value. |
+## Using Custom Types
 
-### Type-Specific Interfaces
+Use a custom type by switching the schema definition and data handling from a framework-defined type to the custom type.
 
-| Case                        | Interface                                                                                                                  | Description                                                                                                                                                                                                                                                                                                                                                                                                                |
-|-----------------------------|----------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Elements of the same type   | [`TypeWithElementType`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/attr#TypeWithElementType)       | Attribute types that contain elements of the same type, like maps and lists, are required to implement `attr.TypeWithElementType`, which adds `WithElementType` and `ElementType` methods to the `attr.Type` interface. `WithElementType` must return a copy of the attribute type, but with its element type set to the passed type. `ElementType` must return the attribute type's element type.                         |
-| Elements of different types | [`TypeWithElementTypes`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/attr#TypeWithElementType)      | Attribute types that contain elements of differing types, like tuples, are required to implement the `attr.TypeWithElementTypes`, which adds `WithElementTypes` and `ElementTypes` methods to the `attr.Type` interface. `WithElementTypes` must return a copy of the attribute type, but with its element types set to the passed element types. `ElementTypes` must return the attribute type's element types.           |
-| Contain attributes          | [`TypeWithAttributeTypes`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/attr#TypeWithAttributeTypes) | Attribute types that contain attributes, like objects, are required to implement the `attr.TypeWithAttributeTypes` interface, which adds `WithAttributeTypes` and `AttributeTypes` methods to the `attr.Type` interface. `WithAttributeTypes` must return a copy of the attribute type, but with its attribute types set to the passed attribute types. `AttributeTypes` must return the attribute type's attribute types. |
+### Schema Definition
 
-### `attr.Value` Interface
+The framework schema types accept a `CustomType` field where applicable, such as the [`resource/schema.StringAttribute` type](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource/schema#StringAttribute.CustomType). When the `CustomType` is omitted, the framework defaults to the associated base type.
 
-Use the [`attr.Value`
-interface](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/attr#Value)
-to implement an attribute value. It tells the framework how to express that
-attribute value in a way that Terraform will understand. `attr.Value` has the
-following methods.
+Implement the `CustomType` field in a schema type to switch from the base type to a custom type.
 
-| Method             | Description                                                                                                                                                                                                                     |
-|--------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `ToTerraformValue` | Returns a Go type that is valid input for [`tftypes.NewValue`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-go/tftypes#NewValue) for the `tftypes.Type` specified by the `attr.Type` that creates the `attr.Value`. |
-| `Equal`            | Returns true if the passed attribute value should be considered to the attribute value the method is being called on. The passed attribute value is not guaranteed to be of the same Go type.                                   |
-
-## Custom Type and Value
-
-A minimal implementation of a custom type for `ListType` and `List` that leverages embedding looks as follows:
+In this example, a string attribute implements a custom type.
 
 ```go
-type CustomListType struct {
-    types.ListType
-}
-
-func (c CustomListType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
-    val, err := c.ListType.ValueFromTerraform(ctx, in)
-
-    return CustomListValue{
-        // unchecked type assertion
-        val.(types.List),
-    }, err
-}
-
-type CustomListValue struct {
-    types.List
-}
-
-func (c CustomListValue) DoSomething(ctx context.Context) {
-    tflog.Info(ctx, "called DoSomething on CustomListValue")
+schema.StringAttribute{
+    CustomType: CustomStringType{},
+    // ... other fields ...
 }
 ```
 
-## Terraform Configuration
+### Data Handling
 
-Using the custom type does not require any changes to the Terraform configuration.
+Each custom type will also include a value type, which must be used anywhere the value is referenced in data source, provider, or resource logic.
 
-```hcl
-resource "example_resource" "example" {
-  list_attribute = ["list-element", "list-element"]
+Switch any usage of a base value type to the custom value type. Any logic will need to be updated to match the custom value type implementation.
 
-  list_nested_attribute = [
-    {
-      int64_attribute = 9223372036854775807
-      list_attribute  = ["list-element", "list-element"]
-    },
-    {
-      int64_attribute = 9223372036854775807
-      list_attribute  = ["list-element", "list-element"]
-    }
-  ]
+In this example, a custom value type is used in a data model approach:
 
-  list_nested_block {
-    bool_attribute    = true
-    float64_attribute = 1234.5
-    int64_attribute   = 9223372036854775807
-    list_attribute    = ["list-element", "list-element"]
-    list_nested_nested_block {
-      bool_attribute = true
-    }
-    list_nested_nested_block {
-      bool_attribute = false
-    }
-  }
-  list_nested_block {
-    bool_attribute    = true
-    float64_attribute = 1234.5
-    int64_attribute   = 9223372036854775807
-    list_attribute    = ["list-element", "list-element"]
-    list_nested_nested_block {
-      bool_attribute = true
-    }
-    list_nested_nested_block {
-      bool_attribute = false
-    }
-  }
+```go
+type ThingModel struct {
+    // Instead of types.String
+    Timestamp CustomStringValue `tfsdk:"timestamp"`
+    // ... other fields ...
 }
 ```
 
-## Schema
+## Developing Custom Types
 
-Use the custom type in the schema as follows:
+Create a custom type by extending an existing framework schema type and its associated value type. Once created, define [semantic equality](#semantic-equality) and/or [validation](#validation) logic for the custom type.
+
+### Schema Type
+
+Extend a framework schema type by creating a Go type that implements one of the  `github.com/hashicorp/terraform-plugin-framework/types/basetypes` package `*Typable` interfaces.
+
+It is recommended to use Go type embedding of the base type to simplify the implementation and ensure it is up to date with the latest data handling features of the framework. With type embedding, the following [`attr.Type`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/attr#Type) methods should be overriden by the custom type:
+
+- `Equal(attr.Type) bool`
+- `ValueFromTerraform(context.Context, tftypes.Value) (attr.Value, error)`
+- `ValueType(context.Context) attr.Value`
+- `String() string`
+
+<Tip>
+
+The commonly used `types` package types are aliases to the `basetypes` package types mentioned in this table.
+
+</Tip>
+
+| Framework Schema Type | Custom Schema Type Interface |
+| --- | --- |
+| [`basetypes.BoolType`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/types/basetypes#BoolType) | [`basetypes.BoolTypable`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/types/basetypes#BoolTypable) |
+| [`basetypes.Float64Type`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/types/basetypes#Float64Type) | [`basetypes.Float64Typable`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/types/basetypes#Float64Typable) |
+| [`basetypes.Int64Type`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/types/basetypes#Int64Type) | [`basetypes.Int64Typable`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/types/basetypes#Int64Typable) |
+| [`basetypes.ListType`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/types/basetypes#ListType) | [`basetypes.ListTypable`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/types/basetypes#ListTypable) |
+| [`basetypes.MapType`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/types/basetypes#MapType) | [`basetypes.MapTypable`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/types/basetypes#MapTypable) |
+| [`basetypes.NumberType`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/types/basetypes#NumberType) | [`basetypes.NumberTypable`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/types/basetypes#NumberTypable) |
+| [`basetypes.ObjectType`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/types/basetypes#ObjectType) | [`basetypes.ObjectTypable`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/types/basetypes#ObjectTypable) |
+| [`basetypes.SetType`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/types/basetypes#SetType) | [`basetypes.SetTypable`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/types/basetypes#SetTypable) |
+| [`basetypes.StringType`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/types/basetypes#StringType) | [`basetypes.StringTypable`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/types/basetypes#StringTypable) |
+
+In this example, the `basetypes.StringTypable` interface is implemented to create a custom string type with an associated [value type](#value-type):
 
 ```go
-func (e *exampleResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
-    resp.Schema = schema.Schema{
-        Attributes: map[string]schema.Attribute{
-            "list_attribute": schema.ListAttribute{
-                Optional:    true,
-                ElementType: types.StringType,
-                CustomType: CustomListType{
-                    types.ListType{
-                        ElemType: types.StringType,
-                    },
-                },
-            },
+import (
+    "context"
+    "fmt"
 
-            "list_nested_attribute": schema.ListNestedAttribute{
-                Optional: true,
-                CustomType: CustomListType{
-                    types.ListType{
-                        ElemType: types.ObjectType{
-                            AttrTypes: map[string]attr.Type{
-                                "int64_attribute": types.Int64Type,
-                                "list_attribute": types.ListType{
-                                    ElemType: types.StringType,
-                                },
-                            },
-                        },
-                    },
-                },
-                NestedObject: schema.NestedAttributeObject{
-                    Attributes: map[string]schema.Attribute{
-                        "int64_attribute": schema.Int64Attribute{
-                            Optional: true,
-                        },
-                        "list_attribute": schema.ListAttribute{
-                            Optional:    true,
-                            ElementType: types.StringType,
-                        },
-                    },
-                },
-            },
-        },
+    "github.com/hashicorp/terraform-plugin-framework/attr"
+    "github.com/hashicorp/terraform-plugin-framework/diag"
+    "github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+    "github.com/hashicorp/terraform-plugin-go/tftypes"
+)
 
-        Blocks: map[string]schema.Block{
-            "list_nested_block": schema.ListNestedBlock{
-                CustomType: CustomListType{
-                    types.ListType{
-                        ElemType: types.ObjectType{
-                            AttrTypes: map[string]attr.Type{
-                                "bool_attribute":    types.BoolType,
-                                "float64_attribute": types.Float64Type,
-                                "int64_attribute":   types.Int64Type,
-                                "list_attribute": types.ListType{
-                                    ElemType: types.StringType,
-                                },
-                                "list_nested_nested_block": types.ListType{
-                                    ElemType: types.ObjectType{
-                                        AttrTypes: map[string]attr.Type{
-                                            "bool_attribute": types.BoolType,
-                                        },
-                                    },
-                                },
-                            },
-                        },
-                    },
-                },
-                NestedObject: schema.NestedBlockObject{
-                    Attributes: map[string]schema.Attribute{
-                        "bool_attribute": schema.BoolAttribute{
-                            Optional: true,
-                        },
-                        "float64_attribute": schema.Float64Attribute{
-                            Optional: true,
-                        },
+// Ensure the implementation satifies the expected interfaces
+var _ basetypes.StringTypable = CustomStringType{}
 
-                        "int64_attribute": schema.Int64Attribute{
-                            Optional: true,
-                        },
-                        "list_attribute": schema.ListAttribute{
-                            Optional:    true,
-                            ElementType: types.StringType,
-                        },
-                    },
-                    Blocks: map[string]schema.Block{
-                        "list_nested_nested_block": schema.ListNestedBlock{
-                            NestedObject: schema.NestedBlockObject{
-                                Attributes: map[string]schema.Attribute{
-                                    "bool_attribute": schema.BoolAttribute{
-                                        Optional: true,
-                                    },
-                                },
-                            },
-                        },
-                    },
-                },
-            },
-        },
+type CustomStringType struct {
+    basetypes.StringType
+    // ... potentially other fields ...
+}
+
+func (t CustomStringType) Equal(o attr.Type) bool {
+    other, ok := o.(CustomStringType)
+
+    if !ok {
+        return false
     }
+
+    return t.StringType.Equal(other.StringType)
+}
+
+func (t CustomStringType) String() string {
+    return "CustomStringType"
+}
+
+func (t CustomStringType) ValueFromString(ctx context.Context, in basetypes.StringValue) (basetypes.StringValuable, diag.Diagnostics) {
+    // CustomStringValue defined in the value type section
+    value := CustomStringValue{
+        StringValue: in,
+    }
+
+    return value, nil
+}
+
+func (t CustomStringType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+    attrValue, err := t.StringType.ValueFromTerraform(ctx, in)
+
+    if err != nil {
+        return nil, err
+    }
+
+    stringValue, ok := attrValue.(basetypes.StringValue)
+
+    if !ok {
+        return nil, fmt.Errorf("unexpected value type of %T", attrValue)
+    }
+
+    stringValuable, diags := t.ValueFromString(ctx, stringValue)
+
+    if diags.HasError() {
+        return nil, fmt.Errorf("unexpected error converting StringValue to StringValuable: %v", diags)
+    }
+
+    return stringValuable, nil
+}
+
+func (t CustomStringType) ValueType(ctx context.Context) attr.Value {
+    // CustomStringValue defined in the value type section
+    return CustomStringValue{}
 }
 ```
 
-## Model
+### Value Type
 
-The custom type value is then used within the model.
+Extend a framework value type by creating a Go type that implements one of the `github.com/hashicorp/terraform-plugin-framework/types/basetypes` package `*Valuable` interfaces.
 
-Where previously the model would have looked as follows:
+It is recommended to use Go type embedding of the base type to simplify the implementation and ensure it is up to date with the latest data handling features of the framework. With type embedding, the following [`attr.Value`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/attr#Value) methods should be overriden by the custom type:
+
+- `Equal(attr.Value) bool`
+- `Type(context.Context) attr.Type`
+
+<Tip>
+
+The commonly used `types` package types are aliases to the `basetypes` package types mentioned in this table.
+
+</Tip>
+
+| Framework Schema Type | Custom Schema Type Interface |
+| --- | --- |
+| [`basetypes.BoolValue`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/types/basetypes#BoolValue) | [`basetypes.BoolValuable`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/types/basetypes#BoolValuable) |
+| [`basetypes.Float64Value`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/types/basetypes#Float64Value) | [`basetypes.Float64Valuable`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/types/basetypes#Float64Valuable) |
+| [`basetypes.Int64Value`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/types/basetypes#Int64Value) | [`basetypes.Int64Valuable`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/types/basetypes#Int64Valuable) |
+| [`basetypes.ListValue`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/types/basetypes#ListValue) | [`basetypes.ListValuable`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/types/basetypes#ListValuable) |
+| [`basetypes.MapValue`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/types/basetypes#MapValue) | [`basetypes.MapValuable`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/types/basetypes#MapValuable) |
+| [`basetypes.NumberValue`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/types/basetypes#NumberValue) | [`basetypes.NumberValuable`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/types/basetypes#NumberValuable) |
+| [`basetypes.ObjectValue`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/types/basetypes#ObjectValue) | [`basetypes.ObjectValuable`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/types/basetypes#ObjectValuable) |
+| [`basetypes.SetValue`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/types/basetypes#SetValue) | [`basetypes.SetValuable`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/types/basetypes#SetValuable) |
+| [`basetypes.StringValue`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/types/basetypes#StringValue) | [`basetypes.StringValuable`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/types/basetypes#StringValuable) |
+
+In this example, the `basetypes.StringValuable` interface is implemented to create a custom string value type with an associated [schema type](#schema-type):
 
 ```go
-type exampleResourceData struct {
-    ListAttribute         types.List `tfsdk:"list_attribute"`
-    ListNestedAttribute   types.List `tfsdk:"list_nested_attribute"`
-    ListNestedBlock       types.List `tfsdk:"list_nested_block"`
+import (
+    "context"
+    "fmt"
+
+    "github.com/hashicorp/terraform-plugin-framework/attr"
+    "github.com/hashicorp/terraform-plugin-framework/diag"
+    "github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+    "github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// Ensure the implementation satifies the expected interfaces
+var _ basetypes.StringValuable = CustomStringValue{}
+
+type CustomStringValue struct {
+    basetypes.StringValue
+    // ... potentially other fields ...
+}
+
+func (v CustomStringValue) Equal(o attr.Value) bool {
+    other, ok := o.(CustomStringValue)
+
+    if !ok {
+        return false
+    }
+
+    return v.StringValue.Equal(other.StringValue)
+}
+
+func (v CustomStringValue) Type(ctx context.Context) attr.Type {
+    // CustomStringType defined in the schema type section
+    return CustomStringType{}
 }
 ```
 
-The custom type value is used by updating the model to:
+From this point, the custom type can be extended with other behaviors.
+
+### Semantic Equality
+
+Semantic equality handling enables the value type to automatically keep a prior value when a new value is determined to be inconsequentially different. This handling can prevent unexpected drift detection for values and in some cases prevent Terraform data handling errors.
+
+This value type functionality is checked in the following scenarios:
+
+- When refreshing a data source, the response state value from the `Read` method logic is compared to the configuration value.
+- When refreshing a resource, the response new state value from the `Read` method logic is compared to the request prior state value.
+- When creating or updating a resource, the response new state value from the `Create` or `Update` method logic is compared to the request plan value.
+
+The framework will only call semantic equality logic if both the prior and new values are known. Null or unknown values are unnecessary to check.
+
+Implement the associated `github.com/hashicorp/terraform-plugin-framework/types/basetypes` package `*ValuableWithSemanticEquals` interface on the value type to define and enable this behavior.
+
+In this example, the custom string value type will preserve the prior value if the expected RFC3339 timestamps are considered equivalent:
 
 ```go
-type exampleResourceData struct {
-    ListAttribute         CustomListValue `tfsdk:"list_attribute"`
-    ListNestedAttribute   CustomListValue `tfsdk:"list_nested_attribute"`
-    ListNestedBlock       CustomListValue `tfsdk:"list_nested_block"`
-}
-```
+// CustomStringValue defined in the value type section
+// Ensure the implementation satifies the expected interfaces
+var _ basetypes.StringValuableWithSemanticEquals = CustomStringValue{}
 
-## Create
+func (v CustomStringValue) StringSemanticEquals(ctx context.Context, newValuable basetypes.StringValuable) (bool, diag.Diagnostics) {
+    var diags diag.Diagnostics
 
-The functions on `CustomListValue` are then available.
+    // The framework should always pass the correct value type, but always check
+    newValue, ok := newValuable.(CustomStringValue)
 
-```go
-func (e *exampleResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-    var data exampleResourceData
+    if !ok {
+        diags.AddError(
+            "Semantic Equality Check Error",
+            "An unexpected value type was received while performing semantic equality checks. "+
+            "Please report this to the provider developers.\n\n"+
+            "Expected Value Type: "+fmt.Sprintf("%T", v)+"\n"+
+            "Got Value Type: "+fmt.Sprintf("%T", newValuable),
+        )
 
-    diags := req.Config.Get(ctx, &data)
-    resp.Diagnostics.Append(diags...)
-
-    if resp.Diagnostics.HasError() {
         return
     }
 
-    data.ListAttribute.DoSomething(ctx)
-    data.ListNestedAttribute.DoSomething(ctx)
-    data.ListNestedBlock.DoSomething(ctx)
+    // Skipping error checking if CustomStringValue already implemented RFC3339 validation
+    priorTime, _ := time.Parse(time.RFC3339, v.StringValue.ValueString())
 
-    /*...*/
+    // Skipping error checking if CustomStringValue already implemented RFC3339 validation
+    newTime, _ := time.Parse(time.RFC3339, newValue.ValueString())
+
+    // If the times are equivalent, keep the prior value
+    return priorTime.Equal(newTime)
+}
+```
+
+### Validation
+
+Validation handling enables the schema type to automatically raise warning and/or error diagnostics when a value is determined to be invalid. This handling simplifies schema definitions by removing the need for each attribute to repetitively define validators. This schema type functionality is automatically checked by the framework any time a value is created.
+
+Implement the [`xattr.TypeWithValidation`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/attr/xattr#TypeWithValidation) interface on the value type to define and enable this behavior.
+
+<Note>
+
+This functionality uses the lower level [`tftypes`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-go/tftypes) type system compared to other framework logic.
+
+</Note>
+
+In this example, the custom string value type will ensure the string is a valid RFC3339 timestamp:
+
+```go
+// CustomStringType defined in the schema type section
+func (t CustomStringType) Validate(ctx context.Context, value tftypes.Value, valuePath path.Path) diag.Diagnostics {
+    if value.IsNull() || !value.IsKnown() {
+        return nil
+    }
+
+    var diags diags.Diagnostics
+    var valueString string
+
+    if err := value.As(&valueString); err != nil {
+        diags.AddAttributeError(
+            valuePath,
+            "Invalid Terraform Value",
+            "An unexpected error occurred while attempting to convert a Terraform value to a string. "+
+                "This generally is an issue with the provider schema implementation. "+,
+                "Please contact the provider developers.\n\n"+,
+                "Path: "+valuePath.String()+"\n"+
+                "Error: "+err.Error(),
+        ),
+
+        return diags
+    }
+
+    if _, err := time.Parse(time.RFC3339, valueString); err != nil {
+        diags.AddAttributeError(
+            valuePath,
+            "Invalid RFC 3339 String Value",
+            "An unexpected error occurred while converting a string value that was expected to be RFC 3339 format. "+
+                "The RFC 3339 string format is YYYY-MM-DDTHH:MM:SSZ, such as 2006-01-02T15:04:05Z or 2006-01-02T15:04:05+07:00.\n\n",
+                "Path: "+valuePath.String()+"\n"+
+                "Given Value: "+valueString+"\n"+
+                "Error: "+err.Error(),
+        ),
+
+        return diags
+    }
+
+    return diags
 }
 ```


### PR DESCRIPTION
Closes #70

This change set includes an initial implementation of type-based semantic equality functionality for the framework.

Semantic equality functionality enables provider developers to prevent drift detection and certain cases of Terraform data consistency errors, by writing logic that defines when a prior value should be preserved when compared to a new value with inconsequential differences. The definition of inconsequential depends on the context of the value, but typically it refers to when values have equivalent meaning with differing syntax. For example, the JSON specification defines whitespace as optional and object properties as unordered. Remote systems or code libraries may normalize JSON encoded strings into a differing byte ordering and/or length while remaining exactly equivalent in terms of the JSON specification.

Other example use cases:

- Other encodings, such as Base64 or YAML string.
- Networking values, such as an IPv4 address string.
- Time values, such as an RFC3339 string.
- Provider-specific values, such as an AWS ARN or AzureRM location string.

Type-based refers to the logic being baked into the extensible custom type system. This design is preferable over being schema-based, which refers to logic being repetitively coded across multiple attribute definitions. Being type-based means the provider developer can state these intentions by nature of pointing to a custom type which bakes in this logic, rather than needing to remember all the details to duplicate. For example, proper JSON string handling in the prior terraform-plugin-sdk required implementing an attribute as a string type with an appropriate JSON validation reference and JSON normalization reference. With these changes, a bespoke and reusable JSON string type with automatic validation and equivalency handling can be created.

Developers can implement semantic equality logic by implementing a new type-specific interface, which has one method that receives the new value and should return whether the prior value should be preserved or any diagnostics. An example implementation:

```go
// Ensure the implementation satisfies the expected interfaces
// Other value type implementation details are omitted for brevity
var _ basetypes.StringValuableWithSemanticEquals = CustomStringValue{}

func (v CustomStringValue) StringSemanticEquals(ctx context.Context, newValuable basetypes.StringValuable) (bool, diag.Diagnostics) {
    var diags diag.Diagnostics

    // The framework should always pass the correct value type, but always check
    newValue, ok := newValuable.(CustomStringValue)

    if !ok {
        diags.AddError(
            "Semantic Equality Check Error",
            "An unexpected value type was received while performing semantic equality checks. "+
            "Please report this to the provider developers.\n\n"+
            "Expected Value Type: "+fmt.Sprintf("%T", v)+"\n"+
            "Got Value Type: "+fmt.Sprintf("%T", newValuable),
        )

        return
    }

    // Skipping error checking if CustomStringValue already implemented RFC3339 validation
    priorTime, _ := time.Parse(time.RFC3339, v.ValueString())

    // Skipping error checking if CustomStringValue already implemented RFC3339 validation
    newTime, _ := time.Parse(time.RFC3339, newValue.ValueString())

    // If the times are equivalent, keep the prior value
    return priorTime.Equal(newTime)
}
```

This value type functionality is checked in the following scenarios:

- When refreshing a data source, the response state value from the `Read` method logic is compared to the configuration value.
- When refreshing a resource, the response new state value from the `Read` method logic is compared to the request prior state value.
- When creating or updating a resource, the response new state value from the `Create` or `Update` method logic is compared to the request plan value.

The framework will only call semantic equality logic if both the prior and new values are known. Null or unknown values are unnecessary to check.

The website documentation for custom types has been rewritten to remove details more pertinent to the original design of the framework and instead focus on how developers can either use existing custom types or create custom types based on the `basetypes` package `Typable` and `Valuable` interfaces.
