### PR TITLE
Update tftypes  -> tfsdk in validation.mdx

### DIFF
--- a/website/docs/plugin/framework/validation.mdx
+++ b/website/docs/plugin/framework/validation.mdx
@@ -192,7 +192,7 @@ func (v int64IsGreaterThanValidator) ValidateInt64(ctx context.Context, req vali
 			// implementation, in this case a types.Int64 value.
 			var matchedPathConfig types.Int64
 
-			diags = tftypes.ValueAs(ctx, matchedPathValue, &matchedPathConfig)
+			diags = tfsdk.ValueAs(ctx, matchedPathValue, &matchedPathConfig)
 
 			resp.Diagnostics.Append(diags...)
 


### PR DESCRIPTION
Fixing the typo in the document.
`tftypes` doesn't have `ValueAs` function. This should be replaced by `tfsdk.ValueAs` from `terraform-plugin-framework@v1.2.0`