### PR TITLE
internal/reflection: Migrate reflection tests for struct tags to exported methods

### DIFF
--- a/internal/reflect/helpers_test.go
+++ b/internal/reflect/helpers_test.go
@@ -4,12 +4,9 @@
 package reflect
 
 import (
-	"context"
 	"fmt"
 	"reflect"
 	"testing"
-
-	"github.com/hashicorp/terraform-plugin-framework/path"
 )
 
 func TestTrueReflectValue(t *testing.T) {
@@ -93,66 +90,6 @@ func TestCommaSeparatedString(t *testing.T) {
 				t.Errorf("Expected %q, got %q", test.expected, got)
 			}
 		})
-	}
-}
-
-func TestGetStructTags_untagged(t *testing.T) {
-	t.Parallel()
-	type testStruct struct {
-		ExportedAndUntagged string
-	}
-	_, err := getStructTags(context.Background(), reflect.ValueOf(testStruct{}), path.Empty())
-	if err == nil {
-		t.Error("Expected error, got nil")
-	}
-	expected := `: need a struct tag for "tfsdk" on ExportedAndUntagged`
-	if err.Error() != expected {
-		t.Errorf("Expected error to be %q, got %q", expected, err.Error())
-	}
-}
-
-func TestGetStructTags_invalidTag(t *testing.T) {
-	t.Parallel()
-	type testStruct struct {
-		InvalidTag string `tfsdk:"invalidTag"`
-	}
-	_, err := getStructTags(context.Background(), reflect.ValueOf(testStruct{}), path.Empty())
-	if err == nil {
-		t.Errorf("Expected error, got nil")
-	}
-	expected := `invalidTag: invalid field name, must only use lowercase letters, underscores, and numbers, and must start with a letter`
-	if err.Error() != expected {
-		t.Errorf("Expected error to be %q, got %q", expected, err.Error())
-	}
-}
-
-func TestGetStructTags_duplicateTag(t *testing.T) {
-	t.Parallel()
-	type testStruct struct {
-		Field1 string `tfsdk:"my_field"`
-		Field2 string `tfsdk:"my_field"`
-	}
-	_, err := getStructTags(context.Background(), reflect.ValueOf(testStruct{}), path.Empty())
-	if err == nil {
-		t.Errorf("Expected error, got nil")
-	}
-	expected := `my_field: can't use field name for both Field1 and Field2`
-	if err.Error() != expected {
-		t.Errorf("Expected error to be %q, got %q", expected, err.Error())
-	}
-}
-
-func TestGetStructTags_notAStruct(t *testing.T) {
-	t.Parallel()
-	var testStruct string
-
-	_, err := getStructTags(context.Background(), reflect.ValueOf(testStruct), path.Empty())
-	if err == nil {
-		t.Errorf("Expected error, got nil")
-	}
-	expected := `: can't get struct tags of string, is not a struct`
-	if err.Error() != expected {
-		t.Errorf("Expected error to be %q, got %q", expected, err.Error())
 	}
 }
 

--- a/internal/reflect/helpers_test.go
+++ b/internal/reflect/helpers_test.go
@@ -96,28 +96,6 @@ func TestCommaSeparatedString(t *testing.T) {
 	}
 }
 
-func TestGetStructTags_success(t *testing.T) {
-	t.Parallel()
-
-	type testStruct struct {
-		ExportedAndTagged   string `tfsdk:"exported_and_tagged"`
-		unexported          string //nolint:structcheck,unused
-		unexportedAndTagged string `tfsdk:"unexported_and_tagged"`
-		ExportedAndExcluded string `tfsdk:"-"`
-	}
-
-	res, err := getStructTags(context.Background(), reflect.ValueOf(testStruct{}), path.Empty())
-	if err != nil {
-		t.Errorf("Unexpected error: %s", err)
-	}
-	if len(res) != 1 {
-		t.Errorf("Unexpected result: %v", res)
-	}
-	if res["exported_and_tagged"] != 0 {
-		t.Errorf("Unexpected result: %v", res)
-	}
-}
-
 func TestGetStructTags_untagged(t *testing.T) {
 	t.Parallel()
 	type testStruct struct {

--- a/internal/reflect/struct_test.go
+++ b/internal/reflect/struct_test.go
@@ -992,6 +992,71 @@ func TestFromStruct_errors(t *testing.T) {
 				),
 			},
 		},
+		"struct-has-untagged-fields": {
+			typ: types.ObjectType{
+				AttrTypes: map[string]attr.Type{
+					"test": types.StringType,
+				},
+			},
+			val: reflect.ValueOf(
+				struct {
+					Test                types.String `tfsdk:"test"`
+					ExportedAndUntagged string
+				}{},
+			),
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("test"),
+					"Value Conversion Error",
+					"An unexpected error was encountered trying to convert from struct value. "+
+						"This is always an error in the provider. Please report the following to the provider developer:\n\n"+
+						"error retrieving field names from struct tags: test: need a struct tag for \"tfsdk\" on ExportedAndUntagged",
+				),
+			},
+		},
+		"struct-has-invalid-tags": {
+			typ: types.ObjectType{
+				AttrTypes: map[string]attr.Type{
+					"test": types.StringType,
+				},
+			},
+			val: reflect.ValueOf(
+				struct {
+					Test types.String `tfsdk:"invalidTag"`
+				}{},
+			),
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("test"),
+					"Value Conversion Error",
+					"An unexpected error was encountered trying to convert from struct value. "+
+						"This is always an error in the provider. Please report the following to the provider developer:\n\n"+
+						"error retrieving field names from struct tags: test.invalidTag: invalid field name, must only use lowercase letters, underscores, and numbers, and must start with a letter",
+				),
+			},
+		},
+		"struct-has-duplicate-tags": {
+			typ: types.ObjectType{
+				AttrTypes: map[string]attr.Type{
+					"test": types.StringType,
+				},
+			},
+			val: reflect.ValueOf(
+				struct {
+					Test  types.String `tfsdk:"test"`
+					Test2 types.String `tfsdk:"test"`
+				}{},
+			),
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("test"),
+					"Value Conversion Error",
+					"An unexpected error was encountered trying to convert from struct value. "+
+						"This is always an error in the provider. Please report the following to the provider developer:\n\n"+
+						"error retrieving field names from struct tags: test.test: can't use field name for both Test and Test2",
+				),
+			},
+		},
 		"list-zero-value": {
 			typ: types.ObjectType{
 				AttrTypes: map[string]attr.Type{


### PR DESCRIPTION
This PR will make it easier for us to verify internal refactoring that is made to any of the struct reflection logic. That includes:
- Moving the existing `Struct` error tests into a single table-driven test (same as `FromStruct`)
- Moving all the internal testing of `getStructTags` to use the exported `Struct` method
   - The only test that was removed was `TestGetStructTags_notAStruct`, as the exported methods (`FromStruct` & `Struct`) already have tests for this scenario and the logic in `getStructTags` is mostly defensive.
- Added new tests to `FromStruct` for all the error scenarios from `getStructTags` + the success scenario with ignored tags