### PR TITLE
internal/fwserver: Ensure Attribute and Block Plan Modification Returns Custom Value Type Implementations When Using Custom Type NestedAttributeObject/NestedBlockObject

### DIFF
--- a/.changes/unreleased/BUG FIXES-20230816-113531.yaml
+++ b/.changes/unreleased/BUG FIXES-20230816-113531.yaml
@@ -1,0 +1,6 @@
+kind: BUG FIXES
+body: 'internal/fwserver: Prevented `Invalid Element Type` diagnostics for nested
+  attributes and blocks implementing `CustomType` field'
+time: 2023-08-16T11:35:31.553124+01:00
+custom:
+  Issue: "823"

--- a/internal/fwserver/attribute_plan_modification.go
+++ b/internal/fwserver/attribute_plan_modification.go
@@ -193,6 +193,22 @@ func AttributeModifyPlan(ctx context.Context, a fwschema.Attribute, req ModifyAt
 				return
 			}
 
+			planObjectValuable, diags := coerceObjectValuable(ctx, attrPath, planElem)
+
+			resp.Diagnostics.Append(diags...)
+
+			if resp.Diagnostics.HasError() {
+				return
+			}
+
+			typable, diags := coerceObjectTypable(ctx, attrPath, planObjectValuable)
+
+			resp.Diagnostics.Append(diags...)
+
+			if resp.Diagnostics.HasError() {
+				return
+			}
+
 			stateObject, diags := listElemObject(ctx, attrPath, stateList, idx, fwschemadata.DataDescriptionState)
 
 			resp.Diagnostics.Append(diags...)
