### PR TITLE
Update default-values.mdx

### DIFF
--- a/website/docs/plugin/framework/migrating/attributes-blocks/default-values.mdx
+++ b/website/docs/plugin/framework/migrating/attributes-blocks/default-values.mdx
@@ -47,7 +47,7 @@ func (r *resourceExample) Schema(ctx context.Context, req resource.SchemaRequest
         /* ... */
         Attributes: map[string]schema.Attribute{
             "attribute_example": schema.BoolAttribute{
-                Default: booldefault.StaticValue(true),
+                Default: booldefault.StaticBool(true),
                 /* ... */
 ```
 


### PR DESCRIPTION
The default function for `booldefault` package  should be `StaticBool` instead of `StaticValue`.