### PR TITLE
internal/reflect: Use underlying terraform-plugin-go types to validate provider given values

### DIFF
--- a/.changes/unreleased/BUG FIXES-20230719-142413.yaml
+++ b/.changes/unreleased/BUG FIXES-20230719-142413.yaml
@@ -1,0 +1,6 @@
+kind: BUG FIXES
+body: 'tfsdk: Prevented `Value Conversion Error` diagnostics when using `Set()` method
+  with base types instead of custom types'
+time: 2023-07-19T14:24:13.806804-04:00
+custom:
+  Issue: "806"

--- a/internal/reflect/interfaces.go
+++ b/internal/reflect/interfaces.go
@@ -320,17 +320,14 @@ func FromAttributeValue(ctx context.Context, typ attr.Type, val attr.Value, path
 	// compatible. This check will ensure the framework raises its own
 	// error is there is a mismatch, rather than a terraform-plugin-go
 	// error or worse a panic.
-	//
-	// If this validation causes major issues, another option is to
-	// validate via tftypes.Type for both the type and value type.
-	if !typ.Equal(val.Type(ctx)) {
+	if !typ.TerraformType(ctx).Equal(val.Type(ctx).TerraformType(ctx)) {
 		diags.AddAttributeError(
 			path,
 			"Value Conversion Error",
 			"An unexpected error was encountered while verifying an attribute value matched its expected type to prevent unexpected behavior or panics. "+
 				"This is always an error in the provider. Please report the following to the provider developer:\n\n"+
-				fmt.Sprintf("Expected type: %s\n", typ)+
-				fmt.Sprintf("Value type: %s\n", val.Type(ctx))+
+				fmt.Sprintf("Expected framework type from provider logic: %s / underlying type: %s\n", typ, typ.TerraformType(ctx))+
+				fmt.Sprintf("Received framework type from provider logic: %s / underlying type: %s\n", val.Type(ctx), val.Type(ctx).TerraformType(ctx))+
 				fmt.Sprintf("Path: %s", path),
 		)
 

--- a/internal/reflect/interfaces_test.go
+++ b/internal/reflect/interfaces_test.go
@@ -502,13 +502,28 @@ func TestFromAttributeValue(t *testing.T) {
 				CreatedBy: testtypes.BoolType{},
 			},
 		},
+		"BoolTypable-BoolValue": {
+			typ:      testtypes.BoolTypeWithSemanticEquals{},
+			val:      types.BoolNull(),
+			expected: types.BoolNull(),
+		},
 		"Float64Type-Float64Value": {
 			typ:      types.Float64Type,
 			val:      types.Float64Null(),
 			expected: types.Float64Null(),
 		},
+		"Float64Typable-Float64Value": {
+			typ:      testtypes.Float64TypeWithSemanticEquals{},
+			val:      types.Float64Null(),
+			expected: types.Float64Null(),
+		},
 		"Int64Type-Int64Value": {
 			typ:      types.Int64Type,
+			val:      types.Int64Null(),
+			expected: types.Int64Null(),
+		},
+		"Int64Typable-Int64Value": {
+			typ:      testtypes.Int64TypeWithSemanticEquals{},
 			val:      types.Int64Null(),
 			expected: types.Int64Null(),
 		},
@@ -527,11 +542,18 @@ func TestFromAttributeValue(t *testing.T) {
 					"Value Conversion Error",
 					"An unexpected error was encountered while verifying an attribute value matched its expected type to prevent unexpected behavior or panics. "+
 						"This is always an error in the provider. Please report the following to the provider developer:\n\n"+
-						"Expected type: types.ListType[basetypes.StringType]\n"+
-						"Value type: types.ListType[basetypes.BoolType]\n"+
+						"Expected framework type from provider logic: types.ListType[basetypes.StringType] / underlying type: tftypes.List[tftypes.String]\n"+
+						"Received framework type from provider logic: types.ListType[basetypes.BoolType] / underlying type: tftypes.List[tftypes.Bool]\n"+
 						"Path: test",
 				),
 			},
+		},
+		"ListTypable-ListValue-matching-elements": {
+			typ: testtypes.ListType{
+				ListType: types.ListType{ElemType: types.StringType},
+			},
+			val:      types.ListNull(types.StringType),
+			expected: types.ListNull(types.StringType),
 		},
 		"MapType-MapValue-matching-elements": {
 			typ:      types.MapType{ElemType: types.StringType},
@@ -548,11 +570,18 @@ func TestFromAttributeValue(t *testing.T) {
 					"Value Conversion Error",
 					"An unexpected error was encountered while verifying an attribute value matched its expected type to prevent unexpected behavior or panics. "+
 						"This is always an error in the provider. Please report the following to the provider developer:\n\n"+
-						"Expected type: types.MapType[basetypes.StringType]\n"+
-						"Value type: types.MapType[basetypes.BoolType]\n"+
+						"Expected framework type from provider logic: types.MapType[basetypes.StringType] / underlying type: tftypes.Map[tftypes.String]\n"+
+						"Received framework type from provider logic: types.MapType[basetypes.BoolType] / underlying type: tftypes.Map[tftypes.Bool]\n"+
 						"Path: test",
 				),
 			},
