### PR TITLE
types/basetypes: Prevent panics in `ListType`, `MapType`, and `SetType` methods when `ElemType` field is not set

### DIFF
--- a/.changes/unreleased/BUG FIXES-20230609-162628.yaml
+++ b/.changes/unreleased/BUG FIXES-20230609-162628.yaml
@@ -1,0 +1,6 @@
+kind: BUG FIXES
+body: 'types/basetypes: Prevented panics in `ListType`, `MapType`, and `SetType` methods
+  when `ElemType` field is not set'
+time: 2023-06-09T16:26:28.570821-04:00
+custom:
+  Issue: "714"

--- a/internal/reflect/struct_test.go
+++ b/internal/reflect/struct_test.go
@@ -946,9 +946,7 @@ func TestFromStruct_errors(t *testing.T) {
 					"An unexpected error was encountered while verifying an attribute value matched its expected type to prevent unexpected behavior or panics. "+
 						"This is always an error in the provider. Please report the following to the provider developer:\n\n"+
 						"Expected type: types.ListType[basetypes.StringType]\n"+
-						// TODO: Prevent panics with (basetypes.ListType).ElementType() when ElemType is nil
-						// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/714
-						"Value type: %!s(PANIC=String method: runtime error: invalid memory address or nil pointer dereference)\n"+
+						"Value type: types.ListType[!!! MISSING TYPE !!!]\n"+
 						"Path: test.list",
 				),
 			},
@@ -973,9 +971,7 @@ func TestFromStruct_errors(t *testing.T) {
 					"An unexpected error was encountered while verifying an attribute value matched its expected type to prevent unexpected behavior or panics. "+
 						"This is always an error in the provider. Please report the following to the provider developer:\n\n"+
 						"Expected type: types.MapType[basetypes.StringType]\n"+
-						// TODO: Prevent panics with (basetypes.MapType).ElementType() when ElemType is nil
-						// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/714
-						"Value type: %!s(PANIC=String method: runtime error: invalid memory address or nil pointer dereference)\n"+
+						"Value type: types.MapType[!!! MISSING TYPE !!!]\n"+
 						"Path: test.map",
 				),
 			},
@@ -1028,9 +1024,7 @@ func TestFromStruct_errors(t *testing.T) {
 					"An unexpected error was encountered while verifying an attribute value matched its expected type to prevent unexpected behavior or panics. "+
 						"This is always an error in the provider. Please report the following to the provider developer:\n\n"+
 						"Expected type: types.SetType[basetypes.StringType]\n"+
-						// TODO: Prevent panics with (basetypes.SetType).ElementType() when ElemType is nil
-						// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/714
-						"Value type: %!s(PANIC=String method: runtime error: invalid memory address or nil pointer dereference)\n"+
+						"Value type: types.SetType[!!! MISSING TYPE !!!]\n"+
 						"Path: test.set",
 				),
 			},

