### PR TITLE
types/basetypes: Fix Float64Attribute precision comparisons

### DIFF
--- a/.changes/unreleased/BUG FIXES-20230803-120411.yaml
+++ b/.changes/unreleased/BUG FIXES-20230803-120411.yaml
@@ -1,0 +1,6 @@
+kind: BUG FIXES
+body: 'types/basetypes: Fix Float64Attribute bug by preserving precision from number
+  values'
+time: 2023-08-03T12:04:11.996955-04:00
+custom:
+  Issue: "817"

--- a/.changes/unreleased/BUG FIXES-20230803-120411.yaml
+++ b/.changes/unreleased/BUG FIXES-20230803-120411.yaml
@@ -1,6 +1,6 @@
 kind: BUG FIXES
-body: 'types/basetypes: Fix Float64Attribute bug by preserving precision from number
-  values'
+body: 'types/basetypes: Prevented Float64Value Terraform data consistency errors for
+  numbers with high precision floating point rounding errors'
 time: 2023-08-03T12:04:11.996955-04:00
 custom:
   Issue: "817"

--- a/types/basetypes/float64_type.go
+++ b/types/basetypes/float64_type.go
@@ -140,28 +140,24 @@ func (t Float64Type) ValueFromTerraform(ctx context.Context, in tftypes.Value) (
 		return nil, err
 	}
 
-	// Copy the float retrieved from tftypes.Value to avoid any unexpected pass-by-reference shenanigans
-	copiedBigF := new(big.Float)
-	copiedBigF.Copy(bigF)
-
-	f, accuracy := copiedBigF.Float64()
+	f, accuracy := bigF.Float64()
 
 	// Underflow
 	// Reference: https://pkg.go.dev/math/big#Float.Float64
 	if f == 0 && accuracy != big.Exact {
-		return nil, fmt.Errorf("Value %s cannot be represented as a 64-bit floating point.", copiedBigF)
+		return nil, fmt.Errorf("Value %s cannot be represented as a 64-bit floating point.", bigF)
 	}
 
 	// Overflow
 	// Reference: https://pkg.go.dev/math/big#Float.Float64
 	if math.IsInf(f, 0) {
-		return nil, fmt.Errorf("Value %s cannot be represented as a 64-bit floating point.", copiedBigF)
+		return nil, fmt.Errorf("Value %s cannot be represented as a 64-bit floating point.", bigF)
 	}
 
 	// Underlying *big.Float values are not exposed with helper functions, so creating Float64Value via struct literal
 	return Float64Value{
 		state: attr.ValueStateKnown,
-		value: copiedBigF,
+		value: bigF,
 	}, nil
 }
 

