### PR TITLE
internal: Update all provider defined method call logs to TRACE

### DIFF
--- a/.changes/unreleased/NOTES-20230803-173432.yaml
+++ b/.changes/unreleased/NOTES-20230803-173432.yaml
@@ -1,6 +1,0 @@
-kind: NOTES
-body: 'internal: Logging of provider defined method execution changed from `DEBUG`
-  log level to `TRACE`'
-time: 2023-08-03T17:34:32.091271-04:00
-custom:
-  Issue: "818"

--- a/.changes/unreleased/NOTES-20230803-173432.yaml
+++ b/.changes/unreleased/NOTES-20230803-173432.yaml
@@ -1,0 +1,6 @@
+kind: NOTES
+body: 'internal: Logging of provider defined method execution changed from `DEBUG`
+  log level to `TRACE`'
+time: 2023-08-03T17:34:32.091271-04:00
+custom:
+  Issue: "818"

--- a/.changes/unreleased/NOTES-20230803-173640.yaml
+++ b/.changes/unreleased/NOTES-20230803-173640.yaml
@@ -1,0 +1,6 @@
+kind: NOTES
+body: 'internal: Changed provider defined method execution logs from `DEBUG` log level
+  to `TRACE`'
+time: 2023-08-03T17:36:40.939931-04:00
+custom:
+  Issue: "818"

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -54,6 +54,7 @@ We welcome issues of all kinds including feature requests, bug reports, or docum
 Thank you for contributing!
 
 - **Early validation of idea and implementation plan**: Most code changes in this project, unless trivial typo fixes or cosmetic, should be discussed and approved by maintainers in an issue before an implementation is created. This project is complicated enough that there are often several ways to implement something, each of which has different implications and tradeoffs. Working through an implementation plan with the maintainers before you dive into implementation will help ensure that your efforts may be approved and merged.
