### PR TITLE
Adjust `NestedAttributesEqual` to perform shallow compare first

### DIFF
--- a/internal/fwschema/nested_attribute.go
+++ b/internal/fwschema/nested_attribute.go
@@ -22,13 +22,13 @@ type NestedAttribute interface {
 // NestedAttribute. NestedAttribute Equal implementations should still compare
 // the concrete types in addition to using this helper.
 func NestedAttributesEqual(a, b NestedAttribute) bool {
+	if !AttributesEqual(a, b) {
+		return false
+	}
+
 	if a.GetNestingMode() != b.GetNestingMode() {
 		return false
 	}
 
-	if !a.GetNestedObject().Equal(b.GetNestedObject()) {
-		return false
-	}
-
-	return AttributesEqual(a, b)
+	return a.GetNestedObject().Equal(b.GetNestedObject())
 }


### PR DESCRIPTION
Follow-up to #753 

Adjusts the `NestedAttributesEqual` method to perform the compare on the "shallow" portions of the attribute before comparing the nested attributes, similar to `BlocksEqual`: https://github.com/hashicorp/terraform-plugin-framework/blob/532797d138849d5b4404b7711157f360fe0decc2/internal/fwschema/block.go#L71