### PR TITLE
resource: Prevent private state data loss on Delete method error

### DIFF
--- a/.changes/unreleased/BUG FIXES-20231023-165712.yaml
+++ b/.changes/unreleased/BUG FIXES-20231023-165712.yaml
@@ -1,0 +1,6 @@
+kind: BUG FIXES
+body: 'resource: Add `Private` field to `DeleteResource` type, which was missing to
+  allow provider logic to update private state on errors'
+time: 2023-10-23T16:57:12.447739-04:00
+custom:
+  Issue: "863"

--- a/.changes/unreleased/BUG FIXES-20231023-165814.yaml
+++ b/.changes/unreleased/BUG FIXES-20231023-165814.yaml
@@ -1,0 +1,6 @@
+kind: BUG FIXES
+body: 'resource: Prevented private state data loss if resource destruction returned
+  an error'
+time: 2023-10-23T16:58:14.585227-04:00
+custom:
+  Issue: "863"

--- a/internal/proto5server/server_applyresourcechange_test.go
+++ b/internal/proto5server/server_applyresourcechange_test.go
@@ -696,6 +696,130 @@ func TestServerApplyResourceChange(t *testing.T) {
 				}),
 			},
 		},
+		"delete-response-private": {
+			server: &Server{
+				FrameworkServer: fwserver.Server{
+					Provider: &testprovider.Provider{
+						ResourcesMethod: func(_ context.Context) []func() resource.Resource {
+							return []func() resource.Resource{
+								func() resource.Resource {
+									return &testprovider.Resource{
+										SchemaMethod: func(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+											resp.Schema = testSchema
+										},
+										MetadataMethod: func(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
+											resp.TypeName = "test_resource"
+										},
+										CreateMethod: func(_ context.Context, _ resource.CreateRequest, resp *resource.CreateResponse) {
+											resp.Diagnostics.AddError("Unexpected Method Call", "Expected: Delete, Got: Create")
+										},
+										DeleteMethod: func(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+											diags := resp.Private.SetKey(ctx, "providerKey", []byte(`{"key": "value"}`))
+
+											resp.Diagnostics.Append(diags...)
+
+											// Must return error to prevent automatic private state clearing
+											resp.Diagnostics.AddError("error summary", "error detail")
+										},
+										UpdateMethod: func(_ context.Context, _ resource.UpdateRequest, resp *resource.UpdateResponse) {
+											resp.Diagnostics.AddError("Unexpected Method Call", "Expected: Delete, Got: Update")
+										},
+									}
+								},
+							}
+						},
+					},
+				},
+			},
+			request: &tfprotov5.ApplyResourceChangeRequest{
+				PlannedState: &testEmptyDynamicValue,
+				PriorState: testNewDynamicValue(t, testSchemaType, map[string]tftypes.Value{
+					"test_computed": tftypes.NewValue(tftypes.String, nil),
+					"test_required": tftypes.NewValue(tftypes.String, "test-priorstate-value"),
+				}),
+				TypeName: "test_resource",
+			},
+			expectedResponse: &tfprotov5.ApplyResourceChangeResponse{
+				Diagnostics: []*tfprotov5.Diagnostic{
+					{
+						Severity: tfprotov5.DiagnosticSeverityError,
+						Summary:  "error summary",
+						Detail:   "error detail",
+					},
+				},
+				Private: privatestate.MustMarshalToJson(map[string][]byte{
+					"providerKey": []byte(`{"key": "value"}`),
+				}),
+				NewState: testNewDynamicValue(t, testSchemaType, map[string]tftypes.Value{
+					"test_computed": tftypes.NewValue(tftypes.String, nil),
+					"test_required": tftypes.NewValue(tftypes.String, "test-priorstate-value"),
+				}),
+			},
+		},
+		"delete-response-private-updated": {
+			server: &Server{
+				FrameworkServer: fwserver.Server{
+					Provider: &testprovider.Provider{
+						ResourcesMethod: func(_ context.Context) []func() resource.Resource {
+							return []func() resource.Resource{
+								func() resource.Resource {
+									return &testprovider.Resource{
+										SchemaMethod: func(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+											resp.Schema = testSchema
+										},
+										MetadataMethod: func(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
+											resp.TypeName = "test_resource"
+										},
+										CreateMethod: func(_ context.Context, _ resource.CreateRequest, resp *resource.CreateResponse) {
+											resp.Diagnostics.AddError("Unexpected Method Call", "Expected: Delete, Got: Create")
+										},
+										DeleteMethod: func(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+											diags := resp.Private.SetKey(ctx, "providerKey", []byte(`{"key": "value"}`))
+
+											resp.Diagnostics.Append(diags...)
+
+											// Must return error to prevent automatic private state clearing
+											resp.Diagnostics.AddError("error summary", "error detail")
+										},
+										UpdateMethod: func(_ context.Context, _ resource.UpdateRequest, resp *resource.UpdateResponse) {
+											resp.Diagnostics.AddError("Unexpected Method Call", "Expected: Delete, Got: Update")
+										},
+									}
+								},
+							}
+						},
+					},
+				},
+			},
+			request: &tfprotov5.ApplyResourceChangeRequest{
+				PlannedPrivate: privatestate.MustMarshalToJson(map[string][]byte{
+					".frameworkKey": []byte(`{"frameworkKey": "framework value"}`),
+				}),
+				PlannedState: &testEmptyDynamicValue,
+				PriorState: testNewDynamicValue(t, testSchemaType, map[string]tftypes.Value{
+					"test_computed": tftypes.NewValue(tftypes.String, nil),
+					"test_required": tftypes.NewValue(tftypes.String, "test-priorstate-value"),
+				}),
+				TypeName: "test_resource",
+			},
+			expectedResponse: &tfprotov5.ApplyResourceChangeResponse{
+				Diagnostics: []*tfprotov5.Diagnostic{
+					{
+						Severity: tfprotov5.DiagnosticSeverityError,
+						Summary:  "error summary",
+						Detail:   "error detail",
+					},
+				},
+				Private: privatestate.MustMarshalToJson(map[string][]byte{
+					".frameworkKey": []byte(`{"frameworkKey": "framework value"}`),
+					"providerKey":   []byte(`{"key": "value"}`),
+				}),
+				NewState: testNewDynamicValue(t, testSchemaType, map[string]tftypes.Value{
+					"test_computed": tftypes.NewValue(tftypes.String, nil),
+					"test_required": tftypes.NewValue(tftypes.String, "test-priorstate-value"),
+				}),
+			},
+		},
 		"delete-response-newstate": {
 			server: &Server{
 				FrameworkServer: fwserver.Server{

--- a/resource/delete.go
+++ b/resource/delete.go
@@ -37,6 +37,14 @@ type DeleteResponse struct {
 	// should be set during the resource's Update operation.
 	State tfsdk.State
 
+	// Private is the private state resource data following the Delete
+	// operation. This field is pre-populated from DeleteRequest.Private and
+	// can be modified during the resource's Delete operation in cases where
+	// an error diagnostic is being returned. Otherwise if no error diagnostic
+	// is being returned, indicating that the resource was successfully deleted,
+	// this data will be automatically cleared to prevent Terraform errors.
+	Private *privatestate.ProviderData
+
 	// Diagnostics report errors or warnings related to deleting the
 	// resource. An empty slice indicates a successful operation with no
 	// warnings or errors generated.


### PR DESCRIPTION
Closes #863

The previous implementation assumed that Terraform core would preserve private state similar to "regular" state when a provider returned an error diagnostic while destroying a resource. The core implementation instead always uses the response data, which the framework was previously always discarding. This change corrects the errant design while also enabling provider logic to potentially update the private state in this situation.