### PR TITLE
docs: Fix missing return value  on custom-types.mdx

### DIFF
--- a/website/docs/plugin/framework/handling-data/custom-types.mdx
+++ b/website/docs/plugin/framework/handling-data/custom-types.mdx
@@ -271,7 +271,7 @@ func (v CustomStringValue) StringSemanticEquals(ctx context.Context, newValuable
             "Got Value Type: "+fmt.Sprintf("%T", newValuable),
         )
 
-        return
+        return false, diags
     }
 
     // Skipping error checking if CustomStringValue already implemented RFC3339 validation
@@ -281,7 +281,7 @@ func (v CustomStringValue) StringSemanticEquals(ctx context.Context, newValuable
     newTime, _ := time.Parse(time.RFC3339, newValue.ValueString())
 
     // If the times are equivalent, keep the prior value
-    return priorTime.Equal(newTime)
+    return priorTime.Equal(newTime), diags
 }
 ```
 


### PR DESCRIPTION
Fix minor error in custom-types.mdx, the StringSemanticEquals override presented as a sample does not appear to have a return value `diag.Diagnostics`

I'm not familiar with Golang yet, so if I'm wrong, please let me know :)