### PR TITLE
Correct Site Doc Links To "Write State" Page

### DIFF
--- a/website/docs/plugin/framework/handling-data/attributes/bool.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/bool.mdx
@@ -117,4 +117,4 @@ The [accessing values](/terraform/plugin/framework/handling-data/accessing-value
 
 ## Setting Values
 
-The [bool type](/terraform/plugin/framework/handling-data/types/bool#setting-values) documentation covers methods for creating or setting the appropriate value. The [writing data](/terraform/plugin/framework/handing-data/writing-state) documentation covers general methods for writing [schema](/terraform/plugin/framework/handling-data/schemas) (plan and state) data, which is necessary afterwards.
+The [bool type](/terraform/plugin/framework/handling-data/types/bool#setting-values) documentation covers methods for creating or setting the appropriate value. The [writing data](/terraform/plugin/framework/handling-data/writing-state) documentation covers general methods for writing [schema](/terraform/plugin/framework/handling-data/schemas) (plan and state) data, which is necessary afterwards.

--- a/website/docs/plugin/framework/handling-data/attributes/float64.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/float64.mdx
@@ -123,4 +123,4 @@ The [accessing values](/terraform/plugin/framework/handling-data/accessing-value
 
 ## Setting Values
 
-The [float64 type](/terraform/plugin/framework/handling-data/types/float64#setting-values) documentation covers methods for creating or setting the appropriate value. The [writing data](/terraform/plugin/framework/handing-data/writing-state) documentation covers general methods for writing [schema](/terraform/plugin/framework/handling-data/schemas) (plan and state) data, which is necessary afterwards.
+The [float64 type](/terraform/plugin/framework/handling-data/types/float64#setting-values) documentation covers methods for creating or setting the appropriate value. The [writing data](/terraform/plugin/framework/handling-data/writing-state) documentation covers general methods for writing [schema](/terraform/plugin/framework/handling-data/schemas) (plan and state) data, which is necessary afterwards.

--- a/website/docs/plugin/framework/handling-data/attributes/int64.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/int64.mdx
@@ -123,4 +123,4 @@ The [accessing values](/terraform/plugin/framework/handling-data/accessing-value
 
 ## Setting Values
 
-The [int64 type](/terraform/plugin/framework/handling-data/types/int64#setting-values) documentation covers methods for creating or setting the appropriate value. The [writing data](/terraform/plugin/framework/handing-data/writing-state) documentation covers general methods for writing [schema](/terraform/plugin/framework/handling-data/schemas) (plan and state) data, which is necessary afterwards.
+The [int64 type](/terraform/plugin/framework/handling-data/types/int64#setting-values) documentation covers methods for creating or setting the appropriate value. The [writing data](/terraform/plugin/framework/handling-data/writing-state) documentation covers general methods for writing [schema](/terraform/plugin/framework/handling-data/schemas) (plan and state) data, which is necessary afterwards.

--- a/website/docs/plugin/framework/handling-data/attributes/list-nested.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/list-nested.mdx
@@ -172,4 +172,4 @@ The [accessing values](/terraform/plugin/framework/handling-data/accessing-value
 
 ## Setting Values
 
-The [list type](/terraform/plugin/framework/handling-data/types/list#setting-values) documentation covers methods for creating or setting the appropriate value. The [writing data](/terraform/plugin/framework/handing-data/writing-state) documentation covers general methods for writing [schema](/terraform/plugin/framework/handling-data/schemas) (plan and state) data, which is necessary afterwards.
+The [list type](/terraform/plugin/framework/handling-data/types/list#setting-values) documentation covers methods for creating or setting the appropriate value. The [writing data](/terraform/plugin/framework/handling-data/writing-state) documentation covers general methods for writing [schema](/terraform/plugin/framework/handling-data/schemas) (plan and state) data, which is necessary afterwards.

--- a/website/docs/plugin/framework/handling-data/attributes/list.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/list.mdx
@@ -141,4 +141,4 @@ The [accessing values](/terraform/plugin/framework/handling-data/accessing-value
 
 ## Setting Values
 
-The [list type](/terraform/plugin/framework/handling-data/types/list#setting-values) documentation covers methods for creating or setting the appropriate value. The [writing data](/terraform/plugin/framework/handing-data/writing-state) documentation covers general methods for writing [schema](/terraform/plugin/framework/handling-data/schemas) (plan and state) data, which is necessary afterwards.
+The [list type](/terraform/plugin/framework/handling-data/types/list#setting-values) documentation covers methods for creating or setting the appropriate value. The [writing data](/terraform/plugin/framework/handling-data/writing-state) documentation covers general methods for writing [schema](/terraform/plugin/framework/handling-data/schemas) (plan and state) data, which is necessary afterwards.

--- a/website/docs/plugin/framework/handling-data/attributes/map-nested.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/map-nested.mdx
@@ -172,4 +172,4 @@ The [accessing values](/terraform/plugin/framework/handling-data/accessing-value
 
 ## Setting Values
 
-The [map type](/terraform/plugin/framework/handling-data/types/map#setting-values) documentation covers methods for creating or setting the appropriate value. The [writing data](/terraform/plugin/framework/handing-data/writing-state) documentation covers general methods for writing [schema](/terraform/plugin/framework/handling-data/schemas) (plan and state) data, which is necessary afterwards.
+The [map type](/terraform/plugin/framework/handling-data/types/map#setting-values) documentation covers methods for creating or setting the appropriate value. The [writing data](/terraform/plugin/framework/handling-data/writing-state) documentation covers general methods for writing [schema](/terraform/plugin/framework/handling-data/schemas) (plan and state) data, which is necessary afterwards.

--- a/website/docs/plugin/framework/handling-data/attributes/map.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/map.mdx
@@ -144,4 +144,4 @@ The [accessing values](/terraform/plugin/framework/handling-data/accessing-value
 
 ## Setting Values
 
-The [map type](/terraform/plugin/framework/handling-data/types/map#setting-values) documentation covers methods for creating or setting the appropriate value. The [writing data](/terraform/plugin/framework/handing-data/writing-state) documentation covers general methods for writing [schema](/terraform/plugin/framework/handling-data/schemas) (plan and state) data, which is necessary afterwards.
+The [map type](/terraform/plugin/framework/handling-data/types/map#setting-values) documentation covers methods for creating or setting the appropriate value. The [writing data](/terraform/plugin/framework/handling-data/writing-state) documentation covers general methods for writing [schema](/terraform/plugin/framework/handling-data/schemas) (plan and state) data, which is necessary afterwards.

--- a/website/docs/plugin/framework/handling-data/attributes/number.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/number.mdx
@@ -123,4 +123,4 @@ The [accessing values](/terraform/plugin/framework/handling-data/accessing-value
 
 ## Setting Values
 
-The [number type](/terraform/plugin/framework/handling-data/types/number#setting-values) documentation covers methods for creating or setting the appropriate value. The [writing data](/terraform/plugin/framework/handing-data/writing-state) documentation covers general methods for writing [schema](/terraform/plugin/framework/handling-data/schemas) (plan and state) data, which is necessary afterwards.
+The [number type](/terraform/plugin/framework/handling-data/types/number#setting-values) documentation covers methods for creating or setting the appropriate value. The [writing data](/terraform/plugin/framework/handling-data/writing-state) documentation covers general methods for writing [schema](/terraform/plugin/framework/handling-data/schemas) (plan and state) data, which is necessary afterwards.

--- a/website/docs/plugin/framework/handling-data/attributes/object.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/object.mdx
@@ -178,4 +178,4 @@ The [accessing values](/terraform/plugin/framework/handling-data/accessing-value
 
 ## Setting Values
 
-The [object type](/terraform/plugin/framework/handling-data/types/object#setting-values) documentation covers methods for creating or setting the appropriate value. The [writing data](/terraform/plugin/framework/handing-data/writing-state) documentation covers general methods for writing [schema](/terraform/plugin/framework/handling-data/schemas) (plan and state) data, which is necessary afterwards.
+The [object type](/terraform/plugin/framework/handling-data/types/object#setting-values) documentation covers methods for creating or setting the appropriate value. The [writing data](/terraform/plugin/framework/handling-data/writing-state) documentation covers general methods for writing [schema](/terraform/plugin/framework/handling-data/schemas) (plan and state) data, which is necessary afterwards.

--- a/website/docs/plugin/framework/handling-data/attributes/set-nested.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/set-nested.mdx
@@ -172,4 +172,4 @@ The [accessing values](/terraform/plugin/framework/handling-data/accessing-value
 
 ## Setting Values
 
-The [set type](/terraform/plugin/framework/handling-data/types/set#setting-values) documentation covers methods for creating or setting the appropriate value. The [writing data](/terraform/plugin/framework/handing-data/writing-state) documentation covers general methods for writing [schema](/terraform/plugin/framework/handling-data/schemas) (plan and state) data, which is necessary afterwards.
+The [set type](/terraform/plugin/framework/handling-data/types/set#setting-values) documentation covers methods for creating or setting the appropriate value. The [writing data](/terraform/plugin/framework/handling-data/writing-state) documentation covers general methods for writing [schema](/terraform/plugin/framework/handling-data/schemas) (plan and state) data, which is necessary afterwards.

--- a/website/docs/plugin/framework/handling-data/attributes/set.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/set.mdx
@@ -141,4 +141,4 @@ The [accessing values](/terraform/plugin/framework/handling-data/accessing-value
 
 ## Setting Values
 
-The [set type](/terraform/plugin/framework/handling-data/types/set#setting-values) documentation covers methods for creating or setting the appropriate value. The [writing data](/terraform/plugin/framework/handing-data/writing-state) documentation covers general methods for writing [schema](/terraform/plugin/framework/handling-data/schemas) (plan and state) data, which is necessary afterwards.
+The [set type](/terraform/plugin/framework/handling-data/types/set#setting-values) documentation covers methods for creating or setting the appropriate value. The [writing data](/terraform/plugin/framework/handling-data/writing-state) documentation covers general methods for writing [schema](/terraform/plugin/framework/handling-data/schemas) (plan and state) data, which is necessary afterwards.

--- a/website/docs/plugin/framework/handling-data/attributes/single-nested.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/single-nested.mdx
@@ -168,4 +168,4 @@ The [accessing values](/terraform/plugin/framework/handling-data/accessing-value
 
 ## Setting Values
 
-The [object type](/terraform/plugin/framework/handling-data/types/object#setting-values) documentation covers methods for creating or setting the appropriate value. The [writing data](/terraform/plugin/framework/handing-data/writing-state) documentation covers general methods for writing [schema](/terraform/plugin/framework/handling-data/schemas) (plan and state) data, which is necessary afterwards.
+The [object type](/terraform/plugin/framework/handling-data/types/object#setting-values) documentation covers methods for creating or setting the appropriate value. The [writing data](/terraform/plugin/framework/handling-data/writing-state) documentation covers general methods for writing [schema](/terraform/plugin/framework/handling-data/schemas) (plan and state) data, which is necessary afterwards.

--- a/website/docs/plugin/framework/handling-data/attributes/string.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/string.mdx
@@ -125,4 +125,4 @@ The [accessing values](/terraform/plugin/framework/handling-data/accessing-value
 
 ## Setting Values
 
-The [string type](/terraform/plugin/framework/handling-data/types/string#setting-values) documentation covers methods for creating or setting the appropriate value. The [writing data](/terraform/plugin/framework/handing-data/writing-state) documentation covers general methods for writing [schema](/terraform/plugin/framework/handling-data/schemas) (plan and state) data, which is necessary afterwards.
+The [string type](/terraform/plugin/framework/handling-data/types/string#setting-values) documentation covers methods for creating or setting the appropriate value. The [writing data](/terraform/plugin/framework/handling-data/writing-state) documentation covers general methods for writing [schema](/terraform/plugin/framework/handling-data/schemas) (plan and state) data, which is necessary afterwards.

--- a/website/docs/plugin/framework/handling-data/blocks/list-nested.mdx
+++ b/website/docs/plugin/framework/handling-data/blocks/list-nested.mdx
@@ -164,4 +164,4 @@ The [accessing values](/terraform/plugin/framework/handling-data/accessing-value
 
 ## Setting Values
 
-The [list type](/terraform/plugin/framework/handling-data/types/list#setting-values) documentation covers methods for creating or setting the appropriate value. The [writing data](/terraform/plugin/framework/handing-data/writing-state) documentation covers general methods for writing [schema](/terraform/plugin/framework/handling-data/schemas) (plan and state) data, which is necessary afterwards.
+The [list type](/terraform/plugin/framework/handling-data/types/list#setting-values) documentation covers methods for creating or setting the appropriate value. The [writing data](/terraform/plugin/framework/handling-data/writing-state) documentation covers general methods for writing [schema](/terraform/plugin/framework/handling-data/schemas) (plan and state) data, which is necessary afterwards.

--- a/website/docs/plugin/framework/handling-data/blocks/set-nested.mdx
+++ b/website/docs/plugin/framework/handling-data/blocks/set-nested.mdx
@@ -164,4 +164,4 @@ The [accessing values](/terraform/plugin/framework/handling-data/accessing-value
 
 ## Setting Values
 
-The [set type](/terraform/plugin/framework/handling-data/types/set#setting-values) documentation covers methods for creating or setting the appropriate value. The [writing data](/terraform/plugin/framework/handing-data/writing-state) documentation covers general methods for writing [schema](/terraform/plugin/framework/handling-data/schemas) (plan and state) data, which is necessary afterwards.
+The [set type](/terraform/plugin/framework/handling-data/types/set#setting-values) documentation covers methods for creating or setting the appropriate value. The [writing data](/terraform/plugin/framework/handling-data/writing-state) documentation covers general methods for writing [schema](/terraform/plugin/framework/handling-data/schemas) (plan and state) data, which is necessary afterwards.

--- a/website/docs/plugin/framework/handling-data/blocks/single-nested.mdx
+++ b/website/docs/plugin/framework/handling-data/blocks/single-nested.mdx
@@ -155,4 +155,4 @@ The [accessing values](/terraform/plugin/framework/handling-data/accessing-value
 
 ## Setting Values
 
-The [object type](/terraform/plugin/framework/handling-data/types/object#setting-values) documentation covers methods for creating or setting the appropriate value. The [writing data](/terraform/plugin/framework/handing-data/writing-state) documentation covers general methods for writing [schema](/terraform/plugin/framework/handling-data/schemas) (plan and state) data, which is necessary afterwards.
+The [object type](/terraform/plugin/framework/handling-data/types/object#setting-values) documentation covers methods for creating or setting the appropriate value. The [writing data](/terraform/plugin/framework/handling-data/writing-state) documentation covers general methods for writing [schema](/terraform/plugin/framework/handling-data/schemas) (plan and state) data, which is necessary afterwards.


### PR DESCRIPTION
Fixes locations where the incorrect reference `terraform/plugin/framework/handing-data/writing-state` is used, replaced with the correct `terraform/plugin/framework/handling-data/writing-state`. 
