### PR TITLE
Handle nested attribute and block definition equality with Equal() methods

### DIFF
--- a/.changes/unreleased/BUG FIXES-20230609-140931.yaml
+++ b/.changes/unreleased/BUG FIXES-20230609-140931.yaml
@@ -1,0 +1,6 @@
+kind: BUG FIXES
+body: 'datasource/schema: Ensure nested attribute and block Equal methods check nested
+  attribute and block definition equality'
+time: 2023-06-09T14:09:31.199452-04:00
+custom:
+  Issue: "752"

--- a/.changes/unreleased/BUG FIXES-20230609-141014.yaml
+++ b/.changes/unreleased/BUG FIXES-20230609-141014.yaml
@@ -1,0 +1,6 @@
+kind: BUG FIXES
+body: 'provider/metaschema: Ensure nested attribute Equal methods check nested attribute
+  definition equality'
+time: 2023-06-09T14:10:14.269839-04:00
+custom:
+  Issue: "752"

--- a/.changes/unreleased/BUG FIXES-20230609-141029.yaml
+++ b/.changes/unreleased/BUG FIXES-20230609-141029.yaml
@@ -1,0 +1,6 @@
+kind: BUG FIXES
+body: 'provider/schema: Ensure nested attribute and block Equal methods check nested
+  attribute and block definition equality'
+time: 2023-06-09T14:10:29.902111-04:00
+custom:
+  Issue: "752"

--- a/.changes/unreleased/BUG FIXES-20230609-141043.yaml
+++ b/.changes/unreleased/BUG FIXES-20230609-141043.yaml
@@ -1,0 +1,6 @@
+kind: BUG FIXES
+body: 'resource/schema: Ensure nested attribute and block Equal methods check nested
+  attribute and block definition equality'
+time: 2023-06-09T14:10:43.2284-04:00
+custom:
+  Issue: "752"

