### PR TITLE
Fix panic at validators under unknown path

### DIFF
--- a/internal/fwschemadata/data_value.go
+++ b/internal/fwschemadata/data_value.go
@@ -75,8 +75,9 @@ func (d Data) ValueAtPath(ctx context.Context, schemaPath path.Path) (attr.Value
 	// TODO: If ErrInvalidStep, check parent paths for unknown value.
 	//       If found, convert this value to an unknown value.
 	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/186
-
-	if attrTypeWithValidate, ok := attrType.(xattr.TypeWithValidate); ok {
+	//
+	// Note the err==nil condition: this avoid passing malformed tfValue to validators.
+	if attrTypeWithValidate, ok := attrType.(xattr.TypeWithValidate); err == nil && ok {
 		logging.FrameworkTrace(ctx, "Type implements TypeWithValidate")
 		logging.FrameworkTrace(ctx, "Calling provider defined Type Validate")
 		diags.Append(attrTypeWithValidate.Validate(ctx, tfValue, schemaPath)...)
@@ -88,7 +89,6 @@ func (d Data) ValueAtPath(ctx context.Context, schemaPath path.Path) (attr.Value
 	}
 
 	attrValue, err := attrType.ValueFromTerraform(ctx, tfValue)
-
 	if err != nil {
 		diags.AddAttributeError(
 			schemaPath,


### PR DESCRIPTION
I'm observing a panic in PF with versions v1.1.1 through latest, with the following excerpt from the stack trace:

```
github.com/hashicorp/terraform-plugin-framework/internal/fwschemadata.Data.ValueAtPath({{0x3282af6, 0xd}, {0x393f9f8, 0xc000cb5440}, {{0x3937cf0, 0xc000b4e090}, {0x2e47600, 0xc000e81c20}}}, {0x392b2a0, 0xc000b4e5d0}, ...)
        /Users/t0yv0/go/pkg/mod/github.com/hashicorp/terraform-plugin-framework@v1.1.1/internal/fwschemadata/data_value.go:79 +0x675
github.com/hashicorp/terraform-plugin-framework/internal/fwserver.AttributeValidate({0x392b2a0, 0xc000e81140}, {0x393ddf8, 0xc00068f0e0}, {{{0xc000e015c0, 0x3, 0x4}}, {0x1, {0xc000e01600, 0x3, ...}}, ...}, ...)
        /Users/t0yv0/go/pkg/mod/github.com/hashicorp/terraform-plugin-framework@v1.1.1/internal/fwserver/attribute_validation.go:71 +0x275
github.com/hashicorp/terraform-plugin-framework/internal/fwserver.NestedBlockObjectValidate({0x392b2a0, 0xc000e81140}, {0x392ffa0, 0xc000e01580}, {{{0xc000e08620, 0x2, 0x2}}, {0x1, {0xc000e08640, 0x2, ...}}, ...}, ...)
        /Users/t0yv0/go/pkg/mod/github.com/hashicorp/terraform-plugin-framework@v1.1.1/internal/fwserver/block_validation.go:436 +0x985
github.com/hashicorp/terraform-plugin-framework/internal/fwserver.BlockValidate({0x392b2a0, 0xc000e81140}, {0x3938340, 0xc000a72fc0}, {{{0xc000e07670, 0x1, 0x1}}, {0x1, {0xc000e07690, 0x1, ...}}, ...}, ...)
        /Users/t0yv0/go/pkg/mod/github.com/hashicorp/terraform-plugin-framework@v1.1.1/internal/fwserver/block_validation.go:80 +0xf45
github.com/hashicorp/terraform-plugin-framework/internal/fwserver.SchemaValidate({0x392b2a0, 0xc000e81140}, {0x393f9f8, 0xc000cb5440}, {{{{0x3937cf0, 0xc000b4e090}, {0x2e47600, 0xc000e81c20}}, {0x393f9f8, 0xc000cb5440}}}, ...)
        /Users/t0yv0/go/pkg/mod/github.com/hashicorp/terraform-plugin-framework@v1.1.1/internal/fwserver/schema_validation.go:63 +0x485
github.com/hashicorp/terraform-plugin-framework/internal/fwserver.(*Server).ValidateProviderConfig(0xc0006ccdc0, {0x392b2a0, 0xc000e81140}, 0xc00081e130, 0xc000d2f8b8)
        /Users/t0yv0/go/pkg/mod/github.com/hashicorp/terraform-plugin-framework@v1.1.1/internal/fwserver/server_validateproviderconfig.go:84 +0x390
github.com/hashicorp/terraform-plugin-framework/internal/proto6server.(*Server).ValidateProviderConfig(0xc0006ccdc0, {0x392b2a0?, 0xc000cc9a40?}, 0x0?)
        /Users/t0yv0/go/pkg/mod/github.com/hashicorp/terraform-plugin-framework@v1.1.1/internal/proto6server/server_validateproviderconfig.go:36 +0x1dc
```

The context here is that AWS provider has provider schema defined as `{assume_role: [{duration: durationType}]}`, but panics when asked to validate `{assume_role: [unknown]}`.  I'm getting past the panic in the suggested fix.

It's possible to have an alternative fix where Data.ValueAtPath is not being called at all when drilling down an Unknown at the level of fwserver.BlockValidate or higher up the stack.

However it does feel that  Data.ValueAtPath itself can be made more robust by a change like this one. Sending uninitialized value into the validators is not a good idea as they may not be prepared to handle this. 