+		},
+		"MapTypable-MapValue-matching-elements": {
+			typ: testtypes.MapType{
+				MapType: types.MapType{ElemType: types.StringType},
+			},
+			val:      types.MapNull(types.StringType),
+			expected: types.MapNull(types.StringType),
 		},
 		"NumberType-NumberValue": {
 			typ:      types.NumberType,
@@ -567,6 +596,11 @@ func TestFromAttributeValue(t *testing.T) {
 			expected: testtypes.Number{
 				CreatedBy: testtypes.NumberType{},
 			},
+		},
+		"NumberTypable-NumberValue": {
+			typ:      testtypes.NumberTypeWithSemanticEquals{},
+			val:      types.NumberNull(),
+			expected: types.NumberNull(),
 		},
 		"ObjectType-ObjectValue-matching-attributes": {
 			typ:      types.ObjectType{AttrTypes: map[string]attr.Type{"test_attr": types.StringType}},
@@ -583,8 +617,8 @@ func TestFromAttributeValue(t *testing.T) {
 					"Value Conversion Error",
 					"An unexpected error was encountered while verifying an attribute value matched its expected type to prevent unexpected behavior or panics. "+
 						"This is always an error in the provider. Please report the following to the provider developer:\n\n"+
-						"Expected type: types.ObjectType[\"test_attr\":basetypes.StringType]\n"+
-						"Value type: types.ObjectType[\"not_test_attr\":basetypes.StringType]\n"+
+						"Expected framework type from provider logic: types.ObjectType[\"test_attr\":basetypes.StringType] / underlying type: tftypes.Object[\"test_attr\":tftypes.String]\n"+
+						"Received framework type from provider logic: types.ObjectType[\"not_test_attr\":basetypes.StringType] / underlying type: tftypes.Object[\"not_test_attr\":tftypes.String]\n"+
 						"Path: test",
 				),
 			},
@@ -599,11 +633,18 @@ func TestFromAttributeValue(t *testing.T) {
 					"Value Conversion Error",
 					"An unexpected error was encountered while verifying an attribute value matched its expected type to prevent unexpected behavior or panics. "+
 						"This is always an error in the provider. Please report the following to the provider developer:\n\n"+
-						"Expected type: types.ObjectType[\"test_attr\":basetypes.StringType]\n"+
-						"Value type: types.ObjectType[\"test_attr\":basetypes.BoolType]\n"+
+						"Expected framework type from provider logic: types.ObjectType[\"test_attr\":basetypes.StringType] / underlying type: tftypes.Object[\"test_attr\":tftypes.String]\n"+
+						"Received framework type from provider logic: types.ObjectType[\"test_attr\":basetypes.BoolType] / underlying type: tftypes.Object[\"test_attr\":tftypes.Bool]\n"+
 						"Path: test",
 				),
 			},
+		},
+		"ObjectTypable-ObjectValue-matching-attributes": {
+			typ: testtypes.ObjectType{
+				ObjectType: types.ObjectType{AttrTypes: map[string]attr.Type{"test_attr": types.StringType}},
+			},
+			val:      types.ObjectNull(map[string]attr.Type{"test_attr": types.StringType}),
+			expected: types.ObjectNull(map[string]attr.Type{"test_attr": types.StringType}),
 		},
 		"SetType-SetValue-matching-elements": {
 			typ:      types.SetType{ElemType: types.StringType},
@@ -620,11 +661,18 @@ func TestFromAttributeValue(t *testing.T) {
 					"Value Conversion Error",
 					"An unexpected error was encountered while verifying an attribute value matched its expected type to prevent unexpected behavior or panics. "+
 						"This is always an error in the provider. Please report the following to the provider developer:\n\n"+
-						"Expected type: types.SetType[basetypes.StringType]\n"+
-						"Value type: types.SetType[basetypes.BoolType]\n"+
+						"Expected framework type from provider logic: types.SetType[basetypes.StringType] / underlying type: tftypes.Set[tftypes.String]\n"+
+						"Received framework type from provider logic: types.SetType[basetypes.BoolType] / underlying type: tftypes.Set[tftypes.Bool]\n"+
 						"Path: test",
 				),
 			},
+		},
+		"SetTypable-SetValue-matching-elements": {
+			typ: testtypes.SetType{
+				SetType: types.SetType{ElemType: types.StringType},
+			},
+			val:      types.SetNull(types.StringType),
+			expected: types.SetNull(types.StringType),
 		},
 		"StringType-StringValue-null": {
 			typ:      types.StringType,
@@ -649,6 +697,11 @@ func TestFromAttributeValue(t *testing.T) {
 			expected: testtypes.String{
 				CreatedBy: testtypes.StringType{},
 			},
+		},
+		"StringTypable-StringValue": {
+			typ:      testtypes.StringTypeWithSemanticEquals{},
+			val:      types.StringNull(),
+			expected: types.StringNull(),
 		},
 	}
 

