### PR TITLE
Fix missing word in documentation

### DIFF
--- a/website/docs/plugin/framework/diagnostics.mdx
+++ b/website/docs/plugin/framework/diagnostics.mdx
@@ -48,7 +48,7 @@ working with diagnostics, using functionality from the available
 
 ### Severity
 
-`Severity` specifies whether the diagnostic is an error or a warning. Terraform, nor the framework, supports other severity levels. Use [logging](/terraform/plugin/log/writing) for debugging or informational purposes.
+`Severity` specifies whether the diagnostic is an error or a warning. Neither Terraform, nor the framework, supports other severity levels. Use [logging](/terraform/plugin/log/writing) for debugging or informational purposes.
 
 - An **error** will be displayed to the practitioner and halt Terraform's
   execution, not continuing to apply changes to later resources in the graph.


### PR DESCRIPTION
Missing "Neither" from the sentence.