--- a/types/basetypes/list_type.go
+++ b/types/basetypes/list_type.go
@@ -34,6 +34,10 @@ type ListType struct {
 
 // ElementType returns the attr.Type elements will be created from.
 func (l ListType) ElementType() attr.Type {
+	if l.ElemType == nil {
+		return missingType{}
+	}
+
 	return l.ElemType
 }
 
@@ -50,7 +54,7 @@ func (l ListType) WithElementType(typ attr.Type) attr.TypeWithElementType {
 // can understand.
 func (l ListType) TerraformType(ctx context.Context) tftypes.Type {
 	return tftypes.List{
-		ElementType: l.ElemType.TerraformType(ctx),
+		ElementType: l.ElementType().TerraformType(ctx),
 	}
 }
 
@@ -59,16 +63,16 @@ func (l ListType) TerraformType(ctx context.Context) tftypes.Type {
 // type for the provider to consume the data with.
 func (l ListType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
 	if in.Type() == nil {
-		return NewListNull(l.ElemType), nil
+		return NewListNull(l.ElementType()), nil
 	}
 	if !in.Type().Equal(l.TerraformType(ctx)) {
-		return nil, fmt.Errorf("can't use %s as value of List with ElementType %T, can only use %s values", in.String(), l.ElemType, l.ElemType.TerraformType(ctx).String())
+		return nil, fmt.Errorf("can't use %s as value of List with ElementType %T, can only use %s values", in.String(), l.ElementType(), l.ElementType().TerraformType(ctx).String())
 	}
 	if !in.IsKnown() {
-		return NewListUnknown(l.ElemType), nil
+		return NewListUnknown(l.ElementType()), nil
 	}
 	if in.IsNull() {
-		return NewListNull(l.ElemType), nil
+		return NewListNull(l.ElementType()), nil
 	}
 	val := []tftypes.Value{}
 	err := in.As(&val)
@@ -77,7 +81,7 @@ func (l ListType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (att
 	}
 	elems := make([]attr.Value, 0, len(val))
 	for _, elem := range val {
-		av, err := l.ElemType.ValueFromTerraform(ctx, elem)
+		av, err := l.ElementType().ValueFromTerraform(ctx, elem)
 		if err != nil {
 			return nil, err
 		}
@@ -85,19 +89,23 @@ func (l ListType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (att
 	}
 	// ValueFromTerraform above on each element should make this safe.
 	// Otherwise, this will need to do some Diagnostics to error conversion.
-	return NewListValueMust(l.ElemType, elems), nil
+	return NewListValueMust(l.ElementType(), elems), nil
 }
 
 // Equal returns true if `o` is also a ListType and has the same ElemType.
 func (l ListType) Equal(o attr.Type) bool {
-	if l.ElemType == nil {
+	// Preserve prior ElemType nil check behavior
+	if l.ElementType().Equal(missingType{}) {
 		return false
 	}
+
 	other, ok := o.(ListType)
+
 	if !ok {
 		return false
 	}
-	return l.ElemType.Equal(other.ElemType)
+
+	return l.ElementType().Equal(other.ElementType())
 }
 
 // ApplyTerraform5AttributePathStep applies the given AttributePathStep to the
@@ -107,12 +115,12 @@ func (l ListType) ApplyTerraform5AttributePathStep(step tftypes.AttributePathSte
 		return nil, fmt.Errorf("cannot apply step %T to ListType", step)
 	}
 
-	return l.ElemType, nil
+	return l.ElementType(), nil
 }
 
 // String returns a human-friendly description of the ListType.
 func (l ListType) String() string {
-	return "types.ListType[" + l.ElemType.String() + "]"
+	return "types.ListType[" + l.ElementType().String() + "]"
 }
 
 // Validate validates all elements of the list that are of type
@@ -149,7 +157,7 @@ func (l ListType) Validate(ctx context.Context, in tftypes.Value, path path.Path
 		return diags
 	}
 
-	validatableType, isValidatable := l.ElemType.(xattr.TypeWithValidate)
+	validatableType, isValidatable := l.ElementType().(xattr.TypeWithValidate)
 	if !isValidatable {
 		return diags
 	}
@@ -167,7 +175,7 @@ func (l ListType) Validate(ctx context.Context, in tftypes.Value, path path.Path
 // ValueType returns the Value type.
 func (l ListType) ValueType(_ context.Context) attr.Value {
 	return ListValue{
-		elementType: l.ElemType,
+		elementType: l.ElementType(),
 	}
 }
 

--- a/types/basetypes/missing_type.go
+++ b/types/basetypes/missing_type.go
@@ -1,0 +1,59 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package basetypes
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+var _ attr.Type = missingType{}
+
+// missingType is a placeholder attr.Type implementation for when type
+// information is missing. This type is never valid for real usage, which is why
+// it is unexported, but it is primarily used by other base types when an
+// expected attr.Type field is nil for panic prevention and troubleshooting.
+// Ideally those other base type implementations would make it impossible to
+// create a situation which needs this, but those exported APIs are protected by
+// compatibility promises until a major version.
+type missingType struct{}
+
+// ApplyTerraform5AttributePathStep always returns an error.
+func (t missingType) ApplyTerraform5AttributePathStep(step tftypes.AttributePathStep) (interface{}, error) {
+	return nil, fmt.Errorf("cannot apply AttributePathStep %T to %s", step, t.String())
+}
+
+// Equal returns true if the given type is equivalent.
+func (t missingType) Equal(o attr.Type) bool {
+	_, ok := o.(missingType)
+
+	return ok
+}
+
+// String returns a human readable string of the type.
+func (t missingType) String() string {
+	return "!!! MISSING TYPE !!!"
+}
+
+// TerraformType returns DynamicPseudoType.
+func (t missingType) TerraformType(_ context.Context) tftypes.Type {
+	// Ideally, upstream would implement an "invalid" primitive type for this
+	// situation, but DynamicPseudoType is an alternative unexpected type in
+	// the framework until it potentially implements its own dynamic type
+	// handling.
+	return tftypes.DynamicPseudoType
+}
+
+// ValueFromTerraform always returns an error.
+func (t missingType) ValueFromTerraform(_ context.Context, _ tftypes.Value) (attr.Value, error) {
+	return missingValue{}, fmt.Errorf("missing type information; cannot create value")
+}
+
+// ValueType returns the missingValue type.
+func (t missingType) ValueType(_ context.Context) attr.Value {
+	return missingValue{}
+}

--- a/types/basetypes/missing_value.go
+++ b/types/basetypes/missing_value.go
@@ -1,0 +1,61 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package basetypes
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+var _ attr.Value = missingValue{}
+
+// missingValue is a placeholder attr.Value implementation for when type
+// information is missing. This type is never valid for real usage, which is why
+// it is unexported, but it is primarily used by other base types when an
+// expected attr.Value field is nil for panic prevention and troubleshooting.
+// Ideally those other base type implementations would make it impossible to
+// create a situation which needs this, but those exported APIs are protected by
+// compatibility promises until a major version.
+type missingValue struct{}
+
+// Equal returns true if the given value is a missingValue.
+func (v missingValue) Equal(o attr.Value) bool {
+	_, ok := o.(missingValue)
+
+	return ok
+}
+
+// IsNull returns false.
+func (v missingValue) IsNull() bool {
+	// Short of causing a panic, this method must choose a return value and
+	// false was chosen so it is always "known".
+	return false
+}
+
+// IsUnknown returns false.
+func (v missingValue) IsUnknown() bool {
+	// Short of causing a panic, this method must choose a return value and
+	// false was chosen so it is always "known".
+	return false
+}
+
+// String returns a human-readable representation of the value.
+//
+// The string returned here is not protected by any compatibility guarantees,
+// and is intended for logging and error reporting.
+func (v missingValue) String() string {
+	return "!!! MISSING VALUE !!!"
+}
+
+// ToTerraformValue always returns an error.
+func (v missingValue) ToTerraformValue(_ context.Context) (tftypes.Value, error) {
+	return tftypes.Value{}, nil
+}
+
+// Type returns missingType.
+func (v missingValue) Type(_ context.Context) attr.Type {
+	return missingType{}
+}

--- a/types/basetypes/object_type_test.go
+++ b/types/basetypes/object_type_test.go
@@ -377,3 +377,39 @@ func TestObjectTypeEqual(t *testing.T) {
 		})
 	}
 }
+
+func TestObjectTypeString(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		input    ObjectType
+		expected string
+	}{
+		"AttrTypes-empty": {
+			input:    ObjectType{AttrTypes: map[string]attr.Type{}},
+			expected: "types.ObjectType[]",
+		},
+		"AttrTypes-known": {
+			input:    ObjectType{AttrTypes: map[string]attr.Type{"testattr": StringType{}}},
+			expected: "types.ObjectType[\"testattr\":basetypes.StringType]",
+		},
+		"AttrTypes-missing": {
+			input:    ObjectType{},
+			expected: "types.ObjectType[]", // intentionally similar to empty
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.input.String()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #714

Previously before logic updates:

```
--- FAIL: TestListTypeString (0.00s)
    --- FAIL: TestListTypeString/ElemType-missing (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x28 pc=0x102ff0068]

goroutine 19 [running]:
testing.tRunner.func1.2({0x1030efe00, 0x1032e7b10})
	/opt/homebrew/Cellar/go/1.20.5/libexec/src/testing/testing.go:1526 +0x1c8
testing.tRunner.func1()
	/opt/homebrew/Cellar/go/1.20.5/libexec/src/testing/testing.go:1529 +0x384
panic({0x1030efe00, 0x1032e7b10})
	/opt/homebrew/Cellar/go/1.20.5/libexec/src/runtime/panic.go:884 +0x204
github.com/hashicorp/terraform-plugin-framework/types/basetypes.ListType.String(...)
	/Users/bflad/src/github.com/hashicorp/terraform-plugin-framework/types/basetypes/list_type.go:115
github.com/hashicorp/terraform-plugin-framework/types/basetypes.TestListTypeString.func1(0x14000082ea0)
	/Users/bflad/src/github.com/hashicorp/terraform-plugin-framework/types/basetypes/list_type_test.go:287 +0x48
testing.tRunner(0x14000082ea0, 0x1400009a6f0)
	/opt/homebrew/Cellar/go/1.20.5/libexec/src/testing/testing.go:1576 +0x10c
created by testing.(*T).Run
	/opt/homebrew/Cellar/go/1.20.5/libexec/src/testing/testing.go:1629 +0x368

--- FAIL: TestListTypeTerraformType (0.00s)
    --- FAIL: TestListTypeTerraformType/ElemType-missing (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x30 pc=0x104acdd8c]

goroutine 38 [running]:
testing.tRunner.func1.2({0x104bd45a0, 0x104dcbb10})
	/opt/homebrew/Cellar/go/1.20.5/libexec/src/testing/testing.go:1526 +0x1c8
testing.tRunner.func1()
	/opt/homebrew/Cellar/go/1.20.5/libexec/src/testing/testing.go:1529 +0x384
panic({0x104bd45a0, 0x104dcbb10})
	/opt/homebrew/Cellar/go/1.20.5/libexec/src/runtime/panic.go:884 +0x204
github.com/hashicorp/terraform-plugin-framework/types/basetypes.ListType.TerraformType(...)
	/Users/bflad/src/github.com/hashicorp/terraform-plugin-framework/types/basetypes/list_type.go:53
github.com/hashicorp/terraform-plugin-framework/types/basetypes.TestListTypeTerraformType.func1(0x14000103860)
	/Users/bflad/src/github.com/hashicorp/terraform-plugin-framework/types/basetypes/list_type_test.go:71 +0x5c
testing.tRunner(0x14000103860, 0x1400011c9f0)
	/opt/homebrew/Cellar/go/1.20.5/libexec/src/testing/testing.go:1576 +0x10c
created by testing.(*T).Run
	/opt/homebrew/Cellar/go/1.20.5/libexec/src/testing/testing.go:1629 +0x368

--- FAIL: TestListTypeValueFromTerraform (0.00s)
    --- FAIL: TestListTypeValueFromTerraform/missing-element-type (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x30 pc=0x10515a414]

goroutine 28 [running]:
testing.tRunner.func1.2({0x1052785a0, 0x10546fb10})
	/opt/homebrew/Cellar/go/1.20.5/libexec/src/testing/testing.go:1526 +0x1c8
testing.tRunner.func1()
	/opt/homebrew/Cellar/go/1.20.5/libexec/src/testing/testing.go:1529 +0x384
panic({0x1052785a0, 0x10546fb10})
	/opt/homebrew/Cellar/go/1.20.5/libexec/src/runtime/panic.go:884 +0x204
github.com/hashicorp/terraform-plugin-framework/types/basetypes.ListType.ValueFromTerraform({{0x0?, 0x0?}}, {0x1052c5630, 0x140000a4018}, {{0x1052c70d0?, 0x140000a35c0?}, {0x1052599c0?, 0x140000b62b8?}})
	/Users/bflad/src/github.com/hashicorp/terraform-plugin-framework/types/basetypes/list_type.go:61 +0x64
github.com/hashicorp/terraform-plugin-framework/types/basetypes.TestListTypeValueFromTerraform.func1(0x140001389c0)
	/Users/bflad/src/github.com/hashicorp/terraform-plugin-framework/types/basetypes/list_type_test.go:195 +0x60
testing.tRunner(0x140001389c0, 0x140000928a0)
	/opt/homebrew/Cellar/go/1.20.5/libexec/src/testing/testing.go:1576 +0x10c
created by testing.(*T).Run
	/opt/homebrew/Cellar/go/1.20.5/libexec/src/testing/testing.go:1629 +0x368
```