--- a/datasource/schema/list_nested_attribute.go
+++ b/datasource/schema/list_nested_attribute.go
@@ -158,11 +158,13 @@ func (a ListNestedAttribute) ApplyTerraform5AttributePathStep(step tftypes.Attri
 // Equal returns true if the given Attribute is a ListNestedAttribute
 // and all fields are equal.
 func (a ListNestedAttribute) Equal(o fwschema.Attribute) bool {
-	if _, ok := o.(ListNestedAttribute); !ok {
+	other, ok := o.(ListNestedAttribute)
+
+	if !ok {
 		return false
 	}
 
-	return fwschema.AttributesEqual(a, o)
+	return fwschema.NestedAttributesEqual(a, other)
 }
 
 // GetDeprecationMessage returns the DeprecationMessage field value.

--- a/datasource/schema/list_nested_attribute_test.go
+++ b/datasource/schema/list_nested_attribute_test.go
@@ -169,7 +169,28 @@ func TestListNestedAttributeEqual(t *testing.T) {
 			other:    testschema.AttributeWithListValidators{},
 			expected: false,
 		},
-		"different-attributes": {
+		"different-attributes-definitions": {
+			attribute: schema.ListNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{
+							Optional: true,
+						},
+					},
+				},
+			},
+			other: schema.ListNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{
+							Required: true,
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		"different-attributes-types": {
 			attribute: schema.ListNestedAttribute{
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{

--- a/datasource/schema/list_nested_block_test.go
+++ b/datasource/schema/list_nested_block_test.go
@@ -169,7 +169,28 @@ func TestListNestedBlockEqual(t *testing.T) {
 			other:    testschema.BlockWithListValidators{},
 			expected: false,
 		},
-		"different-attributes": {
+		"different-attributes-definitions": {
+			block: schema.ListNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{
+							Optional: true,
+						},
+					},
+				},
+			},
+			other: schema.ListNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{
+							Required: true,
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		"different-attributes-types": {
 			block: schema.ListNestedBlock{
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
@@ -181,6 +202,35 @@ func TestListNestedBlockEqual(t *testing.T) {
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"testattr": schema.BoolAttribute{},
+					},
+				},
+			},
+			expected: false,
+		},
+		"different-blocks-definitions": {
+			block: schema.ListNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Blocks: map[string]schema.Block{
+						"testblock": schema.SingleNestedBlock{
+							Attributes: map[string]schema.Attribute{
+								"testattr": schema.StringAttribute{
+									Optional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			other: schema.ListNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Blocks: map[string]schema.Block{
+						"testblock": schema.SingleNestedBlock{
+							Attributes: map[string]schema.Attribute{
+								"testattr": schema.StringAttribute{
+									Required: true,
+								},
+							},
+						},
 					},
 				},
 			},

--- a/datasource/schema/map_nested_attribute.go
+++ b/datasource/schema/map_nested_attribute.go
@@ -159,11 +159,13 @@ func (a MapNestedAttribute) ApplyTerraform5AttributePathStep(step tftypes.Attrib
 // Equal returns true if the given Attribute is a MapNestedAttribute
 // and all fields are equal.
 func (a MapNestedAttribute) Equal(o fwschema.Attribute) bool {
-	if _, ok := o.(MapNestedAttribute); !ok {
+	other, ok := o.(MapNestedAttribute)
+
+	if !ok {
 		return false
 	}
 
-	return fwschema.AttributesEqual(a, o)
+	return fwschema.NestedAttributesEqual(a, other)
 }
 
 // GetDeprecationMessage returns the DeprecationMessage field value.

--- a/datasource/schema/map_nested_attribute_test.go
+++ b/datasource/schema/map_nested_attribute_test.go
@@ -169,7 +169,28 @@ func TestMapNestedAttributeEqual(t *testing.T) {
 			other:    testschema.AttributeWithMapValidators{},
 			expected: false,
 		},
-		"different-attributes": {
+		"different-attributes-definitions": {
+			attribute: schema.MapNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{
+							Optional: true,
+						},
+					},
+				},
+			},
+			other: schema.MapNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{
+							Required: true,
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		"different-attributes-types": {
 			attribute: schema.MapNestedAttribute{
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{

--- a/datasource/schema/set_nested_attribute.go
+++ b/datasource/schema/set_nested_attribute.go
@@ -154,11 +154,13 @@ func (a SetNestedAttribute) ApplyTerraform5AttributePathStep(step tftypes.Attrib
 // Equal returns true if the given Attribute is a SetNestedAttribute
 // and all fields are equal.
 func (a SetNestedAttribute) Equal(o fwschema.Attribute) bool {
-	if _, ok := o.(SetNestedAttribute); !ok {
+	other, ok := o.(SetNestedAttribute)
+
+	if !ok {
 		return false
 	}
 
-	return fwschema.AttributesEqual(a, o)
+	return fwschema.NestedAttributesEqual(a, other)
 }
 
 // GetDeprecationMessage returns the DeprecationMessage field value.

--- a/datasource/schema/set_nested_attribute_test.go
+++ b/datasource/schema/set_nested_attribute_test.go
@@ -169,7 +169,28 @@ func TestSetNestedAttributeEqual(t *testing.T) {
 			other:    testschema.AttributeWithSetValidators{},
 			expected: false,
 		},
-		"different-attributes": {
+		"different-attributes-definitions": {
+			attribute: schema.SetNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{
+							Optional: true,
+						},
+					},
+				},
+			},
+			other: schema.SetNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{
+							Required: true,
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		"different-attributes-types": {
 			attribute: schema.SetNestedAttribute{
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{

--- a/datasource/schema/set_nested_block_test.go
+++ b/datasource/schema/set_nested_block_test.go
@@ -169,7 +169,28 @@ func TestSetNestedBlockEqual(t *testing.T) {
 			other:    testschema.BlockWithSetValidators{},
 			expected: false,
 		},
-		"different-attributes": {
+		"different-attributes-definitions": {
+			block: schema.SetNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{
+							Optional: true,
+						},
+					},
+				},
+			},
+			other: schema.SetNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{
+							Required: true,
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		"different-attributes-types": {
 			block: schema.SetNestedBlock{
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
@@ -181,6 +202,35 @@ func TestSetNestedBlockEqual(t *testing.T) {
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"testattr": schema.BoolAttribute{},
+					},
+				},
+			},
+			expected: false,
+		},
+		"different-blocks-definitions": {
+			block: schema.SetNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Blocks: map[string]schema.Block{
+						"testblock": schema.SingleNestedBlock{
+							Attributes: map[string]schema.Attribute{
+								"testattr": schema.StringAttribute{
+									Optional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			other: schema.SetNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Blocks: map[string]schema.Block{
+						"testblock": schema.SingleNestedBlock{
+							Attributes: map[string]schema.Attribute{
+								"testattr": schema.StringAttribute{
+									Required: true,
+								},
+							},
+						},
 					},
 				},
 			},

--- a/datasource/schema/single_nested_attribute.go
+++ b/datasource/schema/single_nested_attribute.go
@@ -159,11 +159,13 @@ func (a SingleNestedAttribute) ApplyTerraform5AttributePathStep(step tftypes.Att
 // Equal returns true if the given Attribute is a SingleNestedAttribute
 // and all fields are equal.
 func (a SingleNestedAttribute) Equal(o fwschema.Attribute) bool {
-	if _, ok := o.(SingleNestedAttribute); !ok {
+	other, ok := o.(SingleNestedAttribute)
+
+	if !ok {
 		return false
 	}
 
-	return fwschema.AttributesEqual(a, o)
+	return fwschema.NestedAttributesEqual(a, other)
 }
 
 // GetAttributes returns the Attributes field value.

--- a/datasource/schema/single_nested_attribute_test.go
+++ b/datasource/schema/single_nested_attribute_test.go
@@ -125,7 +125,24 @@ func TestSingleNestedAttributeEqual(t *testing.T) {
 			other:    testschema.AttributeWithObjectValidators{},
 			expected: false,
 		},
-		"different-attributes": {
+		"different-attributes-definitions": {
+			attribute: schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{
+						Optional: true,
+					},
+				},
+			},
+			other: schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{
+						Required: true,
+					},
+				},
+			},
+			expected: false,
+		},
+		"different-attributes-types": {
 			attribute: schema.SingleNestedAttribute{
 				Attributes: map[string]schema.Attribute{
 					"testattr": schema.StringAttribute{},

--- a/datasource/schema/single_nested_block_test.go
+++ b/datasource/schema/single_nested_block_test.go
@@ -181,7 +181,24 @@ func TestSingleNestedBlockEqual(t *testing.T) {
 			other:    testschema.BlockWithObjectValidators{},
 			expected: false,
 		},
-		"different-attributes": {
+		"different-attributes-definitions": {
+			block: schema.SingleNestedBlock{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{
+						Optional: true,
+					},
+				},
+			},
+			other: schema.SingleNestedBlock{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{
+						Required: true,
+					},
+				},
+			},
+			expected: false,
+		},
+		"different-attributes-types": {
 			block: schema.SingleNestedBlock{
 				Attributes: map[string]schema.Attribute{
 					"testattr": schema.StringAttribute{},
@@ -190,6 +207,31 @@ func TestSingleNestedBlockEqual(t *testing.T) {
 			other: schema.SingleNestedBlock{
 				Attributes: map[string]schema.Attribute{
 					"testattr": schema.BoolAttribute{},
+				},
+			},
+			expected: false,
+		},
+		"different-blocks-definitions": {
+			block: schema.SingleNestedBlock{
+				Blocks: map[string]schema.Block{
+					"testblock": schema.SingleNestedBlock{
+						Attributes: map[string]schema.Attribute{
+							"testattr": schema.StringAttribute{
+								Optional: true,
+							},
+						},
+					},
+				},
+			},
+			other: schema.SingleNestedBlock{
+				Blocks: map[string]schema.Block{
+					"testblock": schema.SingleNestedBlock{
+						Attributes: map[string]schema.Attribute{
+							"testattr": schema.StringAttribute{
+								Required: true,
+							},
+						},
+					},
 				},
 			},
 			expected: false,

--- a/internal/fwschema/block.go
+++ b/internal/fwschema/block.go
@@ -85,7 +85,11 @@ func BlocksEqual(a, b Block) bool {
 		return false
 	}
 
-	return true
+	if a.GetNestingMode() != b.GetNestingMode() {
+		return false
+	}
+
+	return a.GetNestedObject().Equal(b.GetNestedObject())
 }
 
 // BlockPathExpressions recursively returns a slice of the current path

--- a/internal/fwschema/nested_attribute.go
+++ b/internal/fwschema/nested_attribute.go
@@ -17,3 +17,18 @@ type NestedAttribute interface {
 	// does not represent nested attributes.
 	GetNestingMode() NestingMode
 }
+
+// NestedAttributesEqual is a helper function to perform equality testing on two
+// NestedAttribute. NestedAttribute Equal implementations should still compare
+// the concrete types in addition to using this helper.
+func NestedAttributesEqual(a, b NestedAttribute) bool {
+	if a.GetNestingMode() != b.GetNestingMode() {
+		return false
+	}
+
+	if !a.GetNestedObject().Equal(b.GetNestedObject()) {
+		return false
+	}
+
+	return AttributesEqual(a, b)
+}

--- a/provider/metaschema/list_nested_attribute.go
+++ b/provider/metaschema/list_nested_attribute.go
@@ -93,11 +93,13 @@ func (a ListNestedAttribute) ApplyTerraform5AttributePathStep(step tftypes.Attri
 // Equal returns true if the given Attribute is a ListNestedAttribute
 // and all fields are equal.
 func (a ListNestedAttribute) Equal(o fwschema.Attribute) bool {
-	if _, ok := o.(ListNestedAttribute); !ok {
+	other, ok := o.(ListNestedAttribute)
+
+	if !ok {
 		return false
 	}
 
-	return fwschema.AttributesEqual(a, o)
+	return fwschema.NestedAttributesEqual(a, other)
 }
 
 // GetDeprecationMessage always returns an empty string as there is no

--- a/provider/metaschema/list_nested_attribute_test.go
+++ b/provider/metaschema/list_nested_attribute_test.go
@@ -162,7 +162,28 @@ func TestListNestedAttributeEqual(t *testing.T) {
 			other:    testschema.AttributeWithListValidators{},
 			expected: false,
 		},
-		"different-attributes": {
+		"different-attributes-definitions": {
+			attribute: metaschema.ListNestedAttribute{
+				NestedObject: metaschema.NestedAttributeObject{
+					Attributes: map[string]metaschema.Attribute{
+						"testattr": metaschema.StringAttribute{
+							Optional: true,
+						},
+					},
+				},
+			},
+			other: metaschema.ListNestedAttribute{
+				NestedObject: metaschema.NestedAttributeObject{
+					Attributes: map[string]metaschema.Attribute{
+						"testattr": metaschema.StringAttribute{
+							Required: true,
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		"different-attributes-types": {
 			attribute: metaschema.ListNestedAttribute{
 				NestedObject: metaschema.NestedAttributeObject{
 					Attributes: map[string]metaschema.Attribute{

--- a/provider/metaschema/map_nested_attribute.go
+++ b/provider/metaschema/map_nested_attribute.go
@@ -93,11 +93,13 @@ func (a MapNestedAttribute) ApplyTerraform5AttributePathStep(step tftypes.Attrib
 // Equal returns true if the given Attribute is a MapNestedAttribute
 // and all fields are equal.
 func (a MapNestedAttribute) Equal(o fwschema.Attribute) bool {
-	if _, ok := o.(MapNestedAttribute); !ok {
+	other, ok := o.(MapNestedAttribute)
+
+	if !ok {
 		return false
 	}
 
-	return fwschema.AttributesEqual(a, o)
+	return fwschema.NestedAttributesEqual(a, other)
 }
 
 // GetDeprecationMessage always returns an empty string as there is no

--- a/provider/metaschema/map_nested_attribute_test.go
+++ b/provider/metaschema/map_nested_attribute_test.go
@@ -162,7 +162,28 @@ func TestMapNestedAttributeEqual(t *testing.T) {
 			other:    testschema.AttributeWithMapValidators{},
 			expected: false,
 		},
-		"different-attributes": {
+		"different-attributes-definitions": {
+			attribute: metaschema.MapNestedAttribute{
+				NestedObject: metaschema.NestedAttributeObject{
+					Attributes: map[string]metaschema.Attribute{
+						"testattr": metaschema.StringAttribute{
+							Optional: true,
+						},
+					},
+				},
+			},
+			other: metaschema.MapNestedAttribute{
+				NestedObject: metaschema.NestedAttributeObject{
+					Attributes: map[string]metaschema.Attribute{
+						"testattr": metaschema.StringAttribute{
+							Required: true,
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		"different-attributes-types": {
 			attribute: metaschema.MapNestedAttribute{
 				NestedObject: metaschema.NestedAttributeObject{
 					Attributes: map[string]metaschema.Attribute{

--- a/provider/metaschema/set_nested_attribute.go
+++ b/provider/metaschema/set_nested_attribute.go
@@ -88,11 +88,13 @@ func (a SetNestedAttribute) ApplyTerraform5AttributePathStep(step tftypes.Attrib
 // Equal returns true if the given Attribute is a SetNestedAttribute
 // and all fields are equal.
 func (a SetNestedAttribute) Equal(o fwschema.Attribute) bool {
-	if _, ok := o.(SetNestedAttribute); !ok {
+	other, ok := o.(SetNestedAttribute)
+
+	if !ok {
 		return false
 	}
 
-	return fwschema.AttributesEqual(a, o)
+	return fwschema.NestedAttributesEqual(a, other)
 }
 
 // GetDeprecationMessage always returns an empty string as there is no

--- a/provider/metaschema/set_nested_attribute_test.go
+++ b/provider/metaschema/set_nested_attribute_test.go
@@ -162,7 +162,28 @@ func TestSetNestedAttributeEqual(t *testing.T) {
 			other:    testschema.AttributeWithSetValidators{},
 			expected: false,
 		},
-		"different-attributes": {
+		"different-attributes-definitions": {
+			attribute: metaschema.SetNestedAttribute{
+				NestedObject: metaschema.NestedAttributeObject{
+					Attributes: map[string]metaschema.Attribute{
+						"testattr": metaschema.StringAttribute{
+							Optional: true,
+						},
+					},
+				},
+			},
+			other: metaschema.SetNestedAttribute{
+				NestedObject: metaschema.NestedAttributeObject{
+					Attributes: map[string]metaschema.Attribute{
+						"testattr": metaschema.StringAttribute{
+							Required: true,
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		"different-attributes-types": {
 			attribute: metaschema.SetNestedAttribute{
 				NestedObject: metaschema.NestedAttributeObject{
 					Attributes: map[string]metaschema.Attribute{

--- a/provider/metaschema/single_nested_attribute.go
+++ b/provider/metaschema/single_nested_attribute.go
@@ -93,11 +93,13 @@ func (a SingleNestedAttribute) ApplyTerraform5AttributePathStep(step tftypes.Att
 // Equal returns true if the given Attribute is a SingleNestedAttribute
 // and all fields are equal.
 func (a SingleNestedAttribute) Equal(o fwschema.Attribute) bool {
-	if _, ok := o.(SingleNestedAttribute); !ok {
+	other, ok := o.(SingleNestedAttribute)
+
+	if !ok {
 		return false
 	}
 
-	return fwschema.AttributesEqual(a, o)
+	return fwschema.NestedAttributesEqual(a, other)
 }
 
 // GetAttributes returns the Attributes field value.

--- a/provider/metaschema/single_nested_attribute_test.go
+++ b/provider/metaschema/single_nested_attribute_test.go
@@ -124,7 +124,24 @@ func TestSingleNestedAttributeEqual(t *testing.T) {
 			other:    testschema.AttributeWithObjectValidators{},
 			expected: false,
 		},
-		"different-attributes": {
+		"different-attributes-definitions": {
+			attribute: metaschema.SingleNestedAttribute{
+				Attributes: map[string]metaschema.Attribute{
+					"testattr": metaschema.StringAttribute{
+						Optional: true,
+					},
+				},
+			},
+			other: metaschema.SingleNestedAttribute{
+				Attributes: map[string]metaschema.Attribute{
+					"testattr": metaschema.StringAttribute{
+						Required: true,
+					},
+				},
+			},
+			expected: false,
+		},
+		"different-attributes-types": {
 			attribute: metaschema.SingleNestedAttribute{
 				Attributes: map[string]metaschema.Attribute{
 					"testattr": metaschema.StringAttribute{},

--- a/provider/schema/list_nested_attribute.go
+++ b/provider/schema/list_nested_attribute.go
@@ -151,11 +151,13 @@ func (a ListNestedAttribute) ApplyTerraform5AttributePathStep(step tftypes.Attri
 // Equal returns true if the given Attribute is a ListNestedAttribute
 // and all fields are equal.
 func (a ListNestedAttribute) Equal(o fwschema.Attribute) bool {
-	if _, ok := o.(ListNestedAttribute); !ok {
+	other, ok := o.(ListNestedAttribute)
+
+	if !ok {
 		return false
 	}
 
-	return fwschema.AttributesEqual(a, o)
+	return fwschema.NestedAttributesEqual(a, other)
 }
 
 // GetDeprecationMessage returns the DeprecationMessage field value.

--- a/provider/schema/list_nested_attribute_test.go
+++ b/provider/schema/list_nested_attribute_test.go
@@ -169,7 +169,28 @@ func TestListNestedAttributeEqual(t *testing.T) {
 			other:    testschema.AttributeWithListValidators{},
 			expected: false,
 		},
-		"different-attributes": {
+		"different-attributes-definitions": {
+			attribute: schema.ListNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{
+							Optional: true,
+						},
+					},
+				},
+			},
+			other: schema.ListNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{
+							Required: true,
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		"different-attributes-types": {
 			attribute: schema.ListNestedAttribute{
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{

--- a/provider/schema/list_nested_block_test.go
+++ b/provider/schema/list_nested_block_test.go
@@ -169,7 +169,28 @@ func TestListNestedBlockEqual(t *testing.T) {
 			other:    testschema.BlockWithListValidators{},
 			expected: false,
 		},
-		"different-attributes": {
+		"different-attributes-definitions": {
+			block: schema.ListNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{
+							Optional: true,
+						},
+					},
+				},
+			},
+			other: schema.ListNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{
+							Required: true,
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		"different-attributes-types": {
 			block: schema.ListNestedBlock{
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
@@ -181,6 +202,35 @@ func TestListNestedBlockEqual(t *testing.T) {
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"testattr": schema.BoolAttribute{},
+					},
+				},
+			},
+			expected: false,
+		},
+		"different-blocks-definitions": {
+			block: schema.ListNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Blocks: map[string]schema.Block{
+						"testblock": schema.SingleNestedBlock{
+							Attributes: map[string]schema.Attribute{
+								"testattr": schema.StringAttribute{
+									Optional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			other: schema.ListNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Blocks: map[string]schema.Block{
+						"testblock": schema.SingleNestedBlock{
+							Attributes: map[string]schema.Attribute{
+								"testattr": schema.StringAttribute{
+									Required: true,
+								},
+							},
+						},
 					},
 				},
 			},

--- a/provider/schema/map_nested_attribute.go
+++ b/provider/schema/map_nested_attribute.go
@@ -152,11 +152,13 @@ func (a MapNestedAttribute) ApplyTerraform5AttributePathStep(step tftypes.Attrib
 // Equal returns true if the given Attribute is a MapNestedAttribute
 // and all fields are equal.
 func (a MapNestedAttribute) Equal(o fwschema.Attribute) bool {
-	if _, ok := o.(MapNestedAttribute); !ok {
+	other, ok := o.(MapNestedAttribute)
+
+	if !ok {
 		return false
 	}
 
-	return fwschema.AttributesEqual(a, o)
+	return fwschema.NestedAttributesEqual(a, other)
 }
 
 // GetDeprecationMessage returns the DeprecationMessage field value.

--- a/provider/schema/map_nested_attribute_test.go
+++ b/provider/schema/map_nested_attribute_test.go
@@ -169,7 +169,28 @@ func TestMapNestedAttributeEqual(t *testing.T) {
 			other:    testschema.AttributeWithMapValidators{},
 			expected: false,
 		},
-		"different-attributes": {
+		"different-attributes-definitions": {
+			attribute: schema.MapNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{
+							Optional: true,
+						},
+					},
+				},
+			},
+			other: schema.MapNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{
+							Required: true,
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		"different-attributes-types": {
 			attribute: schema.MapNestedAttribute{
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{

--- a/provider/schema/set_nested_attribute.go
+++ b/provider/schema/set_nested_attribute.go
@@ -147,11 +147,13 @@ func (a SetNestedAttribute) ApplyTerraform5AttributePathStep(step tftypes.Attrib
 // Equal returns true if the given Attribute is a SetNestedAttribute
 // and all fields are equal.
 func (a SetNestedAttribute) Equal(o fwschema.Attribute) bool {
-	if _, ok := o.(SetNestedAttribute); !ok {
+	other, ok := o.(SetNestedAttribute)
+
+	if !ok {
 		return false
 	}
 
-	return fwschema.AttributesEqual(a, o)
+	return fwschema.NestedAttributesEqual(a, other)
 }
 
 // GetDeprecationMessage returns the DeprecationMessage field value.

--- a/provider/schema/set_nested_attribute_test.go
+++ b/provider/schema/set_nested_attribute_test.go
@@ -169,7 +169,28 @@ func TestSetNestedAttributeEqual(t *testing.T) {
 			other:    testschema.AttributeWithSetValidators{},
 			expected: false,
 		},
-		"different-attributes": {
+		"different-attributes-definitions": {
+			attribute: schema.SetNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{
+							Optional: true,
+						},
+					},
+				},
+			},
+			other: schema.SetNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{
+							Required: true,
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		"different-attributes-types": {
 			attribute: schema.SetNestedAttribute{
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{

--- a/provider/schema/set_nested_block_test.go
+++ b/provider/schema/set_nested_block_test.go
@@ -169,7 +169,28 @@ func TestSetNestedBlockEqual(t *testing.T) {
 			other:    testschema.BlockWithSetValidators{},
 			expected: false,
 		},
-		"different-attributes": {
+		"different-attributes-definitions": {
+			block: schema.SetNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{
+							Optional: true,
+						},
+					},
+				},
+			},
+			other: schema.SetNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{
+							Required: true,
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		"different-attributes-types": {
 			block: schema.SetNestedBlock{
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
@@ -181,6 +202,35 @@ func TestSetNestedBlockEqual(t *testing.T) {
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"testattr": schema.BoolAttribute{},
+					},
+				},
+			},
+			expected: false,
+		},
+		"different-blocks-definitions": {
+			block: schema.SetNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Blocks: map[string]schema.Block{
+						"testblock": schema.SingleNestedBlock{
+							Attributes: map[string]schema.Attribute{
+								"testattr": schema.StringAttribute{
+									Optional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			other: schema.SetNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Blocks: map[string]schema.Block{
+						"testblock": schema.SingleNestedBlock{
+							Attributes: map[string]schema.Attribute{
+								"testattr": schema.StringAttribute{
+									Required: true,
+								},
+							},
+						},
 					},
 				},
 			},

--- a/provider/schema/single_nested_attribute.go
+++ b/provider/schema/single_nested_attribute.go
@@ -152,11 +152,13 @@ func (a SingleNestedAttribute) ApplyTerraform5AttributePathStep(step tftypes.Att
 // Equal returns true if the given Attribute is a SingleNestedAttribute
 // and all fields are equal.
 func (a SingleNestedAttribute) Equal(o fwschema.Attribute) bool {
-	if _, ok := o.(SingleNestedAttribute); !ok {
+	other, ok := o.(SingleNestedAttribute)
+
+	if !ok {
 		return false
 	}
 
-	return fwschema.AttributesEqual(a, o)
+	return fwschema.NestedAttributesEqual(a, other)
 }
 
 // GetAttributes returns the Attributes field value.

--- a/provider/schema/single_nested_attribute_test.go
+++ b/provider/schema/single_nested_attribute_test.go
@@ -125,7 +125,24 @@ func TestSingleNestedAttributeEqual(t *testing.T) {
 			other:    testschema.AttributeWithObjectValidators{},
 			expected: false,
 		},
-		"different-attributes": {
+		"different-attributes-definitions": {
+			attribute: schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{
+						Optional: true,
+					},
+				},
+			},
+			other: schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{
+						Required: true,
+					},
+				},
+			},
+			expected: false,
+		},
+		"different-attributes-types": {
 			attribute: schema.SingleNestedAttribute{
 				Attributes: map[string]schema.Attribute{
 					"testattr": schema.StringAttribute{},

--- a/provider/schema/single_nested_block_test.go
+++ b/provider/schema/single_nested_block_test.go
@@ -181,7 +181,24 @@ func TestSingleNestedBlockEqual(t *testing.T) {
 			other:    testschema.BlockWithObjectValidators{},
 			expected: false,
 		},
-		"different-attributes": {
+		"different-attributes-definitions": {
+			block: schema.SingleNestedBlock{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{
+						Optional: true,
+					},
+				},
+			},
+			other: schema.SingleNestedBlock{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{
+						Required: true,
+					},
+				},
+			},
+			expected: false,
+		},
+		"different-attributes-types": {
 			block: schema.SingleNestedBlock{
 				Attributes: map[string]schema.Attribute{
 					"testattr": schema.StringAttribute{},
@@ -190,6 +207,31 @@ func TestSingleNestedBlockEqual(t *testing.T) {
 			other: schema.SingleNestedBlock{
 				Attributes: map[string]schema.Attribute{
 					"testattr": schema.BoolAttribute{},
+				},
+			},
+			expected: false,
+		},
+		"different-blocks-definitions": {
+			block: schema.SingleNestedBlock{
+				Blocks: map[string]schema.Block{
+					"testblock": schema.SingleNestedBlock{
+						Attributes: map[string]schema.Attribute{
+							"testattr": schema.StringAttribute{
+								Optional: true,
+							},
+						},
+					},
+				},
+			},
+			other: schema.SingleNestedBlock{
+				Blocks: map[string]schema.Block{
+					"testblock": schema.SingleNestedBlock{
+						Attributes: map[string]schema.Attribute{
+							"testattr": schema.StringAttribute{
+								Required: true,
+							},
+						},
+					},
 				},
 			},
 			expected: false,

--- a/resource/schema/list_nested_attribute.go
+++ b/resource/schema/list_nested_attribute.go
@@ -190,11 +190,13 @@ func (a ListNestedAttribute) ApplyTerraform5AttributePathStep(step tftypes.Attri
 // Equal returns true if the given Attribute is a ListNestedAttribute
 // and all fields are equal.
 func (a ListNestedAttribute) Equal(o fwschema.Attribute) bool {
-	if _, ok := o.(ListNestedAttribute); !ok {
+	other, ok := o.(ListNestedAttribute)
+
+	if !ok {
 		return false
 	}
 
-	return fwschema.AttributesEqual(a, o)
+	return fwschema.NestedAttributesEqual(a, other)
 }
 
 // GetDeprecationMessage returns the DeprecationMessage field value.

--- a/resource/schema/list_nested_attribute_test.go
+++ b/resource/schema/list_nested_attribute_test.go
@@ -176,7 +176,28 @@ func TestListNestedAttributeEqual(t *testing.T) {
 			other:    testschema.AttributeWithListValidators{},
 			expected: false,
 		},
-		"different-attributes": {
+		"different-attributes-definitions": {
+			attribute: schema.ListNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{
+							Optional: true,
+						},
+					},
+				},
+			},
+			other: schema.ListNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{
+							Required: true,
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		"different-attributes-types": {
 			attribute: schema.ListNestedAttribute{
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{

--- a/resource/schema/list_nested_block_test.go
+++ b/resource/schema/list_nested_block_test.go
@@ -170,7 +170,28 @@ func TestListNestedBlockEqual(t *testing.T) {
 			other:    testschema.BlockWithListValidators{},
 			expected: false,
 		},
-		"different-attributes": {
+		"different-attributes-definitions": {
+			block: schema.ListNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{
+							Optional: true,
+						},
+					},
+				},
+			},
+			other: schema.ListNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{
+							Required: true,
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		"different-attributes-types": {
 			block: schema.ListNestedBlock{
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
@@ -182,6 +203,35 @@ func TestListNestedBlockEqual(t *testing.T) {
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"testattr": schema.BoolAttribute{},
+					},
+				},
+			},
+			expected: false,
+		},
+		"different-blocks-definitions": {
+			block: schema.ListNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Blocks: map[string]schema.Block{
+						"testblock": schema.SingleNestedBlock{
+							Attributes: map[string]schema.Attribute{
+								"testattr": schema.StringAttribute{
+									Optional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			other: schema.ListNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Blocks: map[string]schema.Block{
+						"testblock": schema.SingleNestedBlock{
+							Attributes: map[string]schema.Attribute{
+								"testattr": schema.StringAttribute{
+									Required: true,
+								},
+							},
+						},
 					},
 				},
 			},

--- a/resource/schema/map_nested_attribute.go
+++ b/resource/schema/map_nested_attribute.go
@@ -190,11 +190,13 @@ func (a MapNestedAttribute) ApplyTerraform5AttributePathStep(step tftypes.Attrib
 // Equal returns true if the given Attribute is a MapNestedAttribute
 // and all fields are equal.
 func (a MapNestedAttribute) Equal(o fwschema.Attribute) bool {
-	if _, ok := o.(MapNestedAttribute); !ok {
+	other, ok := o.(MapNestedAttribute)
+
+	if !ok {
 		return false
 	}
 
-	return fwschema.AttributesEqual(a, o)
+	return fwschema.NestedAttributesEqual(a, other)
 }
 
 // GetDeprecationMessage returns the DeprecationMessage field value.

--- a/resource/schema/map_nested_attribute_test.go
+++ b/resource/schema/map_nested_attribute_test.go
@@ -176,7 +176,28 @@ func TestMapNestedAttributeEqual(t *testing.T) {
 			other:    testschema.AttributeWithMapValidators{},
 			expected: false,
 		},
-		"different-attributes": {
+		"different-attributes-definitions": {
+			attribute: schema.MapNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{
+							Optional: true,
+						},
+					},
+				},
+			},
+			other: schema.MapNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{
+							Required: true,
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		"different-attributes-types": {
 			attribute: schema.MapNestedAttribute{
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{

--- a/resource/schema/set_nested_attribute.go
+++ b/resource/schema/set_nested_attribute.go
@@ -185,11 +185,13 @@ func (a SetNestedAttribute) ApplyTerraform5AttributePathStep(step tftypes.Attrib
 // Equal returns true if the given Attribute is a SetNestedAttribute
 // and all fields are equal.
 func (a SetNestedAttribute) Equal(o fwschema.Attribute) bool {
-	if _, ok := o.(SetNestedAttribute); !ok {
+	other, ok := o.(SetNestedAttribute)
+
+	if !ok {
 		return false
 	}
 
-	return fwschema.AttributesEqual(a, o)
+	return fwschema.NestedAttributesEqual(a, other)
 }
 
 // GetDeprecationMessage returns the DeprecationMessage field value.

--- a/resource/schema/set_nested_attribute_test.go
+++ b/resource/schema/set_nested_attribute_test.go
@@ -176,7 +176,28 @@ func TestSetNestedAttributeEqual(t *testing.T) {
 			other:    testschema.AttributeWithSetValidators{},
 			expected: false,
 		},
-		"different-attributes": {
+		"different-attributes-definitions": {
+			attribute: schema.SetNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{
+							Optional: true,
+						},
+					},
+				},
+			},
+			other: schema.SetNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{
+							Required: true,
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		"different-attributes-types": {
 			attribute: schema.SetNestedAttribute{
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{

--- a/resource/schema/set_nested_block_test.go
+++ b/resource/schema/set_nested_block_test.go
@@ -170,7 +170,28 @@ func TestSetNestedBlockEqual(t *testing.T) {
 			other:    testschema.BlockWithSetValidators{},
 			expected: false,
 		},
-		"different-attributes": {
+		"different-attributes-definitions": {
+			block: schema.SetNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{
+							Optional: true,
+						},
+					},
+				},
+			},
+			other: schema.SetNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{
+							Required: true,
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		"different-attributes-types": {
 			block: schema.SetNestedBlock{
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
@@ -182,6 +203,35 @@ func TestSetNestedBlockEqual(t *testing.T) {
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"testattr": schema.BoolAttribute{},
+					},
+				},
+			},
+			expected: false,
+		},
+		"different-blocks-definitions": {
+			block: schema.SetNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Blocks: map[string]schema.Block{
+						"testblock": schema.SingleNestedBlock{
+							Attributes: map[string]schema.Attribute{
+								"testattr": schema.StringAttribute{
+									Optional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			other: schema.SetNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Blocks: map[string]schema.Block{
+						"testblock": schema.SingleNestedBlock{
+							Attributes: map[string]schema.Attribute{
+								"testattr": schema.StringAttribute{
+									Required: true,
+								},
+							},
+						},
 					},
 				},
 			},

--- a/resource/schema/single_nested_attribute.go
+++ b/resource/schema/single_nested_attribute.go
@@ -190,11 +190,13 @@ func (a SingleNestedAttribute) ApplyTerraform5AttributePathStep(step tftypes.Att
 // Equal returns true if the given Attribute is a SingleNestedAttribute
 // and all fields are equal.
 func (a SingleNestedAttribute) Equal(o fwschema.Attribute) bool {
-	if _, ok := o.(SingleNestedAttribute); !ok {
+	other, ok := o.(SingleNestedAttribute)
+
+	if !ok {
 		return false
 	}
 
-	return fwschema.AttributesEqual(a, o)
+	return fwschema.NestedAttributesEqual(a, other)
 }
 
 // GetAttributes returns the Attributes field value.

--- a/resource/schema/single_nested_attribute_test.go
+++ b/resource/schema/single_nested_attribute_test.go
@@ -132,7 +132,24 @@ func TestSingleNestedAttributeEqual(t *testing.T) {
 			other:    testschema.AttributeWithObjectValidators{},
 			expected: false,
 		},
-		"different-attributes": {
+		"different-attributes-definitions": {
+			attribute: schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{
+						Optional: true,
+					},
+				},
+			},
+			other: schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{
+						Required: true,
+					},
+				},
+			},
+			expected: false,
+		},
+		"different-attributes-types": {
 			attribute: schema.SingleNestedAttribute{
 				Attributes: map[string]schema.Attribute{
 					"testattr": schema.StringAttribute{},

--- a/resource/schema/single_nested_block_test.go
+++ b/resource/schema/single_nested_block_test.go
@@ -182,7 +182,24 @@ func TestSingleNestedBlockEqual(t *testing.T) {
 			other:    testschema.BlockWithObjectValidators{},
 			expected: false,
 		},
-		"different-attributes": {
+		"different-attributes-definitions": {
+			block: schema.SingleNestedBlock{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{
+						Optional: true,
+					},
+				},
+			},
+			other: schema.SingleNestedBlock{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{
+						Required: true,
+					},
+				},
+			},
+			expected: false,
+		},
+		"different-attributes-types": {
 			block: schema.SingleNestedBlock{
 				Attributes: map[string]schema.Attribute{
 					"testattr": schema.StringAttribute{},
@@ -191,6 +208,31 @@ func TestSingleNestedBlockEqual(t *testing.T) {
 			other: schema.SingleNestedBlock{
 				Attributes: map[string]schema.Attribute{
 					"testattr": schema.BoolAttribute{},
+				},
+			},
+			expected: false,
+		},
+		"different-blocks-definitions": {
+			block: schema.SingleNestedBlock{
+				Blocks: map[string]schema.Block{
+					"testblock": schema.SingleNestedBlock{
+						Attributes: map[string]schema.Attribute{
+							"testattr": schema.StringAttribute{
+								Optional: true,
+							},
+						},
+					},
+				},
+			},
+			other: schema.SingleNestedBlock{
+				Blocks: map[string]schema.Block{
+					"testblock": schema.SingleNestedBlock{
+						Attributes: map[string]schema.Attribute{
+							"testattr": schema.StringAttribute{
+								Required: true,
+							},
+						},
+					},
 				},
 			},
 			expected: false,


### PR DESCRIPTION
Closes #752

Previously before logic updates:

```
--- FAIL: TestSingleNestedAttributeEqual (0.00s)
    --- FAIL: TestSingleNestedAttributeEqual/different-attribute-definitions (0.00s)
        /Users/bflad/src/github.com/hashicorp/terraform-plugin-framework/datasource/schema/single_nested_attribute_test.go:182: unexpected difference:   bool(
            - 	true,
            + 	false,
              )
```