### PR TITLE
Typo in documentation related to NestedAttributeObject

### DIFF
--- a/website/docs/plugin/framework/handling-data/attributes/list-nested.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/list-nested.mdx
@@ -70,7 +70,7 @@ func (r ThingResource) Schema(ctx context.Context, req resource.SchemaRequest, r
     resp.Schema = schema.Schema{
         Attributes: map[string]schema.Attribute{
             "example_attribute": schema.ListNestedAttribute{
-                NestedObject: schema.NestedAttributeOjbect{
+                NestedObject: schema.NestedAttributeObject{
                     Attributes: map[string]schema.Attribute{
                         "attr1": schema.ListAttribute{
                             ElementType: types.StringType,

--- a/website/docs/plugin/framework/handling-data/attributes/list-nested.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/list-nested.mdx
@@ -42,7 +42,7 @@ func (r ThingResource) Schema(ctx context.Context, req resource.SchemaRequest, r
     resp.Schema = schema.Schema{
         Attributes: map[string]schema.Attribute{
             "example_attribute": schema.ListNestedAttribute{
-                NestedObject: schema.NestedAttributeOjbect{
+                NestedObject: schema.NestedAttributeObject{
                     Attributes: map[string]schema.Attribute{
                         "attr": schema.StringAttribute{
                             Required: true,

--- a/website/docs/plugin/framework/handling-data/attributes/map-nested.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/map-nested.mdx
@@ -42,7 +42,7 @@ func (r ThingResource) Schema(ctx context.Context, req resource.SchemaRequest, r
     resp.Schema = schema.Schema{
         Attributes: map[string]schema.Attribute{
             "example_attribute": schema.MapNestedAttribute{
-                NestedObject: schema.NestedAttributeOjbect{
+                NestedObject: schema.NestedAttributeObject{
                     Attributes: map[string]schema.Attribute{
                         "attr": schema.StringAttribute{
                             Required: true,
@@ -70,7 +70,7 @@ func (r ThingResource) Schema(ctx context.Context, req resource.SchemaRequest, r
     resp.Schema = schema.Schema{
         Attributes: map[string]schema.Attribute{
             "example_attribute": schema.MapNestedAttribute{
-                NestedObject: schema.NestedAttributeOjbect{
+                NestedObject: schema.NestedAttributeObject{
                     Attributes: map[string]schema.Attribute{
                         "attr1": schema.ListAttribute{
                             ElementType: types.StringType,

--- a/website/docs/plugin/framework/handling-data/attributes/set-nested.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/set-nested.mdx
@@ -42,7 +42,7 @@ func (r ThingResource) Schema(ctx context.Context, req resource.SchemaRequest, r
     resp.Schema = schema.Schema{
         Attributes: map[string]schema.Attribute{
             "example_attribute": schema.SetNestedAttribute{
-                NestedObject: schema.NestedAttributeOjbect{
+                NestedObject: schema.NestedAttributeObject{
                     Attributes: map[string]schema.Attribute{
                         "attr": schema.StringAttribute{
                             Required: true,
@@ -70,7 +70,7 @@ func (r ThingResource) Schema(ctx context.Context, req resource.SchemaRequest, r
     resp.Schema = schema.Schema{
         Attributes: map[string]schema.Attribute{
             "example_attribute": schema.SetNestedAttribute{
-                NestedObject: schema.NestedAttributeOjbect{
+                NestedObject: schema.NestedAttributeObject{
                     Attributes: map[string]schema.Attribute{
                         "attr1": schema.ListAttribute{
                             ElementType: types.StringType,


### PR DESCRIPTION
The PR fixes some typos in the documentation related to NestedAttributeObject.