--- a/internal/reflect/struct_test.go
+++ b/internal/reflect/struct_test.go
@@ -986,8 +986,8 @@ func TestFromStruct_errors(t *testing.T) {
 					"Value Conversion Error",
 					"An unexpected error was encountered while verifying an attribute value matched its expected type to prevent unexpected behavior or panics. "+
 						"This is always an error in the provider. Please report the following to the provider developer:\n\n"+
-						"Expected type: basetypes.StringType\n"+
-						"Value type: basetypes.BoolType\n"+
+						"Expected framework type from provider logic: basetypes.StringType / underlying type: tftypes.String\n"+
+						"Received framework type from provider logic: basetypes.BoolType / underlying type: tftypes.Bool\n"+
 						"Path: test.string",
 				),
 			},
@@ -1076,8 +1076,8 @@ func TestFromStruct_errors(t *testing.T) {
 					"Value Conversion Error",
 					"An unexpected error was encountered while verifying an attribute value matched its expected type to prevent unexpected behavior or panics. "+
 						"This is always an error in the provider. Please report the following to the provider developer:\n\n"+
-						"Expected type: types.ListType[basetypes.StringType]\n"+
-						"Value type: types.ListType[!!! MISSING TYPE !!!]\n"+
+						"Expected framework type from provider logic: types.ListType[basetypes.StringType] / underlying type: tftypes.List[tftypes.String]\n"+
+						"Received framework type from provider logic: types.ListType[!!! MISSING TYPE !!!] / underlying type: tftypes.List[tftypes.DynamicPseudoType]\n"+
 						"Path: test.list",
 				),
 			},
@@ -1101,8 +1101,8 @@ func TestFromStruct_errors(t *testing.T) {
 					"Value Conversion Error",
 					"An unexpected error was encountered while verifying an attribute value matched its expected type to prevent unexpected behavior or panics. "+
 						"This is always an error in the provider. Please report the following to the provider developer:\n\n"+
-						"Expected type: types.MapType[basetypes.StringType]\n"+
-						"Value type: types.MapType[!!! MISSING TYPE !!!]\n"+
+						"Expected framework type from provider logic: types.MapType[basetypes.StringType] / underlying type: tftypes.Map[tftypes.String]\n"+
+						"Received framework type from provider logic: types.MapType[!!! MISSING TYPE !!!] / underlying type: tftypes.Map[tftypes.DynamicPseudoType]\n"+
 						"Path: test.map",
 				),
 			},
@@ -1129,8 +1129,8 @@ func TestFromStruct_errors(t *testing.T) {
 					"Value Conversion Error",
 					"An unexpected error was encountered while verifying an attribute value matched its expected type to prevent unexpected behavior or panics. "+
 						"This is always an error in the provider. Please report the following to the provider developer:\n\n"+
-						"Expected type: types.ObjectType[\"test\":basetypes.StringType]\n"+
-						"Value type: types.ObjectType[]\n"+
+						"Expected framework type from provider logic: types.ObjectType[\"test\":basetypes.StringType] / underlying type: tftypes.Object[\"test\":tftypes.String]\n"+
+						"Received framework type from provider logic: types.ObjectType[] / underlying type: tftypes.Object[]\n"+
 						"Path: test.object",
 				),
 			},
@@ -1154,8 +1154,8 @@ func TestFromStruct_errors(t *testing.T) {
 					"Value Conversion Error",
 					"An unexpected error was encountered while verifying an attribute value matched its expected type to prevent unexpected behavior or panics. "+
 						"This is always an error in the provider. Please report the following to the provider developer:\n\n"+
-						"Expected type: types.SetType[basetypes.StringType]\n"+
-						"Value type: types.SetType[!!! MISSING TYPE !!!]\n"+
+						"Expected framework type from provider logic: types.SetType[basetypes.StringType] / underlying type: tftypes.Set[tftypes.String]\n"+
+						"Received framework type from provider logic: types.SetType[!!! MISSING TYPE !!!] / underlying type: tftypes.Set[tftypes.DynamicPseudoType]\n"+
 						"Path: test.set",
 				),
 			},


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform-plugin-framework/pull/715
Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/793
Reference: https://github.com/hashicorp/terraform-provider-aws/issues/32441

The original intention of this logic was to raise a framework error instead of underlying terraform-plugin-go error or panic when providers returned an errant value from their logic. In practice though, comparing the framework types (which may include either base or custom types) was too strict. Technically, as long as the underlying terraform-plugin-go types are equivalent, then this check should pass. Terraform will catch any errant modifications of the actual values, should there be a difference between the base types and custom types.