### PR TITLE
website: Move acceptance testing id requirement to troubleshooting section

### DIFF
--- a/website/docs/plugin/framework/acctests.mdx
+++ b/website/docs/plugin/framework/acctests.mdx
@@ -9,22 +9,15 @@ description: >-
 
 Implement provider resource and data source acceptance tests with the [terraform-plugin-testing module](/terraform/plugin/testing). These tests are designed to execute Terraform commands against real Terraform configurations, simulating practitioner experiences with creating, refreshing, updating, and deleting infrastructure.
 
-This page only describes requirements and specifics of using the testing module with a framework provider. Refer to the [testing module documentation](/terraform/plugin/testing) for additional information on all available functionality in tests.
+This page only describes requirements of using the testing module with a framework provider. Refer to the [testing module documentation](/terraform/plugin/testing) for additional information on all available functionality in tests.
 
 ## Requirements
-
-Successfully implementing acceptance testing of framework providers requires:
-
-- [Specifying the provider](#specify-provider) so the testing module can automatically start and stop the framework provider during tests.
-- [Implementing an `id` attribute](#implement-id-attribute), which is a required implementation detail of the testing module.
-
-### Specify Provider
 
 The testing module must know how to reference your provider code before Terraform commands and configurations can succeed. This is achieved by pointing the testing module at a [provider server](/terraform/plugin/framework/provider-servers) which wraps your [provider](/terraform/plugin/framework/providers).
 
 Use one of the [`resource.TestCase` type](/terraform/plugin/testing/acceptance-tests/testcase) [`ProtoV6ProviderFactories` field](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-testing/helper/resource#TestCase.ProtoV6ProviderFactories) for [protocol version 6](/terraform/plugin/terraform-plugin-protocol#protocol-version-6) or [`ProtoV5ProviderFactories` field](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-testing/helper/resource#TestCase.ProtoV5ProviderFactories) for [protocol version 5](/terraform/plugin/terraform-plugin-protocol#protocol-version-5). It is only necessary to test with the single protocol version matching the production provider server, typically defined in the `main.go` file of the provider codebase.
 
-#### Protocol Version 6
+### Protocol Version 6
 
 Use the [`providerserver.NewProtocol6WithError`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/providerserver#NewProtocol6WithError) helper function to implement the provider server in the [`ProtoV6ProviderFactories` field](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-testing/helper/resource#TestCase.ProtoV6ProviderFactories).
 
@@ -38,7 +31,7 @@ resource.Test(t, resource.TestCase{
 })
 ```
 
-#### Protocol Version 5
+### Protocol Version 5
 
 Use the [`providerserver.NewProtocol5WithError`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/providerserver#NewProtocol5WithError) helper function to implement the provider server in the [`ProtoV5ProviderFactories` field](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-testing/helper/resource#TestCase.ProtoV5ProviderFactories).
 
@@ -52,7 +45,15 @@ resource.Test(t, resource.TestCase{
 })
 ```
 
-### Implement id Attribute
+## Troubleshooting
+
+### No id found in attributes
+
+<Highlight>
+
+terraform-plugin-testing version 1.5.0 and later no longer require managed resources and data resources to implement the `id` attribute.
+
+</Highlight>
 
 In SDKv2, resources and data sources automatically included an implicit, root level `id` attribute. In the framework, the `id` attribute is not implicitly added.
 


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform-plugin-testing/issues/84

terraform-plugin-testing version 1.5.0 and later will no longer require managed resources and data resources to implement the `id` attribute.