--- a/types/basetypes/float64_type.go
+++ b/types/basetypes/float64_type.go
@@ -136,6 +136,7 @@ func (t Float64Type) ValueFromTerraform(ctx context.Context, in tftypes.Value) (
 
 	var bigF *big.Float
 	err := in.As(&bigF)
+
 	if err != nil {
 		return nil, err
 	}

--- a/types/basetypes/float64_type.go
+++ b/types/basetypes/float64_type.go
@@ -136,26 +136,33 @@ func (t Float64Type) ValueFromTerraform(ctx context.Context, in tftypes.Value) (
 
 	var bigF *big.Float
 	err := in.As(&bigF)
-
 	if err != nil {
 		return nil, err
 	}
 
-	f, accuracy := bigF.Float64()
+	// Copy the float retrieved from tftypes.Value to avoid any unexpected pass-by-reference shenanigans
+	copiedBigF := new(big.Float)
+	copiedBigF.Copy(bigF)
+
+	f, accuracy := copiedBigF.Float64()
 
 	// Underflow
 	// Reference: https://pkg.go.dev/math/big#Float.Float64
 	if f == 0 && accuracy != big.Exact {
-		return nil, fmt.Errorf("Value %s cannot be represented as a 64-bit floating point.", bigF)
+		return nil, fmt.Errorf("Value %s cannot be represented as a 64-bit floating point.", copiedBigF)
 	}
 
 	// Overflow
 	// Reference: https://pkg.go.dev/math/big#Float.Float64
 	if math.IsInf(f, 0) {
-		return nil, fmt.Errorf("Value %s cannot be represented as a 64-bit floating point.", bigF)
+		return nil, fmt.Errorf("Value %s cannot be represented as a 64-bit floating point.", copiedBigF)
 	}
 
-	return NewFloat64Value(f), nil
+	// Underlying *big.Float values are not exposed with helper functions, so creating Float64Value via struct literal
+	return Float64Value{
+		state: attr.ValueStateKnown,
+		value: copiedBigF,
+	}, nil
 }
 
 // ValueType returns the Value type.

--- a/types/basetypes/float64_type_test.go
+++ b/types/basetypes/float64_type_test.go
@@ -123,11 +123,6 @@ func TestFloat64TypeValueFromTerraform(t *testing.T) {
 			input:       tftypes.NewValue(tftypes.Number, 123.456),
 			expectation: NewFloat64Value(123.456),
 		},
-		// TODO: Add NaN test? Currently panics
-		// "value-nan": {
-		// 	input:       tftypes.NewValue(tftypes.Number, math.NaN()),
-		// 	expectation: NewFloat64Value(???),
-		// },
 		"unknown": {
 			input:       tftypes.NewValue(tftypes.Number, tftypes.UnknownValue),
 			expectation: NewFloat64Unknown(),

--- a/types/basetypes/float64_type_test.go
+++ b/types/basetypes/float64_type_test.go
@@ -123,6 +123,11 @@ func TestFloat64TypeValueFromTerraform(t *testing.T) {
 			input:       tftypes.NewValue(tftypes.Number, 123.456),
 			expectation: NewFloat64Value(123.456),
 		},
+		// TODO: Add NaN test? Currently panics
+		// "value-nan": {
+		// 	input:       tftypes.NewValue(tftypes.Number, math.NaN()),
+		// 	expectation: NewFloat64Value(???),
+		// },
 		"unknown": {
 			input:       tftypes.NewValue(tftypes.Number, tftypes.UnknownValue),
 			expectation: NewFloat64Unknown(),
@@ -136,17 +141,36 @@ func TestFloat64TypeValueFromTerraform(t *testing.T) {
 			expectedErr: "can't unmarshal tftypes.String into *big.Float, expected *big.Float",
 		},
 		// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/647
+		// To ensure underlying *big.Float precision matches, create `expectation` via struct literal
 		"zero-string-float": {
-			input:       tftypes.NewValue(tftypes.Number, testMustParseFloat("0.0")),
-			expectation: NewFloat64Value(0.0),
+			input: tftypes.NewValue(tftypes.Number, testMustParseFloat("0.0")),
+			expectation: Float64Value{
+				state: attr.ValueStateKnown,
+				value: testMustParseFloat("0.0"),
+			},
 		},
 		"positive-string-float": {
-			input:       tftypes.NewValue(tftypes.Number, testMustParseFloat("123.2")),
-			expectation: NewFloat64Value(123.2),
+			input: tftypes.NewValue(tftypes.Number, testMustParseFloat("123.2")),
+			expectation: Float64Value{
+				state: attr.ValueStateKnown,
+				value: testMustParseFloat("123.2"),
+			},
 		},
 		"negative-string-float": {
-			input:       tftypes.NewValue(tftypes.Number, testMustParseFloat("-123.2")),
-			expectation: NewFloat64Value(-123.2),
+			input: tftypes.NewValue(tftypes.Number, testMustParseFloat("-123.2")),
+			expectation: Float64Value{
+				state: attr.ValueStateKnown,
+				value: testMustParseFloat("-123.2"),
+			},
+		},
+		// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/815
+		// To ensure underlying *big.Float precision matches, create `expectation` via struct literal
+		"retain-string-float-512-precision": {
+			input: tftypes.NewValue(tftypes.Number, testMustParseFloat("0.010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003")),
+			expectation: Float64Value{
+				state: attr.ValueStateKnown,
+				value: testMustParseFloat("0.010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003"),
+			},
 		},
 		// Reference: https://pkg.go.dev/math/big#Float.Float64
 		// Reference: https://pkg.go.dev/math#pkg-constants

--- a/types/basetypes/float64_value.go
+++ b/types/basetypes/float64_value.go
@@ -132,6 +132,11 @@ func (f Float64Value) Equal(other attr.Value) bool {
 		return true
 	}
 
+	// Not possible to create a known Float64Value with a nil value, but check anyways
+	if f.value == nil || o.value == nil {
+		return false
+	}
+
 	return f.value.Cmp(o.value) == 0
 }
 

--- a/types/basetypes/float64_value.go
+++ b/types/basetypes/float64_value.go
@@ -133,8 +133,8 @@ func (f Float64Value) Equal(other attr.Value) bool {
 	}
 
 	// Not possible to create a known Float64Value with a nil value, but check anyways
-	if f.value == nil || o.value == nil {
-		return false
+	if f.value == nil {
+		return o.value == nil
 	}
 
 	return f.value.Cmp(o.value) == 0

--- a/types/basetypes/float64_value.go
+++ b/types/basetypes/float64_value.go
@@ -15,9 +15,8 @@ import (
 )
 
 var (
-	_ Float64Valuable = Float64Value{}
-	// TODO: Do we need this? TBD
-	// _ Float64ValuableWithSemanticEquals = Float64Value{}
+	_ Float64Valuable                   = Float64Value{}
+	_ Float64ValuableWithSemanticEquals = Float64Value{}
 )
 
 // Float64Valuable extends attr.Value for float64 value types.
@@ -96,26 +95,26 @@ type Float64Value struct {
 	value *big.Float
 }
 
-// TODO: Do we need this? TBD
-// func (f Float64Value) Float64SemanticEquals(ctx context.Context, newValuable Float64Valuable) (bool, diag.Diagnostics) {
-// 	var diags diag.Diagnostics
+// TODO: docs
+func (f Float64Value) Float64SemanticEquals(ctx context.Context, newValuable Float64Valuable) (bool, diag.Diagnostics) {
+	var diags diag.Diagnostics
 
-// 	newValue, ok := newValuable.(Float64Value)
-// 	if !ok {
-// 		diags.AddError(
-// 			"Semantic Equality Check Error",
-// 			"An unexpected value type was received while performing semantic equality checks. "+
-// 				"Please report this to the provider developers.\n\n"+
-// 				"Expected Value Type: "+fmt.Sprintf("%T", f)+"\n"+
-// 				"Got Value Type: "+fmt.Sprintf("%T", newValuable),
-// 		)
+	newValue, ok := newValuable.(Float64Value)
+	if !ok {
+		diags.AddError(
+			"Semantic Equality Check Error",
+			"An unexpected value type was received while performing semantic equality checks. "+
+				"Please report this to the provider developers.\n\n"+
+				"Expected Value Type: "+fmt.Sprintf("%T", f)+"\n"+
+				"Got Value Type: "+fmt.Sprintf("%T", newValuable),
+		)
 
-// 		return false, diags
-// 	}
+		return false, diags
+	}
 
-// 	// TODO: is this the best way to compare?
-// 	return f.ValueFloat64() == newValue.ValueFloat64(), diags
-// }
+	// TODO: is this the best way to compare?
+	return f.ValueFloat64() == newValue.ValueFloat64(), diags
+}
 
 // Equal returns true if `other` is a Float64 and has the same value as `f`.
 func (f Float64Value) Equal(other attr.Value) bool {

--- a/types/basetypes/float64_value.go
+++ b/types/basetypes/float64_value.go
@@ -134,8 +134,8 @@ func (f Float64Value) Equal(other attr.Value) bool {
 	}
 
 	// Not possible to create a known Float64Value with a nil value, but check anyways
-	if f.value == nil {
-		return o.value == nil
+	if f.value == nil || o.value == nil {
+		return f.value == o.value
 	}
 
 	return f.value.Cmp(o.value) == 0

--- a/types/basetypes/float64_value.go
+++ b/types/basetypes/float64_value.go
@@ -68,7 +68,6 @@ func NewFloat64Unknown() Float64Value {
 // Setting the deprecated Float64 type Null, Unknown, or Value fields after
 // creating a Float64 with this function has no effect.
 func NewFloat64Value(value float64) Float64Value {
-	// TODO: Should we check math.IsNaN first? It will panic if NaN
 	return Float64Value{
 		state: attr.ValueStateKnown,
 		value: big.NewFloat(value),
@@ -95,7 +94,9 @@ type Float64Value struct {
 	value *big.Float
 }
 
-// TODO: docs
+// Float64SemanticEquals returns true if the given Float64Value is semantically equal to the current Float64Value.
+// The underlying value *big.Float can store more precise float values then the Go built-in float64 type. This only
+// compares the precision of the value that can be represented as the Go built-in float64, which is 53 bits of precision.
 func (f Float64Value) Float64SemanticEquals(ctx context.Context, newValuable Float64Valuable) (bool, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
@@ -112,7 +113,6 @@ func (f Float64Value) Float64SemanticEquals(ctx context.Context, newValuable Flo
 		return false, diags
 	}
 
-	// TODO: is this the best way to compare?
 	return f.ValueFloat64() == newValue.ValueFloat64(), diags
 }
 
@@ -130,11 +130,6 @@ func (f Float64Value) Equal(other attr.Value) bool {
 
 	if f.state != attr.ValueStateKnown {
 		return true
-	}
-
-	// TODO: Is this needed? Make it easier to read if so :)
-	if f.value == nil {
-		return o.value == nil
 	}
 
 	return f.value.Cmp(o.value) == 0

--- a/types/basetypes/float64_value.go
+++ b/types/basetypes/float64_value.go
@@ -63,7 +63,7 @@ func NewFloat64Unknown() Float64Value {
 }
 
 // Float64Value creates a Float64 with a known value. Access the value via the Float64
-// type ValueFloat64 method.
+// type ValueFloat64 method. Passing a value of `NaN` will result in a panic.
 //
 // Setting the deprecated Float64 type Null, Unknown, or Value fields after
 // creating a Float64 with this function has no effect.
@@ -76,6 +76,7 @@ func NewFloat64Value(value float64) Float64Value {
 
 // NewFloat64PointerValue creates a Float64 with a null value if nil or a known
 // value. Access the value via the Float64 type ValueFloat64Pointer method.
+// Passing a value of `NaN` will result in a panic.
 func NewFloat64PointerValue(value *float64) Float64Value {
 	if value == nil {
 		return NewFloat64Null()

--- a/types/basetypes/float64_value_test.go
+++ b/types/basetypes/float64_value_test.go
@@ -157,6 +157,22 @@ func TestFloat64ValueEqual(t *testing.T) {
 			},
 			expectation: false,
 		},
+		"knownnil-known": {
+			input: Float64Value{
+				state: attr.ValueStateKnown,
+				value: nil,
+			},
+			candidate:   NewFloat64Value(0.1),
+			expectation: false,
+		},
+		"known-knownnil": {
+			input: NewFloat64Value(0.1),
+			candidate: Float64Value{
+				state: attr.ValueStateKnown,
+				value: nil,
+			},
+			expectation: false,
+		},
 		"known-unknown": {
 			input:       NewFloat64Value(123),
 			candidate:   NewFloat64Unknown(),

--- a/types/basetypes/float64_value_test.go
+++ b/types/basetypes/float64_value_test.go
@@ -97,14 +97,52 @@ func TestFloat64ValueEqual(t *testing.T) {
 		expectation bool
 	}
 	tests := map[string]testCase{
-		"known-known-same": {
+		"known-known-53-precison-same": {
 			input:       NewFloat64Value(123),
 			candidate:   NewFloat64Value(123),
 			expectation: true,
 		},
-		"known-known-diff": {
+		"known-known-53-precison-diff": {
 			input:       NewFloat64Value(123),
 			candidate:   NewFloat64Value(456),
+			expectation: false,
+		},
+		"known-known-512-precision-same": {
+			input: Float64Value{
+				state: attr.ValueStateKnown,
+				value: testMustParseFloat("0.010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003"),
+			},
+			candidate: Float64Value{
+				state: attr.ValueStateKnown,
+				value: testMustParseFloat("0.010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003"),
+			},
+			expectation: true,
+		},
+		"known-known-512-precision-mantissa-diff": {
+			input: Float64Value{
+				state: attr.ValueStateKnown,
+				value: testMustParseFloat("0.010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001"),
+			},
+			candidate: Float64Value{
+				state: attr.ValueStateKnown,
+				value: testMustParseFloat("0.01"),
+			},
+			expectation: false,
+		},
+		"known-known-precisiondiff-mantissa-same": {
+			input: NewFloat64Value(123),
+			candidate: Float64Value{
+				state: attr.ValueStateKnown,
+				value: testMustParseFloat("123"),
+			},
+			expectation: true,
+		},
+		"known-known-precisiondiff-mantissa-diff": {
+			input: NewFloat64Value(0.1),
+			candidate: Float64Value{
+				state: attr.ValueStateKnown,
+				value: testMustParseFloat("0.1"),
+			},
 			expectation: false,
 		},
 		"known-unknown": {
@@ -395,3 +433,5 @@ func TestNewFloat64PointerValue(t *testing.T) {
 		})
 	}
 }
+
+// TODO: semantic equality tests for 53 vs. 512 precision

--- a/types/basetypes/float64_value_test.go
+++ b/types/basetypes/float64_value_test.go
@@ -173,6 +173,17 @@ func TestFloat64ValueEqual(t *testing.T) {
 			},
 			expectation: false,
 		},
+		"knownnil-knownnil": {
+			input: Float64Value{
+				state: attr.ValueStateKnown,
+				value: nil,
+			},
+			candidate: Float64Value{
+				state: attr.ValueStateKnown,
+				value: nil,
+			},
+			expectation: true,
+		},
 		"known-unknown": {
 			input:       NewFloat64Value(123),
 			candidate:   NewFloat64Unknown(),

--- a/types/basetypes/float64_value_test.go
+++ b/types/basetypes/float64_value_test.go
@@ -99,13 +99,13 @@ func TestFloat64ValueEqual(t *testing.T) {
 	}
 	tests := map[string]testCase{
 		"known-known-53-precison-same": {
-			input:       NewFloat64Value(123),
-			candidate:   NewFloat64Value(123),
+			input:       NewFloat64Value(123.123),
+			candidate:   NewFloat64Value(123.123),
 			expectation: true,
 		},
 		"known-known-53-precison-diff": {
-			input:       NewFloat64Value(123),
-			candidate:   NewFloat64Value(456),
+			input:       NewFloat64Value(123.123),
+			candidate:   NewFloat64Value(456.456),
 			expectation: false,
 		},
 		"known-known-512-precision-same": {
@@ -468,7 +468,7 @@ func TestFloat64ValueFloat64SemanticEquals(t *testing.T) {
 		"not equal - float differing precision": {
 			currentFloat64: Float64Value{
 				state: attr.ValueStateKnown,
-				value: testMustParseFloat("0.010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001"),
+				value: testMustParseFloat("0.01"),
 			},
 			givenFloat64:  NewFloat64Value(0.02),
 			expectedMatch: false,
@@ -486,12 +486,13 @@ func TestFloat64ValueFloat64SemanticEquals(t *testing.T) {
 		"semantically equal - float differing precision": {
 			currentFloat64: Float64Value{
 				state: attr.ValueStateKnown,
-				value: testMustParseFloat("0.010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001"),
+				value: testMustParseFloat("0.01"),
 			},
 			givenFloat64:  NewFloat64Value(0.01),
 			expectedMatch: true,
 		},
-		"semantically equal - float same precision, different value": {
+		// Only 53 bits of precision are compared, Go built-in float64
+		"semantically equal - float 512 precision, different value not significant": {
 			currentFloat64: Float64Value{
 				state: attr.ValueStateKnown,
 				value: testMustParseFloat("0.010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001"),


### PR DESCRIPTION
Closes #815 
Related corner tests: https://github.com/hashicorp/terraform-provider-corner/pull/170

### Context
Terraform core's `number` type can store up to [512 bits of precision](https://github.com/zclconf/go-cty/blob/main/docs/types.md#ctynumber) for floating numbers. This level of precision is typically only encountered when performing an arithmetic operation like below:
```bash
 $ terraform console
> 1 - 0.99
0.010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003
```

The `Float64Attribute` underlying value of Go's built-in `float64` type was losing this precision and responding with invalid plan value errors seen in #815 .

### Solution
This PR replaces the underlying value of `Float64Attribute` with a `*big.Float` type, which is already supported in [`terraform-plugin-go`](https://github.com/hashicorp/terraform-plugin-go/blob/81f0d496aaa39e43cc185f5c961df5fcd86192da/tftypes/primitive.go#L176). Semantic equality logic has also been implemented to ensure that `Computed` values do not replace more precise prior values.