+- **Logging**: Refer to the [logging](#logging) section for guidance on choosing the appropriate log level for messages.
 - **Unit and Integration Tests**: It may go without saying, but every new patch should be covered by tests wherever possible (see [Testing](#testing) below).
 - **Go Modules**: We use [Go Modules](https://github.com/golang/go/wiki/Modules) to manage and version all our dependencies. Please make sure that you reflect dependency changes in your pull requests appropriately (e.g. `go get`, `go mod tidy` or other commands). Refer to the [dependency updates](#dependency-updates) section for more information about how this project maintains existing dependencies.
 - **Changelog**: Refer to the [changelog](#changelog) section for more information about how to create changelog entries.
@@ -125,6 +126,17 @@ To run the Go linters locally, install the `golangci-lint` tool, and run:
 ```shell
 golangci-lint run ./...
 ```
+
+## Logging
+
+Code contributions that introduce new log messages should utilize the helper functions in the [`internal/logging`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/internal/logging) package. Here are some examples on when to use each helper:
+
+- [`FrameworkError`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/internal/logging#FrameworkError) - Logs at `ERROR` level, can be used to provide additional detail alongside user-facing errors that are returned with [`diag.Diagnostics`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/diag#Diagnostics).
+- [`FrameworkWarn`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/internal/logging#FrameworkWarn) - Logs at `WARN` level, can be used to signal unexpected scenarios that may not result in a user-facing error, but can be used to track down potential provider implementation bugs.
+- [`FrameworkDebug`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/internal/logging#FrameworkDebug) - Logs at `DEBUG` level, can be used to describe internal logic behavior, such as [semantic equality](https://developer.hashicorp.com/terraform/plugin/framework/handling-data/custom-types#semantic-equality) being triggered to preserve a prior value, or a null `Computed` attribute being marked as unknown.
+- [`FrameworkTrace`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/internal/logging#FrameworkTrace) - Logs at `TRACE` level, can be used to describe internal logic execution, such as logging a message before and after a provider-defined method is called. As the name suggests, these messages are used to "trace" where a program is at during execution.
+
+More general guidance about logging can be found in the [Plugin Development documentation.](https://developer.hashicorp.com/terraform/plugin/log/managing)
 
 ## Testing
 

--- a/internal/fwschemadata/data_set_at_path.go
+++ b/internal/fwschemadata/data_set_at_path.go
@@ -71,9 +71,9 @@ func (d *Data) SetAtPath(ctx context.Context, path path.Path, val interface{}) d
 
 	if attrTypeWithValidate, ok := attrType.(xattr.TypeWithValidate); ok {
 		logging.FrameworkTrace(ctx, "Type implements TypeWithValidate")
-		logging.FrameworkDebug(ctx, "Calling provider defined Type Validate")
+		logging.FrameworkTrace(ctx, "Calling provider defined Type Validate")
 		diags.Append(attrTypeWithValidate.Validate(ctx, tfVal, path)...)
-		logging.FrameworkDebug(ctx, "Called provider defined Type Validate")
+		logging.FrameworkTrace(ctx, "Called provider defined Type Validate")
 
 		if diags.HasError() {
 			return diags
@@ -189,9 +189,9 @@ func (d Data) SetAtPathTransformFunc(ctx context.Context, path path.Path, tfVal 
 
 	if attrTypeWithValidate, ok := parentAttrType.(xattr.TypeWithValidate); ok {
 		logging.FrameworkTrace(ctx, "Type implements TypeWithValidate")
-		logging.FrameworkDebug(ctx, "Calling provider defined Type Validate")
+		logging.FrameworkTrace(ctx, "Calling provider defined Type Validate")
 		diags.Append(attrTypeWithValidate.Validate(ctx, parentValue, parentPath)...)
-		logging.FrameworkDebug(ctx, "Called provider defined Type Validate")
+		logging.FrameworkTrace(ctx, "Called provider defined Type Validate")
 
 		if diags.HasError() {
 			return nil, diags

--- a/internal/fwschemadata/data_value.go
+++ b/internal/fwschemadata/data_value.go
@@ -78,9 +78,9 @@ func (d Data) ValueAtPath(ctx context.Context, schemaPath path.Path) (attr.Value
 
 	if attrTypeWithValidate, ok := attrType.(xattr.TypeWithValidate); ok {
 		logging.FrameworkTrace(ctx, "Type implements TypeWithValidate")
-		logging.FrameworkDebug(ctx, "Calling provider defined Type Validate")
+		logging.FrameworkTrace(ctx, "Calling provider defined Type Validate")
 		diags.Append(attrTypeWithValidate.Validate(ctx, tfValue, schemaPath)...)
-		logging.FrameworkDebug(ctx, "Called provider defined Type Validate")
+		logging.FrameworkTrace(ctx, "Called provider defined Type Validate")
 
 		if diags.HasError() {
 			return nil, diags

--- a/internal/fwserver/attribute_plan_modification.go
+++ b/internal/fwserver/attribute_plan_modification.go
@@ -685,7 +685,7 @@ func AttributePlanModifyBool(ctx context.Context, attribute fwxschema.AttributeW
 			Private:   resp.Private,
 		}
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Calling provider defined planmodifier.Bool",
 			map[string]interface{}{
@@ -695,7 +695,7 @@ func AttributePlanModifyBool(ctx context.Context, attribute fwxschema.AttributeW
 
 		planModifier.PlanModifyBool(ctx, planModifyReq, planModifyResp)
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Called provider defined planmodifier.Bool",
 			map[string]interface{}{
@@ -845,7 +845,7 @@ func AttributePlanModifyFloat64(ctx context.Context, attribute fwxschema.Attribu
 			Private:   resp.Private,
 		}
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Calling provider defined planmodifier.Float64",
 			map[string]interface{}{
@@ -855,7 +855,7 @@ func AttributePlanModifyFloat64(ctx context.Context, attribute fwxschema.Attribu
 
 		planModifier.PlanModifyFloat64(ctx, planModifyReq, planModifyResp)
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Called provider defined planmodifier.Float64",
 			map[string]interface{}{
@@ -1005,7 +1005,7 @@ func AttributePlanModifyInt64(ctx context.Context, attribute fwxschema.Attribute
 			Private:   resp.Private,
 		}
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Calling provider defined planmodifier.Int64",
 			map[string]interface{}{
@@ -1015,7 +1015,7 @@ func AttributePlanModifyInt64(ctx context.Context, attribute fwxschema.Attribute
 
 		planModifier.PlanModifyInt64(ctx, planModifyReq, planModifyResp)
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Called provider defined planmodifier.Int64",
 			map[string]interface{}{
@@ -1165,7 +1165,7 @@ func AttributePlanModifyList(ctx context.Context, attribute fwxschema.AttributeW
 			Private:   resp.Private,
 		}
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Calling provider defined planmodifier.List",
 			map[string]interface{}{
@@ -1175,7 +1175,7 @@ func AttributePlanModifyList(ctx context.Context, attribute fwxschema.AttributeW
 
 		planModifier.PlanModifyList(ctx, planModifyReq, planModifyResp)
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Called provider defined planmodifier.List",
 			map[string]interface{}{
@@ -1325,7 +1325,7 @@ func AttributePlanModifyMap(ctx context.Context, attribute fwxschema.AttributeWi
 			Private:   resp.Private,
 		}
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Calling provider defined planmodifier.Map",
 			map[string]interface{}{
@@ -1335,7 +1335,7 @@ func AttributePlanModifyMap(ctx context.Context, attribute fwxschema.AttributeWi
 
 		planModifier.PlanModifyMap(ctx, planModifyReq, planModifyResp)
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Called provider defined planmodifier.Map",
 			map[string]interface{}{
@@ -1485,7 +1485,7 @@ func AttributePlanModifyNumber(ctx context.Context, attribute fwxschema.Attribut
 			Private:   resp.Private,
 		}
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Calling provider defined planmodifier.Number",
 			map[string]interface{}{
@@ -1495,7 +1495,7 @@ func AttributePlanModifyNumber(ctx context.Context, attribute fwxschema.Attribut
 
 		planModifier.PlanModifyNumber(ctx, planModifyReq, planModifyResp)
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Called provider defined planmodifier.Number",
 			map[string]interface{}{
@@ -1645,7 +1645,7 @@ func AttributePlanModifyObject(ctx context.Context, attribute fwxschema.Attribut
 			Private:   resp.Private,
 		}
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Calling provider defined planmodifier.Object",
 			map[string]interface{}{
@@ -1655,7 +1655,7 @@ func AttributePlanModifyObject(ctx context.Context, attribute fwxschema.Attribut
 
 		planModifier.PlanModifyObject(ctx, planModifyReq, planModifyResp)
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Called provider defined planmodifier.Object",
 			map[string]interface{}{
@@ -1805,7 +1805,7 @@ func AttributePlanModifySet(ctx context.Context, attribute fwxschema.AttributeWi
 			Private:   resp.Private,
 		}
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Calling provider defined planmodifier.Set",
 			map[string]interface{}{
@@ -1815,7 +1815,7 @@ func AttributePlanModifySet(ctx context.Context, attribute fwxschema.AttributeWi
 
 		planModifier.PlanModifySet(ctx, planModifyReq, planModifyResp)
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Called provider defined planmodifier.Set",
 			map[string]interface{}{
@@ -1965,7 +1965,7 @@ func AttributePlanModifyString(ctx context.Context, attribute fwxschema.Attribut
 			Private:   resp.Private,
 		}
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Calling provider defined planmodifier.String",
 			map[string]interface{}{
@@ -1975,7 +1975,7 @@ func AttributePlanModifyString(ctx context.Context, attribute fwxschema.Attribut
 
 		planModifier.PlanModifyString(ctx, planModifyReq, planModifyResp)
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Called provider defined planmodifier.String",
 			map[string]interface{}{
@@ -2024,7 +2024,7 @@ func NestedAttributeObjectPlanModify(ctx context.Context, o fwschema.NestedAttri
 				Private:   resp.Private,
 			}
 
-			logging.FrameworkDebug(
+			logging.FrameworkTrace(
 				ctx,
 				"Calling provider defined planmodifier.Object",
 				map[string]interface{}{
@@ -2034,7 +2034,7 @@ func NestedAttributeObjectPlanModify(ctx context.Context, o fwschema.NestedAttri
 
 			objectPlanModifier.PlanModifyObject(ctx, req, planModifyResp)
 
-			logging.FrameworkDebug(
+			logging.FrameworkTrace(
 				ctx,
 				"Called provider defined planmodifier.Object",
 				map[string]interface{}{

--- a/internal/fwserver/attribute_validation.go
+++ b/internal/fwserver/attribute_validation.go
@@ -184,7 +184,7 @@ func AttributeValidateBool(ctx context.Context, attribute fwxschema.AttributeWit
 		// from modifying or removing diagnostics.
 		validateResp := &validator.BoolResponse{}
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Calling provider defined validator.Bool",
 			map[string]interface{}{
@@ -194,7 +194,7 @@ func AttributeValidateBool(ctx context.Context, attribute fwxschema.AttributeWit
 
 		attributeValidator.ValidateBool(ctx, validateReq, validateResp)
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Called provider defined validator.Bool",
 			map[string]interface{}{
@@ -249,7 +249,7 @@ func AttributeValidateFloat64(ctx context.Context, attribute fwxschema.Attribute
 		// from modifying or removing diagnostics.
 		validateResp := &validator.Float64Response{}
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Calling provider defined validator.Float64",
 			map[string]interface{}{
@@ -259,7 +259,7 @@ func AttributeValidateFloat64(ctx context.Context, attribute fwxschema.Attribute
 
 		attributeValidator.ValidateFloat64(ctx, validateReq, validateResp)
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Called provider defined validator.Float64",
 			map[string]interface{}{
@@ -314,7 +314,7 @@ func AttributeValidateInt64(ctx context.Context, attribute fwxschema.AttributeWi
 		// from modifying or removing diagnostics.
 		validateResp := &validator.Int64Response{}
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Calling provider defined validator.Int64",
 			map[string]interface{}{
@@ -324,7 +324,7 @@ func AttributeValidateInt64(ctx context.Context, attribute fwxschema.AttributeWi
 
 		attributeValidator.ValidateInt64(ctx, validateReq, validateResp)
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Called provider defined validator.Int64",
 			map[string]interface{}{
@@ -379,7 +379,7 @@ func AttributeValidateList(ctx context.Context, attribute fwxschema.AttributeWit
 		// from modifying or removing diagnostics.
 		validateResp := &validator.ListResponse{}
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Calling provider defined validator.List",
 			map[string]interface{}{
@@ -389,7 +389,7 @@ func AttributeValidateList(ctx context.Context, attribute fwxschema.AttributeWit
 
 		attributeValidator.ValidateList(ctx, validateReq, validateResp)
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Called provider defined validator.List",
 			map[string]interface{}{
@@ -444,7 +444,7 @@ func AttributeValidateMap(ctx context.Context, attribute fwxschema.AttributeWith
 		// from modifying or removing diagnostics.
 		validateResp := &validator.MapResponse{}
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Calling provider defined validator.Map",
 			map[string]interface{}{
@@ -454,7 +454,7 @@ func AttributeValidateMap(ctx context.Context, attribute fwxschema.AttributeWith
 
 		attributeValidator.ValidateMap(ctx, validateReq, validateResp)
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Called provider defined validator.Map",
 			map[string]interface{}{
@@ -509,7 +509,7 @@ func AttributeValidateNumber(ctx context.Context, attribute fwxschema.AttributeW
 		// from modifying or removing diagnostics.
 		validateResp := &validator.NumberResponse{}
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Calling provider defined validator.Number",
 			map[string]interface{}{
@@ -519,7 +519,7 @@ func AttributeValidateNumber(ctx context.Context, attribute fwxschema.AttributeW
 
 		attributeValidator.ValidateNumber(ctx, validateReq, validateResp)
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Called provider defined validator.Number",
 			map[string]interface{}{
@@ -574,7 +574,7 @@ func AttributeValidateObject(ctx context.Context, attribute fwxschema.AttributeW
 		// from modifying or removing diagnostics.
 		validateResp := &validator.ObjectResponse{}
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Calling provider defined validator.Object",
 			map[string]interface{}{
@@ -584,7 +584,7 @@ func AttributeValidateObject(ctx context.Context, attribute fwxschema.AttributeW
 
 		attributeValidator.ValidateObject(ctx, validateReq, validateResp)
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Called provider defined validator.Object",
 			map[string]interface{}{
@@ -639,7 +639,7 @@ func AttributeValidateSet(ctx context.Context, attribute fwxschema.AttributeWith
 		// from modifying or removing diagnostics.
 		validateResp := &validator.SetResponse{}
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Calling provider defined validator.Set",
 			map[string]interface{}{
@@ -649,7 +649,7 @@ func AttributeValidateSet(ctx context.Context, attribute fwxschema.AttributeWith
 
 		attributeValidator.ValidateSet(ctx, validateReq, validateResp)
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Called provider defined validator.Set",
 			map[string]interface{}{
@@ -704,7 +704,7 @@ func AttributeValidateString(ctx context.Context, attribute fwxschema.AttributeW
 		// from modifying or removing diagnostics.
 		validateResp := &validator.StringResponse{}
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Calling provider defined validator.String",
 			map[string]interface{}{
@@ -714,7 +714,7 @@ func AttributeValidateString(ctx context.Context, attribute fwxschema.AttributeW
 
 		attributeValidator.ValidateString(ctx, validateReq, validateResp)
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Called provider defined validator.String",
 			map[string]interface{}{
@@ -933,7 +933,7 @@ func NestedAttributeObjectValidate(ctx context.Context, o fwschema.NestedAttribu
 			// from modifying or removing diagnostics.
 			validateResp := &validator.ObjectResponse{}
 
-			logging.FrameworkDebug(
+			logging.FrameworkTrace(
 				ctx,
 				"Calling provider defined validator.Object",
 				map[string]interface{}{
@@ -943,7 +943,7 @@ func NestedAttributeObjectValidate(ctx context.Context, o fwschema.NestedAttribu
 
 			objectValidator.ValidateObject(ctx, validateReq, validateResp)
 
-			logging.FrameworkDebug(
+			logging.FrameworkTrace(
 				ctx,
 				"Called provider defined validator.Object",
 				map[string]interface{}{

--- a/internal/fwserver/block_plan_modification.go
+++ b/internal/fwserver/block_plan_modification.go
@@ -489,7 +489,7 @@ func BlockPlanModifyList(ctx context.Context, block fwxschema.BlockWithListPlanM
 			Private:   resp.Private,
 		}
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Calling provider defined planmodifier.List",
 			map[string]interface{}{
@@ -499,7 +499,7 @@ func BlockPlanModifyList(ctx context.Context, block fwxschema.BlockWithListPlanM
 
 		planModifier.PlanModifyList(ctx, planModifyReq, planModifyResp)
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Called provider defined planmodifier.List",
 			map[string]interface{}{
@@ -649,7 +649,7 @@ func BlockPlanModifyObject(ctx context.Context, block fwxschema.BlockWithObjectP
 			Private:   resp.Private,
 		}
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Calling provider defined planmodifier.Object",
 			map[string]interface{}{
@@ -659,7 +659,7 @@ func BlockPlanModifyObject(ctx context.Context, block fwxschema.BlockWithObjectP
 
 		planModifier.PlanModifyObject(ctx, planModifyReq, planModifyResp)
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Called provider defined planmodifier.Object",
 			map[string]interface{}{
@@ -809,7 +809,7 @@ func BlockPlanModifySet(ctx context.Context, block fwxschema.BlockWithSetPlanMod
 			Private:   resp.Private,
 		}
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Calling provider defined planmodifier.Set",
 			map[string]interface{}{
@@ -819,7 +819,7 @@ func BlockPlanModifySet(ctx context.Context, block fwxschema.BlockWithSetPlanMod
 
 		planModifier.PlanModifySet(ctx, planModifyReq, planModifyResp)
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Called provider defined planmodifier.Set",
 			map[string]interface{}{
@@ -868,7 +868,7 @@ func NestedBlockObjectPlanModify(ctx context.Context, o fwschema.NestedBlockObje
 				Private:   resp.Private,
 			}
 
-			logging.FrameworkDebug(
+			logging.FrameworkTrace(
 				ctx,
 				"Calling provider defined planmodifier.Object",
 				map[string]interface{}{
@@ -878,7 +878,7 @@ func NestedBlockObjectPlanModify(ctx context.Context, o fwschema.NestedBlockObje
 
 			objectPlanModifier.PlanModifyObject(ctx, req, planModifyResp)
 
-			logging.FrameworkDebug(
+			logging.FrameworkTrace(
 				ctx,
 				"Called provider defined planmodifier.Object",
 				map[string]interface{}{

--- a/internal/fwserver/block_validation.go
+++ b/internal/fwserver/block_validation.go
@@ -214,7 +214,7 @@ func BlockValidateList(ctx context.Context, block fwxschema.BlockWithListValidat
 		// from modifying or removing diagnostics.
 		validateResp := &validator.ListResponse{}
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Calling provider defined validator.List",
 			map[string]interface{}{
@@ -224,7 +224,7 @@ func BlockValidateList(ctx context.Context, block fwxschema.BlockWithListValidat
 
 		blockValidator.ValidateList(ctx, validateReq, validateResp)
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Called provider defined validator.List",
 			map[string]interface{}{
@@ -279,7 +279,7 @@ func BlockValidateObject(ctx context.Context, block fwxschema.BlockWithObjectVal
 		// from modifying or removing diagnostics.
 		validateResp := &validator.ObjectResponse{}
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Calling provider defined validator.Object",
 			map[string]interface{}{
@@ -289,7 +289,7 @@ func BlockValidateObject(ctx context.Context, block fwxschema.BlockWithObjectVal
 
 		blockValidator.ValidateObject(ctx, validateReq, validateResp)
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Called provider defined validator.Object",
 			map[string]interface{}{
@@ -344,7 +344,7 @@ func BlockValidateSet(ctx context.Context, block fwxschema.BlockWithSetValidator
 		// from modifying or removing diagnostics.
 		validateResp := &validator.SetResponse{}
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Calling provider defined validator.Set",
 			map[string]interface{}{
@@ -354,7 +354,7 @@ func BlockValidateSet(ctx context.Context, block fwxschema.BlockWithSetValidator
 
 		blockValidator.ValidateSet(ctx, validateReq, validateResp)
 
-		logging.FrameworkDebug(
+		logging.FrameworkTrace(
 			ctx,
 			"Called provider defined validator.Set",
 			map[string]interface{}{
@@ -406,7 +406,7 @@ func NestedBlockObjectValidate(ctx context.Context, o fwschema.NestedBlockObject
 			// from modifying or removing diagnostics.
 			validateResp := &validator.ObjectResponse{}
 
-			logging.FrameworkDebug(
+			logging.FrameworkTrace(
 				ctx,
 				"Calling provider defined validator.Object",
 				map[string]interface{}{
@@ -416,7 +416,7 @@ func NestedBlockObjectValidate(ctx context.Context, o fwschema.NestedBlockObject
 
 			objectValidator.ValidateObject(ctx, validateReq, validateResp)
 
-			logging.FrameworkDebug(
+			logging.FrameworkTrace(
 				ctx,
 				"Called provider defined validator.Object",
 				map[string]interface{}{

--- a/internal/fwserver/server.go
+++ b/internal/fwserver/server.go
@@ -142,9 +142,9 @@ func (s *Server) DataSourceFuncs(ctx context.Context) (map[string]func() datasou
 
 	s.dataSourceFuncs = make(map[string]func() datasource.DataSource)
 
-	logging.FrameworkDebug(ctx, "Calling provider defined Provider DataSources")
+	logging.FrameworkTrace(ctx, "Calling provider defined Provider DataSources")
 	dataSourceFuncsSlice := s.Provider.DataSources(ctx)
-	logging.FrameworkDebug(ctx, "Called provider defined Provider DataSources")
+	logging.FrameworkTrace(ctx, "Called provider defined Provider DataSources")
 
 	for _, dataSourceFunc := range dataSourceFuncsSlice {
 		dataSource := dataSourceFunc()
@@ -207,9 +207,9 @@ func (s *Server) DataSourceSchema(ctx context.Context, typeName string) (fwschem
 	schemaReq := datasource.SchemaRequest{}
 	schemaResp := datasource.SchemaResponse{}
 
-	logging.FrameworkDebug(ctx, "Calling provider defined DataSource Schema method", map[string]interface{}{logging.KeyDataSourceType: typeName})
+	logging.FrameworkTrace(ctx, "Calling provider defined DataSource Schema method", map[string]interface{}{logging.KeyDataSourceType: typeName})
 	dataSource.Schema(ctx, schemaReq, &schemaResp)
-	logging.FrameworkDebug(ctx, "Called provider defined DataSource Schema method", map[string]interface{}{logging.KeyDataSourceType: typeName})
+	logging.FrameworkTrace(ctx, "Called provider defined DataSource Schema method", map[string]interface{}{logging.KeyDataSourceType: typeName})
 
 	diags.Append(schemaResp.Diagnostics...)
 
@@ -245,9 +245,9 @@ func (s *Server) DataSourceSchemas(ctx context.Context) (map[string]fwschema.Sch
 		schemaReq := datasource.SchemaRequest{}
 		schemaResp := datasource.SchemaResponse{}
 
-		logging.FrameworkDebug(ctx, "Calling provider defined DataSource Schema", map[string]interface{}{logging.KeyDataSourceType: typeName})
+		logging.FrameworkTrace(ctx, "Calling provider defined DataSource Schema", map[string]interface{}{logging.KeyDataSourceType: typeName})
 		dataSource.Schema(ctx, schemaReq, &schemaResp)
-		logging.FrameworkDebug(ctx, "Called provider defined DataSource Schema", map[string]interface{}{logging.KeyDataSourceType: typeName})
+		logging.FrameworkTrace(ctx, "Called provider defined DataSource Schema", map[string]interface{}{logging.KeyDataSourceType: typeName})
 
 		diags.Append(schemaResp.Diagnostics...)
 
@@ -283,9 +283,9 @@ func (s *Server) ProviderSchema(ctx context.Context) (fwschema.Schema, diag.Diag
 	schemaReq := provider.SchemaRequest{}
 	schemaResp := provider.SchemaResponse{}
 
-	logging.FrameworkDebug(ctx, "Calling provider defined Provider Schema")
+	logging.FrameworkTrace(ctx, "Calling provider defined Provider Schema")
 	s.Provider.Schema(ctx, schemaReq, &schemaResp)
-	logging.FrameworkDebug(ctx, "Called provider defined Provider Schema")
+	logging.FrameworkTrace(ctx, "Called provider defined Provider Schema")
 
 	s.providerSchema = schemaResp.Schema
 	s.providerSchemaDiags = schemaResp.Diagnostics
@@ -317,9 +317,9 @@ func (s *Server) ProviderMetaSchema(ctx context.Context) (fwschema.Schema, diag.
 	req := provider.MetaSchemaRequest{}
 	resp := &provider.MetaSchemaResponse{}
 
-	logging.FrameworkDebug(ctx, "Calling provider defined Provider MetaSchema")
+	logging.FrameworkTrace(ctx, "Calling provider defined Provider MetaSchema")
 	providerWithMetaSchema.MetaSchema(ctx, req, resp)
-	logging.FrameworkDebug(ctx, "Called provider defined Provider MetaSchema")
+	logging.FrameworkTrace(ctx, "Called provider defined Provider MetaSchema")
 
 	s.providerMetaSchema = resp.Schema
 	s.providerMetaSchemaDiags = resp.Diagnostics
@@ -360,9 +360,9 @@ func (s *Server) ResourceFuncs(ctx context.Context) (map[string]func() resource.
 
 	s.resourceFuncs = make(map[string]func() resource.Resource)
 
-	logging.FrameworkDebug(ctx, "Calling provider defined Provider Resources")
+	logging.FrameworkTrace(ctx, "Calling provider defined Provider Resources")
 	resourceFuncsSlice := s.Provider.Resources(ctx)
-	logging.FrameworkDebug(ctx, "Called provider defined Provider Resources")
+	logging.FrameworkTrace(ctx, "Called provider defined Provider Resources")
 
 	for _, resourceFunc := range resourceFuncsSlice {
 		res := resourceFunc()
@@ -425,9 +425,9 @@ func (s *Server) ResourceSchema(ctx context.Context, typeName string) (fwschema.
 	schemaReq := resource.SchemaRequest{}
 	schemaResp := resource.SchemaResponse{}
 
-	logging.FrameworkDebug(ctx, "Calling provider defined Resource Schema method", map[string]interface{}{logging.KeyResourceType: typeName})
+	logging.FrameworkTrace(ctx, "Calling provider defined Resource Schema method", map[string]interface{}{logging.KeyResourceType: typeName})
 	r.Schema(ctx, schemaReq, &schemaResp)
-	logging.FrameworkDebug(ctx, "Called provider defined Resource Schema method", map[string]interface{}{logging.KeyResourceType: typeName})
+	logging.FrameworkTrace(ctx, "Called provider defined Resource Schema method", map[string]interface{}{logging.KeyResourceType: typeName})
 
 	diags.Append(schemaResp.Diagnostics...)
 
@@ -463,9 +463,9 @@ func (s *Server) ResourceSchemas(ctx context.Context) (map[string]fwschema.Schem
 		schemaReq := resource.SchemaRequest{}
 		schemaResp := resource.SchemaResponse{}
 
-		logging.FrameworkDebug(ctx, "Calling provider defined Resource Schema method", map[string]interface{}{logging.KeyResourceType: typeName})
+		logging.FrameworkTrace(ctx, "Calling provider defined Resource Schema method", map[string]interface{}{logging.KeyResourceType: typeName})
 		r.Schema(ctx, schemaReq, &schemaResp)
-		logging.FrameworkDebug(ctx, "Called provider defined Resource Schema method", map[string]interface{}{logging.KeyResourceType: typeName})
+		logging.FrameworkTrace(ctx, "Called provider defined Resource Schema method", map[string]interface{}{logging.KeyResourceType: typeName})
 
 		diags.Append(schemaResp.Diagnostics...)
 

--- a/internal/fwserver/server_configureprovider.go
+++ b/internal/fwserver/server_configureprovider.go
@@ -12,7 +12,7 @@ import (
 
 // ConfigureProvider implements the framework server ConfigureProvider RPC.
 func (s *Server) ConfigureProvider(ctx context.Context, req *provider.ConfigureRequest, resp *provider.ConfigureResponse) {
-	logging.FrameworkDebug(ctx, "Calling provider defined Provider Configure")
+	logging.FrameworkTrace(ctx, "Calling provider defined Provider Configure")
 
 	if req != nil {
 		s.Provider.Configure(ctx, *req, resp)
@@ -20,7 +20,7 @@ func (s *Server) ConfigureProvider(ctx context.Context, req *provider.ConfigureR
 		s.Provider.Configure(ctx, provider.ConfigureRequest{}, resp)
 	}
 
-	logging.FrameworkDebug(ctx, "Called provider defined Provider Configure")
+	logging.FrameworkTrace(ctx, "Called provider defined Provider Configure")
 
 	s.DataSourceConfigureData = resp.DataSourceData
 	s.ResourceConfigureData = resp.ResourceData

--- a/internal/fwserver/server_createresource.go
+++ b/internal/fwserver/server_createresource.go
@@ -51,9 +51,9 @@ func (s *Server) CreateResource(ctx context.Context, req *CreateResourceRequest,
 		}
 		configureResp := resource.ConfigureResponse{}
 
-		logging.FrameworkDebug(ctx, "Calling provider defined Resource Configure")
+		logging.FrameworkTrace(ctx, "Calling provider defined Resource Configure")
 		resourceWithConfigure.Configure(ctx, configureReq, &configureResp)
-		logging.FrameworkDebug(ctx, "Called provider defined Resource Configure")
+		logging.FrameworkTrace(ctx, "Called provider defined Resource Configure")
 
 		resp.Diagnostics.Append(configureResp.Diagnostics...)
 
@@ -97,9 +97,9 @@ func (s *Server) CreateResource(ctx context.Context, req *CreateResourceRequest,
 		createReq.ProviderMeta = *req.ProviderMeta
 	}
 
-	logging.FrameworkDebug(ctx, "Calling provider defined Resource Create")
+	logging.FrameworkTrace(ctx, "Calling provider defined Resource Create")
 	req.Resource.Create(ctx, createReq, &createResp)
-	logging.FrameworkDebug(ctx, "Called provider defined Resource Create")
+	logging.FrameworkTrace(ctx, "Called provider defined Resource Create")
 
 	resp.Diagnostics = createResp.Diagnostics
 	resp.NewState = &createResp.State

--- a/internal/fwserver/server_deleteresource.go
+++ b/internal/fwserver/server_deleteresource.go
@@ -49,9 +49,9 @@ func (s *Server) DeleteResource(ctx context.Context, req *DeleteResourceRequest,
 		}
 		configureResp := resource.ConfigureResponse{}
 
-		logging.FrameworkDebug(ctx, "Calling provider defined Resource Configure")
+		logging.FrameworkTrace(ctx, "Calling provider defined Resource Configure")
 		resourceWithConfigure.Configure(ctx, configureReq, &configureResp)
-		logging.FrameworkDebug(ctx, "Called provider defined Resource Configure")
+		logging.FrameworkTrace(ctx, "Called provider defined Resource Configure")
 
 		resp.Diagnostics.Append(configureResp.Diagnostics...)
 
@@ -86,9 +86,9 @@ func (s *Server) DeleteResource(ctx context.Context, req *DeleteResourceRequest,
 		deleteReq.Private = req.PlannedPrivate.Provider
 	}
 
-	logging.FrameworkDebug(ctx, "Calling provider defined Resource Delete")
+	logging.FrameworkTrace(ctx, "Calling provider defined Resource Delete")
 	req.Resource.Delete(ctx, deleteReq, &deleteResp)
-	logging.FrameworkDebug(ctx, "Called provider defined Resource Delete")
+	logging.FrameworkTrace(ctx, "Called provider defined Resource Delete")
 
 	if !deleteResp.Diagnostics.HasError() {
 		logging.FrameworkTrace(ctx, "No provider defined Delete errors detected, ensuring State is cleared")

--- a/internal/fwserver/server_getproviderschema.go
+++ b/internal/fwserver/server_getproviderschema.go
@@ -36,9 +36,9 @@ func (s *Server) GetProviderSchema(ctx context.Context, req *GetProviderSchemaRe
 	metadataReq := provider.MetadataRequest{}
 	metadataResp := provider.MetadataResponse{}
 
-	logging.FrameworkDebug(ctx, "Calling provider defined Provider Metadata")
+	logging.FrameworkTrace(ctx, "Calling provider defined Provider Metadata")
 	s.Provider.Metadata(ctx, metadataReq, &metadataResp)
-	logging.FrameworkDebug(ctx, "Called provider defined Provider Metadata")
+	logging.FrameworkTrace(ctx, "Called provider defined Provider Metadata")
 
 	s.providerTypeName = metadataResp.TypeName
 

--- a/internal/fwserver/server_importresourcestate.go
+++ b/internal/fwserver/server_importresourcestate.go
@@ -58,9 +58,9 @@ func (s *Server) ImportResourceState(ctx context.Context, req *ImportResourceSta
 		}
 		configureResp := resource.ConfigureResponse{}
 
-		logging.FrameworkDebug(ctx, "Calling provider defined Resource Configure")
+		logging.FrameworkTrace(ctx, "Calling provider defined Resource Configure")
 		resourceWithConfigure.Configure(ctx, configureReq, &configureResp)
-		logging.FrameworkDebug(ctx, "Called provider defined Resource Configure")
+		logging.FrameworkTrace(ctx, "Called provider defined Resource Configure")
 
 		resp.Diagnostics.Append(configureResp.Diagnostics...)
 
@@ -103,9 +103,9 @@ func (s *Server) ImportResourceState(ctx context.Context, req *ImportResourceSta
 		Private: privateProviderData,
 	}
 
-	logging.FrameworkDebug(ctx, "Calling provider defined Resource ImportState")
+	logging.FrameworkTrace(ctx, "Calling provider defined Resource ImportState")
 	resourceWithImportState.ImportState(ctx, importReq, &importResp)
-	logging.FrameworkDebug(ctx, "Called provider defined Resource ImportState")
+	logging.FrameworkTrace(ctx, "Called provider defined Resource ImportState")
 
 	resp.Diagnostics.Append(importResp.Diagnostics...)
 

--- a/internal/fwserver/server_planresourcechange.go
+++ b/internal/fwserver/server_planresourcechange.go
@@ -57,9 +57,9 @@ func (s *Server) PlanResourceChange(ctx context.Context, req *PlanResourceChange
 		}
 		configureResp := resource.ConfigureResponse{}
 
-		logging.FrameworkDebug(ctx, "Calling provider defined Resource Configure")
+		logging.FrameworkTrace(ctx, "Calling provider defined Resource Configure")
 		resourceWithConfigure.Configure(ctx, configureReq, &configureResp)
-		logging.FrameworkDebug(ctx, "Called provider defined Resource Configure")
+		logging.FrameworkTrace(ctx, "Called provider defined Resource Configure")
 
 		resp.Diagnostics.Append(configureResp.Diagnostics...)
 
@@ -276,9 +276,9 @@ func (s *Server) PlanResourceChange(ctx context.Context, req *PlanResourceChange
 			Private:         modifyPlanReq.Private,
 		}
 
-		logging.FrameworkDebug(ctx, "Calling provider defined Resource ModifyPlan")
+		logging.FrameworkTrace(ctx, "Calling provider defined Resource ModifyPlan")
 		resourceWithModifyPlan.ModifyPlan(ctx, modifyPlanReq, &modifyPlanResp)
-		logging.FrameworkDebug(ctx, "Called provider defined Resource ModifyPlan")
+		logging.FrameworkTrace(ctx, "Called provider defined Resource ModifyPlan")
 
 		resp.Diagnostics = modifyPlanResp.Diagnostics
 		resp.PlannedState = planToState(modifyPlanResp.Plan)

--- a/internal/fwserver/server_readdatasource.go
+++ b/internal/fwserver/server_readdatasource.go
@@ -44,9 +44,9 @@ func (s *Server) ReadDataSource(ctx context.Context, req *ReadDataSourceRequest,
 		}
 		configureResp := datasource.ConfigureResponse{}
 
-		logging.FrameworkDebug(ctx, "Calling provider defined DataSource Configure")
+		logging.FrameworkTrace(ctx, "Calling provider defined DataSource Configure")
 		dataSourceWithConfigure.Configure(ctx, configureReq, &configureResp)
-		logging.FrameworkDebug(ctx, "Called provider defined DataSource Configure")
+		logging.FrameworkTrace(ctx, "Called provider defined DataSource Configure")
 
 		resp.Diagnostics.Append(configureResp.Diagnostics...)
 
@@ -75,9 +75,9 @@ func (s *Server) ReadDataSource(ctx context.Context, req *ReadDataSourceRequest,
 		readReq.ProviderMeta = *req.ProviderMeta
 	}
 
-	logging.FrameworkDebug(ctx, "Calling provider defined DataSource Read")
+	logging.FrameworkTrace(ctx, "Calling provider defined DataSource Read")
 	req.DataSource.Read(ctx, readReq, &readResp)
-	logging.FrameworkDebug(ctx, "Called provider defined DataSource Read")
+	logging.FrameworkTrace(ctx, "Called provider defined DataSource Read")
 
 	resp.Diagnostics = readResp.Diagnostics
 	resp.State = &readResp.State

--- a/internal/fwserver/server_readresource.go
+++ b/internal/fwserver/server_readresource.go
@@ -55,9 +55,9 @@ func (s *Server) ReadResource(ctx context.Context, req *ReadResourceRequest, res
 		}
 		configureResp := resource.ConfigureResponse{}
 
-		logging.FrameworkDebug(ctx, "Calling provider defined Resource Configure")
+		logging.FrameworkTrace(ctx, "Calling provider defined Resource Configure")
 		resourceWithConfigure.Configure(ctx, configureReq, &configureResp)
-		logging.FrameworkDebug(ctx, "Called provider defined Resource Configure")
+		logging.FrameworkTrace(ctx, "Called provider defined Resource Configure")
 
 		resp.Diagnostics.Append(configureResp.Diagnostics...)
 
@@ -97,9 +97,9 @@ func (s *Server) ReadResource(ctx context.Context, req *ReadResourceRequest, res
 		resp.Private = req.Private
 	}
 
-	logging.FrameworkDebug(ctx, "Calling provider defined Resource Read")
+	logging.FrameworkTrace(ctx, "Calling provider defined Resource Read")
 	req.Resource.Read(ctx, readReq, &readResp)
-	logging.FrameworkDebug(ctx, "Called provider defined Resource Read")
+	logging.FrameworkTrace(ctx, "Called provider defined Resource Read")
 
 	resp.Diagnostics = readResp.Diagnostics
 	resp.NewState = &readResp.State

--- a/internal/fwserver/server_updateresource.go
+++ b/internal/fwserver/server_updateresource.go
@@ -52,9 +52,9 @@ func (s *Server) UpdateResource(ctx context.Context, req *UpdateResourceRequest,
 		}
 		configureResp := resource.ConfigureResponse{}
 
-		logging.FrameworkDebug(ctx, "Calling provider defined Resource Configure")
+		logging.FrameworkTrace(ctx, "Calling provider defined Resource Configure")
 		resourceWithConfigure.Configure(ctx, configureReq, &configureResp)
-		logging.FrameworkDebug(ctx, "Called provider defined Resource Configure")
+		logging.FrameworkTrace(ctx, "Called provider defined Resource Configure")
 
 		resp.Diagnostics.Append(configureResp.Diagnostics...)
 
@@ -118,9 +118,9 @@ func (s *Server) UpdateResource(ctx context.Context, req *UpdateResourceRequest,
 		resp.Private = req.PlannedPrivate
 	}
 
-	logging.FrameworkDebug(ctx, "Calling provider defined Resource Update")
+	logging.FrameworkTrace(ctx, "Calling provider defined Resource Update")
 	req.Resource.Update(ctx, updateReq, &updateResp)
-	logging.FrameworkDebug(ctx, "Called provider defined Resource Update")
+	logging.FrameworkTrace(ctx, "Called provider defined Resource Update")
 
 	resp.Diagnostics = updateResp.Diagnostics
 	resp.NewState = &updateResp.State

--- a/internal/fwserver/server_upgraderesourcestate.go
+++ b/internal/fwserver/server_upgraderesourcestate.go
@@ -110,9 +110,9 @@ func (s *Server) UpgradeResourceState(ctx context.Context, req *UpgradeResourceS
 		}
 		configureResp := resource.ConfigureResponse{}
 
-		logging.FrameworkDebug(ctx, "Calling provider defined Resource Configure")
+		logging.FrameworkTrace(ctx, "Calling provider defined Resource Configure")
 		resourceWithConfigure.Configure(ctx, configureReq, &configureResp)
-		logging.FrameworkDebug(ctx, "Called provider defined Resource Configure")
+		logging.FrameworkTrace(ctx, "Called provider defined Resource Configure")
 
 		resp.Diagnostics.Append(configureResp.Diagnostics...)
 
@@ -135,9 +135,9 @@ func (s *Server) UpgradeResourceState(ctx context.Context, req *UpgradeResourceS
 
 	logging.FrameworkTrace(ctx, "Resource implements ResourceWithUpgradeState")
 
-	logging.FrameworkDebug(ctx, "Calling provider defined Resource UpgradeState")
+	logging.FrameworkTrace(ctx, "Calling provider defined Resource UpgradeState")
 	resourceStateUpgraders := resourceWithUpgradeState.UpgradeState(ctx)
-	logging.FrameworkDebug(ctx, "Called provider defined Resource UpgradeState")
+	logging.FrameworkTrace(ctx, "Called provider defined Resource UpgradeState")
 
 	// Panic prevention
 	if resourceStateUpgraders == nil {
@@ -194,9 +194,9 @@ func (s *Server) UpgradeResourceState(ctx context.Context, req *UpgradeResourceS
 	// by calling the equivalent of SetAttribute(GetAttribute()) and skipping
 	// any errors.
 
-	logging.FrameworkDebug(ctx, "Calling provider defined StateUpgrader")
+	logging.FrameworkTrace(ctx, "Calling provider defined StateUpgrader")
 	resourceStateUpgrader.StateUpgrader(ctx, upgradeResourceStateRequest, &upgradeResourceStateResponse)
-	logging.FrameworkDebug(ctx, "Called provider defined StateUpgrader")
+	logging.FrameworkTrace(ctx, "Called provider defined StateUpgrader")
 
 	resp.Diagnostics.Append(upgradeResourceStateResponse.Diagnostics...)
 

--- a/internal/fwserver/server_validatedatasourceconfig.go
+++ b/internal/fwserver/server_validatedatasourceconfig.go
@@ -39,9 +39,9 @@ func (s *Server) ValidateDataSourceConfig(ctx context.Context, req *ValidateData
 		}
 		configureResp := datasource.ConfigureResponse{}
 
-		logging.FrameworkDebug(ctx, "Calling provider defined DataSource Configure")
+		logging.FrameworkTrace(ctx, "Calling provider defined DataSource Configure")
 		dataSourceWithConfigure.Configure(ctx, configureReq, &configureResp)
-		logging.FrameworkDebug(ctx, "Called provider defined DataSource Configure")
+		logging.FrameworkTrace(ctx, "Called provider defined DataSource Configure")
 
 		resp.Diagnostics.Append(configureResp.Diagnostics...)
 
@@ -62,7 +62,7 @@ func (s *Server) ValidateDataSourceConfig(ctx context.Context, req *ValidateData
 			// from modifying or removing diagnostics.
 			vdscResp := &datasource.ValidateConfigResponse{}
 
-			logging.FrameworkDebug(
+			logging.FrameworkTrace(
 				ctx,
 				"Calling provider defined ConfigValidator",
 				map[string]interface{}{
@@ -70,7 +70,7 @@ func (s *Server) ValidateDataSourceConfig(ctx context.Context, req *ValidateData
 				},
 			)
 			configValidator.ValidateDataSource(ctx, vdscReq, vdscResp)
-			logging.FrameworkDebug(
+			logging.FrameworkTrace(
 				ctx,
 				"Called provider defined ConfigValidator",
 				map[string]interface{}{
@@ -89,9 +89,9 @@ func (s *Server) ValidateDataSourceConfig(ctx context.Context, req *ValidateData
 		// from modifying or removing diagnostics.
 		vdscResp := &datasource.ValidateConfigResponse{}
 
-		logging.FrameworkDebug(ctx, "Calling provider defined DataSource ValidateConfig")
+		logging.FrameworkTrace(ctx, "Calling provider defined DataSource ValidateConfig")
 		dataSource.ValidateConfig(ctx, vdscReq, vdscResp)
-		logging.FrameworkDebug(ctx, "Called provider defined DataSource ValidateConfig")
+		logging.FrameworkTrace(ctx, "Called provider defined DataSource ValidateConfig")
 
 		resp.Diagnostics.Append(vdscResp.Diagnostics...)
 	}

--- a/internal/fwserver/server_validateproviderconfig.go
+++ b/internal/fwserver/server_validateproviderconfig.go
@@ -43,7 +43,7 @@ func (s *Server) ValidateProviderConfig(ctx context.Context, req *ValidateProvid
 			// from modifying or removing diagnostics.
 			vpcRes := &provider.ValidateConfigResponse{}
 
-			logging.FrameworkDebug(
+			logging.FrameworkTrace(
 				ctx,
 				"Calling provider defined ConfigValidator",
 				map[string]interface{}{
@@ -51,7 +51,7 @@ func (s *Server) ValidateProviderConfig(ctx context.Context, req *ValidateProvid
 				},
 			)
 			configValidator.ValidateProvider(ctx, vpcReq, vpcRes)
-			logging.FrameworkDebug(
+			logging.FrameworkTrace(
 				ctx,
 				"Called provider defined ConfigValidator",
 				map[string]interface{}{
@@ -70,9 +70,9 @@ func (s *Server) ValidateProviderConfig(ctx context.Context, req *ValidateProvid
 		// from modifying or removing diagnostics.
 		vpcRes := &provider.ValidateConfigResponse{}
 
-		logging.FrameworkDebug(ctx, "Calling provider defined Provider ValidateConfig")
+		logging.FrameworkTrace(ctx, "Calling provider defined Provider ValidateConfig")
 		providerWithValidateConfig.ValidateConfig(ctx, vpcReq, vpcRes)
-		logging.FrameworkDebug(ctx, "Called provider defined Provider ValidateConfig")
+		logging.FrameworkTrace(ctx, "Called provider defined Provider ValidateConfig")
 
 		resp.Diagnostics.Append(vpcRes.Diagnostics...)
 	}

--- a/internal/fwserver/server_validateresourceconfig.go
+++ b/internal/fwserver/server_validateresourceconfig.go
@@ -39,9 +39,9 @@ func (s *Server) ValidateResourceConfig(ctx context.Context, req *ValidateResour
 		}
 		configureResp := resource.ConfigureResponse{}
 
-		logging.FrameworkDebug(ctx, "Calling provider defined Resource Configure")
+		logging.FrameworkTrace(ctx, "Calling provider defined Resource Configure")
 		resourceWithConfigure.Configure(ctx, configureReq, &configureResp)
-		logging.FrameworkDebug(ctx, "Called provider defined Resource Configure")
+		logging.FrameworkTrace(ctx, "Called provider defined Resource Configure")
 
 		resp.Diagnostics.Append(configureResp.Diagnostics...)
 
@@ -62,7 +62,7 @@ func (s *Server) ValidateResourceConfig(ctx context.Context, req *ValidateResour
 			// from modifying or removing diagnostics.
 			vdscResp := &resource.ValidateConfigResponse{}
 
-			logging.FrameworkDebug(
+			logging.FrameworkTrace(
 				ctx,
 				"Calling provider defined ResourceConfigValidator",
 				map[string]interface{}{
@@ -70,7 +70,7 @@ func (s *Server) ValidateResourceConfig(ctx context.Context, req *ValidateResour
 				},
 			)
 			configValidator.ValidateResource(ctx, vdscReq, vdscResp)
-			logging.FrameworkDebug(
+			logging.FrameworkTrace(
 				ctx,
 				"Called provider defined ResourceConfigValidator",
 				map[string]interface{}{
@@ -89,9 +89,9 @@ func (s *Server) ValidateResourceConfig(ctx context.Context, req *ValidateResour
 		// from modifying or removing diagnostics.
 		vdscResp := &resource.ValidateConfigResponse{}
 
-		logging.FrameworkDebug(ctx, "Calling provider defined Resource ValidateConfig")
+		logging.FrameworkTrace(ctx, "Calling provider defined Resource ValidateConfig")
 		resourceWithValidateConfig.ValidateConfig(ctx, vdscReq, vdscResp)
-		logging.FrameworkDebug(ctx, "Called provider defined Resource ValidateConfig")
+		logging.FrameworkTrace(ctx, "Called provider defined Resource ValidateConfig")
 
 		resp.Diagnostics.Append(vdscResp.Diagnostics...)
 	}

--- a/internal/proto5server/server_getproviderschema_test.go
+++ b/internal/proto5server/server_getproviderschema_test.go
@@ -518,12 +518,12 @@ func TestServerGetProviderSchema_logging(t *testing.T) {
 
 	expectedEntries := []map[string]interface{}{
 		{
-			"@level":   "debug",
+			"@level":   "trace",
 			"@message": "Calling provider defined Provider Metadata",
 			"@module":  "sdk.framework",
 		},
 		{
-			"@level":   "debug",
+			"@level":   "trace",
 			"@message": "Called provider defined Provider Metadata",
 			"@module":  "sdk.framework",
 		},
@@ -533,12 +533,12 @@ func TestServerGetProviderSchema_logging(t *testing.T) {
 			"@module":  "sdk.framework",
 		},
 		{
-			"@level":   "debug",
+			"@level":   "trace",
 			"@message": "Calling provider defined Provider Schema",
 			"@module":  "sdk.framework",
 		},
 		{
-			"@level":   "debug",
+			"@level":   "trace",
 			"@message": "Called provider defined Provider Schema",
 			"@module":  "sdk.framework",
 		},
@@ -548,12 +548,12 @@ func TestServerGetProviderSchema_logging(t *testing.T) {
 			"@module":  "sdk.framework",
 		},
 		{
-			"@level":   "debug",
+			"@level":   "trace",
 			"@message": "Calling provider defined Provider Resources",
 			"@module":  "sdk.framework",
 		},
 		{
-			"@level":   "debug",
+			"@level":   "trace",
 			"@message": "Called provider defined Provider Resources",
 			"@module":  "sdk.framework",
 		},
@@ -563,12 +563,12 @@ func TestServerGetProviderSchema_logging(t *testing.T) {
 			"@module":  "sdk.framework",
 		},
 		{
-			"@level":   "debug",
+			"@level":   "trace",
 			"@message": "Calling provider defined Provider DataSources",
 			"@module":  "sdk.framework",
 		},
 		{
-			"@level":   "debug",
+			"@level":   "trace",
 			"@message": "Called provider defined Provider DataSources",
 			"@module":  "sdk.framework",
 		},

--- a/internal/proto6server/server_getproviderschema_test.go
+++ b/internal/proto6server/server_getproviderschema_test.go
@@ -518,12 +518,12 @@ func TestServerGetProviderSchema_logging(t *testing.T) {
 
 	expectedEntries := []map[string]interface{}{
 		{
-			"@level":   "debug",
+			"@level":   "trace",
 			"@message": "Calling provider defined Provider Metadata",
 			"@module":  "sdk.framework",
 		},
 		{
-			"@level":   "debug",
+			"@level":   "trace",
 			"@message": "Called provider defined Provider Metadata",
 			"@module":  "sdk.framework",
 		},
@@ -533,12 +533,12 @@ func TestServerGetProviderSchema_logging(t *testing.T) {
 			"@module":  "sdk.framework",
 		},
 		{
-			"@level":   "debug",
+			"@level":   "trace",
 			"@message": "Calling provider defined Provider Schema",
 			"@module":  "sdk.framework",
 		},
 		{
-			"@level":   "debug",
+			"@level":   "trace",
 			"@message": "Called provider defined Provider Schema",
 			"@module":  "sdk.framework",
 		},
@@ -548,12 +548,12 @@ func TestServerGetProviderSchema_logging(t *testing.T) {
 			"@module":  "sdk.framework",
 		},
 		{
-			"@level":   "debug",
+			"@level":   "trace",
 			"@message": "Calling provider defined Provider Resources",
 			"@module":  "sdk.framework",
 		},
 		{
-			"@level":   "debug",
+			"@level":   "trace",
 			"@message": "Called provider defined Provider Resources",
 			"@module":  "sdk.framework",
 		},
@@ -563,12 +563,12 @@ func TestServerGetProviderSchema_logging(t *testing.T) {
 			"@module":  "sdk.framework",
 		},
 		{
-			"@level":   "debug",
+			"@level":   "trace",
 			"@message": "Calling provider defined Provider DataSources",
 			"@module":  "sdk.framework",
 		},
 		{
-			"@level":   "debug",
+			"@level":   "trace",
 			"@message": "Called provider defined Provider DataSources",
 			"@module":  "sdk.framework",
 		},


### PR DESCRIPTION
Closes #812 

Per https://developer.hashicorp.com/terraform/plugin/log/managing#log-levels, moving these logs to `TRACE` as these messages define where the provider code is at in execution.