@@ -219,7 +235,26 @@ func AttributeModifyPlan(ctx context.Context, a fwschema.Attribute, req ModifyAt
 
 			NestedAttributeObjectPlanModify(ctx, nestedAttributeObject, objectReq, objectResp)
 
-			planElements[idx] = objectResp.AttributePlan
+			respValue, diags := coerceObjectValue(ctx, attrPath, objectResp.AttributePlan)
+
+			resp.Diagnostics.Append(diags...)
+
+			if resp.Diagnostics.HasError() {
+				return
+			}
+
+			// A custom value type must be returned in the final response to prevent
+			// later correctness errors.
+			// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/821
+			respValuable, diags := typable.ValueFromObject(ctx, respValue)
+
+			resp.Diagnostics.Append(diags...)
+
+			if resp.Diagnostics.HasError() {
+				return
+			}
+
+			planElements[idx] = respValuable
 			resp.Diagnostics.Append(objectResp.Diagnostics...)
 			resp.Private = objectResp.Private
 			resp.RequiresReplace.Append(objectResp.RequiresReplace...)
@@ -309,6 +344,22 @@ func AttributeModifyPlan(ctx context.Context, a fwschema.Attribute, req ModifyAt
 				return
 			}
 
+			planObjectValuable, diags := coerceObjectValuable(ctx, attrPath, planElem)
+
+			resp.Diagnostics.Append(diags...)
+
+			if resp.Diagnostics.HasError() {
+				return
+			}
+
+			typable, diags := coerceObjectTypable(ctx, attrPath, planObjectValuable)
+
+			resp.Diagnostics.Append(diags...)
+
+			if resp.Diagnostics.HasError() {
+				return
+			}
+
 			stateObject, diags := setElemObject(ctx, attrPath, stateSet, idx, fwschemadata.DataDescriptionState)
 
 			resp.Diagnostics.Append(diags...)
@@ -335,7 +386,26 @@ func AttributeModifyPlan(ctx context.Context, a fwschema.Attribute, req ModifyAt
 
 			NestedAttributeObjectPlanModify(ctx, nestedAttributeObject, objectReq, objectResp)
 
-			planElements[idx] = objectResp.AttributePlan
+			respValue, diags := coerceObjectValue(ctx, attrPath, objectResp.AttributePlan)
+
+			resp.Diagnostics.Append(diags...)
+
+			if resp.Diagnostics.HasError() {
+				return
+			}
+
+			// A custom value type must be returned in the final response to prevent
+			// later correctness errors.
+			// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/821
+			respValuable, diags := typable.ValueFromObject(ctx, respValue)
+
+			resp.Diagnostics.Append(diags...)
+
+			if resp.Diagnostics.HasError() {
+				return
+			}
+
+			planElements[idx] = respValuable
 			resp.Diagnostics.Append(objectResp.Diagnostics...)
 			resp.Private = objectResp.Private
 			resp.RequiresReplace.Append(objectResp.RequiresReplace...)
@@ -425,6 +495,22 @@ func AttributeModifyPlan(ctx context.Context, a fwschema.Attribute, req ModifyAt
 				return
 			}
 
+			planObjectValuable, diags := coerceObjectValuable(ctx, attrPath, planElem)
+
+			resp.Diagnostics.Append(diags...)
+
+			if resp.Diagnostics.HasError() {
+				return
+			}
+
+			typable, diags := coerceObjectTypable(ctx, attrPath, planObjectValuable)
+
+			resp.Diagnostics.Append(diags...)
+
+			if resp.Diagnostics.HasError() {
+				return
+			}
+
 			stateObject, diags := mapElemObject(ctx, attrPath, stateMap, key, fwschemadata.DataDescriptionState)
 
 			resp.Diagnostics.Append(diags...)
@@ -451,7 +537,26 @@ func AttributeModifyPlan(ctx context.Context, a fwschema.Attribute, req ModifyAt
 
 			NestedAttributeObjectPlanModify(ctx, nestedAttributeObject, objectReq, objectResp)
 
-			planElements[key] = objectResp.AttributePlan
+			respValue, diags := coerceObjectValue(ctx, attrPath, objectResp.AttributePlan)
+
+			resp.Diagnostics.Append(diags...)
+
+			if resp.Diagnostics.HasError() {
+				return
+			}
+
+			// A custom value type must be returned in the final response to prevent
+			// later correctness errors.
+			// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/821
+			respValuable, diags := typable.ValueFromObject(ctx, respValue)
+
+			resp.Diagnostics.Append(diags...)
+
+			if resp.Diagnostics.HasError() {
+				return
+			}
+
+			planElements[key] = respValuable
 			resp.Diagnostics.Append(objectResp.Diagnostics...)
 			resp.Private = objectResp.Private
 			resp.RequiresReplace.Append(objectResp.RequiresReplace...)

--- a/internal/fwserver/attribute_plan_modification_test.go
+++ b/internal/fwserver/attribute_plan_modification_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
 
 func TestAttributeModifyPlan(t *testing.T) {
@@ -129,6 +130,388 @@ func TestAttributeModifyPlan(t *testing.T) {
 			expectedResp: ModifyAttributePlanResponse{
 				AttributePlan: types.StringValue("TESTATTRONE"),
 				Private:       testProviderData,
+			},
+		},
+		"attribute-list-nested-custom-nested-object": {
+			attribute: schema.ListNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					CustomType: testschema.NestedObjectCustomType{
+						ObjectType: basetypes.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"nested_attr": types.StringType,
+							},
+						},
+					},
+					Attributes: map[string]schema.Attribute{
+						"nested_attr": schema.StringAttribute{
+							Required: true,
+						},
+					},
+				},
+				Required: true,
+			},
+			req: ModifyAttributePlanRequest{
+				AttributeConfig: types.ListValueMust(
+					testschema.NestedObjectCustomType{
+						ObjectType: types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"nested_attr": types.StringType,
+							},
+						},
+					},
+					[]attr.Value{
+						testschema.NestedObjectCustomValue{
+							ObjectValue: types.ObjectValueMust(
+								map[string]attr.Type{
+									"nested_attr": types.StringType,
+								},
+								map[string]attr.Value{
+									"nested_attr": types.StringValue("testvalue"),
+								},
+							),
+						},
+					},
+				),
+				AttributePath: path.Root("test"),
+				AttributePlan: types.ListValueMust(
+					testschema.NestedObjectCustomType{
+						ObjectType: types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"nested_attr": types.StringType,
+							},
+						},
+					},
+					[]attr.Value{
+						testschema.NestedObjectCustomValue{
+							ObjectValue: types.ObjectValueMust(
+								map[string]attr.Type{
+									"nested_attr": types.StringType,
+								},
+								map[string]attr.Value{
+									"nested_attr": types.StringValue("testvalue"),
+								},
+							),
+						},
+					},
+				),
+				AttributeState: types.ListValueMust(
+					testschema.NestedObjectCustomType{
+						ObjectType: types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"nested_attr": types.StringType,
+							},
+						},
+					},
+					[]attr.Value{
+						testschema.NestedObjectCustomValue{
+							ObjectValue: types.ObjectValueMust(
+								map[string]attr.Type{
+									"nested_attr": types.StringType,
+								},
+								map[string]attr.Value{
+									"nested_attr": types.StringValue("testvalue"),
+								},
+							),
+						},
+					},
+				),
+			},
+			expectedResp: ModifyAttributePlanResponse{
+				AttributePlan: types.ListValueMust(
+					testschema.NestedObjectCustomType{
+						ObjectType: types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"nested_attr": types.StringType,
+							},
+						},
+					},
+					[]attr.Value{
+						testschema.NestedObjectCustomValue{
+							ObjectValue: types.ObjectValueMust(
+								map[string]attr.Type{
+									"nested_attr": types.StringType,
+								},
+								map[string]attr.Value{
+									"nested_attr": types.StringValue("testvalue"),
+								},
+							),
+						},
+					},
+				),
+			},
+		},
+		"attribute-list-nested-nested-custom-nested-object": {
+			attribute: schema.ListNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					CustomType: testschema.ListNestedObjectCustomType{
+						ObjectType: basetypes.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"nested_list_nested_attribute": types.ListType{
+									ElemType: testschema.NestedObjectCustomType{
+										ObjectType: types.ObjectType{
+											AttrTypes: map[string]attr.Type{
+												"nested_attr": types.StringType,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					Attributes: map[string]schema.Attribute{
+						"nested_list_nested_attribute": schema.ListNestedAttribute{
+							NestedObject: schema.NestedAttributeObject{
+								CustomType: testschema.NestedObjectCustomType{
+									ObjectType: basetypes.ObjectType{
+										AttrTypes: map[string]attr.Type{
+											"nested_attr": types.StringType,
+										},
+									},
+								},
+								Attributes: map[string]schema.Attribute{
+									"nested_attr": schema.StringAttribute{
+										Required: true,
+									},
+								},
+							},
+							Required: true,
+						},
+					},
+				},
+				Required: true,
+			},
+			req: ModifyAttributePlanRequest{
+				AttributeConfig: types.ListValueMust(
+					testschema.ListNestedObjectCustomType{
+						ObjectType: types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"nested_list_nested_attribute": types.ListType{
+									ElemType: testschema.NestedObjectCustomType{
+										ObjectType: types.ObjectType{
+											AttrTypes: map[string]attr.Type{
+												"nested_attr": types.StringType,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					[]attr.Value{
+						testschema.ListNestedObjectCustomValue{
+							ObjectValue: types.ObjectValueMust(
+								map[string]attr.Type{
+									"nested_list_nested_attribute": types.ListType{
+										ElemType: testschema.NestedObjectCustomType{
+											ObjectType: types.ObjectType{
+												AttrTypes: map[string]attr.Type{
+													"nested_attr": types.StringType,
+												},
+											},
+										},
+									},
+								},
+								map[string]attr.Value{
+									"nested_list_nested_attribute": types.ListValueMust(
+										testschema.NestedObjectCustomType{
+											ObjectType: types.ObjectType{
+												AttrTypes: map[string]attr.Type{
+													"nested_attr": types.StringType,
+												},
+											},
+										},
+										[]attr.Value{
+											testschema.NestedObjectCustomValue{
+												ObjectValue: types.ObjectValueMust(
+													map[string]attr.Type{
+														"nested_attr": types.StringType,
+													},
+													map[string]attr.Value{
+														"nested_attr": types.StringValue("testvalue"),
+													},
+												),
+											},
+										},
+									),
+								},
+							),
+						},
+					},
+				),
+				AttributePath: path.Root("test"),
+				AttributePlan: types.ListValueMust(
+					testschema.ListNestedObjectCustomType{
+						ObjectType: types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"nested_list_nested_attribute": types.ListType{
+									ElemType: testschema.NestedObjectCustomType{
+										ObjectType: types.ObjectType{
+											AttrTypes: map[string]attr.Type{
+												"nested_attr": types.StringType,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					[]attr.Value{
+						testschema.ListNestedObjectCustomValue{
+							ObjectValue: types.ObjectValueMust(
+								map[string]attr.Type{
+									"nested_list_nested_attribute": types.ListType{
+										ElemType: testschema.NestedObjectCustomType{
+											ObjectType: types.ObjectType{
+												AttrTypes: map[string]attr.Type{
+													"nested_attr": types.StringType,
+												},
+											},
+										},
+									},
+								},
+								map[string]attr.Value{
+									"nested_list_nested_attribute": types.ListValueMust(
+										testschema.NestedObjectCustomType{
+											ObjectType: types.ObjectType{
+												AttrTypes: map[string]attr.Type{
+													"nested_attr": types.StringType,
+												},
+											},
+										},
+										[]attr.Value{
+											testschema.NestedObjectCustomValue{
+												ObjectValue: types.ObjectValueMust(
+													map[string]attr.Type{
+														"nested_attr": types.StringType,
+													},
+													map[string]attr.Value{
+														"nested_attr": types.StringValue("testvalue"),
+													},
+												),
+											},
+										},
+									),
+								},
+							),
+						},
+					},
+				),
+				AttributeState: types.ListValueMust(
+					testschema.ListNestedObjectCustomType{
+						ObjectType: types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"nested_list_nested_attribute": types.ListType{
+									ElemType: testschema.NestedObjectCustomType{
+										ObjectType: types.ObjectType{
+											AttrTypes: map[string]attr.Type{
+												"nested_attr": types.StringType,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					[]attr.Value{
+						testschema.ListNestedObjectCustomValue{
+							ObjectValue: types.ObjectValueMust(
+								map[string]attr.Type{
+									"nested_list_nested_attribute": types.ListType{
+										ElemType: testschema.NestedObjectCustomType{
+											ObjectType: types.ObjectType{
+												AttrTypes: map[string]attr.Type{
+													"nested_attr": types.StringType,
+												},
+											},
+										},
+									},
+								},
+								map[string]attr.Value{
+									"nested_list_nested_attribute": types.ListValueMust(
+										testschema.NestedObjectCustomType{
+											ObjectType: types.ObjectType{
+												AttrTypes: map[string]attr.Type{
+													"nested_attr": types.StringType,
+												},
+											},
+										},
+										[]attr.Value{
+											testschema.NestedObjectCustomValue{
+												ObjectValue: types.ObjectValueMust(
+													map[string]attr.Type{
+														"nested_attr": types.StringType,
+													},
+													map[string]attr.Value{
+														"nested_attr": types.StringValue("testvalue"),
+													},
+												),
+											},
+										},
+									),
+								},
+							),
+						},
+					},
+				),
+			},
+			expectedResp: ModifyAttributePlanResponse{
+				AttributePlan: types.ListValueMust(
+					testschema.ListNestedObjectCustomType{
+						ObjectType: types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"nested_list_nested_attribute": types.ListType{
+									ElemType: testschema.NestedObjectCustomType{
+										ObjectType: types.ObjectType{
+											AttrTypes: map[string]attr.Type{
+												"nested_attr": types.StringType,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					[]attr.Value{
+						testschema.ListNestedObjectCustomValue{
+							ObjectValue: types.ObjectValueMust(
+								map[string]attr.Type{
+									"nested_list_nested_attribute": types.ListType{
+										ElemType: testschema.NestedObjectCustomType{
+											ObjectType: types.ObjectType{
+												AttrTypes: map[string]attr.Type{
+													"nested_attr": types.StringType,
+												},
+											},
+										},
+									},
+								},
+								map[string]attr.Value{
+									"nested_list_nested_attribute": types.ListValueMust(
+										testschema.NestedObjectCustomType{
+											ObjectType: types.ObjectType{
+												AttrTypes: map[string]attr.Type{
+													"nested_attr": types.StringType,
+												},
+											},
+										},
+										[]attr.Value{
+											testschema.NestedObjectCustomValue{
+												ObjectValue: types.ObjectValueMust(
+													map[string]attr.Type{
+														"nested_attr": types.StringType,
+													},
+													map[string]attr.Value{
+														"nested_attr": types.StringValue("testvalue"),
+													},
+												),
+											},
+										},
+									),
+								},
+							),
+						},
+					},
+				),
 			},
 		},
 		"attribute-list-nested-private": {
@@ -645,6 +1028,381 @@ func TestAttributeModifyPlan(t *testing.T) {
 								"nested_required": types.StringValue("testvalue2"),
 							},
 						),
+					},
+				),
+			},
+		},
+		"attribute-set-nested-custom-nested-object": {
+			attribute: schema.SetNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"nested_attr": schema.StringAttribute{
+							Required: true,
+						},
+					},
+				},
+				Required: true,
+			},
+			req: ModifyAttributePlanRequest{
+				AttributeConfig: types.SetValueMust(
+					testschema.NestedObjectCustomType{
+						ObjectType: types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"nested_attr": types.StringType,
+							},
+						},
+					},
+					[]attr.Value{
+						testschema.NestedObjectCustomValue{
+							ObjectValue: types.ObjectValueMust(
+								map[string]attr.Type{
+									"nested_attr": types.StringType,
+								},
+								map[string]attr.Value{
+									"nested_attr": types.StringValue("testvalue"),
+								},
+							),
+						},
+					},
+				),
+				AttributePath: path.Root("test"),
+				AttributePlan: types.SetValueMust(
+					testschema.NestedObjectCustomType{
+						ObjectType: types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"nested_attr": types.StringType,
+							},
+						},
+					},
+					[]attr.Value{
+						testschema.NestedObjectCustomValue{
+							ObjectValue: types.ObjectValueMust(
+								map[string]attr.Type{
+									"nested_attr": types.StringType,
+								},
+								map[string]attr.Value{
+									"nested_attr": types.StringValue("testvalue"),
+								},
+							),
+						},
+					},
+				),
+				AttributeState: types.SetValueMust(
+					testschema.NestedObjectCustomType{
+						ObjectType: types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"nested_attr": types.StringType,
+							},
+						},
+					},
+					[]attr.Value{
+						testschema.NestedObjectCustomValue{
+							ObjectValue: types.ObjectValueMust(
+								map[string]attr.Type{
+									"nested_attr": types.StringType,
+								},
+								map[string]attr.Value{
+									"nested_attr": types.StringValue("testvalue"),
+								},
+							),
+						},
+					},
+				),
+			},
+			expectedResp: ModifyAttributePlanResponse{
+				AttributePlan: types.SetValueMust(
+					testschema.NestedObjectCustomType{
+						ObjectType: types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"nested_attr": types.StringType,
+							},
+						},
+					},
+					[]attr.Value{
+						testschema.NestedObjectCustomValue{
+							ObjectValue: types.ObjectValueMust(
+								map[string]attr.Type{
+									"nested_attr": types.StringType,
+								},
+								map[string]attr.Value{
+									"nested_attr": types.StringValue("testvalue"),
+								},
+							),
+						},
+					},
+				),
+			},
+		},
+		"attribute-set-nested-nested-custom-nested-object": {
+			attribute: schema.SetNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					CustomType: testschema.SetNestedObjectCustomType{
+						ObjectType: basetypes.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"nested_set_nested_attribute": types.SetType{
+									ElemType: testschema.NestedObjectCustomType{
+										ObjectType: types.ObjectType{
+											AttrTypes: map[string]attr.Type{
+												"nested_attr": types.StringType,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					Attributes: map[string]schema.Attribute{
+						"nested_set_nested_attribute": schema.SetNestedAttribute{
+							NestedObject: schema.NestedAttributeObject{
+								CustomType: testschema.NestedObjectCustomType{
+									ObjectType: basetypes.ObjectType{
+										AttrTypes: map[string]attr.Type{
+											"nested_attr": types.StringType,
+										},
+									},
+								},
+								Attributes: map[string]schema.Attribute{
+									"nested_attr": schema.StringAttribute{
+										Required: true,
+									},
+								},
+							},
+							Required: true,
+						},
+					},
+				},
+				Required: true,
+			},
+			req: ModifyAttributePlanRequest{
+				AttributeConfig: types.SetValueMust(
+					testschema.SetNestedObjectCustomType{
+						ObjectType: types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"nested_set_nested_attribute": types.SetType{
+									ElemType: testschema.NestedObjectCustomType{
+										ObjectType: types.ObjectType{
+											AttrTypes: map[string]attr.Type{
+												"nested_attr": types.StringType,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					[]attr.Value{
+						testschema.SetNestedObjectCustomValue{
+							ObjectValue: types.ObjectValueMust(
+								map[string]attr.Type{
+									"nested_set_nested_attribute": types.SetType{
+										ElemType: testschema.NestedObjectCustomType{
+											ObjectType: types.ObjectType{
+												AttrTypes: map[string]attr.Type{
+													"nested_attr": types.StringType,
+												},
+											},
+										},
+									},
+								},
+								map[string]attr.Value{
+									"nested_set_nested_attribute": types.SetValueMust(
+										testschema.NestedObjectCustomType{
+											ObjectType: types.ObjectType{
+												AttrTypes: map[string]attr.Type{
+													"nested_attr": types.StringType,
+												},
+											},
+										},
+										[]attr.Value{
+											testschema.NestedObjectCustomValue{
+												ObjectValue: types.ObjectValueMust(
+													map[string]attr.Type{
+														"nested_attr": types.StringType,
+													},
+													map[string]attr.Value{
+														"nested_attr": types.StringValue("testvalue"),
+													},
+												),
+											},
+										},
+									),
+								},
+							),
+						},
+					},
+				),
+				AttributePath: path.Root("test"),
+				AttributePlan: types.SetValueMust(
+					testschema.SetNestedObjectCustomType{
+						ObjectType: types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"nested_set_nested_attribute": types.SetType{
+									ElemType: testschema.NestedObjectCustomType{
+										ObjectType: types.ObjectType{
+											AttrTypes: map[string]attr.Type{
+												"nested_attr": types.StringType,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					[]attr.Value{
+						testschema.SetNestedObjectCustomValue{
+							ObjectValue: types.ObjectValueMust(
+								map[string]attr.Type{
+									"nested_set_nested_attribute": types.SetType{
+										ElemType: testschema.NestedObjectCustomType{
+											ObjectType: types.ObjectType{
+												AttrTypes: map[string]attr.Type{
+													"nested_attr": types.StringType,
+												},
+											},
+										},
+									},
+								},
+								map[string]attr.Value{
+									"nested_set_nested_attribute": types.SetValueMust(
+										testschema.NestedObjectCustomType{
+											ObjectType: types.ObjectType{
+												AttrTypes: map[string]attr.Type{
+													"nested_attr": types.StringType,
+												},
+											},
+										},
+										[]attr.Value{
+											testschema.NestedObjectCustomValue{
+												ObjectValue: types.ObjectValueMust(
+													map[string]attr.Type{
+														"nested_attr": types.StringType,
+													},
+													map[string]attr.Value{
+														"nested_attr": types.StringValue("testvalue"),
+													},
+												),
+											},
+										},
+									),
+								},
+							),
+						},
+					},
+				),
+				AttributeState: types.SetValueMust(
+					testschema.SetNestedObjectCustomType{
+						ObjectType: types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"nested_set_nested_attribute": types.SetType{
+									ElemType: testschema.NestedObjectCustomType{
+										ObjectType: types.ObjectType{
+											AttrTypes: map[string]attr.Type{
+												"nested_attr": types.StringType,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					[]attr.Value{
+						testschema.SetNestedObjectCustomValue{
+							ObjectValue: types.ObjectValueMust(
+								map[string]attr.Type{
+									"nested_set_nested_attribute": types.SetType{
+										ElemType: testschema.NestedObjectCustomType{
+											ObjectType: types.ObjectType{
+												AttrTypes: map[string]attr.Type{
+													"nested_attr": types.StringType,
+												},
+											},
+										},
+									},
+								},
+								map[string]attr.Value{
+									"nested_set_nested_attribute": types.SetValueMust(
+										testschema.NestedObjectCustomType{
+											ObjectType: types.ObjectType{
+												AttrTypes: map[string]attr.Type{
+													"nested_attr": types.StringType,
+												},
+											},
+										},
+										[]attr.Value{
+											testschema.NestedObjectCustomValue{
+												ObjectValue: types.ObjectValueMust(
+													map[string]attr.Type{
+														"nested_attr": types.StringType,
+													},
+													map[string]attr.Value{
+														"nested_attr": types.StringValue("testvalue"),
+													},
+												),
+											},
+										},
+									),
+								},
+							),
+						},
+					},
+				),
+			},
+			expectedResp: ModifyAttributePlanResponse{
+				AttributePlan: types.SetValueMust(
+					testschema.SetNestedObjectCustomType{
+						ObjectType: types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"nested_set_nested_attribute": types.SetType{
+									ElemType: testschema.NestedObjectCustomType{
+										ObjectType: types.ObjectType{
+											AttrTypes: map[string]attr.Type{
+												"nested_attr": types.StringType,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					[]attr.Value{
+						testschema.SetNestedObjectCustomValue{
+							ObjectValue: types.ObjectValueMust(
+								map[string]attr.Type{
+									"nested_set_nested_attribute": types.SetType{
+										ElemType: testschema.NestedObjectCustomType{
+											ObjectType: types.ObjectType{
+												AttrTypes: map[string]attr.Type{
+													"nested_attr": types.StringType,
+												},
+											},
+										},
+									},
+								},
+								map[string]attr.Value{
+									"nested_set_nested_attribute": types.SetValueMust(
+										testschema.NestedObjectCustomType{
+											ObjectType: types.ObjectType{
+												AttrTypes: map[string]attr.Type{
+													"nested_attr": types.StringType,
+												},
+											},
+										},
+										[]attr.Value{
+											testschema.NestedObjectCustomValue{
+												ObjectValue: types.ObjectValueMust(
+													map[string]attr.Type{
+														"nested_attr": types.StringType,
+													},
+													map[string]attr.Value{
+														"nested_attr": types.StringValue("testvalue"),
+													},
+												),
+											},
+										},
+									),
+								},
+							),
+						},
 					},
 				),
 			},
@@ -1308,6 +2066,388 @@ func TestAttributeModifyPlan(t *testing.T) {
 				),
 			},
 		},
+		"attribute-map-nested-custom-nested-object": {
+			attribute: schema.MapNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					CustomType: testschema.NestedObjectCustomType{
+						ObjectType: basetypes.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"nested_attr": types.StringType,
+							},
+						},
+					},
+					Attributes: map[string]schema.Attribute{
+						"nested_attr": schema.StringAttribute{
+							Required: true,
+						},
+					},
+				},
+				Required: true,
+			},
+			req: ModifyAttributePlanRequest{
+				AttributeConfig: types.MapValueMust(
+					testschema.NestedObjectCustomType{
+						ObjectType: types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"nested_attr": types.StringType,
+							},
+						},
+					},
+					map[string]attr.Value{
+						"testkey": testschema.NestedObjectCustomValue{
+							ObjectValue: types.ObjectValueMust(
+								map[string]attr.Type{
+									"nested_attr": types.StringType,
+								},
+								map[string]attr.Value{
+									"nested_attr": types.StringValue("testvalue"),
+								},
+							),
+						},
+					},
+				),
+				AttributePath: path.Root("test"),
+				AttributePlan: types.MapValueMust(
+					testschema.NestedObjectCustomType{
+						ObjectType: types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"nested_attr": types.StringType,
+							},
+						},
+					},
+					map[string]attr.Value{
+						"testkey": testschema.NestedObjectCustomValue{
+							ObjectValue: types.ObjectValueMust(
+								map[string]attr.Type{
+									"nested_attr": types.StringType,
+								},
+								map[string]attr.Value{
+									"nested_attr": types.StringValue("testvalue"),
+								},
+							),
+						},
+					},
+				),
+				AttributeState: types.MapValueMust(
+					testschema.NestedObjectCustomType{
+						ObjectType: types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"nested_attr": types.StringType,
+							},
+						},
+					},
+					map[string]attr.Value{
+						"testkey": testschema.NestedObjectCustomValue{
+							ObjectValue: types.ObjectValueMust(
+								map[string]attr.Type{
+									"nested_attr": types.StringType,
+								},
+								map[string]attr.Value{
+									"nested_attr": types.StringValue("testvalue"),
+								},
+							),
+						},
+					},
+				),
+			},
+			expectedResp: ModifyAttributePlanResponse{
+				AttributePlan: types.MapValueMust(
+					testschema.NestedObjectCustomType{
+						ObjectType: types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"nested_attr": types.StringType,
+							},
+						},
+					},
+					map[string]attr.Value{
+						"testkey": testschema.NestedObjectCustomValue{
+							ObjectValue: types.ObjectValueMust(
+								map[string]attr.Type{
+									"nested_attr": types.StringType,
+								},
+								map[string]attr.Value{
+									"nested_attr": types.StringValue("testvalue"),
+								},
+							),
+						},
+					},
+				),
+			},
+		},
+		"attribute-map-nested-nested-custom-nested-object": {
+			attribute: schema.MapNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					CustomType: testschema.MapNestedObjectCustomType{
+						ObjectType: basetypes.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"nested_map_nested_attribute": types.MapType{
+									ElemType: testschema.NestedObjectCustomType{
+										ObjectType: types.ObjectType{
+											AttrTypes: map[string]attr.Type{
+												"nested_attr": types.StringType,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					Attributes: map[string]schema.Attribute{
+						"nested_map_nested_attribute": schema.MapNestedAttribute{
+							NestedObject: schema.NestedAttributeObject{
+								CustomType: testschema.NestedObjectCustomType{
+									ObjectType: basetypes.ObjectType{
+										AttrTypes: map[string]attr.Type{
+											"nested_attr": types.StringType,
+										},
+									},
+								},
+								Attributes: map[string]schema.Attribute{
+									"nested_attr": schema.StringAttribute{
+										Required: true,
+									},
+								},
+							},
+							Required: true,
+						},
+					},
+				},
+				Required: true,
+			},
+			req: ModifyAttributePlanRequest{
+				AttributeConfig: types.MapValueMust(
+					testschema.MapNestedObjectCustomType{
+						ObjectType: types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"nested_map_nested_attribute": types.MapType{
+									ElemType: testschema.NestedObjectCustomType{
+										ObjectType: types.ObjectType{
+											AttrTypes: map[string]attr.Type{
+												"nested_attr": types.StringType,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					map[string]attr.Value{
+						"outer": testschema.MapNestedObjectCustomValue{
+							ObjectValue: types.ObjectValueMust(
+								map[string]attr.Type{
+									"nested_map_nested_attribute": types.MapType{
+										ElemType: testschema.NestedObjectCustomType{
+											ObjectType: types.ObjectType{
+												AttrTypes: map[string]attr.Type{
+													"nested_attr": types.StringType,
+												},
+											},
+										},
+									},
+								},
+								map[string]attr.Value{
+									"nested_map_nested_attribute": types.MapValueMust(
+										testschema.NestedObjectCustomType{
+											ObjectType: types.ObjectType{
+												AttrTypes: map[string]attr.Type{
+													"nested_attr": types.StringType,
+												},
+											},
+										},
+										map[string]attr.Value{
+											"inner": testschema.NestedObjectCustomValue{
+												ObjectValue: types.ObjectValueMust(
+													map[string]attr.Type{
+														"nested_attr": types.StringType,
+													},
+													map[string]attr.Value{
+														"nested_attr": types.StringValue("testvalue"),
+													},
+												),
+											},
+										},
+									),
+								},
+							),
+						},
+					},
+				),
+				AttributePath: path.Root("test"),
+				AttributePlan: types.MapValueMust(
+					testschema.MapNestedObjectCustomType{
+						ObjectType: types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"nested_map_nested_attribute": types.MapType{
+									ElemType: testschema.NestedObjectCustomType{
+										ObjectType: types.ObjectType{
+											AttrTypes: map[string]attr.Type{
+												"nested_attr": types.StringType,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					map[string]attr.Value{
+						"outer": testschema.MapNestedObjectCustomValue{
+							ObjectValue: types.ObjectValueMust(
+								map[string]attr.Type{
+									"nested_map_nested_attribute": types.MapType{
+										ElemType: testschema.NestedObjectCustomType{
+											ObjectType: types.ObjectType{
+												AttrTypes: map[string]attr.Type{
+													"nested_attr": types.StringType,
+												},
+											},
+										},
+									},
+								},
+								map[string]attr.Value{
+									"nested_map_nested_attribute": types.MapValueMust(
+										testschema.NestedObjectCustomType{
+											ObjectType: types.ObjectType{
+												AttrTypes: map[string]attr.Type{
+													"nested_attr": types.StringType,
+												},
+											},
+										},
+										map[string]attr.Value{
+											"inner": testschema.NestedObjectCustomValue{
+												ObjectValue: types.ObjectValueMust(
+													map[string]attr.Type{
+														"nested_attr": types.StringType,
+													},
+													map[string]attr.Value{
+														"nested_attr": types.StringValue("testvalue"),
+													},
+												),
+											},
+										},
+									),
+								},
+							),
+						},
+					},
+				),
+				AttributeState: types.MapValueMust(
+					testschema.MapNestedObjectCustomType{
+						ObjectType: types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"nested_map_nested_attribute": types.MapType{
+									ElemType: testschema.NestedObjectCustomType{
+										ObjectType: types.ObjectType{
+											AttrTypes: map[string]attr.Type{
+												"nested_attr": types.StringType,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					map[string]attr.Value{
+						"outer": testschema.MapNestedObjectCustomValue{
+							ObjectValue: types.ObjectValueMust(
+								map[string]attr.Type{
+									"nested_map_nested_attribute": types.MapType{
+										ElemType: testschema.NestedObjectCustomType{
+											ObjectType: types.ObjectType{
+												AttrTypes: map[string]attr.Type{
+													"nested_attr": types.StringType,
+												},
+											},
+										},
+									},
+								},
+								map[string]attr.Value{
+									"nested_map_nested_attribute": types.MapValueMust(
+										testschema.NestedObjectCustomType{
+											ObjectType: types.ObjectType{
+												AttrTypes: map[string]attr.Type{
+													"nested_attr": types.StringType,
+												},
+											},
+										},
+										map[string]attr.Value{
+											"inner": testschema.NestedObjectCustomValue{
+												ObjectValue: types.ObjectValueMust(
+													map[string]attr.Type{
+														"nested_attr": types.StringType,
+													},
+													map[string]attr.Value{
+														"nested_attr": types.StringValue("testvalue"),
+													},
+												),
+											},
+										},
+									),
+								},
+							),
+						},
+					},
+				),
+			},
+			expectedResp: ModifyAttributePlanResponse{
+				AttributePlan: types.MapValueMust(
+					testschema.MapNestedObjectCustomType{
+						ObjectType: types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"nested_map_nested_attribute": types.MapType{
+									ElemType: testschema.NestedObjectCustomType{
+										ObjectType: types.ObjectType{
+											AttrTypes: map[string]attr.Type{
+												"nested_attr": types.StringType,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					map[string]attr.Value{
+						"outer": testschema.MapNestedObjectCustomValue{
+							ObjectValue: types.ObjectValueMust(
+								map[string]attr.Type{
+									"nested_map_nested_attribute": types.MapType{
+										ElemType: testschema.NestedObjectCustomType{
+											ObjectType: types.ObjectType{
+												AttrTypes: map[string]attr.Type{
+													"nested_attr": types.StringType,
+												},
+											},
+										},
+									},
+								},
+								map[string]attr.Value{
+									"nested_map_nested_attribute": types.MapValueMust(
+										testschema.NestedObjectCustomType{
+											ObjectType: types.ObjectType{
+												AttrTypes: map[string]attr.Type{
+													"nested_attr": types.StringType,
+												},
+											},
+										},
+										map[string]attr.Value{
+											"inner": testschema.NestedObjectCustomValue{
+												ObjectValue: types.ObjectValueMust(
+													map[string]attr.Type{
+														"nested_attr": types.StringType,
+													},
+													map[string]attr.Value{
+														"nested_attr": types.StringValue("testvalue"),
+													},
+												),
+											},
+										},
+									),
+								},
+							),
+						},
+					},
+				),
+			},
+		},
 		"attribute-map-nested-private": {
 			attribute: testschema.NestedAttributeWithMapPlanModifiers{
 				NestedObject: testschema.NestedAttributeObject{
@@ -1549,6 +2689,184 @@ func TestAttributeModifyPlan(t *testing.T) {
 								},
 								map[string]attr.Value{
 									"nested_computed": types.StringValue("statevalue1"),
+								},
+							),
+						},
+					),
+				},
+			},
+		},
+		"attribute-single-nested-custom": {
+			attribute: schema.SingleNestedAttribute{
+				CustomType: testschema.NestedObjectCustomType{
+					ObjectType: basetypes.ObjectType{
+						AttrTypes: map[string]attr.Type{
+							"testing": types.StringType,
+						},
+					},
+				},
+				Attributes: map[string]schema.Attribute{
+					"testing": schema.StringAttribute{
+						Required: true,
+					},
+				},
+				Required: true,
+			},
+			req: ModifyAttributePlanRequest{
+				AttributeConfig: testschema.NestedObjectCustomValue{
+					ObjectValue: types.ObjectValueMust(
+						map[string]attr.Type{
+							"testing": types.StringType,
+						},
+						map[string]attr.Value{
+							"testing": types.StringValue("testvalue"),
+						},
+					),
+				},
+				AttributePath: path.Root("test"),
+				AttributePlan: testschema.NestedObjectCustomValue{
+					ObjectValue: types.ObjectValueMust(
+						map[string]attr.Type{
+							"testing": types.StringType,
+						},
+						map[string]attr.Value{
+							"testing": types.StringValue("testvalue"),
+						},
+					),
+				},
+				AttributeState: testschema.NestedObjectCustomValue{
+					ObjectValue: types.ObjectValueMust(
+						map[string]attr.Type{
+							"testing": types.StringType,
+						},
+						map[string]attr.Value{
+							"testing": types.StringValue("testvalue"),
+						},
+					),
+				},
+			},
+			expectedResp: ModifyAttributePlanResponse{
+				AttributePlan: testschema.NestedObjectCustomValue{
+					ObjectValue: types.ObjectValueMust(
+						map[string]attr.Type{
+							"testing": types.StringType,
+						},
+						map[string]attr.Value{
+							"testing": types.StringValue("testvalue"),
+						},
+					),
+				},
+			},
+		},
+		"attribute-single-nested-nested-custom-nested-object": {
+			attribute: schema.SingleNestedAttribute{
+				CustomType: testschema.NestedObjectCustomType{
+					ObjectType: basetypes.ObjectType{
+						AttrTypes: map[string]attr.Type{
+							"nested_single_nested_attribute": testschema.NestedObjectCustomType{
+								ObjectType: basetypes.ObjectType{
+									AttrTypes: map[string]attr.Type{
+										"testing": types.StringType,
+									},
+								},
+							},
+						},
+					},
+				},
+				Attributes: map[string]schema.Attribute{
+					"nested_single_nested_attribute": schema.SingleNestedAttribute{
+						Attributes: map[string]schema.Attribute{
+							"testing": schema.StringAttribute{
+								Required: true,
+							},
+						},
+					},
+				},
+				Required: true,
+			},
+			req: ModifyAttributePlanRequest{
+				AttributeConfig: testschema.NestedObjectCustomValue{
+					ObjectValue: types.ObjectValueMust(
+						map[string]attr.Type{
+							"nested_single_nested_attribute": types.ObjectType{
+								AttrTypes: map[string]attr.Type{
+									"testing": types.StringType,
+								},
+							},
+						},
+						map[string]attr.Value{
+							"nested_single_nested_attribute": types.ObjectValueMust(
+								map[string]attr.Type{
+									"testing": types.StringType,
+								},
+								map[string]attr.Value{
+									"testing": types.StringValue("testvalue"),
+								},
+							),
+						},
+					),
+				},
+				AttributePath: path.Root("test"),
+				AttributePlan: testschema.NestedObjectCustomValue{
+					ObjectValue: types.ObjectValueMust(
+						map[string]attr.Type{
+							"nested_single_nested_attribute": types.ObjectType{
+								AttrTypes: map[string]attr.Type{
+									"testing": types.StringType,
+								},
+							},
+						},
+						map[string]attr.Value{
+							"nested_single_nested_attribute": types.ObjectValueMust(
+								map[string]attr.Type{
+									"testing": types.StringType,
+								},
+								map[string]attr.Value{
+									"testing": types.StringValue("testvalue"),
+								},
+							),
+						},
+					),
+				},
+				AttributeState: testschema.NestedObjectCustomValue{
+					ObjectValue: types.ObjectValueMust(
+						map[string]attr.Type{
+							"nested_single_nested_attribute": types.ObjectType{
+								AttrTypes: map[string]attr.Type{
+									"testing": types.StringType,
+								},
+							},
+						},
+						map[string]attr.Value{
+							"nested_single_nested_attribute": types.ObjectValueMust(
+								map[string]attr.Type{
+									"testing": types.StringType,
+								},
+								map[string]attr.Value{
+									"testing": types.StringValue("testvalue"),
+								},
+							),
+						},
+					),
+				},
+			},
+			expectedResp: ModifyAttributePlanResponse{
+				AttributePlan: testschema.NestedObjectCustomValue{
+					ObjectValue: types.ObjectValueMust(
+						map[string]attr.Type{
+							"nested_single_nested_attribute": types.ObjectType{
+								AttrTypes: map[string]attr.Type{
+									"testing": types.StringType,
+								},
+							},
+						},
+						map[string]attr.Value{
+							"nested_single_nested_attribute": types.ObjectValueMust(
+								map[string]attr.Type{
+									"testing": types.StringType,
+								},
+								map[string]attr.Value{
+									"testing": types.StringValue("testvalue"),
 								},
 							),
 						},

--- a/internal/fwserver/attribute_plan_modification_test.go
+++ b/internal/fwserver/attribute_plan_modification_test.go
@@ -247,7 +247,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 					CustomType: testschema.ListNestedObjectCustomType{
 						ObjectType: basetypes.ObjectType{
 							AttrTypes: map[string]attr.Type{
-								"nested_list_nested_attribute": types.ListType{
+								"nested_list_nested": types.ListType{
 									ElemType: testschema.NestedObjectCustomType{
 										ObjectType: types.ObjectType{
 											AttrTypes: map[string]attr.Type{
@@ -260,7 +260,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 						},
 					},
 					Attributes: map[string]fwschema.Attribute{
-						"nested_list_nested_attribute": testschema.NestedAttribute{
+						"nested_list_nested": testschema.NestedAttribute{
 							NestedObject: testschema.NestedAttributeObject{
 								CustomType: testschema.NestedObjectCustomType{
 									ObjectType: basetypes.ObjectType{
@@ -288,7 +288,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 					testschema.ListNestedObjectCustomType{
 						ObjectType: types.ObjectType{
 							AttrTypes: map[string]attr.Type{
-								"nested_list_nested_attribute": types.ListType{
+								"nested_list_nested": types.ListType{
 									ElemType: testschema.NestedObjectCustomType{
 										ObjectType: types.ObjectType{
 											AttrTypes: map[string]attr.Type{
@@ -304,7 +304,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 						testschema.ListNestedObjectCustomValue{
 							ObjectValue: types.ObjectValueMust(
 								map[string]attr.Type{
-									"nested_list_nested_attribute": types.ListType{
+									"nested_list_nested": types.ListType{
 										ElemType: testschema.NestedObjectCustomType{
 											ObjectType: types.ObjectType{
 												AttrTypes: map[string]attr.Type{
@@ -315,7 +315,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 									},
 								},
 								map[string]attr.Value{
-									"nested_list_nested_attribute": types.ListValueMust(
+									"nested_list_nested": types.ListValueMust(
 										testschema.NestedObjectCustomType{
 											ObjectType: types.ObjectType{
 												AttrTypes: map[string]attr.Type{
@@ -346,7 +346,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 					testschema.ListNestedObjectCustomType{
 						ObjectType: types.ObjectType{
 							AttrTypes: map[string]attr.Type{
-								"nested_list_nested_attribute": types.ListType{
+								"nested_list_nested": types.ListType{
 									ElemType: testschema.NestedObjectCustomType{
 										ObjectType: types.ObjectType{
 											AttrTypes: map[string]attr.Type{
@@ -362,7 +362,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 						testschema.ListNestedObjectCustomValue{
 							ObjectValue: types.ObjectValueMust(
 								map[string]attr.Type{
-									"nested_list_nested_attribute": types.ListType{
+									"nested_list_nested": types.ListType{
 										ElemType: testschema.NestedObjectCustomType{
 											ObjectType: types.ObjectType{
 												AttrTypes: map[string]attr.Type{
@@ -373,7 +373,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 									},
 								},
 								map[string]attr.Value{
-									"nested_list_nested_attribute": types.ListValueMust(
+									"nested_list_nested": types.ListValueMust(
 										testschema.NestedObjectCustomType{
 											ObjectType: types.ObjectType{
 												AttrTypes: map[string]attr.Type{
@@ -403,7 +403,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 					testschema.ListNestedObjectCustomType{
 						ObjectType: types.ObjectType{
 							AttrTypes: map[string]attr.Type{
-								"nested_list_nested_attribute": types.ListType{
+								"nested_list_nested": types.ListType{
 									ElemType: testschema.NestedObjectCustomType{
 										ObjectType: types.ObjectType{
 											AttrTypes: map[string]attr.Type{
@@ -419,7 +419,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 						testschema.ListNestedObjectCustomValue{
 							ObjectValue: types.ObjectValueMust(
 								map[string]attr.Type{
-									"nested_list_nested_attribute": types.ListType{
+									"nested_list_nested": types.ListType{
 										ElemType: testschema.NestedObjectCustomType{
 											ObjectType: types.ObjectType{
 												AttrTypes: map[string]attr.Type{
@@ -430,7 +430,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 									},
 								},
 								map[string]attr.Value{
-									"nested_list_nested_attribute": types.ListValueMust(
+									"nested_list_nested": types.ListValueMust(
 										testschema.NestedObjectCustomType{
 											ObjectType: types.ObjectType{
 												AttrTypes: map[string]attr.Type{
@@ -462,7 +462,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 					testschema.ListNestedObjectCustomType{
 						ObjectType: types.ObjectType{
 							AttrTypes: map[string]attr.Type{
-								"nested_list_nested_attribute": types.ListType{
+								"nested_list_nested": types.ListType{
 									ElemType: testschema.NestedObjectCustomType{
 										ObjectType: types.ObjectType{
 											AttrTypes: map[string]attr.Type{
@@ -478,7 +478,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 						testschema.ListNestedObjectCustomValue{
 							ObjectValue: types.ObjectValueMust(
 								map[string]attr.Type{
-									"nested_list_nested_attribute": types.ListType{
+									"nested_list_nested": types.ListType{
 										ElemType: testschema.NestedObjectCustomType{
 											ObjectType: types.ObjectType{
 												AttrTypes: map[string]attr.Type{
@@ -489,7 +489,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 									},
 								},
 								map[string]attr.Value{
-									"nested_list_nested_attribute": types.ListValueMust(
+									"nested_list_nested": types.ListValueMust(
 										testschema.NestedObjectCustomType{
 											ObjectType: types.ObjectType{
 												AttrTypes: map[string]attr.Type{
@@ -1143,7 +1143,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 					CustomType: testschema.SetNestedObjectCustomType{
 						ObjectType: basetypes.ObjectType{
 							AttrTypes: map[string]attr.Type{
-								"nested_set_nested_attribute": types.SetType{
+								"nested_set_nested": types.SetType{
 									ElemType: testschema.NestedObjectCustomType{
 										ObjectType: types.ObjectType{
 											AttrTypes: map[string]attr.Type{
@@ -1156,7 +1156,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 						},
 					},
 					Attributes: map[string]fwschema.Attribute{
-						"nested_set_nested_attribute": testschema.NestedAttribute{
+						"nested_set_nested": testschema.NestedAttribute{
 							NestedObject: testschema.NestedAttributeObject{
 								CustomType: testschema.NestedObjectCustomType{
 									ObjectType: basetypes.ObjectType{
@@ -1184,7 +1184,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 					testschema.SetNestedObjectCustomType{
 						ObjectType: types.ObjectType{
 							AttrTypes: map[string]attr.Type{
-								"nested_set_nested_attribute": types.SetType{
+								"nested_set_nested": types.SetType{
 									ElemType: testschema.NestedObjectCustomType{
 										ObjectType: types.ObjectType{
 											AttrTypes: map[string]attr.Type{
@@ -1200,7 +1200,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 						testschema.SetNestedObjectCustomValue{
 							ObjectValue: types.ObjectValueMust(
 								map[string]attr.Type{
-									"nested_set_nested_attribute": types.SetType{
+									"nested_set_nested": types.SetType{
 										ElemType: testschema.NestedObjectCustomType{
 											ObjectType: types.ObjectType{
 												AttrTypes: map[string]attr.Type{
@@ -1211,7 +1211,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 									},
 								},
 								map[string]attr.Value{
-									"nested_set_nested_attribute": types.SetValueMust(
+									"nested_set_nested": types.SetValueMust(
 										testschema.NestedObjectCustomType{
 											ObjectType: types.ObjectType{
 												AttrTypes: map[string]attr.Type{
@@ -1242,7 +1242,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 					testschema.SetNestedObjectCustomType{
 						ObjectType: types.ObjectType{
 							AttrTypes: map[string]attr.Type{
-								"nested_set_nested_attribute": types.SetType{
+								"nested_set_nested": types.SetType{
 									ElemType: testschema.NestedObjectCustomType{
 										ObjectType: types.ObjectType{
 											AttrTypes: map[string]attr.Type{
@@ -1258,7 +1258,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 						testschema.SetNestedObjectCustomValue{
 							ObjectValue: types.ObjectValueMust(
 								map[string]attr.Type{
-									"nested_set_nested_attribute": types.SetType{
+									"nested_set_nested": types.SetType{
 										ElemType: testschema.NestedObjectCustomType{
 											ObjectType: types.ObjectType{
 												AttrTypes: map[string]attr.Type{
@@ -1269,7 +1269,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 									},
 								},
 								map[string]attr.Value{
-									"nested_set_nested_attribute": types.SetValueMust(
+									"nested_set_nested": types.SetValueMust(
 										testschema.NestedObjectCustomType{
 											ObjectType: types.ObjectType{
 												AttrTypes: map[string]attr.Type{
@@ -1299,7 +1299,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 					testschema.SetNestedObjectCustomType{
 						ObjectType: types.ObjectType{
 							AttrTypes: map[string]attr.Type{
-								"nested_set_nested_attribute": types.SetType{
+								"nested_set_nested": types.SetType{
 									ElemType: testschema.NestedObjectCustomType{
 										ObjectType: types.ObjectType{
 											AttrTypes: map[string]attr.Type{
@@ -1315,7 +1315,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 						testschema.SetNestedObjectCustomValue{
 							ObjectValue: types.ObjectValueMust(
 								map[string]attr.Type{
-									"nested_set_nested_attribute": types.SetType{
+									"nested_set_nested": types.SetType{
 										ElemType: testschema.NestedObjectCustomType{
 											ObjectType: types.ObjectType{
 												AttrTypes: map[string]attr.Type{
@@ -1326,7 +1326,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 									},
 								},
 								map[string]attr.Value{
-									"nested_set_nested_attribute": types.SetValueMust(
+									"nested_set_nested": types.SetValueMust(
 										testschema.NestedObjectCustomType{
 											ObjectType: types.ObjectType{
 												AttrTypes: map[string]attr.Type{
@@ -1358,7 +1358,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 					testschema.SetNestedObjectCustomType{
 						ObjectType: types.ObjectType{
 							AttrTypes: map[string]attr.Type{
-								"nested_set_nested_attribute": types.SetType{
+								"nested_set_nested": types.SetType{
 									ElemType: testschema.NestedObjectCustomType{
 										ObjectType: types.ObjectType{
 											AttrTypes: map[string]attr.Type{
@@ -1374,7 +1374,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 						testschema.SetNestedObjectCustomValue{
 							ObjectValue: types.ObjectValueMust(
 								map[string]attr.Type{
-									"nested_set_nested_attribute": types.SetType{
+									"nested_set_nested": types.SetType{
 										ElemType: testschema.NestedObjectCustomType{
 											ObjectType: types.ObjectType{
 												AttrTypes: map[string]attr.Type{
@@ -1385,7 +1385,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 									},
 								},
 								map[string]attr.Value{
-									"nested_set_nested_attribute": types.SetValueMust(
+									"nested_set_nested": types.SetValueMust(
 										testschema.NestedObjectCustomType{
 											ObjectType: types.ObjectType{
 												AttrTypes: map[string]attr.Type{
@@ -2187,7 +2187,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 					CustomType: testschema.MapNestedObjectCustomType{
 						ObjectType: basetypes.ObjectType{
 							AttrTypes: map[string]attr.Type{
-								"nested_map_nested_attribute": types.MapType{
+								"nested_map_nested": types.MapType{
 									ElemType: testschema.NestedObjectCustomType{
 										ObjectType: types.ObjectType{
 											AttrTypes: map[string]attr.Type{
@@ -2200,7 +2200,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 						},
 					},
 					Attributes: map[string]fwschema.Attribute{
-						"nested_map_nested_attribute": testschema.NestedAttribute{
+						"nested_map_nested": testschema.NestedAttribute{
 							NestedObject: testschema.NestedAttributeObject{
 								CustomType: testschema.NestedObjectCustomType{
 									ObjectType: basetypes.ObjectType{
@@ -2228,7 +2228,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 					testschema.MapNestedObjectCustomType{
 						ObjectType: types.ObjectType{
 							AttrTypes: map[string]attr.Type{
-								"nested_map_nested_attribute": types.MapType{
+								"nested_map_nested": types.MapType{
 									ElemType: testschema.NestedObjectCustomType{
 										ObjectType: types.ObjectType{
 											AttrTypes: map[string]attr.Type{
@@ -2244,7 +2244,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 						"outer": testschema.MapNestedObjectCustomValue{
 							ObjectValue: types.ObjectValueMust(
 								map[string]attr.Type{
-									"nested_map_nested_attribute": types.MapType{
+									"nested_map_nested": types.MapType{
 										ElemType: testschema.NestedObjectCustomType{
 											ObjectType: types.ObjectType{
 												AttrTypes: map[string]attr.Type{
@@ -2255,7 +2255,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 									},
 								},
 								map[string]attr.Value{
-									"nested_map_nested_attribute": types.MapValueMust(
+									"nested_map_nested": types.MapValueMust(
 										testschema.NestedObjectCustomType{
 											ObjectType: types.ObjectType{
 												AttrTypes: map[string]attr.Type{
@@ -2286,7 +2286,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 					testschema.MapNestedObjectCustomType{
 						ObjectType: types.ObjectType{
 							AttrTypes: map[string]attr.Type{
-								"nested_map_nested_attribute": types.MapType{
+								"nested_map_nested": types.MapType{
 									ElemType: testschema.NestedObjectCustomType{
 										ObjectType: types.ObjectType{
 											AttrTypes: map[string]attr.Type{
@@ -2302,7 +2302,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 						"outer": testschema.MapNestedObjectCustomValue{
 							ObjectValue: types.ObjectValueMust(
 								map[string]attr.Type{
-									"nested_map_nested_attribute": types.MapType{
+									"nested_map_nested": types.MapType{
 										ElemType: testschema.NestedObjectCustomType{
 											ObjectType: types.ObjectType{
 												AttrTypes: map[string]attr.Type{
@@ -2313,7 +2313,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 									},
 								},
 								map[string]attr.Value{
-									"nested_map_nested_attribute": types.MapValueMust(
+									"nested_map_nested": types.MapValueMust(
 										testschema.NestedObjectCustomType{
 											ObjectType: types.ObjectType{
 												AttrTypes: map[string]attr.Type{
@@ -2343,7 +2343,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 					testschema.MapNestedObjectCustomType{
 						ObjectType: types.ObjectType{
 							AttrTypes: map[string]attr.Type{
-								"nested_map_nested_attribute": types.MapType{
+								"nested_map_nested": types.MapType{
 									ElemType: testschema.NestedObjectCustomType{
 										ObjectType: types.ObjectType{
 											AttrTypes: map[string]attr.Type{
@@ -2359,7 +2359,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 						"outer": testschema.MapNestedObjectCustomValue{
 							ObjectValue: types.ObjectValueMust(
 								map[string]attr.Type{
-									"nested_map_nested_attribute": types.MapType{
+									"nested_map_nested": types.MapType{
 										ElemType: testschema.NestedObjectCustomType{
 											ObjectType: types.ObjectType{
 												AttrTypes: map[string]attr.Type{
@@ -2370,7 +2370,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 									},
 								},
 								map[string]attr.Value{
-									"nested_map_nested_attribute": types.MapValueMust(
+									"nested_map_nested": types.MapValueMust(
 										testschema.NestedObjectCustomType{
 											ObjectType: types.ObjectType{
 												AttrTypes: map[string]attr.Type{
@@ -2402,7 +2402,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 					testschema.MapNestedObjectCustomType{
 						ObjectType: types.ObjectType{
 							AttrTypes: map[string]attr.Type{
-								"nested_map_nested_attribute": types.MapType{
+								"nested_map_nested": types.MapType{
 									ElemType: testschema.NestedObjectCustomType{
 										ObjectType: types.ObjectType{
 											AttrTypes: map[string]attr.Type{
@@ -2418,7 +2418,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 						"outer": testschema.MapNestedObjectCustomValue{
 							ObjectValue: types.ObjectValueMust(
 								map[string]attr.Type{
-									"nested_map_nested_attribute": types.MapType{
+									"nested_map_nested": types.MapType{
 										ElemType: testschema.NestedObjectCustomType{
 											ObjectType: types.ObjectType{
 												AttrTypes: map[string]attr.Type{
@@ -2429,7 +2429,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 									},
 								},
 								map[string]attr.Value{
-									"nested_map_nested_attribute": types.MapValueMust(
+									"nested_map_nested": types.MapValueMust(
 										testschema.NestedObjectCustomType{
 											ObjectType: types.ObjectType{
 												AttrTypes: map[string]attr.Type{

--- a/internal/fwserver/attribute_plan_modification_test.go
+++ b/internal/fwserver/attribute_plan_modification_test.go
@@ -133,8 +133,8 @@ func TestAttributeModifyPlan(t *testing.T) {
 			},
 		},
 		"attribute-list-nested-custom-nested-object": {
-			attribute: schema.ListNestedAttribute{
-				NestedObject: schema.NestedAttributeObject{
+			attribute: testschema.NestedAttribute{
+				NestedObject: testschema.NestedAttributeObject{
 					CustomType: testschema.NestedObjectCustomType{
 						ObjectType: basetypes.ObjectType{
 							AttrTypes: map[string]attr.Type{
@@ -142,13 +142,14 @@ func TestAttributeModifyPlan(t *testing.T) {
 							},
 						},
 					},
-					Attributes: map[string]schema.Attribute{
-						"nested_attr": schema.StringAttribute{
+					Attributes: map[string]fwschema.Attribute{
+						"nested_attr": testschema.Attribute{
 							Required: true,
 						},
 					},
 				},
-				Required: true,
+				Required:    true,
+				NestingMode: fwschema.NestingModeList,
 			},
 			req: ModifyAttributePlanRequest{
 				AttributeConfig: types.ListValueMust(
@@ -241,8 +242,8 @@ func TestAttributeModifyPlan(t *testing.T) {
 			},
 		},
 		"attribute-list-nested-nested-custom-nested-object": {
-			attribute: schema.ListNestedAttribute{
-				NestedObject: schema.NestedAttributeObject{
+			attribute: testschema.NestedAttribute{
+				NestedObject: testschema.NestedAttributeObject{
 					CustomType: testschema.ListNestedObjectCustomType{
 						ObjectType: basetypes.ObjectType{
 							AttrTypes: map[string]attr.Type{
@@ -258,9 +259,9 @@ func TestAttributeModifyPlan(t *testing.T) {
 							},
 						},
 					},
-					Attributes: map[string]schema.Attribute{
-						"nested_list_nested_attribute": schema.ListNestedAttribute{
-							NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]fwschema.Attribute{
+						"nested_list_nested_attribute": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
 								CustomType: testschema.NestedObjectCustomType{
 									ObjectType: basetypes.ObjectType{
 										AttrTypes: map[string]attr.Type{
@@ -268,17 +269,19 @@ func TestAttributeModifyPlan(t *testing.T) {
 										},
 									},
 								},
-								Attributes: map[string]schema.Attribute{
-									"nested_attr": schema.StringAttribute{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_attr": testschema.Attribute{
 										Required: true,
 									},
 								},
 							},
-							Required: true,
+							Required:    true,
+							NestingMode: fwschema.NestingModeList,
 						},
 					},
 				},
-				Required: true,
+				Required:    true,
+				NestingMode: fwschema.NestingModeList,
 			},
 			req: ModifyAttributePlanRequest{
 				AttributeConfig: types.ListValueMust(
@@ -1033,15 +1036,16 @@ func TestAttributeModifyPlan(t *testing.T) {
 			},
 		},
 		"attribute-set-nested-custom-nested-object": {
-			attribute: schema.SetNestedAttribute{
-				NestedObject: schema.NestedAttributeObject{
-					Attributes: map[string]schema.Attribute{
-						"nested_attr": schema.StringAttribute{
+			attribute: testschema.NestedAttribute{
+				NestedObject: testschema.NestedAttributeObject{
+					Attributes: map[string]fwschema.Attribute{
+						"nested_attr": testschema.Attribute{
 							Required: true,
 						},
 					},
 				},
-				Required: true,
+				Required:    true,
+				NestingMode: fwschema.NestingModeSet,
 			},
 			req: ModifyAttributePlanRequest{
 				AttributeConfig: types.SetValueMust(
@@ -1134,8 +1138,8 @@ func TestAttributeModifyPlan(t *testing.T) {
 			},
 		},
 		"attribute-set-nested-nested-custom-nested-object": {
-			attribute: schema.SetNestedAttribute{
-				NestedObject: schema.NestedAttributeObject{
+			attribute: testschema.NestedAttribute{
+				NestedObject: testschema.NestedAttributeObject{
 					CustomType: testschema.SetNestedObjectCustomType{
 						ObjectType: basetypes.ObjectType{
 							AttrTypes: map[string]attr.Type{
@@ -1151,9 +1155,9 @@ func TestAttributeModifyPlan(t *testing.T) {
 							},
 						},
 					},
-					Attributes: map[string]schema.Attribute{
-						"nested_set_nested_attribute": schema.SetNestedAttribute{
-							NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]fwschema.Attribute{
+						"nested_set_nested_attribute": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
 								CustomType: testschema.NestedObjectCustomType{
 									ObjectType: basetypes.ObjectType{
 										AttrTypes: map[string]attr.Type{
@@ -1161,17 +1165,19 @@ func TestAttributeModifyPlan(t *testing.T) {
 										},
 									},
 								},
-								Attributes: map[string]schema.Attribute{
-									"nested_attr": schema.StringAttribute{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_attr": testschema.Attribute{
 										Required: true,
 									},
 								},
 							},
-							Required: true,
+							Required:    true,
+							NestingMode: fwschema.NestingModeSet,
 						},
 					},
 				},
-				Required: true,
+				Required:    true,
+				NestingMode: fwschema.NestingModeSet,
 			},
 			req: ModifyAttributePlanRequest{
 				AttributeConfig: types.SetValueMust(
@@ -2067,8 +2073,8 @@ func TestAttributeModifyPlan(t *testing.T) {
 			},
 		},
 		"attribute-map-nested-custom-nested-object": {
-			attribute: schema.MapNestedAttribute{
-				NestedObject: schema.NestedAttributeObject{
+			attribute: testschema.NestedAttribute{
+				NestedObject: testschema.NestedAttributeObject{
 					CustomType: testschema.NestedObjectCustomType{
 						ObjectType: basetypes.ObjectType{
 							AttrTypes: map[string]attr.Type{
@@ -2076,13 +2082,14 @@ func TestAttributeModifyPlan(t *testing.T) {
 							},
 						},
 					},
-					Attributes: map[string]schema.Attribute{
-						"nested_attr": schema.StringAttribute{
+					Attributes: map[string]fwschema.Attribute{
+						"nested_attr": testschema.Attribute{
 							Required: true,
 						},
 					},
 				},
-				Required: true,
+				Required:    true,
+				NestingMode: fwschema.NestingModeMap,
 			},
 			req: ModifyAttributePlanRequest{
 				AttributeConfig: types.MapValueMust(
@@ -2175,8 +2182,8 @@ func TestAttributeModifyPlan(t *testing.T) {
 			},
 		},
 		"attribute-map-nested-nested-custom-nested-object": {
-			attribute: schema.MapNestedAttribute{
-				NestedObject: schema.NestedAttributeObject{
+			attribute: testschema.NestedAttribute{
+				NestedObject: testschema.NestedAttributeObject{
 					CustomType: testschema.MapNestedObjectCustomType{
 						ObjectType: basetypes.ObjectType{
 							AttrTypes: map[string]attr.Type{
@@ -2192,9 +2199,9 @@ func TestAttributeModifyPlan(t *testing.T) {
 							},
 						},
 					},
-					Attributes: map[string]schema.Attribute{
-						"nested_map_nested_attribute": schema.MapNestedAttribute{
-							NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]fwschema.Attribute{
+						"nested_map_nested_attribute": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
 								CustomType: testschema.NestedObjectCustomType{
 									ObjectType: basetypes.ObjectType{
 										AttrTypes: map[string]attr.Type{
@@ -2202,17 +2209,19 @@ func TestAttributeModifyPlan(t *testing.T) {
 										},
 									},
 								},
-								Attributes: map[string]schema.Attribute{
-									"nested_attr": schema.StringAttribute{
+								Attributes: map[string]fwschema.Attribute{
+									"nested_attr": testschema.Attribute{
 										Required: true,
 									},
 								},
 							},
-							Required: true,
+							Required:    true,
+							NestingMode: fwschema.NestingModeMap,
 						},
 					},
 				},
-				Required: true,
+				Required:    true,
+				NestingMode: fwschema.NestingModeMap,
 			},
 			req: ModifyAttributePlanRequest{
 				AttributeConfig: types.MapValueMust(
@@ -2697,7 +2706,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 			},
 		},
 		"attribute-single-nested-custom": {
-			attribute: schema.SingleNestedAttribute{
+			attribute: testschema.NestedAttribute{
 				CustomType: testschema.NestedObjectCustomType{
 					ObjectType: basetypes.ObjectType{
 						AttrTypes: map[string]attr.Type{
@@ -2705,12 +2714,15 @@ func TestAttributeModifyPlan(t *testing.T) {
 						},
 					},
 				},
-				Attributes: map[string]schema.Attribute{
-					"testing": schema.StringAttribute{
-						Required: true,
+				NestedObject: testschema.NestedAttributeObject{
+					Attributes: map[string]fwschema.Attribute{
+						"testing": testschema.Attribute{
+							Required: true,
+						},
 					},
 				},
-				Required: true,
+				Required:    true,
+				NestingMode: fwschema.NestingModeSingle,
 			},
 			req: ModifyAttributePlanRequest{
 				AttributeConfig: testschema.NestedObjectCustomValue{
@@ -2759,7 +2771,7 @@ func TestAttributeModifyPlan(t *testing.T) {
 			},
 		},
 		"attribute-single-nested-nested-custom-nested-object": {
-			attribute: schema.SingleNestedAttribute{
+			attribute: testschema.NestedAttribute{
 				CustomType: testschema.NestedObjectCustomType{
 					ObjectType: basetypes.ObjectType{
 						AttrTypes: map[string]attr.Type{
@@ -2773,16 +2785,23 @@ func TestAttributeModifyPlan(t *testing.T) {
 						},
 					},
 				},
-				Attributes: map[string]schema.Attribute{
-					"nested_single_nested_attribute": schema.SingleNestedAttribute{
-						Attributes: map[string]schema.Attribute{
-							"testing": schema.StringAttribute{
-								Required: true,
+				NestedObject: testschema.NestedAttributeObject{
+					Attributes: map[string]fwschema.Attribute{
+						"nested_single_nested_attribute": testschema.NestedAttribute{
+							NestedObject: testschema.NestedAttributeObject{
+								Attributes: map[string]fwschema.Attribute{
+									"testing": testschema.Attribute{
+										Required: true,
+									},
+								},
 							},
+							Required:    true,
+							NestingMode: fwschema.NestingModeSingle,
 						},
 					},
 				},
-				Required: true,
+				Required:    true,
+				NestingMode: fwschema.NestingModeSingle,
 			},
 			req: ModifyAttributePlanRequest{
 				AttributeConfig: testschema.NestedObjectCustomValue{

--- a/internal/fwserver/block_plan_modification.go
+++ b/internal/fwserver/block_plan_modification.go
@@ -113,6 +113,22 @@ func BlockModifyPlan(ctx context.Context, b fwschema.Block, req ModifyAttributeP
 				return
 			}
 
+			planObjectValuable, diags := coerceObjectValuable(ctx, attrPath, planElem)
+
+			resp.Diagnostics.Append(diags...)
+
+			if resp.Diagnostics.HasError() {
+				return
+			}
+
+			typable, diags := coerceObjectTypable(ctx, attrPath, planObjectValuable)
+
+			resp.Diagnostics.Append(diags...)
+
+			if resp.Diagnostics.HasError() {
+				return
+			}
+
 			stateObject, diags := listElemObject(ctx, attrPath, stateList, idx, fwschemadata.DataDescriptionState)
 
 			resp.Diagnostics.Append(diags...)
@@ -139,7 +155,26 @@ func BlockModifyPlan(ctx context.Context, b fwschema.Block, req ModifyAttributeP
 
 			NestedBlockObjectPlanModify(ctx, nestedBlockObject, objectReq, objectResp)
 
-			planElements[idx] = objectResp.AttributePlan
+			respValue, diags := coerceObjectValue(ctx, attrPath, objectResp.AttributePlan)
+
+			resp.Diagnostics.Append(diags...)
+
+			if resp.Diagnostics.HasError() {
+				return
+			}
+
+			// A custom value type must be returned in the final response to prevent
+			// later correctness errors.
+			// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/821
+			respValuable, diags := typable.ValueFromObject(ctx, respValue)
+
+			resp.Diagnostics.Append(diags...)
+
+			if resp.Diagnostics.HasError() {
+				return
+			}
+
+			planElements[idx] = respValuable
 			resp.Diagnostics.Append(objectResp.Diagnostics...)
 			resp.Private = objectResp.Private
 			resp.RequiresReplace.Append(objectResp.RequiresReplace...)
@@ -229,6 +264,22 @@ func BlockModifyPlan(ctx context.Context, b fwschema.Block, req ModifyAttributeP
 				return
 			}
 
+			planObjectValuable, diags := coerceObjectValuable(ctx, attrPath, planElem)
+
+			resp.Diagnostics.Append(diags...)
+
+			if resp.Diagnostics.HasError() {
+				return
+			}
+
+			typable, diags := coerceObjectTypable(ctx, attrPath, planObjectValuable)
+
+			resp.Diagnostics.Append(diags...)
+
+			if resp.Diagnostics.HasError() {
+				return
+			}
+
 			stateObject, diags := setElemObject(ctx, attrPath, stateSet, idx, fwschemadata.DataDescriptionState)
 
 			resp.Diagnostics.Append(diags...)
@@ -255,7 +306,26 @@ func BlockModifyPlan(ctx context.Context, b fwschema.Block, req ModifyAttributeP
 
 			NestedBlockObjectPlanModify(ctx, nestedBlockObject, objectReq, objectResp)
 
-			planElements[idx] = objectResp.AttributePlan
+			respValue, diags := coerceObjectValue(ctx, attrPath, objectResp.AttributePlan)
+
+			resp.Diagnostics.Append(diags...)
+
+			if resp.Diagnostics.HasError() {
+				return
+			}
+
+			// A custom value type must be returned in the final response to prevent
+			// later correctness errors.
+			// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/821
+			respValuable, diags := typable.ValueFromObject(ctx, respValue)
+
+			resp.Diagnostics.Append(diags...)
+
+			if resp.Diagnostics.HasError() {
+				return
+			}
+
+			planElements[idx] = respValuable
 			resp.Diagnostics.Append(objectResp.Diagnostics...)
 			resp.Private = objectResp.Private
 			resp.RequiresReplace.Append(objectResp.RequiresReplace...)

--- a/internal/fwserver/block_plan_modification_test.go
+++ b/internal/fwserver/block_plan_modification_test.go
@@ -604,13 +604,13 @@ func TestBlockModifyPlan(t *testing.T) {
 				),
 			},
 		},
-		"attribute-list-nested-nested-custom-nested-object": {
+		"block-list-nested-nested-custom-nested-object": {
 			block: testschema.Block{
 				NestedObject: testschema.NestedBlockObject{
 					CustomType: testschema.ListNestedObjectCustomType{
 						ObjectType: basetypes.ObjectType{
 							AttrTypes: map[string]attr.Type{
-								"nested_list_nested_attribute": types.ListType{
+								"nested_list_nested": types.ListType{
 									ElemType: testschema.NestedObjectCustomType{
 										ObjectType: types.ObjectType{
 											AttrTypes: map[string]attr.Type{
@@ -623,7 +623,7 @@ func TestBlockModifyPlan(t *testing.T) {
 						},
 					},
 					Blocks: map[string]fwschema.Block{
-						"nested_list_nested_attribute": testschema.Block{
+						"nested_list_nested": testschema.Block{
 							NestedObject: testschema.NestedBlockObject{
 								CustomType: testschema.NestedObjectCustomType{
 									ObjectType: basetypes.ObjectType{
@@ -649,7 +649,7 @@ func TestBlockModifyPlan(t *testing.T) {
 					testschema.ListNestedObjectCustomType{
 						ObjectType: types.ObjectType{
 							AttrTypes: map[string]attr.Type{
-								"nested_list_nested_attribute": types.ListType{
+								"nested_list_nested": types.ListType{
 									ElemType: testschema.NestedObjectCustomType{
 										ObjectType: types.ObjectType{
 											AttrTypes: map[string]attr.Type{
@@ -665,7 +665,7 @@ func TestBlockModifyPlan(t *testing.T) {
 						testschema.ListNestedObjectCustomValue{
 							ObjectValue: types.ObjectValueMust(
 								map[string]attr.Type{
-									"nested_list_nested_attribute": types.ListType{
+									"nested_list_nested": types.ListType{
 										ElemType: testschema.NestedObjectCustomType{
 											ObjectType: types.ObjectType{
 												AttrTypes: map[string]attr.Type{
@@ -676,7 +676,7 @@ func TestBlockModifyPlan(t *testing.T) {
 									},
 								},
 								map[string]attr.Value{
-									"nested_list_nested_attribute": types.ListValueMust(
+									"nested_list_nested": types.ListValueMust(
 										testschema.NestedObjectCustomType{
 											ObjectType: types.ObjectType{
 												AttrTypes: map[string]attr.Type{
@@ -707,7 +707,7 @@ func TestBlockModifyPlan(t *testing.T) {
 					testschema.ListNestedObjectCustomType{
 						ObjectType: types.ObjectType{
 							AttrTypes: map[string]attr.Type{
-								"nested_list_nested_attribute": types.ListType{
+								"nested_list_nested": types.ListType{
 									ElemType: testschema.NestedObjectCustomType{
 										ObjectType: types.ObjectType{
 											AttrTypes: map[string]attr.Type{
@@ -723,7 +723,7 @@ func TestBlockModifyPlan(t *testing.T) {
 						testschema.ListNestedObjectCustomValue{
 							ObjectValue: types.ObjectValueMust(
 								map[string]attr.Type{
-									"nested_list_nested_attribute": types.ListType{
+									"nested_list_nested": types.ListType{
 										ElemType: testschema.NestedObjectCustomType{
 											ObjectType: types.ObjectType{
 												AttrTypes: map[string]attr.Type{
@@ -734,7 +734,7 @@ func TestBlockModifyPlan(t *testing.T) {
 									},
 								},
 								map[string]attr.Value{
-									"nested_list_nested_attribute": types.ListValueMust(
+									"nested_list_nested": types.ListValueMust(
 										testschema.NestedObjectCustomType{
 											ObjectType: types.ObjectType{
 												AttrTypes: map[string]attr.Type{
@@ -764,7 +764,7 @@ func TestBlockModifyPlan(t *testing.T) {
 					testschema.ListNestedObjectCustomType{
 						ObjectType: types.ObjectType{
 							AttrTypes: map[string]attr.Type{
-								"nested_list_nested_attribute": types.ListType{
+								"nested_list_nested": types.ListType{
 									ElemType: testschema.NestedObjectCustomType{
 										ObjectType: types.ObjectType{
 											AttrTypes: map[string]attr.Type{
@@ -780,7 +780,7 @@ func TestBlockModifyPlan(t *testing.T) {
 						testschema.ListNestedObjectCustomValue{
 							ObjectValue: types.ObjectValueMust(
 								map[string]attr.Type{
-									"nested_list_nested_attribute": types.ListType{
+									"nested_list_nested": types.ListType{
 										ElemType: testschema.NestedObjectCustomType{
 											ObjectType: types.ObjectType{
 												AttrTypes: map[string]attr.Type{
@@ -791,7 +791,7 @@ func TestBlockModifyPlan(t *testing.T) {
 									},
 								},
 								map[string]attr.Value{
-									"nested_list_nested_attribute": types.ListValueMust(
+									"nested_list_nested": types.ListValueMust(
 										testschema.NestedObjectCustomType{
 											ObjectType: types.ObjectType{
 												AttrTypes: map[string]attr.Type{
@@ -823,7 +823,7 @@ func TestBlockModifyPlan(t *testing.T) {
 					testschema.ListNestedObjectCustomType{
 						ObjectType: types.ObjectType{
 							AttrTypes: map[string]attr.Type{
-								"nested_list_nested_attribute": types.ListType{
+								"nested_list_nested": types.ListType{
 									ElemType: testschema.NestedObjectCustomType{
 										ObjectType: types.ObjectType{
 											AttrTypes: map[string]attr.Type{
@@ -839,7 +839,7 @@ func TestBlockModifyPlan(t *testing.T) {
 						testschema.ListNestedObjectCustomValue{
 							ObjectValue: types.ObjectValueMust(
 								map[string]attr.Type{
-									"nested_list_nested_attribute": types.ListType{
+									"nested_list_nested": types.ListType{
 										ElemType: testschema.NestedObjectCustomType{
 											ObjectType: types.ObjectType{
 												AttrTypes: map[string]attr.Type{
@@ -850,7 +850,7 @@ func TestBlockModifyPlan(t *testing.T) {
 									},
 								},
 								map[string]attr.Value{
-									"nested_list_nested_attribute": types.ListValueMust(
+									"nested_list_nested": types.ListValueMust(
 										testschema.NestedObjectCustomType{
 											ObjectType: types.ObjectType{
 												AttrTypes: map[string]attr.Type{
@@ -1374,7 +1374,7 @@ func TestBlockModifyPlan(t *testing.T) {
 					CustomType: testschema.SetNestedObjectCustomType{
 						ObjectType: basetypes.ObjectType{
 							AttrTypes: map[string]attr.Type{
-								"nested_set_nested_attribute": types.SetType{
+								"nested_set_nested": types.SetType{
 									ElemType: testschema.NestedObjectCustomType{
 										ObjectType: types.ObjectType{
 											AttrTypes: map[string]attr.Type{
@@ -1387,7 +1387,7 @@ func TestBlockModifyPlan(t *testing.T) {
 						},
 					},
 					Blocks: map[string]fwschema.Block{
-						"nested_set_nested_attribute": testschema.Block{
+						"nested_set_nested": testschema.Block{
 							NestedObject: testschema.NestedBlockObject{
 								CustomType: testschema.NestedObjectCustomType{
 									ObjectType: basetypes.ObjectType{
@@ -1413,7 +1413,7 @@ func TestBlockModifyPlan(t *testing.T) {
 					testschema.SetNestedObjectCustomType{
 						ObjectType: types.ObjectType{
 							AttrTypes: map[string]attr.Type{
-								"nested_set_nested_attribute": types.SetType{
+								"nested_set_nested": types.SetType{
 									ElemType: testschema.NestedObjectCustomType{
 										ObjectType: types.ObjectType{
 											AttrTypes: map[string]attr.Type{
@@ -1429,7 +1429,7 @@ func TestBlockModifyPlan(t *testing.T) {
 						testschema.SetNestedObjectCustomValue{
 							ObjectValue: types.ObjectValueMust(
 								map[string]attr.Type{
-									"nested_set_nested_attribute": types.SetType{
+									"nested_set_nested": types.SetType{
 										ElemType: testschema.NestedObjectCustomType{
 											ObjectType: types.ObjectType{
 												AttrTypes: map[string]attr.Type{
@@ -1440,7 +1440,7 @@ func TestBlockModifyPlan(t *testing.T) {
 									},
 								},
 								map[string]attr.Value{
-									"nested_set_nested_attribute": types.SetValueMust(
+									"nested_set_nested": types.SetValueMust(
 										testschema.NestedObjectCustomType{
 											ObjectType: types.ObjectType{
 												AttrTypes: map[string]attr.Type{
@@ -1471,7 +1471,7 @@ func TestBlockModifyPlan(t *testing.T) {
 					testschema.SetNestedObjectCustomType{
 						ObjectType: types.ObjectType{
 							AttrTypes: map[string]attr.Type{
-								"nested_set_nested_attribute": types.SetType{
+								"nested_set_nested": types.SetType{
 									ElemType: testschema.NestedObjectCustomType{
 										ObjectType: types.ObjectType{
 											AttrTypes: map[string]attr.Type{
@@ -1487,7 +1487,7 @@ func TestBlockModifyPlan(t *testing.T) {
 						testschema.SetNestedObjectCustomValue{
 							ObjectValue: types.ObjectValueMust(
 								map[string]attr.Type{
-									"nested_set_nested_attribute": types.SetType{
+									"nested_set_nested": types.SetType{
 										ElemType: testschema.NestedObjectCustomType{
 											ObjectType: types.ObjectType{
 												AttrTypes: map[string]attr.Type{
@@ -1498,7 +1498,7 @@ func TestBlockModifyPlan(t *testing.T) {
 									},
 								},
 								map[string]attr.Value{
-									"nested_set_nested_attribute": types.SetValueMust(
+									"nested_set_nested": types.SetValueMust(
 										testschema.NestedObjectCustomType{
 											ObjectType: types.ObjectType{
 												AttrTypes: map[string]attr.Type{
@@ -1528,7 +1528,7 @@ func TestBlockModifyPlan(t *testing.T) {
 					testschema.SetNestedObjectCustomType{
 						ObjectType: types.ObjectType{
 							AttrTypes: map[string]attr.Type{
-								"nested_set_nested_attribute": types.SetType{
+								"nested_set_nested": types.SetType{
 									ElemType: testschema.NestedObjectCustomType{
 										ObjectType: types.ObjectType{
 											AttrTypes: map[string]attr.Type{
@@ -1544,7 +1544,7 @@ func TestBlockModifyPlan(t *testing.T) {
 						testschema.SetNestedObjectCustomValue{
 							ObjectValue: types.ObjectValueMust(
 								map[string]attr.Type{
-									"nested_set_nested_attribute": types.SetType{
+									"nested_set_nested": types.SetType{
 										ElemType: testschema.NestedObjectCustomType{
 											ObjectType: types.ObjectType{
 												AttrTypes: map[string]attr.Type{
@@ -1555,7 +1555,7 @@ func TestBlockModifyPlan(t *testing.T) {
 									},
 								},
 								map[string]attr.Value{
-									"nested_set_nested_attribute": types.SetValueMust(
+									"nested_set_nested": types.SetValueMust(
 										testschema.NestedObjectCustomType{
 											ObjectType: types.ObjectType{
 												AttrTypes: map[string]attr.Type{
@@ -1587,7 +1587,7 @@ func TestBlockModifyPlan(t *testing.T) {
 					testschema.SetNestedObjectCustomType{
 						ObjectType: types.ObjectType{
 							AttrTypes: map[string]attr.Type{
-								"nested_set_nested_attribute": types.SetType{
+								"nested_set_nested": types.SetType{
 									ElemType: testschema.NestedObjectCustomType{
 										ObjectType: types.ObjectType{
 											AttrTypes: map[string]attr.Type{
@@ -1603,7 +1603,7 @@ func TestBlockModifyPlan(t *testing.T) {
 						testschema.SetNestedObjectCustomValue{
 							ObjectValue: types.ObjectValueMust(
 								map[string]attr.Type{
-									"nested_set_nested_attribute": types.SetType{
+									"nested_set_nested": types.SetType{
 										ElemType: testschema.NestedObjectCustomType{
 											ObjectType: types.ObjectType{
 												AttrTypes: map[string]attr.Type{
@@ -1614,7 +1614,7 @@ func TestBlockModifyPlan(t *testing.T) {
 									},
 								},
 								map[string]attr.Value{
-									"nested_set_nested_attribute": types.SetValueMust(
+									"nested_set_nested": types.SetValueMust(
 										testschema.NestedObjectCustomType{
 											ObjectType: types.ObjectType{
 												AttrTypes: map[string]attr.Type{
@@ -2978,7 +2978,7 @@ func TestBlockModifyPlan(t *testing.T) {
 				CustomType: testschema.NestedObjectCustomType{
 					ObjectType: basetypes.ObjectType{
 						AttrTypes: map[string]attr.Type{
-							"nested_single_nested_attribute": testschema.NestedObjectCustomType{
+							"nested_single_nested_block": testschema.NestedObjectCustomType{
 								ObjectType: basetypes.ObjectType{
 									AttrTypes: map[string]attr.Type{
 										"testing": types.StringType,
@@ -2990,7 +2990,7 @@ func TestBlockModifyPlan(t *testing.T) {
 				},
 				NestedObject: testschema.NestedBlockObject{
 					Blocks: map[string]fwschema.Block{
-						"nested_single_nested_attribute": testschema.Block{
+						"nested_single_nested_block": testschema.Block{
 							NestedObject: testschema.NestedBlockObject{
 								Attributes: map[string]fwschema.Attribute{
 									"testing": testschema.Attribute{
@@ -3008,14 +3008,14 @@ func TestBlockModifyPlan(t *testing.T) {
 				AttributeConfig: testschema.NestedObjectCustomValue{
 					ObjectValue: types.ObjectValueMust(
 						map[string]attr.Type{
-							"nested_single_nested_attribute": types.ObjectType{
+							"nested_single_nested_block": types.ObjectType{
 								AttrTypes: map[string]attr.Type{
 									"testing": types.StringType,
 								},
 							},
 						},
 						map[string]attr.Value{
-							"nested_single_nested_attribute": types.ObjectValueMust(
+							"nested_single_nested_block": types.ObjectValueMust(
 								map[string]attr.Type{
 									"testing": types.StringType,
 								},
@@ -3030,14 +3030,14 @@ func TestBlockModifyPlan(t *testing.T) {
 				AttributePlan: testschema.NestedObjectCustomValue{
 					ObjectValue: types.ObjectValueMust(
 						map[string]attr.Type{
-							"nested_single_nested_attribute": types.ObjectType{
+							"nested_single_nested_block": types.ObjectType{
 								AttrTypes: map[string]attr.Type{
 									"testing": types.StringType,
 								},
 							},
 						},
 						map[string]attr.Value{
-							"nested_single_nested_attribute": types.ObjectValueMust(
+							"nested_single_nested_block": types.ObjectValueMust(
 								map[string]attr.Type{
 									"testing": types.StringType,
 								},
@@ -3051,14 +3051,14 @@ func TestBlockModifyPlan(t *testing.T) {
 				AttributeState: testschema.NestedObjectCustomValue{
 					ObjectValue: types.ObjectValueMust(
 						map[string]attr.Type{
-							"nested_single_nested_attribute": types.ObjectType{
+							"nested_single_nested_block": types.ObjectType{
 								AttrTypes: map[string]attr.Type{
 									"testing": types.StringType,
 								},
 							},
 						},
 						map[string]attr.Value{
-							"nested_single_nested_attribute": types.ObjectValueMust(
+							"nested_single_nested_block": types.ObjectValueMust(
 								map[string]attr.Type{
 									"testing": types.StringType,
 								},
@@ -3074,14 +3074,14 @@ func TestBlockModifyPlan(t *testing.T) {
 				AttributePlan: testschema.NestedObjectCustomValue{
 					ObjectValue: types.ObjectValueMust(
 						map[string]attr.Type{
-							"nested_single_nested_attribute": types.ObjectType{
+							"nested_single_nested_block": types.ObjectType{
 								AttrTypes: map[string]attr.Type{
 									"testing": types.StringType,
 								},
 							},
 						},
 						map[string]attr.Value{
-							"nested_single_nested_attribute": types.ObjectValueMust(
+							"nested_single_nested_block": types.ObjectValueMust(
 								map[string]attr.Type{
 									"testing": types.StringType,
 								},

--- a/internal/fwserver/block_plan_modification_test.go
+++ b/internal/fwserver/block_plan_modification_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
 
 func TestBlockModifyPlan(t *testing.T) {
@@ -495,6 +496,388 @@ func TestBlockModifyPlan(t *testing.T) {
 				Private: testProviderData,
 			},
 		},
+		"block-list-nested-custom-nested-object": {
+			block: testschema.Block{
+				NestedObject: testschema.NestedBlockObject{
+					CustomType: testschema.NestedObjectCustomType{
+						ObjectType: basetypes.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"nested_attr": types.StringType,
+							},
+						},
+					},
+					Attributes: map[string]fwschema.Attribute{
+						"nested_attr": testschema.Attribute{
+							Required: true,
+						},
+					},
+				},
+				NestingMode: fwschema.BlockNestingModeList,
+			},
+			req: ModifyAttributePlanRequest{
+				AttributeConfig: types.ListValueMust(
+					testschema.NestedObjectCustomType{
+						ObjectType: types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"nested_attr": types.StringType,
+							},
+						},
+					},
+					[]attr.Value{
+						testschema.NestedObjectCustomValue{
+							ObjectValue: types.ObjectValueMust(
+								map[string]attr.Type{
+									"nested_attr": types.StringType,
+								},
+								map[string]attr.Value{
+									"nested_attr": types.StringValue("testvalue"),
+								},
+							),
+						},
+					},
+				),
+				AttributePath: path.Root("test"),
+				AttributePlan: types.ListValueMust(
+					testschema.NestedObjectCustomType{
+						ObjectType: types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"nested_attr": types.StringType,
+							},
+						},
+					},
+					[]attr.Value{
+						testschema.NestedObjectCustomValue{
+							ObjectValue: types.ObjectValueMust(
+								map[string]attr.Type{
+									"nested_attr": types.StringType,
+								},
+								map[string]attr.Value{
+									"nested_attr": types.StringValue("testvalue"),
+								},
+							),
+						},
+					},
+				),
+				AttributeState: types.ListValueMust(
+					testschema.NestedObjectCustomType{
+						ObjectType: types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"nested_attr": types.StringType,
+							},
+						},
+					},
+					[]attr.Value{
+						testschema.NestedObjectCustomValue{
+							ObjectValue: types.ObjectValueMust(
+								map[string]attr.Type{
+									"nested_attr": types.StringType,
+								},
+								map[string]attr.Value{
+									"nested_attr": types.StringValue("testvalue"),
+								},
+							),
+						},
+					},
+				),
+			},
+			expectedResp: ModifyAttributePlanResponse{
+				AttributePlan: types.ListValueMust(
+					testschema.NestedObjectCustomType{
+						ObjectType: types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"nested_attr": types.StringType,
+							},
+						},
+					},
+					[]attr.Value{
+						testschema.NestedObjectCustomValue{
+							ObjectValue: types.ObjectValueMust(
+								map[string]attr.Type{
+									"nested_attr": types.StringType,
+								},
+								map[string]attr.Value{
+									"nested_attr": types.StringValue("testvalue"),
+								},
+							),
+						},
+					},
+				),
+			},
+		},
+		"attribute-list-nested-nested-custom-nested-object": {
+			block: testschema.Block{
+				NestedObject: testschema.NestedBlockObject{
+					CustomType: testschema.ListNestedObjectCustomType{
+						ObjectType: basetypes.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"nested_list_nested_attribute": types.ListType{
+									ElemType: testschema.NestedObjectCustomType{
+										ObjectType: types.ObjectType{
+											AttrTypes: map[string]attr.Type{
+												"nested_attr": types.StringType,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					Blocks: map[string]fwschema.Block{
+						"nested_list_nested_attribute": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								CustomType: testschema.NestedObjectCustomType{
+									ObjectType: basetypes.ObjectType{
+										AttrTypes: map[string]attr.Type{
+											"nested_attr": types.StringType,
+										},
+									},
+								},
+								Attributes: map[string]fwschema.Attribute{
+									"nested_attr": testschema.Attribute{
+										Required: true,
+									},
+								},
+							},
+							NestingMode: fwschema.BlockNestingModeList,
+						},
+					},
+				},
+				NestingMode: fwschema.BlockNestingModeList,
+			},
+			req: ModifyAttributePlanRequest{
+				AttributeConfig: types.ListValueMust(
+					testschema.ListNestedObjectCustomType{
+						ObjectType: types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"nested_list_nested_attribute": types.ListType{
+									ElemType: testschema.NestedObjectCustomType{
+										ObjectType: types.ObjectType{
+											AttrTypes: map[string]attr.Type{
+												"nested_attr": types.StringType,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					[]attr.Value{
+						testschema.ListNestedObjectCustomValue{
+							ObjectValue: types.ObjectValueMust(
+								map[string]attr.Type{
+									"nested_list_nested_attribute": types.ListType{
+										ElemType: testschema.NestedObjectCustomType{
+											ObjectType: types.ObjectType{
+												AttrTypes: map[string]attr.Type{
+													"nested_attr": types.StringType,
+												},
+											},
+										},
+									},
+								},
+								map[string]attr.Value{
+									"nested_list_nested_attribute": types.ListValueMust(
+										testschema.NestedObjectCustomType{
+											ObjectType: types.ObjectType{
+												AttrTypes: map[string]attr.Type{
+													"nested_attr": types.StringType,
+												},
+											},
+										},
+										[]attr.Value{
+											testschema.NestedObjectCustomValue{
+												ObjectValue: types.ObjectValueMust(
+													map[string]attr.Type{
+														"nested_attr": types.StringType,
+													},
+													map[string]attr.Value{
+														"nested_attr": types.StringValue("testvalue"),
+													},
+												),
+											},
+										},
+									),
+								},
+							),
+						},
+					},
+				),
+				AttributePath: path.Root("test"),
+				AttributePlan: types.ListValueMust(
+					testschema.ListNestedObjectCustomType{
+						ObjectType: types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"nested_list_nested_attribute": types.ListType{
+									ElemType: testschema.NestedObjectCustomType{
+										ObjectType: types.ObjectType{
+											AttrTypes: map[string]attr.Type{
+												"nested_attr": types.StringType,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					[]attr.Value{
+						testschema.ListNestedObjectCustomValue{
+							ObjectValue: types.ObjectValueMust(
+								map[string]attr.Type{
+									"nested_list_nested_attribute": types.ListType{
+										ElemType: testschema.NestedObjectCustomType{
+											ObjectType: types.ObjectType{
+												AttrTypes: map[string]attr.Type{
+													"nested_attr": types.StringType,
+												},
+											},
+										},
+									},
+								},
+								map[string]attr.Value{
+									"nested_list_nested_attribute": types.ListValueMust(
+										testschema.NestedObjectCustomType{
+											ObjectType: types.ObjectType{
+												AttrTypes: map[string]attr.Type{
+													"nested_attr": types.StringType,
+												},
+											},
+										},
+										[]attr.Value{
+											testschema.NestedObjectCustomValue{
+												ObjectValue: types.ObjectValueMust(
+													map[string]attr.Type{
+														"nested_attr": types.StringType,
+													},
+													map[string]attr.Value{
+														"nested_attr": types.StringValue("testvalue"),
+													},
+												),
+											},
+										},
+									),
+								},
+							),
+						},
+					},
+				),
+				AttributeState: types.ListValueMust(
+					testschema.ListNestedObjectCustomType{
+						ObjectType: types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"nested_list_nested_attribute": types.ListType{
+									ElemType: testschema.NestedObjectCustomType{
+										ObjectType: types.ObjectType{
+											AttrTypes: map[string]attr.Type{
+												"nested_attr": types.StringType,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					[]attr.Value{
+						testschema.ListNestedObjectCustomValue{
+							ObjectValue: types.ObjectValueMust(
+								map[string]attr.Type{
+									"nested_list_nested_attribute": types.ListType{
+										ElemType: testschema.NestedObjectCustomType{
+											ObjectType: types.ObjectType{
+												AttrTypes: map[string]attr.Type{
+													"nested_attr": types.StringType,
+												},
+											},
+										},
+									},
+								},
+								map[string]attr.Value{
+									"nested_list_nested_attribute": types.ListValueMust(
+										testschema.NestedObjectCustomType{
+											ObjectType: types.ObjectType{
+												AttrTypes: map[string]attr.Type{
+													"nested_attr": types.StringType,
+												},
+											},
+										},
+										[]attr.Value{
+											testschema.NestedObjectCustomValue{
+												ObjectValue: types.ObjectValueMust(
+													map[string]attr.Type{
+														"nested_attr": types.StringType,
+													},
+													map[string]attr.Value{
+														"nested_attr": types.StringValue("testvalue"),
+													},
+												),
+											},
+										},
+									),
+								},
+							),
+						},
+					},
+				),
+			},
+			expectedResp: ModifyAttributePlanResponse{
+				AttributePlan: types.ListValueMust(
+					testschema.ListNestedObjectCustomType{
+						ObjectType: types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"nested_list_nested_attribute": types.ListType{
+									ElemType: testschema.NestedObjectCustomType{
+										ObjectType: types.ObjectType{
+											AttrTypes: map[string]attr.Type{
+												"nested_attr": types.StringType,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					[]attr.Value{
+						testschema.ListNestedObjectCustomValue{
+							ObjectValue: types.ObjectValueMust(
+								map[string]attr.Type{
+									"nested_list_nested_attribute": types.ListType{
+										ElemType: testschema.NestedObjectCustomType{
+											ObjectType: types.ObjectType{
+												AttrTypes: map[string]attr.Type{
+													"nested_attr": types.StringType,
+												},
+											},
+										},
+									},
+								},
+								map[string]attr.Value{
+									"nested_list_nested_attribute": types.ListValueMust(
+										testschema.NestedObjectCustomType{
+											ObjectType: types.ObjectType{
+												AttrTypes: map[string]attr.Type{
+													"nested_attr": types.StringType,
+												},
+											},
+										},
+										[]attr.Value{
+											testschema.NestedObjectCustomValue{
+												ObjectValue: types.ObjectValueMust(
+													map[string]attr.Type{
+														"nested_attr": types.StringType,
+													},
+													map[string]attr.Value{
+														"nested_attr": types.StringValue("testvalue"),
+													},
+												),
+											},
+										},
+									),
+								},
+							),
+						},
+					},
+				),
+			},
+		},
 		"block-list-nested-private": {
 			block: testschema.BlockWithListPlanModifiers{
 				Attributes: map[string]fwschema.Attribute{
@@ -882,6 +1265,381 @@ func TestBlockModifyPlan(t *testing.T) {
 					},
 				),
 				Private: testProviderData,
+			},
+		},
+		"block-set-nested-custom-nested-object": {
+			block: testschema.Block{
+				NestedObject: testschema.NestedBlockObject{
+					Attributes: map[string]fwschema.Attribute{
+						"nested_attr": testschema.Attribute{
+							Required: true,
+						},
+					},
+				},
+				NestingMode: fwschema.BlockNestingModeSet,
+			},
+			req: ModifyAttributePlanRequest{
+				AttributeConfig: types.SetValueMust(
+					testschema.NestedObjectCustomType{
+						ObjectType: types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"nested_attr": types.StringType,
+							},
+						},
+					},
+					[]attr.Value{
+						testschema.NestedObjectCustomValue{
+							ObjectValue: types.ObjectValueMust(
+								map[string]attr.Type{
+									"nested_attr": types.StringType,
+								},
+								map[string]attr.Value{
+									"nested_attr": types.StringValue("testvalue"),
+								},
+							),
+						},
+					},
+				),
+				AttributePath: path.Root("test"),
+				AttributePlan: types.SetValueMust(
+					testschema.NestedObjectCustomType{
+						ObjectType: types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"nested_attr": types.StringType,
+							},
+						},
+					},
+					[]attr.Value{
+						testschema.NestedObjectCustomValue{
+							ObjectValue: types.ObjectValueMust(
+								map[string]attr.Type{
+									"nested_attr": types.StringType,
+								},
+								map[string]attr.Value{
+									"nested_attr": types.StringValue("testvalue"),
+								},
+							),
+						},
+					},
+				),
+				AttributeState: types.SetValueMust(
+					testschema.NestedObjectCustomType{
+						ObjectType: types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"nested_attr": types.StringType,
+							},
+						},
+					},
+					[]attr.Value{
+						testschema.NestedObjectCustomValue{
+							ObjectValue: types.ObjectValueMust(
+								map[string]attr.Type{
+									"nested_attr": types.StringType,
+								},
+								map[string]attr.Value{
+									"nested_attr": types.StringValue("testvalue"),
+								},
+							),
+						},
+					},
+				),
+			},
+			expectedResp: ModifyAttributePlanResponse{
+				AttributePlan: types.SetValueMust(
+					testschema.NestedObjectCustomType{
+						ObjectType: types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"nested_attr": types.StringType,
+							},
+						},
+					},
+					[]attr.Value{
+						testschema.NestedObjectCustomValue{
+							ObjectValue: types.ObjectValueMust(
+								map[string]attr.Type{
+									"nested_attr": types.StringType,
+								},
+								map[string]attr.Value{
+									"nested_attr": types.StringValue("testvalue"),
+								},
+							),
+						},
+					},
+				),
+			},
+		},
+		"block-set-nested-nested-custom-nested-object": {
+			block: testschema.Block{
+				NestedObject: testschema.NestedBlockObject{
+					CustomType: testschema.SetNestedObjectCustomType{
+						ObjectType: basetypes.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"nested_set_nested_attribute": types.SetType{
+									ElemType: testschema.NestedObjectCustomType{
+										ObjectType: types.ObjectType{
+											AttrTypes: map[string]attr.Type{
+												"nested_attr": types.StringType,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					Blocks: map[string]fwschema.Block{
+						"nested_set_nested_attribute": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								CustomType: testschema.NestedObjectCustomType{
+									ObjectType: basetypes.ObjectType{
+										AttrTypes: map[string]attr.Type{
+											"nested_attr": types.StringType,
+										},
+									},
+								},
+								Attributes: map[string]fwschema.Attribute{
+									"nested_attr": testschema.Attribute{
+										Required: true,
+									},
+								},
+							},
+							NestingMode: fwschema.BlockNestingModeSet,
+						},
+					},
+				},
+				NestingMode: fwschema.BlockNestingModeSet,
+			},
+			req: ModifyAttributePlanRequest{
+				AttributeConfig: types.SetValueMust(
+					testschema.SetNestedObjectCustomType{
+						ObjectType: types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"nested_set_nested_attribute": types.SetType{
+									ElemType: testschema.NestedObjectCustomType{
+										ObjectType: types.ObjectType{
+											AttrTypes: map[string]attr.Type{
+												"nested_attr": types.StringType,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					[]attr.Value{
+						testschema.SetNestedObjectCustomValue{
+							ObjectValue: types.ObjectValueMust(
+								map[string]attr.Type{
+									"nested_set_nested_attribute": types.SetType{
+										ElemType: testschema.NestedObjectCustomType{
+											ObjectType: types.ObjectType{
+												AttrTypes: map[string]attr.Type{
+													"nested_attr": types.StringType,
+												},
+											},
+										},
+									},
+								},
+								map[string]attr.Value{
+									"nested_set_nested_attribute": types.SetValueMust(
+										testschema.NestedObjectCustomType{
+											ObjectType: types.ObjectType{
+												AttrTypes: map[string]attr.Type{
+													"nested_attr": types.StringType,
+												},
+											},
+										},
+										[]attr.Value{
+											testschema.NestedObjectCustomValue{
+												ObjectValue: types.ObjectValueMust(
+													map[string]attr.Type{
+														"nested_attr": types.StringType,
+													},
+													map[string]attr.Value{
+														"nested_attr": types.StringValue("testvalue"),
+													},
+												),
+											},
+										},
+									),
+								},
+							),
+						},
+					},
+				),
+				AttributePath: path.Root("test"),
+				AttributePlan: types.SetValueMust(
+					testschema.SetNestedObjectCustomType{
+						ObjectType: types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"nested_set_nested_attribute": types.SetType{
+									ElemType: testschema.NestedObjectCustomType{
+										ObjectType: types.ObjectType{
+											AttrTypes: map[string]attr.Type{
+												"nested_attr": types.StringType,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					[]attr.Value{
+						testschema.SetNestedObjectCustomValue{
+							ObjectValue: types.ObjectValueMust(
+								map[string]attr.Type{
+									"nested_set_nested_attribute": types.SetType{
+										ElemType: testschema.NestedObjectCustomType{
+											ObjectType: types.ObjectType{
+												AttrTypes: map[string]attr.Type{
+													"nested_attr": types.StringType,
+												},
+											},
+										},
+									},
+								},
+								map[string]attr.Value{
+									"nested_set_nested_attribute": types.SetValueMust(
+										testschema.NestedObjectCustomType{
+											ObjectType: types.ObjectType{
+												AttrTypes: map[string]attr.Type{
+													"nested_attr": types.StringType,
+												},
+											},
+										},
+										[]attr.Value{
+											testschema.NestedObjectCustomValue{
+												ObjectValue: types.ObjectValueMust(
+													map[string]attr.Type{
+														"nested_attr": types.StringType,
+													},
+													map[string]attr.Value{
+														"nested_attr": types.StringValue("testvalue"),
+													},
+												),
+											},
+										},
+									),
+								},
+							),
+						},
+					},
+				),
+				AttributeState: types.SetValueMust(
+					testschema.SetNestedObjectCustomType{
+						ObjectType: types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"nested_set_nested_attribute": types.SetType{
+									ElemType: testschema.NestedObjectCustomType{
+										ObjectType: types.ObjectType{
+											AttrTypes: map[string]attr.Type{
+												"nested_attr": types.StringType,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					[]attr.Value{
+						testschema.SetNestedObjectCustomValue{
+							ObjectValue: types.ObjectValueMust(
+								map[string]attr.Type{
+									"nested_set_nested_attribute": types.SetType{
+										ElemType: testschema.NestedObjectCustomType{
+											ObjectType: types.ObjectType{
+												AttrTypes: map[string]attr.Type{
+													"nested_attr": types.StringType,
+												},
+											},
+										},
+									},
+								},
+								map[string]attr.Value{
+									"nested_set_nested_attribute": types.SetValueMust(
+										testschema.NestedObjectCustomType{
+											ObjectType: types.ObjectType{
+												AttrTypes: map[string]attr.Type{
+													"nested_attr": types.StringType,
+												},
+											},
+										},
+										[]attr.Value{
+											testschema.NestedObjectCustomValue{
+												ObjectValue: types.ObjectValueMust(
+													map[string]attr.Type{
+														"nested_attr": types.StringType,
+													},
+													map[string]attr.Value{
+														"nested_attr": types.StringValue("testvalue"),
+													},
+												),
+											},
+										},
+									),
+								},
+							),
+						},
+					},
+				),
+			},
+			expectedResp: ModifyAttributePlanResponse{
+				AttributePlan: types.SetValueMust(
+					testschema.SetNestedObjectCustomType{
+						ObjectType: types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"nested_set_nested_attribute": types.SetType{
+									ElemType: testschema.NestedObjectCustomType{
+										ObjectType: types.ObjectType{
+											AttrTypes: map[string]attr.Type{
+												"nested_attr": types.StringType,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					[]attr.Value{
+						testschema.SetNestedObjectCustomValue{
+							ObjectValue: types.ObjectValueMust(
+								map[string]attr.Type{
+									"nested_set_nested_attribute": types.SetType{
+										ElemType: testschema.NestedObjectCustomType{
+											ObjectType: types.ObjectType{
+												AttrTypes: map[string]attr.Type{
+													"nested_attr": types.StringType,
+												},
+											},
+										},
+									},
+								},
+								map[string]attr.Value{
+									"nested_set_nested_attribute": types.SetValueMust(
+										testschema.NestedObjectCustomType{
+											ObjectType: types.ObjectType{
+												AttrTypes: map[string]attr.Type{
+													"nested_attr": types.StringType,
+												},
+											},
+										},
+										[]attr.Value{
+											testschema.NestedObjectCustomValue{
+												ObjectValue: types.ObjectValueMust(
+													map[string]attr.Type{
+														"nested_attr": types.StringType,
+													},
+													map[string]attr.Value{
+														"nested_attr": types.StringValue("testvalue"),
+													},
+												),
+											},
+										},
+									),
+								},
+							),
+						},
+					},
+				),
 			},
 		},
 		"block-set-nested-private": {
@@ -2149,6 +2907,191 @@ func TestBlockModifyPlan(t *testing.T) {
 					},
 				),
 				Private: testProviderData,
+			},
+		},
+		"block-single-nested-custom": {
+			block: testschema.Block{
+				CustomType: testschema.NestedObjectCustomType{
+					ObjectType: basetypes.ObjectType{
+						AttrTypes: map[string]attr.Type{
+							"testing": types.StringType,
+						},
+					},
+				},
+				NestedObject: testschema.NestedBlockObject{
+					Attributes: map[string]fwschema.Attribute{
+						"testing": testschema.Attribute{
+							Required: true,
+						},
+					},
+				},
+				NestingMode: fwschema.BlockNestingModeSingle,
+			},
+			req: ModifyAttributePlanRequest{
+				AttributeConfig: testschema.NestedObjectCustomValue{
+					ObjectValue: types.ObjectValueMust(
+						map[string]attr.Type{
+							"testing": types.StringType,
+						},
+						map[string]attr.Value{
+							"testing": types.StringValue("testvalue"),
+						},
+					),
+				},
+				AttributePath: path.Root("test"),
+				AttributePlan: testschema.NestedObjectCustomValue{
+					ObjectValue: types.ObjectValueMust(
+						map[string]attr.Type{
+							"testing": types.StringType,
+						},
+						map[string]attr.Value{
+							"testing": types.StringValue("testvalue"),
+						},
+					),
+				},
+				AttributeState: testschema.NestedObjectCustomValue{
+					ObjectValue: types.ObjectValueMust(
+						map[string]attr.Type{
+							"testing": types.StringType,
+						},
+						map[string]attr.Value{
+							"testing": types.StringValue("testvalue"),
+						},
+					),
+				},
+			},
+			expectedResp: ModifyAttributePlanResponse{
+				AttributePlan: testschema.NestedObjectCustomValue{
+					ObjectValue: types.ObjectValueMust(
+						map[string]attr.Type{
+							"testing": types.StringType,
+						},
+						map[string]attr.Value{
+							"testing": types.StringValue("testvalue"),
+						},
+					),
+				},
+			},
+		},
+		"block-single-nested-nested-custom-nested-object": {
+			block: testschema.Block{
+				CustomType: testschema.NestedObjectCustomType{
+					ObjectType: basetypes.ObjectType{
+						AttrTypes: map[string]attr.Type{
+							"nested_single_nested_attribute": testschema.NestedObjectCustomType{
+								ObjectType: basetypes.ObjectType{
+									AttrTypes: map[string]attr.Type{
+										"testing": types.StringType,
+									},
+								},
+							},
+						},
+					},
+				},
+				NestedObject: testschema.NestedBlockObject{
+					Blocks: map[string]fwschema.Block{
+						"nested_single_nested_attribute": testschema.Block{
+							NestedObject: testschema.NestedBlockObject{
+								Attributes: map[string]fwschema.Attribute{
+									"testing": testschema.Attribute{
+										Required: true,
+									},
+								},
+							},
+							NestingMode: fwschema.BlockNestingModeSingle,
+						},
+					},
+				},
+				NestingMode: fwschema.BlockNestingModeSingle,
+			},
+			req: ModifyAttributePlanRequest{
+				AttributeConfig: testschema.NestedObjectCustomValue{
+					ObjectValue: types.ObjectValueMust(
+						map[string]attr.Type{
+							"nested_single_nested_attribute": types.ObjectType{
+								AttrTypes: map[string]attr.Type{
+									"testing": types.StringType,
+								},
+							},
+						},
+						map[string]attr.Value{
+							"nested_single_nested_attribute": types.ObjectValueMust(
+								map[string]attr.Type{
+									"testing": types.StringType,
+								},
+								map[string]attr.Value{
+									"testing": types.StringValue("testvalue"),
+								},
+							),
+						},
+					),
+				},
+				AttributePath: path.Root("test"),
+				AttributePlan: testschema.NestedObjectCustomValue{
+					ObjectValue: types.ObjectValueMust(
+						map[string]attr.Type{
+							"nested_single_nested_attribute": types.ObjectType{
+								AttrTypes: map[string]attr.Type{
+									"testing": types.StringType,
+								},
+							},
+						},
+						map[string]attr.Value{
+							"nested_single_nested_attribute": types.ObjectValueMust(
+								map[string]attr.Type{
+									"testing": types.StringType,
+								},
+								map[string]attr.Value{
+									"testing": types.StringValue("testvalue"),
+								},
+							),
+						},
+					),
+				},
+				AttributeState: testschema.NestedObjectCustomValue{
+					ObjectValue: types.ObjectValueMust(
+						map[string]attr.Type{
+							"nested_single_nested_attribute": types.ObjectType{
+								AttrTypes: map[string]attr.Type{
+									"testing": types.StringType,
+								},
+							},
+						},
+						map[string]attr.Value{
+							"nested_single_nested_attribute": types.ObjectValueMust(
+								map[string]attr.Type{
+									"testing": types.StringType,
+								},
+								map[string]attr.Value{
+									"testing": types.StringValue("testvalue"),
+								},
+							),
+						},
+					),
+				},
+			},
+			expectedResp: ModifyAttributePlanResponse{
+				AttributePlan: testschema.NestedObjectCustomValue{
+					ObjectValue: types.ObjectValueMust(
+						map[string]attr.Type{
+							"nested_single_nested_attribute": types.ObjectType{
+								AttrTypes: map[string]attr.Type{
+									"testing": types.StringType,
+								},
+							},
+						},
+						map[string]attr.Value{
+							"nested_single_nested_attribute": types.ObjectValueMust(
+								map[string]attr.Type{
+									"testing": types.StringType,
+								},
+								map[string]attr.Value{
+									"testing": types.StringValue("testvalue"),
+								},
+							),
+						},
+					),
+				},
 			},
 		},
 		"block-single-nested-private": {

--- a/internal/testing/testschema/nested_attribute.go
+++ b/internal/testing/testschema/nested_attribute.go
@@ -11,12 +11,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
 
 var _ fwschema.NestedAttribute = NestedAttribute{}
 
 type NestedAttribute struct {
 	Computed            bool
+	CustomType          basetypes.ObjectTypable
 	DeprecationMessage  string
 	Description         string
 	MarkdownDescription string

--- a/internal/testing/testschema/nested_attribute_object.go
+++ b/internal/testing/testschema/nested_attribute_object.go
@@ -6,11 +6,12 @@ package testschema
 import (
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
 // Ensure the implementation satisifies the desired interfaces.
@@ -18,6 +19,7 @@ var _ fwschema.NestedAttributeObject = NestedAttributeObject{}
 
 type NestedAttributeObject struct {
 	Attributes map[string]fwschema.Attribute
+	CustomType basetypes.ObjectTypable
 }
 
 // ApplyTerraform5AttributePathStep performs an AttributeName step on the

--- a/internal/testing/testschema/nested_attribute_object_custom_type.go
+++ b/internal/testing/testschema/nested_attribute_object_custom_type.go
@@ -1,0 +1,96 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package testschema
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+var _ basetypes.ObjectTypable = NestedObjectCustomType{}
+
+type NestedObjectCustomType struct {
+	basetypes.ObjectType
+}
+
+func (c NestedObjectCustomType) Equal(o attr.Type) bool {
+	other, ok := o.(NestedObjectCustomType)
+
+	if !ok {
+		return false
+	}
+
+	return c.ObjectType.Equal(other.ObjectType)
+}
+
+func (c NestedObjectCustomType) String() string {
+	return "NestedObjectCustomType"
+}
+
+func (c NestedObjectCustomType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	value := NestedObjectCustomValue{
+		ObjectValue: in,
+	}
+
+	return value, nil
+}
+
+func (c NestedObjectCustomType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	attrValue, err := c.ObjectType.ValueFromTerraform(ctx, in)
+
+	if err != nil {
+		return nil, err
+	}
+
+	objectValue, ok := attrValue.(basetypes.ObjectValue)
+
+	if !ok {
+		return nil, fmt.Errorf("unexpected value type of %T", attrValue)
+	}
+
+	objectValuable, diags := c.ValueFromObject(ctx, objectValue)
+
+	if diags.HasError() {
+		return nil, fmt.Errorf("unexpected error converting ObjectValue to ObjectValuable: %v", diags)
+	}
+
+	return objectValuable, nil
+}
+
+func (c NestedObjectCustomType) ValueType(ctx context.Context) attr.Value {
+	return NestedObjectCustomValue{}
+}
+
+var _ basetypes.ObjectValuable = NestedObjectCustomValue{}
+
+type NestedObjectCustomValue struct {
+	basetypes.ObjectValue
+}
+
+func (c NestedObjectCustomValue) Equal(o attr.Value) bool {
+	other, ok := o.(NestedObjectCustomValue)
+
+	if !ok {
+		return false
+	}
+
+	return c.ObjectValue.Equal(other.ObjectValue)
+}
+
+func (c NestedObjectCustomValue) Type(ctx context.Context) attr.Type {
+	return NestedObjectCustomType{
+		basetypes.ObjectType{
+			AttrTypes: map[string]attr.Type{
+				"nested_attr": types.StringType,
+			},
+		},
+	}
+}

--- a/internal/testing/testschema/nested_attribute_object_custom_type.go
+++ b/internal/testing/testschema/nested_attribute_object_custom_type.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
 
@@ -88,9 +87,7 @@ func (c NestedObjectCustomValue) Equal(o attr.Value) bool {
 func (c NestedObjectCustomValue) Type(ctx context.Context) attr.Type {
 	return NestedObjectCustomType{
 		basetypes.ObjectType{
-			AttrTypes: map[string]attr.Type{
-				"nested_attr": types.StringType,
-			},
+			AttrTypes: c.AttributeTypes(ctx),
 		},
 	}
 }

--- a/internal/testing/testschema/nested_attribute_object_list_custom_type.go
+++ b/internal/testing/testschema/nested_attribute_object_list_custom_type.go
@@ -1,0 +1,104 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package testschema
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+var _ basetypes.ObjectTypable = ListNestedObjectCustomType{}
+
+type ListNestedObjectCustomType struct {
+	basetypes.ObjectType
+}
+
+func (c ListNestedObjectCustomType) Equal(o attr.Type) bool {
+	other, ok := o.(ListNestedObjectCustomType)
+
+	if !ok {
+		return false
+	}
+
+	return c.ObjectType.Equal(other.ObjectType)
+}
+
+func (c ListNestedObjectCustomType) String() string {
+	return "ListNestedObjectCustomType"
+}
+
+func (c ListNestedObjectCustomType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	value := ListNestedObjectCustomValue{
+		ObjectValue: in,
+	}
+
+	return value, nil
+}
+
+func (c ListNestedObjectCustomType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	attrValue, err := c.ObjectType.ValueFromTerraform(ctx, in)
+
+	if err != nil {
+		return nil, err
+	}
+
+	objectValue, ok := attrValue.(basetypes.ObjectValue)
+
+	if !ok {
+		return nil, fmt.Errorf("unexpected value type of %T", attrValue)
+	}
+
+	objectValuable, diags := c.ValueFromObject(ctx, objectValue)
+
+	if diags.HasError() {
+		return nil, fmt.Errorf("unexpected error converting ObjectValue to ObjectValuable: %v", diags)
+	}
+
+	return objectValuable, nil
+}
+
+func (c ListNestedObjectCustomType) ValueType(ctx context.Context) attr.Value {
+	return ListNestedObjectCustomValue{}
+}
+
+var _ basetypes.ObjectValuable = ListNestedObjectCustomValue{}
+
+type ListNestedObjectCustomValue struct {
+	basetypes.ObjectValue
+}
+
+func (c ListNestedObjectCustomValue) Equal(o attr.Value) bool {
+	other, ok := o.(ListNestedObjectCustomValue)
+
+	if !ok {
+		return false
+	}
+
+	return c.ObjectValue.Equal(other.ObjectValue)
+}
+
+func (c ListNestedObjectCustomValue) Type(ctx context.Context) attr.Type {
+	return ListNestedObjectCustomType{
+		basetypes.ObjectType{
+			AttrTypes: map[string]attr.Type{
+				"nested_list_nested_attribute": types.ListType{
+					ElemType: NestedObjectCustomType{
+						ObjectType: types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"nested_attr": types.StringType,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/testing/testschema/nested_attribute_object_list_custom_type.go
+++ b/internal/testing/testschema/nested_attribute_object_list_custom_type.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
 
@@ -88,17 +87,7 @@ func (c ListNestedObjectCustomValue) Equal(o attr.Value) bool {
 func (c ListNestedObjectCustomValue) Type(ctx context.Context) attr.Type {
 	return ListNestedObjectCustomType{
 		basetypes.ObjectType{
-			AttrTypes: map[string]attr.Type{
-				"nested_list_nested": types.ListType{
-					ElemType: NestedObjectCustomType{
-						ObjectType: types.ObjectType{
-							AttrTypes: map[string]attr.Type{
-								"nested_attr": types.StringType,
-							},
-						},
-					},
-				},
-			},
+			AttrTypes: c.AttributeTypes(ctx),
 		},
 	}
 }

--- a/internal/testing/testschema/nested_attribute_object_list_custom_type.go
+++ b/internal/testing/testschema/nested_attribute_object_list_custom_type.go
@@ -89,7 +89,7 @@ func (c ListNestedObjectCustomValue) Type(ctx context.Context) attr.Type {
 	return ListNestedObjectCustomType{
 		basetypes.ObjectType{
 			AttrTypes: map[string]attr.Type{
-				"nested_list_nested_attribute": types.ListType{
+				"nested_list_nested": types.ListType{
 					ElemType: NestedObjectCustomType{
 						ObjectType: types.ObjectType{
 							AttrTypes: map[string]attr.Type{

--- a/internal/testing/testschema/nested_attribute_object_map_custom_type.go
+++ b/internal/testing/testschema/nested_attribute_object_map_custom_type.go
@@ -89,7 +89,7 @@ func (c MapNestedObjectCustomValue) Type(ctx context.Context) attr.Type {
 	return MapNestedObjectCustomType{
 		basetypes.ObjectType{
 			AttrTypes: map[string]attr.Type{
-				"nested_map_nested_attribute": types.MapType{
+				"nested_map_nested": types.MapType{
 					ElemType: NestedObjectCustomType{
 						ObjectType: types.ObjectType{
 							AttrTypes: map[string]attr.Type{

--- a/internal/testing/testschema/nested_attribute_object_map_custom_type.go
+++ b/internal/testing/testschema/nested_attribute_object_map_custom_type.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
 
@@ -88,17 +87,7 @@ func (c MapNestedObjectCustomValue) Equal(o attr.Value) bool {
 func (c MapNestedObjectCustomValue) Type(ctx context.Context) attr.Type {
 	return MapNestedObjectCustomType{
 		basetypes.ObjectType{
-			AttrTypes: map[string]attr.Type{
-				"nested_map_nested": types.MapType{
-					ElemType: NestedObjectCustomType{
-						ObjectType: types.ObjectType{
-							AttrTypes: map[string]attr.Type{
-								"nested_attr": types.StringType,
-							},
-						},
-					},
-				},
-			},
+			AttrTypes: c.AttributeTypes(ctx),
 		},
 	}
 }

--- a/internal/testing/testschema/nested_attribute_object_map_custom_type.go
+++ b/internal/testing/testschema/nested_attribute_object_map_custom_type.go
@@ -1,0 +1,104 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package testschema
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+var _ basetypes.ObjectTypable = MapNestedObjectCustomType{}
+
+type MapNestedObjectCustomType struct {
+	basetypes.ObjectType
+}
+
+func (c MapNestedObjectCustomType) Equal(o attr.Type) bool {
+	other, ok := o.(MapNestedObjectCustomType)
+
+	if !ok {
+		return false
+	}
+
+	return c.ObjectType.Equal(other.ObjectType)
+}
+
+func (c MapNestedObjectCustomType) String() string {
+	return "MapNestedObjectCustomType"
+}
+
+func (c MapNestedObjectCustomType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	value := MapNestedObjectCustomValue{
+		ObjectValue: in,
+	}
+
+	return value, nil
+}
+
+func (c MapNestedObjectCustomType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	attrValue, err := c.ObjectType.ValueFromTerraform(ctx, in)
+
+	if err != nil {
+		return nil, err
+	}
+
+	objectValue, ok := attrValue.(basetypes.ObjectValue)
+
+	if !ok {
+		return nil, fmt.Errorf("unexpected value type of %T", attrValue)
+	}
+
+	objectValuable, diags := c.ValueFromObject(ctx, objectValue)
+
+	if diags.HasError() {
+		return nil, fmt.Errorf("unexpected error converting ObjectValue to ObjectValuable: %v", diags)
+	}
+
+	return objectValuable, nil
+}
+
+func (c MapNestedObjectCustomType) ValueType(ctx context.Context) attr.Value {
+	return MapNestedObjectCustomValue{}
+}
+
+var _ basetypes.ObjectValuable = MapNestedObjectCustomValue{}
+
+type MapNestedObjectCustomValue struct {
+	basetypes.ObjectValue
+}
+
+func (c MapNestedObjectCustomValue) Equal(o attr.Value) bool {
+	other, ok := o.(MapNestedObjectCustomValue)
+
+	if !ok {
+		return false
+	}
+
+	return c.ObjectValue.Equal(other.ObjectValue)
+}
+
+func (c MapNestedObjectCustomValue) Type(ctx context.Context) attr.Type {
+	return MapNestedObjectCustomType{
+		basetypes.ObjectType{
+			AttrTypes: map[string]attr.Type{
+				"nested_map_nested_attribute": types.MapType{
+					ElemType: NestedObjectCustomType{
+						ObjectType: types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"nested_attr": types.StringType,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/testing/testschema/nested_attribute_object_set_custom_type.go
+++ b/internal/testing/testschema/nested_attribute_object_set_custom_type.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
 
@@ -88,17 +87,7 @@ func (c SetNestedObjectCustomValue) Equal(o attr.Value) bool {
 func (c SetNestedObjectCustomValue) Type(ctx context.Context) attr.Type {
 	return SetNestedObjectCustomType{
 		basetypes.ObjectType{
-			AttrTypes: map[string]attr.Type{
-				"nested_set_nested": types.SetType{
-					ElemType: NestedObjectCustomType{
-						ObjectType: types.ObjectType{
-							AttrTypes: map[string]attr.Type{
-								"nested_attr": types.StringType,
-							},
-						},
-					},
-				},
-			},
+			AttrTypes: c.AttributeTypes(ctx),
 		},
 	}
 }

--- a/internal/testing/testschema/nested_attribute_object_set_custom_type.go
+++ b/internal/testing/testschema/nested_attribute_object_set_custom_type.go
@@ -1,0 +1,104 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package testschema
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+var _ basetypes.ObjectTypable = SetNestedObjectCustomType{}
+
+type SetNestedObjectCustomType struct {
+	basetypes.ObjectType
+}
+
+func (c SetNestedObjectCustomType) Equal(o attr.Type) bool {
+	other, ok := o.(SetNestedObjectCustomType)
+
+	if !ok {
+		return false
+	}
+
+	return c.ObjectType.Equal(other.ObjectType)
+}
+
+func (c SetNestedObjectCustomType) String() string {
+	return "SetNestedObjectCustomType"
+}
+
+func (c SetNestedObjectCustomType) ValueFromObject(ctx context.Context, in basetypes.ObjectValue) (basetypes.ObjectValuable, diag.Diagnostics) {
+	value := SetNestedObjectCustomValue{
+		ObjectValue: in,
+	}
+
+	return value, nil
+}
+
+func (c SetNestedObjectCustomType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	attrValue, err := c.ObjectType.ValueFromTerraform(ctx, in)
+
+	if err != nil {
+		return nil, err
+	}
+
+	objectValue, ok := attrValue.(basetypes.ObjectValue)
+
+	if !ok {
+		return nil, fmt.Errorf("unexpected value type of %T", attrValue)
+	}
+
+	objectValuable, diags := c.ValueFromObject(ctx, objectValue)
+
+	if diags.HasError() {
+		return nil, fmt.Errorf("unexpected error converting ObjectValue to ObjectValuable: %v", diags)
+	}
+
+	return objectValuable, nil
+}
+
+func (c SetNestedObjectCustomType) ValueType(ctx context.Context) attr.Value {
+	return SetNestedObjectCustomValue{}
+}
+
+var _ basetypes.ObjectValuable = SetNestedObjectCustomValue{}
+
+type SetNestedObjectCustomValue struct {
+	basetypes.ObjectValue
+}
+
+func (c SetNestedObjectCustomValue) Equal(o attr.Value) bool {
+	other, ok := o.(SetNestedObjectCustomValue)
+
+	if !ok {
+		return false
+	}
+
+	return c.ObjectValue.Equal(other.ObjectValue)
+}
+
+func (c SetNestedObjectCustomValue) Type(ctx context.Context) attr.Type {
+	return SetNestedObjectCustomType{
+		basetypes.ObjectType{
+			AttrTypes: map[string]attr.Type{
+				"nested_set_nested_attribute": types.SetType{
+					ElemType: NestedObjectCustomType{
+						ObjectType: types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"nested_attr": types.StringType,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/testing/testschema/nested_attribute_object_set_custom_type.go
+++ b/internal/testing/testschema/nested_attribute_object_set_custom_type.go
@@ -89,7 +89,7 @@ func (c SetNestedObjectCustomValue) Type(ctx context.Context) attr.Type {
 	return SetNestedObjectCustomType{
 		basetypes.ObjectType{
 			AttrTypes: map[string]attr.Type{
-				"nested_set_nested_attribute": types.SetType{
+				"nested_set_nested": types.SetType{
 					ElemType: NestedObjectCustomType{
 						ObjectType: types.ObjectType{
 							AttrTypes: map[string]attr.Type{

--- a/internal/testing/testschema/nested_block_object.go
+++ b/internal/testing/testschema/nested_block_object.go
@@ -4,9 +4,10 @@
 package testschema
 
 import (
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
 // Ensure the implementation satisifies the desired interfaces.
@@ -15,6 +16,7 @@ var _ fwschema.NestedBlockObject = NestedBlockObject{}
 type NestedBlockObject struct {
 	Attributes map[string]fwschema.Attribute
 	Blocks     map[string]fwschema.Block
+	CustomType basetypes.ObjectTypable
 }
 
 // ApplyTerraform5AttributePathStep performs an AttributeName step on the


### PR DESCRIPTION
Closes: #767 
Closes: #821 
Reference: #768

This PR addresses diagnostic errors arising from using a `CustomType` associated with a `NestedObject` within a `ListNestedAttribute`, `ListNestedBlock`, `MapNestedAttribute`, `SetNestedAttribute` or `SetNestedBlock`. The diagnostic error generated is `Invalid ... Element Type`. Further details can be found in #821 and #767.

Previously, before logic updates:

```shell
=== NAME  TestAttributeModifyPlan/attribute-map-nested-nested-custom-nested-object
    attribute_plan_modification_test.go:3285: Unexpected response (-wanted, +got):   fwserver.ModifyAttributePlanResponse{
                AttributePlan: s`{"outer":{"nested_map_nested_attribute":{"inner":{"nested_attr":`...,
        -       Diagnostics:   nil,
        +       Diagnostics: diag.Diagnostics{
        +               diag.ErrorDiagnostic{
        +                       detail:  "While creating a Map value, an invalid element was detected. A M"...,
        +                       summary: "Invalid Map Element Type",
        +               },
        +               diag.ErrorDiagnostic{
        +                       detail:  "While creating a Map value, an invalid element was detected. A M"...,
        +                       summary: "Invalid Map Element Type",
        +               },
        +       },
                RequiresReplace: s"[]",
                Private:         nil,
          }
=== NAME  TestAttributeModifyPlan/attribute-map-nested-custom-nested-object
    attribute_plan_modification_test.go:3285: Unexpected response (-wanted, +got):   fwserver.ModifyAttributePlanResponse{
                AttributePlan: s`{"testkey":{"nested_attr":"testvalue"}}`,
        -       Diagnostics:   nil,
        +       Diagnostics: diag.Diagnostics{
        +               diag.ErrorDiagnostic{
        +                       detail:  "While creating a Map value, an invalid element was detected. A M"...,
        +                       summary: "Invalid Map Element Type",
        +               },
        +       },
                RequiresReplace: s"[]",
                Private:         nil,
          }
=== NAME  TestAttributeModifyPlan/attribute-set-nested-custom-nested-object
    attribute_plan_modification_test.go:3285: Unexpected response (-wanted, +got):   fwserver.ModifyAttributePlanResponse{
                AttributePlan: s`[{"nested_attr":"testvalue"}]`,
        -       Diagnostics:   nil,
        +       Diagnostics: diag.Diagnostics{
        +               diag.ErrorDiagnostic{
        +                       detail:  "While creating a Set value, an invalid element was detected. A S"...,
        +                       summary: "Invalid Set Element Type",
        +               },
        +       },
                RequiresReplace: s"[]",
                Private:         nil,
          }
=== NAME  TestAttributeModifyPlan/attribute-list-nested-nested-custom-nested-object
    attribute_plan_modification_test.go:3285: Unexpected response (-wanted, +got):   fwserver.ModifyAttributePlanResponse{
                AttributePlan: s`[{"nested_list_nested_attribute":[{"nested_attr":"testvalue"}]}]`,
        -       Diagnostics:   nil,
        +       Diagnostics: diag.Diagnostics{
        +               diag.ErrorDiagnostic{
        +                       detail:  "While creating a List value, an invalid element was detected. A "...,
        +                       summary: "Invalid List Element Type",
        +               },
        +               diag.ErrorDiagnostic{
        +                       detail:  "While creating a List value, an invalid element was detected. A "...,
        +                       summary: "Invalid List Element Type",
        +               },
        +       },
                RequiresReplace: s"[]",
                Private:         nil,
          }
=== NAME  TestAttributeModifyPlan/attribute-list-nested-custom-nested-object
    attribute_plan_modification_test.go:3285: Unexpected response (-wanted, +got):   fwserver.ModifyAttributePlanResponse{
                AttributePlan: s`[{"nested_attr":"testvalue"}]`,
        -       Diagnostics:   nil,
        +       Diagnostics: diag.Diagnostics{
        +               diag.ErrorDiagnostic{
        +                       detail:  "While creating a List value, an invalid element was detected. A "...,
        +                       summary: "Invalid List Element Type",
        +               },
        +       },
                RequiresReplace: s"[]",
                Private:         nil,
          }
=== NAME  TestAttributeModifyPlan/attribute-set-nested-nested-custom-nested-object
    attribute_plan_modification_test.go:3285: Unexpected response (-wanted, +got):   fwserver.ModifyAttributePlanResponse{
                AttributePlan: s`[{"nested_set_nested_attribute":[{"nested_attr":"testvalue"}]}]`,
        -       Diagnostics:   nil,
        +       Diagnostics: diag.Diagnostics{
        +               diag.ErrorDiagnostic{
        +                       detail:  "While creating a Set value, an invalid element was detected. A S"...,
        +                       summary: "Invalid Set Element Type",
        +               },
        +               diag.ErrorDiagnostic{
        +                       detail:  "While creating a Set value, an invalid element was detected. A S"...,
        +                       summary: "Invalid Set Element Type",
        +               },
        +       },
                RequiresReplace: s"[]",
                Private:         nil,
          }
```

```shell
=== NAME  TestBlockModifyPlan/block-set-nested-nested-custom-nested-object
    block_plan_modification_test.go:4040: Error: Invalid Set Element Type
        While creating a Set value, an invalid element was detected. A Set must use the single, given element type. This is always an issue with the provider and should be reported to the provider developers.
        
        Set Element Type: NestedObjectCustomType
        Set Index (0) Element Type: types.ObjectType["nested_attr":basetypes.StringType]
=== NAME  TestBlockModifyPlan/block-set-nested-custom-nested-object
    block_plan_modification_test.go:4040: Error: Invalid Set Element Type
        While creating a Set value, an invalid element was detected. A Set must use the single, given element type. This is always an issue with the provider and should be reported to the provider developers.
        
        Set Element Type: NestedObjectCustomType
        Set Index (0) Element Type: types.ObjectType["nested_attr":basetypes.StringType]
=== NAME  TestBlockModifyPlan/block-list-nested-nested-custom-nested-object
    block_plan_modification_test.go:4040: Error: Invalid List Element Type
        While creating a List value, an invalid element was detected. A List must use the single, given element type. This is always an issue with the provider and should be reported to the provider developers.
        
        List Element Type: NestedObjectCustomType
        List Index (0) Element Type: types.ObjectType["nested_attr":basetypes.StringType]
    block_plan_modification_test.go:4040: Error: Invalid List Element Type
        While creating a List value, an invalid element was detected. A List must use the single, given element type. This is always an issue with the provider and should be reported to the provider developers.
        
        List Element Type: ListNestedObjectCustomType
        List Index (0) Element Type: types.ObjectType["nested_list_nested":types.ListType[NestedObjectCustomType]]
    block_plan_modification_test.go:4042: Unexpected response (+wanted, -got):   fwserver.ModifyAttributePlanResponse{
                AttributePlan: s`[{"nested_list_nested":[{"nested_attr":"testvalue"}]}]`,
        -       Diagnostics:   nil,
        +       Diagnostics: diag.Diagnostics{
        +               diag.ErrorDiagnostic{
        +                       detail:  "While creating a List value, an invalid element was detected. A "...,
        +                       summary: "Invalid List Element Type",
        +               },
        +               diag.ErrorDiagnostic{
        +                       detail:  "While creating a List value, an invalid element was detected. A "...,
        +                       summary: "Invalid List Element Type",
        +               },
        +       },
                RequiresReplace: s"[]",
                Private:         nil,
          }
=== NAME  TestBlockModifyPlan/block-set-nested-custom-nested-object
    block_plan_modification_test.go:4042: Unexpected response (+wanted, -got):   fwserver.ModifyAttributePlanResponse{
                AttributePlan: s`[{"nested_attr":"testvalue"}]`,
        -       Diagnostics:   nil,
        +       Diagnostics: diag.Diagnostics{
        +               diag.ErrorDiagnostic{
        +                       detail:  "While creating a Set value, an invalid element was detected. A S"...,
        +                       summary: "Invalid Set Element Type",
        +               },
        +       },
                RequiresReplace: s"[]",
                Private:         nil,
          }
=== NAME  TestBlockModifyPlan/block-set-nested-nested-custom-nested-object
    block_plan_modification_test.go:4040: Error: Invalid Set Element Type
        While creating a Set value, an invalid element was detected. A Set must use the single, given element type. This is always an issue with the provider and should be reported to the provider developers.
        
        Set Element Type: SetNestedObjectCustomType
        Set Index (0) Element Type: types.ObjectType["nested_set_nested":types.SetType[NestedObjectCustomType]]
=== NAME  TestBlockModifyPlan/block-set-nested-nested-custom-nested-object
    block_plan_modification_test.go:4042: Unexpected response (+wanted, -got):   fwserver.ModifyAttributePlanResponse{
                AttributePlan: s`[{"nested_set_nested":[{"nested_attr":"testvalue"}]}]`,
        -       Diagnostics:   nil,
        +       Diagnostics: diag.Diagnostics{
        +               diag.ErrorDiagnostic{
        +                       detail:  "While creating a Set value, an invalid element was detected. A S"...,
        +                       summary: "Invalid Set Element Type",
        +               },
        +               diag.ErrorDiagnostic{
        +                       detail:  "While creating a Set value, an invalid element was detected. A S"...,
        +                       summary: "Invalid Set Element Type",
        +               },
        +       },
                RequiresReplace: s"[]",
                Private:         nil,
          }
=== NAME  TestBlockModifyPlan/block-list-nested-custom-nested-object
    block_plan_modification_test.go:4040: Error: Invalid List Element Type
        While creating a List value, an invalid element was detected. A List must use the single, given element type. This is always an issue with the provider and should be reported to the provider developers.
        
        List Element Type: NestedObjectCustomType
        List Index (0) Element Type: types.ObjectType["nested_attr":basetypes.StringType]
    block_plan_modification_test.go:4042: Unexpected response (+wanted, -got):   fwserver.ModifyAttributePlanResponse{
                AttributePlan: s`[{"nested_attr":"testvalue"}]`,
        -       Diagnostics:   nil,
        +       Diagnostics: diag.Diagnostics{
        +               diag.ErrorDiagnostic{
        +                       detail:  "While creating a List value, an invalid element was detected. A "...,
        +                       summary: "Invalid List Element Type",
        +               },
        +       },
                RequiresReplace: s"[]",
                Private:         nil,
          }
```