### PR TITLE
internal/fwschemadata: Prevent panics in `ValueSemanticEqualityListElements` and `ValueSemanticEqualitySetElements` methods when the length of `newValueElements` is greater than `priorValueElements`

### DIFF
--- a/.changes/unreleased/BUG FIXES-20230614-142449.yaml
+++ b/.changes/unreleased/BUG FIXES-20230614-142449.yaml
@@ -1,0 +1,6 @@
+kind: BUG FIXES
+body: 'types/basetypes: Prevented panic with `ListTypableWithSemanticEquals` and `SetTypableWithSemanticEquals`
+  when proposed new element count was greater than prior element count'
+time: 2023-06-14T14:24:49.334761-04:00
+custom:
+  Issue: "772"

--- a/internal/fwschemadata/value_semantic_equality_list.go
+++ b/internal/fwschemadata/value_semantic_equality_list.go
@@ -136,7 +136,7 @@ func ValueSemanticEqualityListElements(ctx context.Context, req ValueSemanticEqu
 		// Ensure new value always contains all of proposed new value
 		newValueElements[idx] = proposedNewValueElement
 
-		if idx > len(priorValueElements) {
+		if idx >= len(priorValueElements) {
 			continue
 		}
 

--- a/internal/fwschemadata/value_semantic_equality_list_test.go
+++ b/internal/fwschemadata/value_semantic_equality_list_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschemadata"
@@ -326,6 +327,81 @@ func TestValueSemanticEqualityList(t *testing.T) {
 								testtypes.StringValueWithSemanticEquals{
 									StringValue:    types.StringValue("new"),
 									SemanticEquals: false,
+								},
+							},
+						),
+					},
+				),
+			},
+		},
+		"ListValue-ListValue-StringValuableWithSemanticEquals-NewValueElementsGreaterThanPriorValueElements": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: types.ListValueMust(
+					types.ListType{
+						ElemType: testtypes.StringTypeWithSemanticEquals{
+							SemanticEquals: true,
+						},
+					},
+					[]attr.Value{
+						types.ListValueMust(
+							testtypes.StringTypeWithSemanticEquals{
+								SemanticEquals: true,
+							},
+							[]attr.Value{
+								testtypes.StringValueWithSemanticEquals{
+									StringValue:    types.StringValue("prior"),
+									SemanticEquals: true,
+								},
+							},
+						),
+					},
+				),
+				ProposedNewValue: types.ListValueMust(
+					types.ListType{
+						ElemType: testtypes.StringTypeWithSemanticEquals{
+							SemanticEquals: true,
+						},
+					},
+					[]attr.Value{
+						types.ListValueMust(
+							testtypes.StringTypeWithSemanticEquals{
+								SemanticEquals: true,
+							},
+							[]attr.Value{
+								testtypes.StringValueWithSemanticEquals{
+									StringValue:    types.StringValue("new1"),
+									SemanticEquals: true,
+								},
+								testtypes.StringValueWithSemanticEquals{
+									StringValue:    types.StringValue("new2"),
+									SemanticEquals: true,
+								},
+							},
+						),
+					},
+				),
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: types.ListValueMust(
+					types.ListType{
+						ElemType: testtypes.StringTypeWithSemanticEquals{
+							SemanticEquals: true,
+						},
+					},
+					[]attr.Value{
+						types.ListValueMust(
+							testtypes.StringTypeWithSemanticEquals{
+								SemanticEquals: true,
+							},
+							[]attr.Value{
+								testtypes.StringValueWithSemanticEquals{
+									StringValue:    types.StringValue("prior"),
+									SemanticEquals: true,
+								},
+								testtypes.StringValueWithSemanticEquals{
+									StringValue:    types.StringValue("new2"),
+									SemanticEquals: true,
 								},
 							},
 						),

--- a/internal/fwschemadata/value_semantic_equality_set.go
+++ b/internal/fwschemadata/value_semantic_equality_set.go
@@ -136,7 +136,7 @@ func ValueSemanticEqualitySetElements(ctx context.Context, req ValueSemanticEqua
 		// Ensure new value always contains all of proposed new value
 		newValueElements[idx] = proposedNewValueElement
 
-		if idx > len(priorValueElements) {
+		if idx >= len(priorValueElements) {
 			continue
 		}
 

--- a/internal/fwschemadata/value_semantic_equality_set_test.go
+++ b/internal/fwschemadata/value_semantic_equality_set_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschemadata"
@@ -326,6 +327,81 @@ func TestValueSemanticEqualitySet(t *testing.T) {
 								testtypes.StringValueWithSemanticEquals{
 									StringValue:    types.StringValue("new"),
 									SemanticEquals: false,
+								},
+							},
+						),
+					},
+				),
+			},
+		},
+		"SetValue-SetValue-StringValuableWithSemanticEquals-NewValueElementsGreaterThanPriorValueElements": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: types.SetValueMust(
+					types.SetType{
+						ElemType: testtypes.StringTypeWithSemanticEquals{
+							SemanticEquals: true,
+						},
+					},
+					[]attr.Value{
+						types.SetValueMust(
+							testtypes.StringTypeWithSemanticEquals{
+								SemanticEquals: true,
+							},
+							[]attr.Value{
+								testtypes.StringValueWithSemanticEquals{
+									StringValue:    types.StringValue("prior"),
+									SemanticEquals: true,
+								},
+							},
+						),
+					},
+				),
+				ProposedNewValue: types.SetValueMust(
+					types.SetType{
+						ElemType: testtypes.StringTypeWithSemanticEquals{
+							SemanticEquals: true,
+						},
+					},
+					[]attr.Value{
+						types.SetValueMust(
+							testtypes.StringTypeWithSemanticEquals{
+								SemanticEquals: true,
+							},
+							[]attr.Value{
+								testtypes.StringValueWithSemanticEquals{
+									StringValue:    types.StringValue("new1"),
+									SemanticEquals: true,
+								},
+								testtypes.StringValueWithSemanticEquals{
+									StringValue:    types.StringValue("new2"),
+									SemanticEquals: true,
+								},
+							},
+						),
+					},
+				),
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: types.SetValueMust(
+					types.SetType{
+						ElemType: testtypes.StringTypeWithSemanticEquals{
+							SemanticEquals: true,
+						},
+					},
+					[]attr.Value{
+						types.SetValueMust(
+							testtypes.StringTypeWithSemanticEquals{
+								SemanticEquals: true,
+							},
+							[]attr.Value{
+								testtypes.StringValueWithSemanticEquals{
+									StringValue:    types.StringValue("prior"),
+									SemanticEquals: true,
+								},
+								testtypes.StringValueWithSemanticEquals{
+									StringValue:    types.StringValue("new2"),
+									SemanticEquals: true,
 								},
 							},
 						),


### PR DESCRIPTION
Prevents panics when using `types.ListType` and `types.SetType` attributes with a nested `ElementType` with semantic equality and the proposed new value elements is greater than the prior value elements. 

Covering tests results before logic update:

```
--- FAIL: TestValueSemanticEqualityList (0.00s)
    --- FAIL: TestValueSemanticEqualityList/ListValue-ListValue-StringValuableWithSemanticEquals-NewValueElementsGreaterThanPriorValueElements (0.00s)
panic: runtime error: index out of range [1] with length 1 [recovered]
	panic: runtime error: index out of range [1] with length 1

goroutine 5 [running]:
testing.tRunner.func1.2({0x100c59dc0, 0x140000180d8})
	/opt/homebrew/Cellar/go/1.19.4/libexec/src/testing/testing.go:1396 +0x1c8
testing.tRunner.func1()
	/opt/homebrew/Cellar/go/1.19.4/libexec/src/testing/testing.go:1399 +0x378
panic({0x100c59dc0, 0x140000180d8})
	/opt/homebrew/Cellar/go/1.19.4/libexec/src/runtime/panic.go:884 +0x204
github.com/hashicorp/terraform-plugin-framework/internal/fwschemadata.ValueSemanticEqualityListElements({0x100c7dd80, 0x14000065ec0}, {{{0x140001198a0, 0x2, 0x2}}, {0x100c7ee48, 0x14000064f30}, {0x100c7ee48, 0x14000064f60}}, 0x14000065e60)
	/Users/sgoods/Hashicorp/terraform-plugin-framework/internal/fwschemadata/value_semantic_equality_list.go:145 +0xa20
github.com/hashicorp/terraform-plugin-framework/internal/fwschemadata.ValueSemanticEqualityList({0x100c7dd80, 0x14000065ec0}, {{{0x140001198a0, 0x2, 0x2}}, {0x100c7ee48, 0x14000064f30}, {0x100c7ee48, 0x14000064f60}}, 0x14000065e60)
	/Users/sgoods/Hashicorp/terraform-plugin-framework/internal/fwschemadata/value_semantic_equality_list.go:27 +0x314
github.com/hashicorp/terraform-plugin-framework/internal/fwschemadata.ValueSemanticEquality({0x100c7dd10, 0x1400001c100}, {{{0x140001198a0, 0x2, 0x2}}, {0x100c7ee48, 0x14000064f30}, {0x100c7ee48, 0x14000064f60}}, 0x14000065e60)
	/Users/sgoods/Hashicorp/terraform-plugin-framework/internal/fwschemadata/value_semantic_equality.go:71 +0x254
github.com/hashicorp/terraform-plugin-framework/internal/fwschemadata.ValueSemanticEqualityListElements({0x100c7dd10, 0x1400001c100}, {{{0x14000050c90, 0x1, 0x1}}, {0x100c7ee48, 0x14000064fc0}, {0x100c7ee48, 0x14000064ff0}}, 0x14000065e30)
	/Users/sgoods/Hashicorp/terraform-plugin-framework/internal/fwschemadata/value_semantic_equality_list.go:152 +0x5e4
github.com/hashicorp/terraform-plugin-framework/internal/fwschemadata.ValueSemanticEqualityList({0x100c7dd10, 0x1400001c100}, {{{0x14000050c90, 0x1, 0x1}}, {0x100c7ee48, 0x14000064fc0}, {0x100c7ee48, 0x14000064ff0}}, 0x14000065e30)
	/Users/sgoods/Hashicorp/terraform-plugin-framework/internal/fwschemadata/value_semantic_equality_list.go:27 +0x314
github.com/hashicorp/terraform-plugin-framework/internal/fwschemadata_test.TestValueSemanticEqualityList.func1(0x14000003a00)
	/Users/sgoods/Hashicorp/terraform-plugin-framework/internal/fwschemadata/value_semantic_equality_list_test.go:650 +0xa0
testing.tRunner(0x14000003a00, 0x14000010cd0)
	/opt/homebrew/Cellar/go/1.19.4/libexec/src/testing/testing.go:1446 +0x10c
created by testing.(*T).Run
	/opt/homebrew/Cellar/go/1.19.4/libexec/src/testing/testing.go:1493 +0x300


--- FAIL: TestValueSemanticEqualitySet (0.00s)
    --- FAIL: TestValueSemanticEqualitySet/SetValue-SetValue-StringValuableWithSemanticEquals-NewValueElementsGreaterThanPriorValueElements (0.00s)
panic: runtime error: index out of range [1] with length 1 [recovered]
	panic: runtime error: index out of range [1] with length 1

goroutine 5 [running]:
testing.tRunner.func1.2({0x105545dc0, 0x14000018108})
	/opt/homebrew/Cellar/go/1.19.4/libexec/src/testing/testing.go:1396 +0x1c8
testing.tRunner.func1()
	/opt/homebrew/Cellar/go/1.19.4/libexec/src/testing/testing.go:1399 +0x378
panic({0x105545dc0, 0x14000018108})
	/opt/homebrew/Cellar/go/1.19.4/libexec/src/runtime/panic.go:884 +0x204
github.com/hashicorp/terraform-plugin-framework/internal/fwschemadata.ValueSemanticEqualitySetElements({0x105569d80, 0x14000065ec0}, {{{0x140001198a0, 0x2, 0x2}}, {0x10556b088, 0x14000064f30}, {0x10556b088, 0x14000064f60}}, 0x14000065e60)
	/Users/sgoods/Hashicorp/terraform-plugin-framework/internal/fwschemadata/value_semantic_equality_set.go:145 +0xa3c
github.com/hashicorp/terraform-plugin-framework/internal/fwschemadata.ValueSemanticEqualitySet({0x105569d80, 0x14000065ec0}, {{{0x140001198a0, 0x2, 0x2}}, {0x10556b088, 0x14000064f30}, {0x10556b088, 0x14000064f60}}, 0x14000065e60)
	/Users/sgoods/Hashicorp/terraform-plugin-framework/internal/fwschemadata/value_semantic_equality_set.go:27 +0x314
github.com/hashicorp/terraform-plugin-framework/internal/fwschemadata.ValueSemanticEquality({0x105569d10, 0x1400001c100}, {{{0x140001198a0, 0x2, 0x2}}, {0x10556b088, 0x14000064f30}, {0x10556b088, 0x14000064f60}}, 0x14000065e60)
	/Users/sgoods/Hashicorp/terraform-plugin-framework/internal/fwschemadata/value_semantic_equality.go:79 +0x374
github.com/hashicorp/terraform-plugin-framework/internal/fwschemadata.ValueSemanticEqualitySetElements({0x105569d10, 0x1400001c100}, {{{0x14000050c90, 0x1, 0x1}}, {0x10556b088, 0x14000064fc0}, {0x10556b088, 0x14000064ff0}}, 0x14000065e30)
	/Users/sgoods/Hashicorp/terraform-plugin-framework/internal/fwschemadata/value_semantic_equality_set.go:152 +0x600
github.com/hashicorp/terraform-plugin-framework/internal/fwschemadata.ValueSemanticEqualitySet({0x105569d10, 0x1400001c100}, {{{0x14000050c90, 0x1, 0x1}}, {0x10556b088, 0x14000064fc0}, {0x10556b088, 0x14000064ff0}}, 0x14000065e30)
	/Users/sgoods/Hashicorp/terraform-plugin-framework/internal/fwschemadata/value_semantic_equality_set.go:27 +0x314
github.com/hashicorp/terraform-plugin-framework/internal/fwschemadata_test.TestValueSemanticEqualitySet.func1(0x14000003a00)
	/Users/sgoods/Hashicorp/terraform-plugin-framework/internal/fwschemadata/value_semantic_equality_set_test.go:650 +0xa0
testing.tRunner(0x14000003a00, 0x14000010eb0)
	/opt/homebrew/Cellar/go/1.19.4/libexec/src/testing/testing.go:1446 +0x10c
created by testing.(*T).Run
	/opt/homebrew/Cellar/go/1.19.4/libexec/src/testing/testing.go:1493 +0x300


```