### PR TITLE
types/basetypes: Add Tuple type support

### DIFF
--- a/.changes/unreleased/FEATURES-20231102-160132.yaml
+++ b/.changes/unreleased/FEATURES-20231102-160132.yaml
@@ -1,5 +1,5 @@
-kind: FEATURES
-body: 'types/basetypes: Added TupleType and TupleValue implementations'
+kind: ENHANCEMENTS
+body: 'types/basetypes: Added `TupleType` and `TupleValue` implementations, which are only necessary for dynamic value handling'
 time: 2023-11-02T16:01:32.166746-04:00
 custom:
   Issue: "870"

--- a/.changes/unreleased/FEATURES-20231102-160132.yaml
+++ b/.changes/unreleased/FEATURES-20231102-160132.yaml
@@ -1,0 +1,5 @@
+kind: FEATURES
+body: 'types/basetypes: Added TupleType and TupleValue implementations'
+time: 2023-11-02T16:01:32.166746-04:00
+custom:
+  Issue: "870"

--- a/internal/fromtftypes/value_test.go
+++ b/internal/fromtftypes/value_test.go
@@ -255,6 +255,51 @@ func TestValue(t *testing.T) {
 				},
 			),
 		},
+		"tuple-null": {
+			tfType: tftypes.NewValue(
+				tftypes.Tuple{
+					ElementTypes: []tftypes.Type{tftypes.String, tftypes.Bool},
+				},
+				nil,
+			),
+			attrType: types.TupleType{
+				ElemTypes: []attr.Type{types.StringType, types.BoolType},
+			},
+			expected: types.TupleNull([]attr.Type{types.StringType, types.BoolType}),
+		},
+		"tuple-unknown": {
+			tfType: tftypes.NewValue(
+				tftypes.Tuple{
+					ElementTypes: []tftypes.Type{tftypes.String, tftypes.Bool},
+				},
+				tftypes.UnknownValue,
+			),
+			attrType: types.TupleType{
+				ElemTypes: []attr.Type{types.StringType, types.BoolType},
+			},
+			expected: types.TupleUnknown([]attr.Type{types.StringType, types.BoolType}),
+		},
+		"tuple-value": {
+			tfType: tftypes.NewValue(
+				tftypes.Tuple{
+					ElementTypes: []tftypes.Type{tftypes.String, tftypes.Bool},
+				},
+				[]tftypes.Value{
+					tftypes.NewValue(tftypes.String, "test-value"),
+					tftypes.NewValue(tftypes.Bool, true),
+				},
+			),
+			attrType: types.TupleType{
+				ElemTypes: []attr.Type{types.StringType, types.BoolType},
+			},
+			expected: types.TupleValueMust(
+				[]attr.Type{types.StringType, types.BoolType},
+				[]attr.Value{
+					types.StringValue("test-value"),
+					types.BoolValue(true),
+				},
+			),
+		},
 		"string-null": {
 			tfType:   tftypes.NewValue(tftypes.String, nil),
 			attrType: types.StringType,

--- a/internal/reflect/interfaces_test.go
+++ b/internal/reflect/interfaces_test.go
@@ -703,6 +703,27 @@ func TestFromAttributeValue(t *testing.T) {
 			val:      types.StringNull(),
 			expected: types.StringNull(),
 		},
+		"TupleType-TupleValue-matching-elements": {
+			typ:      types.TupleType{ElemTypes: []attr.Type{types.StringType, types.BoolType}},
+			val:      types.TupleNull([]attr.Type{types.StringType, types.BoolType}),
+			expected: types.TupleNull([]attr.Type{types.StringType, types.BoolType}),
+		},
+		"TupleType-TupleValue-mismatching-elements": {
+			typ:      types.TupleType{ElemTypes: []attr.Type{types.StringType, types.BoolType}},
+			val:      types.TupleNull([]attr.Type{types.BoolType, types.StringType}),
+			expected: nil,
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("test"),
+					"Value Conversion Error",
+					"An unexpected error was encountered while verifying an attribute value matched its expected type to prevent unexpected behavior or panics. "+
+						"This is always an error in the provider. Please report the following to the provider developer:\n\n"+
+						"Expected framework type from provider logic: types.TupleType[basetypes.StringType, basetypes.BoolType] / underlying type: tftypes.Tuple[tftypes.String, tftypes.Bool]\n"+
+						"Received framework type from provider logic: types.TupleType[basetypes.BoolType, basetypes.StringType] / underlying type: tftypes.Tuple[tftypes.Bool, tftypes.String]\n"+
+						"Path: test",
+				),
+			},
+		},
 	}
 
 	for name, tc := range testCases {

--- a/internal/reflect/into_test.go
+++ b/internal/reflect/into_test.go
@@ -21,9 +21,6 @@ import (
 func TestInto_Slices(t *testing.T) {
 	t.Parallel()
 
-	// Just using this to get the reflected type for the odd diagnostics :-)
-	var stringSlice []string
-
 	testCases := map[string]struct {
 		typ           attr.Type
 		value         tftypes.Value
@@ -73,7 +70,7 @@ func TestInto_Slices(t *testing.T) {
 							tftypes.NewValue(tftypes.String, "hello"),
 							tftypes.NewValue(tftypes.String, "world"),
 						}),
-						TargetType: reflect.TypeOf(stringSlice),
+						TargetType: reflect.TypeOf([]string{}),
 						Err:        errors.New("cannot reflect tftypes.Tuple[tftypes.String, tftypes.String] using type information provided by basetypes.TupleType, reflection support is currently not implemented for tuples"),
 					},
 				),
@@ -89,7 +86,7 @@ func TestInto_Slices(t *testing.T) {
 					path.Empty(),
 					refl.DiagIntoIncompatibleType{
 						Val:        tftypes.NewValue(tftypes.String, "hello"),
-						TargetType: reflect.TypeOf(stringSlice),
+						TargetType: reflect.TypeOf([]string{}),
 						Err:        errors.New("can't unmarshal tftypes.String into *[]tftypes.Value expected []tftypes.Value"),
 					},
 				),

--- a/internal/reflect/into_test.go
+++ b/internal/reflect/into_test.go
@@ -1,0 +1,119 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package reflect_test
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	refl "github.com/hashicorp/terraform-plugin-framework/internal/reflect"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func TestInto_Slices(t *testing.T) {
+	t.Parallel()
+
+	// Just using this to get the reflected type for the odd diagnostics :-)
+	var stringSlice []string
+
+	testCases := map[string]struct {
+		typ           attr.Type
+		value         tftypes.Value
+		target        []string
+		expected      []string
+		expectedDiags diag.Diagnostics
+	}{
+		"list-to-go-slice": {
+			typ: types.ListType{ElemType: types.StringType},
+			value: tftypes.NewValue(tftypes.List{
+				ElementType: tftypes.String,
+			}, []tftypes.Value{
+				tftypes.NewValue(tftypes.String, "hello"),
+				tftypes.NewValue(tftypes.String, "world"),
+			}),
+			target:   make([]string, 0),
+			expected: []string{"hello", "world"},
+		},
+		"set-to-go-slice": {
+			typ: types.SetType{ElemType: types.StringType},
+			value: tftypes.NewValue(tftypes.Set{
+				ElementType: tftypes.String,
+			}, []tftypes.Value{
+				tftypes.NewValue(tftypes.String, "hello"),
+				tftypes.NewValue(tftypes.String, "world"),
+			}),
+			target:   make([]string, 0),
+			expected: []string{"hello", "world"},
+		},
+		"tuple-to-go-slice-unsupported": {
+			typ: types.TupleType{ElemTypes: []attr.Type{types.StringType, types.StringType}},
+			value: tftypes.NewValue(tftypes.Tuple{
+				ElementTypes: []tftypes.Type{tftypes.String, tftypes.String},
+			}, []tftypes.Value{
+				tftypes.NewValue(tftypes.String, "hello"),
+				tftypes.NewValue(tftypes.String, "world"),
+			}),
+			target:   make([]string, 0),
+			expected: make([]string, 0),
+			expectedDiags: diag.Diagnostics{
+				diag.WithPath(
+					path.Empty(),
+					refl.DiagIntoIncompatibleType{
+						Val: tftypes.NewValue(tftypes.Tuple{
+							ElementTypes: []tftypes.Type{tftypes.String, tftypes.String},
+						}, []tftypes.Value{
+							tftypes.NewValue(tftypes.String, "hello"),
+							tftypes.NewValue(tftypes.String, "world"),
+						}),
+						TargetType: reflect.TypeOf(stringSlice),
+						Err:        errors.New("cannot reflect tftypes.Tuple[tftypes.String, tftypes.String] using type information provided by basetypes.TupleType, reflection support is currently not implemented for tuples"),
+					},
+				),
+			},
+		},
+		"list-to-incompatible-type": {
+			typ:      types.ListType{ElemType: types.StringType},
+			value:    tftypes.NewValue(tftypes.String, "hello"),
+			target:   make([]string, 0),
+			expected: make([]string, 0),
+			expectedDiags: diag.Diagnostics{
+				diag.WithPath(
+					path.Empty(),
+					refl.DiagIntoIncompatibleType{
+						Val:        tftypes.NewValue(tftypes.String, "hello"),
+						TargetType: reflect.TypeOf(stringSlice),
+						Err:        errors.New("can't unmarshal tftypes.String into *[]tftypes.Value expected []tftypes.Value"),
+					},
+				),
+			},
+		},
+	}
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			diags := refl.Into(context.Background(), testCase.typ, testCase.value, &testCase.target, refl.Options{}, path.Empty())
+
+			if diff := cmp.Diff(testCase.target, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+
+			if diff := cmp.Diff(diags, testCase.expectedDiags); diff != "" {
+				for _, d := range diags {
+					t.Logf("%s: %s\n%s\n", d.Severity(), d.Summary(), d.Detail())
+				}
+				t.Errorf("unexpected diagnostics: %s", diff)
+			}
+		})
+	}
+}

--- a/internal/reflect/outof_test.go
+++ b/internal/reflect/outof_test.go
@@ -18,9 +18,6 @@ import (
 func TestFromValue_go_types(t *testing.T) {
 	t.Parallel()
 
-	// Used for testing nil -> null attr.Value
-	var nilSlice []string
-
 	testCases := map[string]struct {
 		typ           attr.Type
 		value         any
@@ -29,17 +26,17 @@ func TestFromValue_go_types(t *testing.T) {
 	}{
 		"nil-go-slice-to-list-value": {
 			typ:      types.ListType{ElemType: types.StringType},
-			value:    nilSlice,
+			value:    new([]string),
 			expected: types.ListNull(types.StringType),
 		},
 		"nil-go-slice-to-set-value": {
 			typ:      types.SetType{ElemType: types.StringType},
-			value:    nilSlice,
+			value:    new([]string),
 			expected: types.SetNull(types.StringType),
 		},
 		"nil-go-slice-to-tuple-value": {
 			typ:      types.TupleType{ElemTypes: []attr.Type{types.StringType, types.StringType}},
-			value:    nilSlice,
+			value:    new([]string),
 			expected: types.TupleNull([]attr.Type{types.StringType, types.StringType}),
 		},
 		"go-slice-to-list-value": {

--- a/internal/reflect/outof_test.go
+++ b/internal/reflect/outof_test.go
@@ -1,0 +1,112 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package reflect_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	refl "github.com/hashicorp/terraform-plugin-framework/internal/reflect"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestFromValue_go_types(t *testing.T) {
+	t.Parallel()
+
+	// Used for testing nil -> null attr.Value
+	var nilSlice []string
+
+	testCases := map[string]struct {
+		typ           attr.Type
+		value         any
+		expected      attr.Value
+		expectedDiags diag.Diagnostics
+	}{
+		"nil-go-slice-to-list-value": {
+			typ:      types.ListType{ElemType: types.StringType},
+			value:    nilSlice,
+			expected: types.ListNull(types.StringType),
+		},
+		"nil-go-slice-to-set-value": {
+			typ:      types.SetType{ElemType: types.StringType},
+			value:    nilSlice,
+			expected: types.SetNull(types.StringType),
+		},
+		"nil-go-slice-to-tuple-value": {
+			typ:      types.TupleType{ElemTypes: []attr.Type{types.StringType, types.StringType}},
+			value:    nilSlice,
+			expected: types.TupleNull([]attr.Type{types.StringType, types.StringType}),
+		},
+		"go-slice-to-list-value": {
+			typ:   types.ListType{ElemType: types.StringType},
+			value: []string{"hello", "world"},
+			expected: types.ListValueMust(
+				types.StringType,
+				[]attr.Value{
+					types.StringValue("hello"),
+					types.StringValue("world"),
+				},
+			),
+		},
+		"go-slice-to-set-value": {
+			typ:   types.SetType{ElemType: types.StringType},
+			value: []string{"hello", "world"},
+			expected: types.SetValueMust(
+				types.StringType,
+				[]attr.Value{
+					types.StringValue("hello"),
+					types.StringValue("world"),
+				},
+			),
+		},
+		"go-slice-to-tuple-value-unsupported": {
+			typ:   types.TupleType{ElemTypes: []attr.Type{types.StringType, types.StringType}},
+			value: []any{"hello", "world"},
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Empty(),
+					"Value Conversion Error",
+					"An unexpected error was encountered trying to convert from slice value. This is always an error in the provider. Please report the following to the provider developer:\n\n"+
+						"cannot use type []interface {} as schema type basetypes.TupleType; reflection support is currently not implemented for tuples",
+				),
+			},
+		},
+		"go-slice-incompatible-type": {
+			typ:   types.StringType,
+			value: []string{"hello", "world"},
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Empty(),
+					"Value Conversion Error",
+					"An unexpected error was encountered trying to convert from slice value. This is always an error in the provider. Please report the following to the provider developer:\n\n"+
+						"cannot use type []string as schema type basetypes.StringType; basetypes.StringType must be an attr.TypeWithElementType or attr.TypeWithElementTypes",
+				),
+			},
+		},
+	}
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, diags := refl.FromValue(context.Background(), testCase.typ, testCase.value, path.Empty())
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+
+			if diff := cmp.Diff(diags, testCase.expectedDiags); diff != "" {
+				for _, d := range diags {
+					t.Logf("%s: %s\n%s\n", d.Severity(), d.Summary(), d.Detail())
+				}
+				t.Errorf("unexpected diagnostics: %s", diff)
+			}
+		})
+	}
+}

--- a/internal/reflect/slice.go
+++ b/internal/reflect/slice.go
@@ -29,16 +29,6 @@ func reflectSlice(ctx context.Context, typ attr.Type, val tftypes.Value, target 
 		}))
 		return target, diags
 	}
-	// TODO: check that the val is a list or set or tuple
-	elemTyper, ok := typ.(attr.TypeWithElementType)
-	if !ok {
-		diags.Append(diag.WithPath(path, DiagIntoIncompatibleType{
-			Val:        val,
-			TargetType: target.Type(),
-			Err:        fmt.Errorf("cannot reflect %s using type information provided by %T, %T must be an attr.TypeWithElementType", val.Type(), typ, typ),
-		}))
-		return target, diags
-	}
 
 	// we need our value to become a list of values so we can iterate over
 	// them and handle them individually
@@ -53,50 +43,69 @@ func reflectSlice(ctx context.Context, typ attr.Type, val tftypes.Value, target 
 		return target, diags
 	}
 
-	// we need to know the type the slice is wrapping
-	elemType := target.Type().Elem()
-	elemAttrType := elemTyper.ElementType()
+	switch t := typ.(type) {
+	// List or Set
+	case attr.TypeWithElementType:
+		// we need to know the type the slice is wrapping
+		elemType := target.Type().Elem()
+		// we want an empty version of the slice
+		slice := reflect.MakeSlice(target.Type(), 0, len(values))
 
-	// we want an empty version of the slice
-	slice := reflect.MakeSlice(target.Type(), 0, len(values))
+		elemAttrType := t.ElementType()
 
-	// go over each of the values passed in, create a Go value of the right
-	// type for them, and add it to our new slice
-	for pos, value := range values {
-		// create a new Go value of the type that can go in the slice
-		targetValue := reflect.Zero(elemType)
+		// go over each of the values passed in, create a Go value of the right
+		// type for them, and add it to our new slice
+		for pos, value := range values {
+			// create a new Go value of the type that can go in the slice
+			targetValue := reflect.Zero(elemType)
 
-		// update our path so we can have nice errors
-		valPath := path.AtListIndex(pos)
+			// update our path so we can have nice errors
+			valPath := path.AtListIndex(pos)
 
-		if typ.TerraformType(ctx).Is(tftypes.Set{}) {
-			attrVal, err := elemAttrType.ValueFromTerraform(ctx, value)
+			if typ.TerraformType(ctx).Is(tftypes.Set{}) {
+				attrVal, err := elemAttrType.ValueFromTerraform(ctx, value)
 
-			if err != nil {
-				diags.AddAttributeError(
-					path,
-					"Value Conversion Error",
-					"An unexpected error was encountered trying to convert to slice value. This is always an error in the provider. Please report the following to the provider developer:\n\n"+err.Error(),
-				)
+				if err != nil {
+					diags.AddAttributeError(
+						path,
+						"Value Conversion Error",
+						"An unexpected error was encountered trying to convert to slice value. This is always an error in the provider. Please report the following to the provider developer:\n\n"+err.Error(),
+					)
+					return target, diags
+				}
+
+				valPath = path.AtSetValue(attrVal)
+			}
+
+			// reflect the value into our new target
+			val, valDiags := BuildValue(ctx, elemAttrType, value, targetValue, opts, valPath)
+			diags.Append(valDiags...)
+
+			if diags.HasError() {
 				return target, diags
 			}
 
-			valPath = path.AtSetValue(attrVal)
+			// add the new target to our slice
+			slice = reflect.Append(slice, val)
 		}
 
-		// reflect the value into our new target
-		val, valDiags := BuildValue(ctx, elemAttrType, value, targetValue, opts, valPath)
-		diags.Append(valDiags...)
-
-		if diags.HasError() {
-			return target, diags
-		}
-
-		// add the new target to our slice
-		slice = reflect.Append(slice, val)
+		return slice, diags
+	// Tuple reflection from slices is currently not supported as usage is limited
+	case attr.TypeWithElementTypes:
+		diags.Append(diag.WithPath(path, DiagIntoIncompatibleType{
+			Val:        val,
+			TargetType: target.Type(),
+			Err:        fmt.Errorf("cannot reflect %s using type information provided by %T, reflection support is currently not implemented for tuples", val.Type(), t),
+		}))
+		return target, diags
+	default:
+		diags.Append(diag.WithPath(path, DiagIntoIncompatibleType{
+			Val:        val,
+			TargetType: target.Type(),
+			Err:        fmt.Errorf("cannot reflect %s using type information provided by %T, %T must be an attr.TypeWithElementType or attr.TypeWithElementTypes", val.Type(), typ, typ),
+		}))
+		return target, diags
 	}
-
-	return slice, diags
 }
 
 // FromSlice returns an attr.Value as produced by `typ` using the data in
@@ -110,7 +119,6 @@ func reflectSlice(ctx context.Context, typ attr.Type, val tftypes.Value, target 
 func FromSlice(ctx context.Context, typ attr.Type, val reflect.Value, path path.Path) (attr.Value, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
-	// TODO: support tuples, which are attr.TypeWithElementTypes
 	tfType := typ.TerraformType(ctx)
 
 	if val.IsNil() {
@@ -138,51 +146,61 @@ func FromSlice(ctx context.Context, typ attr.Type, val reflect.Value, path path.
 		return attrVal, diags
 	}
 
-	t, ok := typ.(attr.TypeWithElementType)
-	if !ok {
-		err := fmt.Errorf("cannot use type %T as schema type %T; %T must be an attr.TypeWithElementType to hold %T", val, typ, typ, val)
+	tfElems := make([]tftypes.Value, 0, val.Len())
+	switch t := typ.(type) {
+	// List or Set
+	case attr.TypeWithElementType:
+		elemType := t.ElementType()
+		for i := 0; i < val.Len(); i++ {
+			// The underlying reflect.Slice is fetched by Index(). For set types,
+			// the path is value-based instead of index-based. Since there is only
+			// the index until the value is retrieved, this will pass the
+			// technically incorrect index-based path at first for framework
+			// debugging purposes, then correct the path afterwards.
+			valPath := path.AtListIndex(i)
+
+			val, valDiags := FromValue(ctx, elemType, val.Index(i).Interface(), valPath)
+			diags.Append(valDiags...)
+
+			if diags.HasError() {
+				return nil, diags
+			}
+
+			tfVal, err := val.ToTerraformValue(ctx)
+			if err != nil {
+				return nil, append(diags, toTerraformValueErrorDiag(err, path))
+			}
+
+			if tfType.Is(tftypes.Set{}) {
+				valPath = path.AtSetValue(val)
+			}
+
+			if typeWithValidate, ok := elemType.(xattr.TypeWithValidate); ok {
+				diags.Append(typeWithValidate.Validate(ctx, tfVal, valPath)...)
+				if diags.HasError() {
+					return nil, diags
+				}
+			}
+
+			tfElems = append(tfElems, tfVal)
+		}
+	// Tuple reflection from slices is currently not supported as usage is limited
+	case attr.TypeWithElementTypes:
+		err := fmt.Errorf("cannot use type %s as schema type %T; reflection support is currently not implemented for tuples", val.Type(), t)
 		diags.AddAttributeError(
 			path,
 			"Value Conversion Error",
 			"An unexpected error was encountered trying to convert from slice value. This is always an error in the provider. Please report the following to the provider developer:\n\n"+err.Error(),
 		)
 		return nil, diags
-	}
-
-	elemType := t.ElementType()
-	tfElems := make([]tftypes.Value, 0, val.Len())
-	for i := 0; i < val.Len(); i++ {
-		// The underlying reflect.Slice is fetched by Index(). For set types,
-		// the path is value-based instead of index-based. Since there is only
-		// the index until the value is retrieved, this will pass the
-		// technically incorrect index-based path at first for framework
-		// debugging purposes, then correct the path afterwards.
-		valPath := path.AtListIndex(i)
-
-		val, valDiags := FromValue(ctx, elemType, val.Index(i).Interface(), valPath)
-		diags.Append(valDiags...)
-
-		if diags.HasError() {
-			return nil, diags
-		}
-
-		tfVal, err := val.ToTerraformValue(ctx)
-		if err != nil {
-			return nil, append(diags, toTerraformValueErrorDiag(err, path))
-		}
-
-		if tfType.Is(tftypes.Set{}) {
-			valPath = path.AtSetValue(val)
-		}
-
-		if typeWithValidate, ok := elemType.(xattr.TypeWithValidate); ok {
-			diags.Append(typeWithValidate.Validate(ctx, tfVal, valPath)...)
-			if diags.HasError() {
-				return nil, diags
-			}
-		}
-
-		tfElems = append(tfElems, tfVal)
+	default:
+		err := fmt.Errorf("cannot use type %s as schema type %T; %T must be an attr.TypeWithElementType or attr.TypeWithElementTypes", val.Type(), t, t)
+		diags.AddAttributeError(
+			path,
+			"Value Conversion Error",
+			"An unexpected error was encountered trying to convert from slice value. This is always an error in the provider. Please report the following to the provider developer:\n\n"+err.Error(),
+		)
+		return nil, diags
 	}
 
 	err := tftypes.ValidateValue(tfType, tfElems)

--- a/internal/reflect/slice.go
+++ b/internal/reflect/slice.go
@@ -48,10 +48,10 @@ func reflectSlice(ctx context.Context, typ attr.Type, val tftypes.Value, target 
 	case attr.TypeWithElementType:
 		// we need to know the type the slice is wrapping
 		elemType := target.Type().Elem()
+		elemAttrType := t.ElementType()
+
 		// we want an empty version of the slice
 		slice := reflect.MakeSlice(target.Type(), 0, len(values))
-
-		elemAttrType := t.ElementType()
 
 		// go over each of the values passed in, create a Go value of the right
 		// type for them, and add it to our new slice

--- a/types/basetypes/tuple_type.go
+++ b/types/basetypes/tuple_type.go
@@ -12,7 +12,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
-var _ attr.Type = TupleType{}
+var (
+	_ attr.Type                 = TupleType{}
+	_ attr.TypeWithElementTypes = TupleType{}
+)
 
 // TupleType implements a tuple type definition. This type intentionally includes less functionality
 // than other types in the type system as it has limited real world application and therefore
@@ -25,6 +28,11 @@ type TupleType struct {
 // ElementTypes returns the ordered attr.Type slice for the tuple.
 func (t TupleType) ElementTypes() []attr.Type {
 	return t.ElemTypes
+}
+
+// WithElementTypes returns a TupleType that is identical to `t`, but with the element types set to `types`.
+func (t TupleType) WithElementTypes(types []attr.Type) attr.TypeWithElementTypes {
+	return TupleType{ElemTypes: types}
 }
 
 // Equal returns true if `o` is also a TupleType and has the same ElemTypes in the same order.

--- a/types/basetypes/tuple_type.go
+++ b/types/basetypes/tuple_type.go
@@ -1,0 +1,131 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package basetypes
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+var _ attr.Type = TupleType{}
+
+// TupleType implements a tuple type definition. This type intentionally includes less functionality
+// than other types in the type system as it has limited real world application and therefore
+// is not exposed to provider developers.
+type TupleType struct {
+	// ElemTypes is an ordered list of element types for the tuple.
+	ElemTypes []attr.Type
+}
+
+// ElementTypes returns the ordered attr.Type slice for the tuple.
+func (t TupleType) ElementTypes() []attr.Type {
+	return t.ElemTypes
+}
+
+// Equal returns true if `o` is also a TupleType and has the same ElemTypes in the same order.
+func (t TupleType) Equal(o attr.Type) bool {
+	other, ok := o.(TupleType)
+
+	if !ok {
+		return false
+	}
+
+	if len(t.ElemTypes) != len(other.ElemTypes) {
+		return false
+	}
+
+	for i, elemType := range t.ElemTypes {
+		if elemType.Equal(other.ElemTypes[i]) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// ApplyTerraform5AttributePathStep applies the given AttributePathStep to the tuple.
+func (t TupleType) ApplyTerraform5AttributePathStep(step tftypes.AttributePathStep) (interface{}, error) {
+	// TODO: is this implemented correctly? Is this needed?
+	indexStep, ok := step.(tftypes.ElementKeyInt)
+	if !ok {
+		return nil, fmt.Errorf("cannot apply step %T to TupleType", step)
+	}
+
+	index := int(indexStep)
+	if len(t.ElemTypes) <= index {
+		return nil, fmt.Errorf("undefined element at index %d in TupleType", index)
+	}
+
+	return t.ElemTypes[index], nil
+}
+
+// String returns a human-friendly description of the TupleType.
+func (t TupleType) String() string {
+
+	// TODO: replace with string builder?
+	var typeStrings []string
+	for _, elemType := range t.ElemTypes {
+		typeStrings = append(typeStrings, elemType.String())
+	}
+
+	return "types.TupleType[" + strings.Join(typeStrings, ",") + "]"
+}
+
+// TerraformType returns the tftypes.Type that should be used to represent this type.
+func (t TupleType) TerraformType(ctx context.Context) tftypes.Type {
+	var tfTypes []tftypes.Type
+	for _, elemType := range t.ElemTypes {
+		tfTypes = append(tfTypes, elemType.TerraformType(ctx))
+	}
+
+	return tftypes.Tuple{
+		ElementTypes: tfTypes,
+	}
+}
+
+// ValueFromTerraform returns an attr.Value given a tftypes.Value. This is meant to convert
+// the tftypes.Value into a more convenient Go type for the provider to consume the data with.
+func (t TupleType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	if in.Type() == nil {
+		return NewTupleNull(t.ElementTypes()), nil
+	}
+	if !in.Type().Equal(t.TerraformType(ctx)) {
+		return nil, fmt.Errorf("expected %s, got %s", t.TerraformType(ctx), in.Type())
+	}
+	if !in.IsKnown() {
+		return NewTupleUnknown(t.ElementTypes()), nil
+	}
+	if in.IsNull() {
+		return NewTupleNull(t.ElementTypes()), nil
+	}
+	val := []tftypes.Value{}
+	err := in.As(&val)
+	if err != nil {
+		return nil, err
+	}
+	elems := make([]attr.Value, 0, len(val))
+	for i, elem := range val {
+		// TODO: is this safe?
+		av, err := t.ElemTypes[i].ValueFromTerraform(ctx, elem)
+		if err != nil {
+			return nil, err
+		}
+		elems = append(elems, av)
+	}
+
+	// ValueFromTerraform above on each element should make this safe.
+	// Otherwise, this will need to do some Diagnostics to error conversion.
+	return NewTupleValueMust(t.ElementTypes(), elems), nil
+}
+
+// ValueType returns the Value type.
+func (t TupleType) ValueType(_ context.Context) attr.Value {
+	return TupleValue{
+		elementTypes: t.ElementTypes(),
+	}
+}

--- a/types/basetypes/tuple_type_test.go
+++ b/types/basetypes/tuple_type_test.go
@@ -1,0 +1,445 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package basetypes
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func TestTupleTypeEqual(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		receiver TupleType
+		input    attr.Type
+		expected bool
+	}
+	tests := map[string]testCase{
+		"equal": {
+			receiver: TupleType{
+				ElemTypes: []attr.Type{
+					StringType{},
+					ObjectType{
+						AttrTypes: map[string]attr.Type{
+							"testattr": NumberType{},
+						},
+					},
+				},
+			},
+			input: TupleType{
+				ElemTypes: []attr.Type{
+					StringType{},
+					ObjectType{
+						AttrTypes: map[string]attr.Type{
+							"testattr": NumberType{},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		"diff-order": {
+			receiver: TupleType{
+				ElemTypes: []attr.Type{
+					StringType{},
+					NumberType{},
+				},
+			},
+			input: TupleType{
+				ElemTypes: []attr.Type{
+					NumberType{},
+					StringType{},
+				},
+			},
+			expected: false,
+		},
+		"diff-length": {
+			receiver: TupleType{
+				ElemTypes: []attr.Type{
+					StringType{},
+					StringType{},
+				},
+			},
+			input: TupleType{
+				ElemTypes: []attr.Type{
+					StringType{},
+				},
+			},
+			expected: false,
+		},
+		"wrong-type": {
+			receiver: TupleType{
+				ElemTypes: []attr.Type{
+					StringType{},
+				},
+			},
+			input:    ListType{ElemType: StringType{}},
+			expected: false,
+		},
+		"nil": {
+			receiver: TupleType{
+				ElemTypes: []attr.Type{
+					StringType{},
+				},
+			},
+			input:    nil,
+			expected: false,
+		},
+		"nil-elems": {
+			receiver: TupleType{},
+			input:    TupleType{},
+			expected: true,
+		},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := test.receiver.Equal(test.input)
+			if test.expected != got {
+				t.Errorf("Expected %v, got %v", test.expected, got)
+			}
+		})
+	}
+}
+
+func TestTupleTypeString(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		input    TupleType
+		expected string
+	}{
+		"ElemTypes-empty": {
+			input: TupleType{
+				ElemTypes: []attr.Type{},
+			},
+			expected: "types.TupleType[]",
+		},
+		"ElemTypes-one": {
+			input: TupleType{
+				ElemTypes: []attr.Type{
+					StringType{},
+				},
+			},
+			expected: "types.TupleType[basetypes.StringType]",
+		},
+		"ElemTypes-multiple": {
+			input: TupleType{
+				ElemTypes: []attr.Type{
+					StringType{},
+					ObjectType{
+						AttrTypes: map[string]attr.Type{
+							"testattr": NumberType{},
+						},
+					},
+				},
+			},
+			expected: "types.TupleType[basetypes.StringType, types.ObjectType[\"testattr\":basetypes.NumberType]]",
+		},
+		"ElemTypes-missing": {
+			input:    TupleType{},
+			expected: "types.TupleType[]", // intentionally similar to empty
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.input.String()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestTupleTypeTerraformType(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		input    TupleType
+		expected tftypes.Type
+	}
+	tests := map[string]testCase{
+		"tuple-of-strings": {
+			input: TupleType{
+				ElemTypes: []attr.Type{
+					StringType{},
+				},
+			},
+			expected: tftypes.Tuple{
+				ElementTypes: []tftypes.Type{
+					tftypes.String,
+				},
+			},
+		},
+		"tuple-of-tuple-of-strings": {
+			input: TupleType{
+				ElemTypes: []attr.Type{
+					TupleType{
+						ElemTypes: []attr.Type{
+							StringType{},
+						},
+					},
+				},
+			},
+			expected: tftypes.Tuple{
+				ElementTypes: []tftypes.Type{
+					tftypes.Tuple{
+						ElementTypes: []tftypes.Type{
+							tftypes.String,
+						},
+					},
+				},
+			},
+		},
+		"tuple-of-tuple-of-object": {
+			input: TupleType{
+				ElemTypes: []attr.Type{
+					TupleType{
+						ElemTypes: []attr.Type{
+							ObjectType{
+								AttrTypes: map[string]attr.Type{
+									"testattr": NumberType{},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: tftypes.Tuple{
+				ElementTypes: []tftypes.Type{
+					tftypes.Tuple{
+						ElementTypes: []tftypes.Type{
+							tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"testattr": tftypes.Number,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"ElemTypes-empty": {
+			input: TupleType{
+				ElemTypes: make([]attr.Type, 0),
+			},
+			expected: tftypes.Tuple{
+				ElementTypes: make([]tftypes.Type, 0),
+			},
+		},
+		"ElemTypes-missing": {
+			input: TupleType{},
+			expected: tftypes.Tuple{
+				ElementTypes: make([]tftypes.Type, 0),
+			},
+		},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := test.input.TerraformType(context.Background())
+			if !got.Equal(test.expected) {
+				t.Errorf("Expected %s, got %s", test.expected, got)
+			}
+		})
+	}
+}
+
+func TestTupleTypeValueFromTerraform(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		receiver    TupleType
+		input       tftypes.Value
+		expected    attr.Value
+		expectedErr string
+	}
+	tests := map[string]testCase{
+		"tuple-with-same-types": {
+			receiver: TupleType{
+				[]attr.Type{StringType{}, StringType{}},
+			},
+			input: tftypes.NewValue(tftypes.Tuple{
+				ElementTypes: []tftypes.Type{tftypes.String, tftypes.String},
+			}, []tftypes.Value{
+				tftypes.NewValue(tftypes.String, "hello"),
+				tftypes.NewValue(tftypes.String, "world"),
+			}),
+			expected: NewTupleValueMust(
+				[]attr.Type{StringType{}, StringType{}},
+				[]attr.Value{
+					NewStringValue("hello"),
+					NewStringValue("world"),
+				},
+			),
+		},
+		"tuple-with-multiple-types": {
+			receiver: TupleType{
+				ElemTypes: []attr.Type{StringType{}, BoolType{}},
+			},
+			input: tftypes.NewValue(tftypes.Tuple{
+				ElementTypes: []tftypes.Type{tftypes.String, tftypes.Bool},
+			}, []tftypes.Value{
+				tftypes.NewValue(tftypes.String, "hello"),
+				tftypes.NewValue(tftypes.Bool, true),
+			}),
+			expected: NewTupleValueMust(
+				[]attr.Type{StringType{}, BoolType{}},
+				[]attr.Value{
+					NewStringValue("hello"),
+					NewBoolValue(true),
+				},
+			),
+		},
+		"unknown-tuple": {
+			receiver: TupleType{
+				ElemTypes: []attr.Type{StringType{}, BoolType{}},
+			},
+			input: tftypes.NewValue(tftypes.Tuple{
+				ElementTypes: []tftypes.Type{tftypes.String, tftypes.Bool},
+			}, tftypes.UnknownValue),
+			expected: NewTupleUnknown([]attr.Type{StringType{}, BoolType{}}),
+		},
+		"partially-unknown-tuple": {
+			receiver: TupleType{
+				ElemTypes: []attr.Type{StringType{}, BoolType{}},
+			},
+			input: tftypes.NewValue(tftypes.Tuple{
+				ElementTypes: []tftypes.Type{tftypes.String, tftypes.Bool},
+			}, []tftypes.Value{
+				tftypes.NewValue(tftypes.String, "hello"),
+				tftypes.NewValue(tftypes.Bool, tftypes.UnknownValue),
+			}),
+			expected: NewTupleValueMust(
+				[]attr.Type{StringType{}, BoolType{}},
+				[]attr.Value{
+					NewStringValue("hello"),
+					NewBoolUnknown(),
+				},
+			),
+		},
+		"null-tuple": {
+			receiver: TupleType{
+				ElemTypes: []attr.Type{StringType{}, BoolType{}},
+			},
+			input: tftypes.NewValue(tftypes.Tuple{
+				ElementTypes: []tftypes.Type{tftypes.String, tftypes.Bool},
+			}, nil),
+			expected: NewTupleNull([]attr.Type{StringType{}, BoolType{}}),
+		},
+		"partially-null-tuple": {
+			receiver: TupleType{
+				ElemTypes: []attr.Type{StringType{}, BoolType{}},
+			},
+			input: tftypes.NewValue(tftypes.Tuple{
+				ElementTypes: []tftypes.Type{tftypes.String, tftypes.Bool},
+			}, []tftypes.Value{
+				tftypes.NewValue(tftypes.String, "hello"),
+				tftypes.NewValue(tftypes.Bool, nil),
+			}),
+			expected: NewTupleValueMust(
+				[]attr.Type{StringType{}, BoolType{}},
+				[]attr.Value{
+					NewStringValue("hello"),
+					NewBoolNull(),
+				},
+			),
+		},
+		"wrong-type": {
+			receiver: TupleType{
+				ElemTypes: []attr.Type{StringType{}},
+			},
+			input:       tftypes.NewValue(tftypes.Bool, true),
+			expectedErr: "expected tftypes.Tuple[tftypes.String], got tftypes.Bool",
+		},
+		"wrong-element-types": {
+			receiver: TupleType{
+				ElemTypes: []attr.Type{StringType{}, BoolType{}},
+			},
+			input: tftypes.NewValue(tftypes.Tuple{
+				ElementTypes: []tftypes.Type{tftypes.Bool, tftypes.String},
+			}, []tftypes.Value{
+				tftypes.NewValue(tftypes.Bool, true),
+				tftypes.NewValue(tftypes.String, "hello"),
+			}),
+			expectedErr: "expected tftypes.Tuple[tftypes.String, tftypes.Bool], got tftypes.Tuple[tftypes.Bool, tftypes.String]",
+		},
+		"mismatched-element-types-length": {
+			receiver: TupleType{
+				ElemTypes: []attr.Type{StringType{}, StringType{}},
+			},
+			input: tftypes.NewValue(tftypes.Tuple{
+				ElementTypes: []tftypes.Type{tftypes.String, tftypes.String, tftypes.String},
+			}, []tftypes.Value{
+				tftypes.NewValue(tftypes.String, "hello"),
+				tftypes.NewValue(tftypes.String, "world"),
+				tftypes.NewValue(tftypes.String, "invalid"),
+			}),
+			expectedErr: "expected tftypes.Tuple[tftypes.String, tftypes.String], got tftypes.Tuple[tftypes.String, tftypes.String, tftypes.String]",
+		},
+		"nil-type": {
+			receiver: TupleType{
+				ElemTypes: []attr.Type{StringType{}},
+			},
+			input:    tftypes.NewValue(nil, nil),
+			expected: NewTupleNull([]attr.Type{StringType{}}),
+		},
+		"missing-element-type": {
+			receiver: TupleType{},
+			input: tftypes.NewValue(tftypes.Tuple{
+				ElementTypes: make([]tftypes.Type, 0),
+			}, make([]tftypes.Value, 0)),
+			expected: NewTupleValueMust(
+				make([]attr.Type, 0),
+				make([]attr.Value, 0),
+			),
+		},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, gotErr := test.receiver.ValueFromTerraform(context.Background(), test.input)
+			if gotErr != nil {
+				if test.expectedErr == "" {
+					t.Errorf("Unexpected error: %s", gotErr.Error())
+					return
+				}
+				if gotErr.Error() != test.expectedErr {
+					t.Errorf("Expected error to be %q, got %q", test.expectedErr, gotErr.Error())
+					return
+				}
+			}
+			if gotErr == nil && test.expectedErr != "" {
+				t.Errorf("Expected error to be %q, got nil", test.expectedErr)
+				return
+			}
+			if diff := cmp.Diff(got, test.expected); diff != "" {
+				t.Errorf("Unexpected diff (-expected, +got): %s", diff)
+			}
+			if test.expected != nil && test.expected.IsNull() != test.input.IsNull() {
+				t.Errorf("Expected null-ness match: expected %t, got %t", test.expected.IsNull(), test.input.IsNull())
+			}
+			if test.expected != nil && test.expected.IsUnknown() != !test.input.IsKnown() {
+				t.Errorf("Expected unknown-ness match: expected %t, got %t", test.expected.IsUnknown(), !test.input.IsKnown())
+			}
+		})
+	}
+}

--- a/types/basetypes/tuple_value.go
+++ b/types/basetypes/tuple_value.go
@@ -131,7 +131,7 @@ func (v TupleValue) Elements() []attr.Value {
 	return result
 }
 
-// ElementTypes returns a copy of the ordered list of element types for the Tuple.
+// ElementTypes returns the ordered list of element types for the Tuple.
 func (v TupleValue) ElementTypes(ctx context.Context) []attr.Type {
 	return v.elementTypes
 }

--- a/types/basetypes/tuple_value.go
+++ b/types/basetypes/tuple_value.go
@@ -1,0 +1,259 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package basetypes
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+var _ attr.Value = TupleValue{}
+
+// NewTupleNull creates a Tuple with a null value.
+func NewTupleNull(elementTypes []attr.Type) TupleValue {
+	return TupleValue{
+		elementTypes: elementTypes,
+		state:        attr.ValueStateNull,
+	}
+}
+
+// NewTupleUnknown creates a Tuple with an unknown value.
+func NewTupleUnknown(elementTypes []attr.Type) TupleValue {
+	return TupleValue{
+		elementTypes: elementTypes,
+		state:        attr.ValueStateUnknown,
+	}
+}
+
+// NewTupleValue creates a Tuple with a known value. Access the value via the Tuple type Elements method.
+func NewTupleValue(elementTypes []attr.Type, elements []attr.Value) (TupleValue, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/521
+	ctx := context.Background()
+
+	if len(elementTypes) != len(elements) {
+		diags.AddError(
+			// TODO: this error message needs to be cleaned up
+			"Invalid Tuple Elements",
+			"While creating a Tuple value, mismatched elements were detected. "+
+				"A Tuple must be an ordered array of element types where values exactly match the defined length element types. "+
+				"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+				fmt.Sprintf("Tuple Expected Types: [%v]\n", elementTypes)+
+				fmt.Sprintf("Tuple Given Types: [%v]", elements),
+		)
+
+		return NewTupleUnknown(elementTypes), diags
+	}
+
+	// validation check for tuples
+	for i, element := range elements {
+		fmt.Println(ctx, i, element)
+
+		if !elementTypes[i].Equal(element.Type(ctx)) {
+			diags.AddError(
+				"Invalid Tuple Element Type",
+				// TODO: this error message needs to be cleaned up
+				"While creating a Tuple value, an invalid element was detected. "+
+					"A Tuple must be an ordered array of element types where values exactly match the element types. "+
+					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+					fmt.Sprintf("Tuple Index (%d) Expected Type: %s\n", i, elementTypes[i])+
+					fmt.Sprintf("Tuple Index (%d) Given Type: %s", i, element.Type(ctx)),
+			)
+		}
+	}
+
+	if diags.HasError() {
+		return NewTupleUnknown(elementTypes), diags
+	}
+
+	return TupleValue{
+		elementTypes: elementTypes,
+		elements:     elements,
+		state:        attr.ValueStateKnown,
+	}, nil
+}
+
+// NewTupleValueMust creates a Tuple with a known value, converting any diagnostics
+// into a panic at runtime. Access the value via the Tuple type Elements method.
+//
+// This creation function is only recommended to create Tuple values which will
+// not potentially affect practitioners, such as testing, or exhaustively
+// tested provider logic.
+func NewTupleValueMust(elementTypes []attr.Type, elements []attr.Value) TupleValue {
+	tuple, diags := NewTupleValue(elementTypes, elements)
+
+	if diags.HasError() {
+		// This could potentially be added to the diag package.
+		diagsStrings := make([]string, 0, len(diags))
+
+		for _, diagnostic := range diags {
+			diagsStrings = append(diagsStrings, fmt.Sprintf(
+				"%s | %s | %s",
+				diagnostic.Severity(),
+				diagnostic.Summary(),
+				diagnostic.Detail()))
+		}
+
+		panic("NewTupleValueMust received error(s): " + strings.Join(diagsStrings, "\n"))
+	}
+
+	return tuple
+}
+
+// TupleValue represents an ordered list of attr.Value, with an attr.Type for each element. This type intentionally
+// includes less functionality than other types in the type system as it has limited real world application and therefore
+// is not exposed to provider developers.
+type TupleValue struct {
+	// elements is the ordered list of known element values for the tuple.
+	elements []attr.Value
+
+	// elementTypes is the ordered list of elements types for the tuple.
+	elementTypes []attr.Type
+
+	// state represents whether the value is null, unknown, or known. The
+	// zero-value is null.
+	state attr.ValueState
+}
+
+// Elements returns a copy of the ordered list of known values for the Tuple.
+func (v TupleValue) Elements() []attr.Value {
+	// Ensure callers cannot mutate the internal elements
+	result := make([]attr.Value, 0, len(v.elements))
+	result = append(result, v.elements...)
+
+	return result
+}
+
+// ElementTypes returns a copy of the ordered list of element types for the Tuple.
+func (v TupleValue) ElementTypes(ctx context.Context) []attr.Type {
+	return v.elementTypes
+}
+
+// Equal returns true if the given attr.Value is also a Tuple, has the same value state,
+// and contains exactly the same element types/values as defined by the Equal method of those
+// underlying types/values.
+func (v TupleValue) Equal(o attr.Value) bool {
+	other, ok := o.(TupleValue)
+	if !ok {
+		return false
+	}
+
+	if len(v.elementTypes) != len(other.elementTypes) {
+		return false
+	}
+
+	for i, elementType := range v.elementTypes {
+		if !elementType.Equal(other.elementTypes[i]) {
+			return false
+		}
+	}
+
+	if v.state != other.state {
+		return false
+	}
+
+	if v.state != attr.ValueStateKnown {
+		return true
+	}
+
+	if len(v.elements) != len(other.elements) {
+		return false
+	}
+
+	for i, element := range v.elements {
+		if !element.Equal(other.elements[i]) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// IsNull returns true if the Tuple represents a null value.
+func (v TupleValue) IsNull() bool {
+	return v.state == attr.ValueStateNull
+}
+
+// IsUnknown returns true if the Tuple represents an unknown value.
+func (v TupleValue) IsUnknown() bool {
+	return v.state == attr.ValueStateUnknown
+}
+
+// String returns a human-readable representation of the Tuple. The string returned here is not protected by any
+// compatibility guarantees, and is intended for logging and error reporting.
+func (v TupleValue) String() string {
+	if v.IsUnknown() {
+		return attr.UnknownValueString
+	}
+
+	if v.IsNull() {
+		return attr.NullValueString
+	}
+
+	var res strings.Builder
+
+	res.WriteString("[")
+	for i, e := range v.Elements() {
+		if i != 0 {
+			res.WriteString(",")
+		}
+		res.WriteString(e.String())
+	}
+	res.WriteString("]")
+
+	return res.String()
+}
+
+// Type returns a TupleType with the elements types for the Tuple.
+func (v TupleValue) Type(ctx context.Context) attr.Type {
+	return TupleType{
+		ElemTypes: v.ElementTypes(ctx),
+	}
+}
+
+// ToTerraformValue returns the equivalent tftypes.Value for the Tuple.
+func (v TupleValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
+	tfTypes := make([]tftypes.Type, len(v.elementTypes))
+	for i, elementType := range v.elementTypes {
+		tfTypes[i] = elementType.TerraformType(ctx)
+	}
+
+	tupleType := tftypes.Tuple{ElementTypes: tfTypes}
+
+	switch v.state {
+	case attr.ValueStateKnown:
+		vals := make([]tftypes.Value, 0, len(v.elements))
+
+		for _, elem := range v.elements {
+			val, err := elem.ToTerraformValue(ctx)
+
+			if err != nil {
+				return tftypes.NewValue(tupleType, tftypes.UnknownValue), err
+			}
+
+			vals = append(vals, val)
+		}
+
+		if err := tftypes.ValidateValue(tupleType, vals); err != nil {
+			return tftypes.NewValue(tupleType, tftypes.UnknownValue), err
+		}
+
+		return tftypes.NewValue(tupleType, vals), nil
+	case attr.ValueStateNull:
+		return tftypes.NewValue(tupleType, nil), nil
+	case attr.ValueStateUnknown:
+		return tftypes.NewValue(tupleType, tftypes.UnknownValue), nil
+	default:
+		panic(fmt.Sprintf("unhandled Tuple state in ToTerraformValue: %s", v.state))
+	}
+}
+
+// TODO: NewTupleValueFrom? (reflection rules)
+// TODO: ElementsAs? (reflection rules)

--- a/types/basetypes/tuple_value.go
+++ b/types/basetypes/tuple_value.go
@@ -165,6 +165,8 @@ func (v TupleValue) Equal(o attr.Value) bool {
 		return true
 	}
 
+	// This statement should never be true, given that element type length must exactly match the number of elements,
+	// but checking to avoid an index out of range panic
 	if len(v.elements) != len(other.elements) {
 		return false
 	}
@@ -199,19 +201,14 @@ func (v TupleValue) String() string {
 		return attr.NullValueString
 	}
 
-	// TODO: replace with simple string.join
-	var res strings.Builder
+	elements := v.Elements()
+	valueStrings := make([]string, len(elements))
 
-	res.WriteString("[")
-	for i, e := range v.Elements() {
-		if i != 0 {
-			res.WriteString(",")
-		}
-		res.WriteString(e.String())
+	for i, element := range elements {
+		valueStrings[i] = element.String()
 	}
-	res.WriteString("]")
 
-	return res.String()
+	return "[" + strings.Join(valueStrings, ",") + "]"
 }
 
 // Type returns a TupleType with the elements types for the Tuple.

--- a/types/basetypes/tuple_value.go
+++ b/types/basetypes/tuple_value.go
@@ -57,8 +57,6 @@ func NewTupleValue(elementTypes []attr.Type, elements []attr.Value) (TupleValue,
 	}
 
 	for i, element := range elements {
-		fmt.Println(ctx, i, element)
-
 		if !elementTypes[i].Equal(element.Type(ctx)) {
 			diags.AddError(
 				"Invalid Tuple Element",

--- a/types/basetypes/tuple_value.go
+++ b/types/basetypes/tuple_value.go
@@ -39,29 +39,31 @@ func NewTupleValue(elementTypes []attr.Type, elements []attr.Value) (TupleValue,
 	ctx := context.Background()
 
 	if len(elementTypes) != len(elements) {
+		givenTypes := make([]attr.Type, len(elements))
+		for i, v := range elements {
+			givenTypes[i] = v.Type(ctx)
+		}
+
 		diags.AddError(
-			// TODO: this error message needs to be cleaned up
 			"Invalid Tuple Elements",
-			"While creating a Tuple value, mismatched elements were detected. "+
-				"A Tuple must be an ordered array of element types where values exactly match the defined length element types. "+
+			"While creating a Tuple value, mismatched element types were detected. "+
+				"A Tuple must be an ordered array of elements where the values exactly match the length and types of the defined element types. "+
 				"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
-				fmt.Sprintf("Tuple Expected Types: [%v]\n", elementTypes)+
-				fmt.Sprintf("Tuple Given Types: [%v]", elements),
+				fmt.Sprintf("Tuple Expected Type: %v\n", elementTypes)+
+				fmt.Sprintf("Tuple Given Type: %v", givenTypes),
 		)
 
 		return NewTupleUnknown(elementTypes), diags
 	}
 
-	// validation check for tuples
 	for i, element := range elements {
 		fmt.Println(ctx, i, element)
 
 		if !elementTypes[i].Equal(element.Type(ctx)) {
 			diags.AddError(
-				"Invalid Tuple Element Type",
-				// TODO: this error message needs to be cleaned up
+				"Invalid Tuple Element",
 				"While creating a Tuple value, an invalid element was detected. "+
-					"A Tuple must be an ordered array of element types where values exactly match the element types. "+
+					"A Tuple must be an ordered array of elements where the values exactly match the length and types of the defined element types. "+
 					"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
 					fmt.Sprintf("Tuple Index (%d) Expected Type: %s\n", i, elementTypes[i])+
 					fmt.Sprintf("Tuple Index (%d) Given Type: %s", i, element.Type(ctx)),
@@ -197,6 +199,7 @@ func (v TupleValue) String() string {
 		return attr.NullValueString
 	}
 
+	// TODO: replace with simple string.join
 	var res strings.Builder
 
 	res.WriteString("[")
@@ -254,6 +257,3 @@ func (v TupleValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error)
 		panic(fmt.Sprintf("unhandled Tuple state in ToTerraformValue: %s", v.state))
 	}
 }
-
-// TODO: NewTupleValueFrom? (reflection rules)
-// TODO: ElementsAs? (reflection rules)

--- a/types/basetypes/tuple_value_test.go
+++ b/types/basetypes/tuple_value_test.go
@@ -1,0 +1,360 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package basetypes
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+)
+
+func TestNewTupleValue(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		elementTypes  []attr.Type
+		elements      []attr.Value
+		expected      TupleValue
+		expectedDiags diag.Diagnostics
+	}{
+		"valid-elements": {
+			elementTypes: []attr.Type{StringType{}, BoolType{}, NumberType{}},
+			elements: []attr.Value{
+				NewStringNull(),
+				NewBoolValue(true),
+				NewNumberUnknown(),
+			},
+			expected: NewTupleValueMust(
+				[]attr.Type{StringType{}, BoolType{}, NumberType{}},
+				[]attr.Value{
+					NewStringNull(),
+					NewBoolValue(true),
+					NewNumberUnknown(),
+				},
+			),
+		},
+		"valid-no-elements-or-types": {
+			elementTypes: []attr.Type{},
+			elements:     []attr.Value{},
+			expected:     NewTupleValueMust([]attr.Type{}, []attr.Value{}),
+		},
+		"invalid-no-elements": {
+			elementTypes: []attr.Type{StringType{}, BoolType{}},
+			elements:     []attr.Value{},
+			expected:     NewTupleUnknown([]attr.Type{StringType{}, BoolType{}}),
+			expectedDiags: diag.Diagnostics{
+				diag.NewErrorDiagnostic(
+					"Invalid Tuple Elements",
+					"While creating a Tuple value, mismatched element types were detected. "+
+						"A Tuple must be an ordered array of elements where the values exactly match the length and types of the defined element types. "+
+						"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+						"Tuple Expected Type: [basetypes.StringType basetypes.BoolType]\n"+
+						"Tuple Given Type: []",
+				),
+			},
+		},
+		"invalid-mismatched-length": {
+			elementTypes: []attr.Type{StringType{}},
+			elements:     []attr.Value{NewStringValue("hello"), NewBoolValue(true)},
+			expected:     NewTupleUnknown([]attr.Type{StringType{}}),
+			expectedDiags: diag.Diagnostics{
+				diag.NewErrorDiagnostic(
+					"Invalid Tuple Elements",
+					"While creating a Tuple value, mismatched element types were detected. "+
+						"A Tuple must be an ordered array of elements where the values exactly match the length and types of the defined element types. "+
+						"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+						"Tuple Expected Type: [basetypes.StringType]\n"+
+						"Tuple Given Type: [basetypes.StringType basetypes.BoolType]",
+				),
+			},
+		},
+		"invalid-mismatched-element-types": {
+			elementTypes: []attr.Type{BoolType{}, StringType{}},
+			elements:     []attr.Value{NewStringValue("hello"), NewBoolValue(true)},
+			expected:     NewTupleUnknown([]attr.Type{BoolType{}, StringType{}}),
+			expectedDiags: diag.Diagnostics{
+				diag.NewErrorDiagnostic(
+					"Invalid Tuple Element",
+					"While creating a Tuple value, an invalid element was detected. "+
+						"A Tuple must be an ordered array of elements where the values exactly match the length and types of the defined element types. "+
+						"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+						"Tuple Index (0) Expected Type: basetypes.BoolType\n"+
+						"Tuple Index (0) Given Type: basetypes.StringType",
+				),
+				diag.NewErrorDiagnostic(
+					"Invalid Tuple Element",
+					"While creating a Tuple value, an invalid element was detected. "+
+						"A Tuple must be an ordered array of elements where the values exactly match the length and types of the defined element types. "+
+						"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+						"Tuple Index (1) Expected Type: basetypes.StringType\n"+
+						"Tuple Index (1) Given Type: basetypes.BoolType",
+				),
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, diags := NewTupleValue(testCase.elementTypes, testCase.elements)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+
+			if diff := cmp.Diff(diags, testCase.expectedDiags); diff != "" {
+				t.Errorf("unexpected diagnostics difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestTupleValueElements(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		input    TupleValue
+		expected []attr.Value
+	}{
+		"known": {
+			input: NewTupleValueMust(
+				[]attr.Type{StringType{}, BoolType{}},
+				[]attr.Value{NewStringValue("test"), NewBoolValue(true)},
+			),
+			expected: []attr.Value{NewStringValue("test"), NewBoolValue(true)},
+		},
+		"null": {
+			input:    NewTupleNull([]attr.Type{StringType{}, BoolType{}}),
+			expected: []attr.Value{},
+		},
+		"unknown": {
+			input:    NewTupleUnknown([]attr.Type{StringType{}, BoolType{}}),
+			expected: []attr.Value{},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.input.Elements()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestTupleValueElements_immutable(t *testing.T) {
+	t.Parallel()
+
+	value := NewTupleValueMust([]attr.Type{StringType{}}, []attr.Value{NewStringValue("original")})
+	value.Elements()[0] = NewStringValue("modified")
+
+	if !value.Equal(NewTupleValueMust([]attr.Type{StringType{}}, []attr.Value{NewStringValue("original")})) {
+		t.Fatal("unexpected Elements mutation")
+	}
+}
+
+func TestTupleValueElementType(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		input    TupleValue
+		expected []attr.Type
+	}{
+		"known": {
+			input:    NewTupleValueMust([]attr.Type{StringType{}, BoolType{}}, []attr.Value{NewStringValue("test"), NewBoolValue(true)}),
+			expected: []attr.Type{StringType{}, BoolType{}},
+		},
+		"null": {
+			input:    NewTupleNull([]attr.Type{StringType{}, BoolType{}}),
+			expected: []attr.Type{StringType{}, BoolType{}},
+		},
+		"unknown": {
+			input:    NewTupleUnknown([]attr.Type{StringType{}, BoolType{}}),
+			expected: []attr.Type{StringType{}, BoolType{}},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.input.ElementTypes(context.Background())
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+// TODO: Equal
+
+func TestTupleValueIsNull(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		input    TupleValue
+		expected bool
+	}{
+		"known": {
+			input:    NewTupleValueMust([]attr.Type{StringType{}, BoolType{}}, []attr.Value{NewStringValue("test"), NewBoolValue(true)}),
+			expected: false,
+		},
+		"null": {
+			input:    NewTupleNull([]attr.Type{StringType{}, BoolType{}}),
+			expected: true,
+		},
+		"unknown": {
+			input:    NewTupleUnknown([]attr.Type{StringType{}, BoolType{}}),
+			expected: false,
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.input.IsNull()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestTupleValueIsUnknown(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		input    TupleValue
+		expected bool
+	}{
+		"known": {
+			input:    NewTupleValueMust([]attr.Type{StringType{}, BoolType{}}, []attr.Value{NewStringValue("test"), NewBoolValue(true)}),
+			expected: false,
+		},
+		"null": {
+			input:    NewTupleNull([]attr.Type{StringType{}, BoolType{}}),
+			expected: false,
+		},
+		"unknown": {
+			input:    NewTupleUnknown([]attr.Type{StringType{}, BoolType{}}),
+			expected: true,
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.input.IsUnknown()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+// TODO: String tests
+
+func TestTupleValueType(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		input       TupleValue
+		expectation attr.Type
+	}
+	tests := map[string]testCase{
+		"known": {
+			input: NewTupleValueMust(
+				[]attr.Type{StringType{}, StringType{}},
+				[]attr.Value{
+					NewStringValue("hello"),
+					NewStringValue("world"),
+				},
+			),
+			expectation: TupleType{ElemTypes: []attr.Type{StringType{}, StringType{}}},
+		},
+		"known-tuple-of-tuples": {
+			input: NewTupleValueMust(
+				[]attr.Type{
+					TupleType{
+						ElemTypes: []attr.Type{StringType{}, StringType{}},
+					},
+					TupleType{
+						ElemTypes: []attr.Type{BoolType{}, BoolType{}},
+					},
+				},
+				[]attr.Value{
+					NewTupleValueMust(
+						[]attr.Type{StringType{}, StringType{}},
+						[]attr.Value{
+							NewStringValue("hello"),
+							NewStringValue("world"),
+						},
+					),
+					NewTupleValueMust(
+						[]attr.Type{BoolType{}, BoolType{}},
+						[]attr.Value{
+							NewBoolValue(true),
+							NewBoolValue(false),
+						},
+					),
+				},
+			),
+			expectation: TupleType{
+				ElemTypes: []attr.Type{
+					TupleType{
+						ElemTypes: []attr.Type{StringType{}, StringType{}},
+					},
+					TupleType{
+						ElemTypes: []attr.Type{BoolType{}, BoolType{}},
+					},
+				},
+			},
+		},
+		"unknown": {
+			input:       NewTupleUnknown([]attr.Type{StringType{}, NumberType{}}),
+			expectation: TupleType{ElemTypes: []attr.Type{StringType{}, NumberType{}}},
+		},
+		"null": {
+			input:       NewTupleNull([]attr.Type{StringType{}, NumberType{}}),
+			expectation: TupleType{ElemTypes: []attr.Type{StringType{}, NumberType{}}},
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := test.input.Type(context.Background())
+			if !cmp.Equal(got, test.expectation) {
+				t.Errorf("Expected %q, got %q", test.expectation, got)
+			}
+		})
+	}
+}
+
+// TODO: ToTerraformValue tests

--- a/types/tuple_type.go
+++ b/types/tuple_type.go
@@ -1,0 +1,8 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package types
+
+import "github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+
+type TupleType = basetypes.TupleType

--- a/types/tuple_value.go
+++ b/types/tuple_value.go
@@ -37,5 +37,3 @@ func TupleValue(elementTypes []attr.Type, elements []attr.Value) (basetypes.Tupl
 func TupleValueMust(elementTypes []attr.Type, elements []attr.Value) basetypes.TupleValue {
 	return basetypes.NewTupleValueMust(elementTypes, elements)
 }
-
-// TODO: TupleValueFrom?

--- a/types/tuple_value.go
+++ b/types/tuple_value.go
@@ -1,0 +1,41 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package types
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+type Tuple = basetypes.TupleValue
+
+// TupleNull creates a Tuple with a null value. Determine whether the value is
+// null via the Tuple type IsNull method.
+func TupleNull(elementTypes []attr.Type) basetypes.TupleValue {
+	return basetypes.NewTupleNull(elementTypes)
+}
+
+// TupleUnknown creates a Tuple with an unknown value. Determine whether the
+// value is unknown via the Tuple type IsUnknown method.
+func TupleUnknown(elementTypes []attr.Type) basetypes.TupleValue {
+	return basetypes.NewTupleUnknown(elementTypes)
+}
+
+// TupleValue creates a Tuple with a known value. Access the value via the Tuple type Elements method.
+func TupleValue(elementTypes []attr.Type, elements []attr.Value) (basetypes.TupleValue, diag.Diagnostics) {
+	return basetypes.NewTupleValue(elementTypes, elements)
+}
+
+// TupleValueMust creates a Tuple with a known value, converting any diagnostics
+// into a panic at runtime. Access the value via the Tuple type Elements method.
+//
+// This creation function is only recommended to create Tuple values which will
+// not potentially affect practitioners, such as testing, or exhaustively
+// tested provider logic.
+func TupleValueMust(elementTypes []attr.Type, elements []attr.Value) basetypes.TupleValue {
+	return basetypes.NewTupleValueMust(elementTypes, elements)
+}
+
+// TODO: TupleValueFrom?

--- a/website/data/plugin-framework-nav-data.json
+++ b/website/data/plugin-framework-nav-data.json
@@ -255,6 +255,10 @@
             "path": "handling-data/types/string"
           },
           {
+            "title": "Tuple",
+            "path": "handling-data/types/tuple"
+          },
+          {
             "title": "Custom Types",
             "path": "handling-data/types/custom"
           }

--- a/website/docs/plugin/framework/handling-data/types/index.mdx
+++ b/website/docs/plugin/framework/handling-data/types/index.mdx
@@ -66,7 +66,7 @@ This type is associated with:
 Type that defines an ordered collection of elements where each element has it's own type.
 
 <Note>
-This type intentionally includes less functionality than other types in the type system as it has limited real world application and therefore is not exposed to provider developers.
+This type intentionally includes less functionality than other types in the type system as it has limited real world application and therefore is not exposed to provider developers except when working with dynamic values.
 </Note>
 
 | Type | Use Case |

--- a/website/docs/plugin/framework/handling-data/types/index.mdx
+++ b/website/docs/plugin/framework/handling-data/types/index.mdx
@@ -60,3 +60,15 @@ This type is associated with:
 | Type | Use Case |
 |----------------|----------|
 | [Object](/terraform/plugin/framework/handling-data/types/object) | Mapping of explicit attribute names to values |
+
+### Tuple Type
+
+Type that defines an ordered collection of elements where each element has it's own type.
+
+<Note>
+This type intentionally includes less functionality than other types in the type system as it has limited real world application and therefore is not exposed to provider developers.
+</Note>
+
+| Type | Use Case |
+|----------------|----------|
+| [Tuple](/terraform/plugin/framework/handling-data/types/tuple) | Ordered collection of multiple element types |

--- a/website/docs/plugin/framework/handling-data/types/list.mdx
+++ b/website/docs/plugin/framework/handling-data/types/list.mdx
@@ -83,7 +83,7 @@ Call one of the following to create a `types.List` value:
 * [`types.ListUnknown(attr.Type) types.List`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/types#ListUnknown): An unknown list value with the given element type.
 * [`types.ListValue(attr.Type, []attr.Value) (types.List, diag.Diagnostics)`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/types#ListValue): A known value with the given element type and values.
 * [`types.ListValueFrom(context.Context, attr.Type, any) (types.List, diag.Diagnostics)`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/types#ListValueFrom): A known value with the given element type and values. This can convert the source data from standard Go types into framework types as noted in the documentation for each element type, such as giving `[]*string` for a `types.List` of `types.String`.
-* [`types.ListValueMust(map[string]attr.Type, map[string]attr.Value) types.List`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/types#ListValueMust): A known value with the given element type and values. Any diagnostics are converted to a runtime panic. This is recommended only for testing or exhaustively tested logic.
+* [`types.ListValueMust(attr.Type, []attr.Value) types.List`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/types#ListValueMust): A known value with the given element type and values. Any diagnostics are converted to a runtime panic. This is recommended only for testing or exhaustively tested logic.
 
 In this example, a known list value is created from framework types:
 

--- a/website/docs/plugin/framework/handling-data/types/set.mdx
+++ b/website/docs/plugin/framework/handling-data/types/set.mdx
@@ -83,7 +83,7 @@ Call one of the following to create a `types.Set` value:
 * [`types.SetUnknown(attr.Type) types.Set`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/types#SetUnknown): An unknown set value with the given element type.
 * [`types.SetValue(attr.Type, []attr.Value) (types.Set, diag.Diagnostics)`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/types#SetValue): A known value with the given element type and values.
 * [`types.SetValueFrom(context.Context, attr.Type, any) (types.Set, diag.Diagnostics)`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/types#SetValueFrom): A known value with the given element type and values. This can convert the source data from standard Go types into framework types as noted in the documentation for each element type, such as giving `[]*string` for a `types.Set` of `types.String`.
-* [`types.SetValueMust(map[string]attr.Type, map[string]attr.Value) types.Set`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/types#SetValueMust): A known value with the given element type and values. Any diagnostics are converted to a runtime panic. This is recommended only for testing or exhaustively tested logic.
+* [`types.SetValueMust(attr.Type, []attr.Value) types.Set`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/types#SetValueMust): A known value with the given element type and values. Any diagnostics are converted to a runtime panic. This is recommended only for testing or exhaustively tested logic.
 
 In this example, a known set value is created from framework types:
 

--- a/website/docs/plugin/framework/handling-data/types/tuple.mdx
+++ b/website/docs/plugin/framework/handling-data/types/tuple.mdx
@@ -16,7 +16,7 @@ The tuple type is used to express Terraform's [tuple type constraint](/terraform
 
 ## Schema Definitions
 
-The tuple type is currently not supported in schema definitions of provider, data sources, or managed resources.
+The tuple type is not supported in schema definitions of provider, data sources, or managed resources as it has limited real world application.
 
 ## Accessing Values
 

--- a/website/docs/plugin/framework/handling-data/types/tuple.mdx
+++ b/website/docs/plugin/framework/handling-data/types/tuple.mdx
@@ -1,0 +1,53 @@
+---
+page_title: 'Plugin Development - Framework: Tuple Type'
+description: >-
+  Learn the tuple value type in the provider development framework.
+---
+
+<Note>
+The tuple type intentionally includes less functionality than other types in the type system as it has limited real world application and therefore is not exposed to provider developers.
+</Note>
+
+# Tuple Type
+
+Tuple types store an ordered collection of elements where each element has it's own type. Values must have **exactly** the same number of elements (no more and no fewer), and the value in each position must match the specified type for that position.
+
+The tuple type is used to express Terraform's [tuple type constraint](/terraform/language/expressions/type-constraints#tuple).
+
+## Schema Definitions
+
+The tuple type is currently not supported in schema definitions of provider, data sources, or managed resources.
+
+## Accessing Values
+
+Access `types.Tuple` information via the following methods:
+
+* [`(types.Tuple).IsNull() bool`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/types/basetypes#TupleValue.IsNull): Returns `true` if the tuple is null.
+* [`(types.Tuple).IsUnknown() bool`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/types/basetypes#TupleValue.IsUnknown): Returns `true` if the tuple is unknown. Returns `false` if the number of elements is known, any of which may be unknown.
+* [`(types.Tuple).Elements() []attr.Value`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/types/basetypes#TupleValue.Elements): Returns the known `[]attr.Value` value, or `nil` if null or unknown.
+
+## Setting Values
+
+Call one of the following to create a `types.Tuple` value:
+
+* [`types.TupleNull([]attr.Type) types.Tuple`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/types#TupleNull): A null tuple value with the given element types.
+* [`types.TupleUnknown([]attr.Type) types.Tuple`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/types#TupleUnknown): An unknown tuple value with the given element types.
+* [`types.TupleValue([]attr.Type, []attr.Value) (types.Tuple, diag.Diagnostics)`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/types#TupleValue): A known value with the given element types and values.
+* [`types.TupleValueMust([]attr.Type, []attr.Value) types.Tuple`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/types#TupleValueMust): A known value with the given element types and values. Any diagnostics are converted to a runtime panic. This is recommended only for testing or exhaustively tested logic.
+
+In this example, a known tuple value (`["one", true, 123]`) is created from framework types:
+
+```go
+elementTypes := []attr.Type{
+	types.StringType,
+	types.BoolType,
+	types.Int64Type,
+}
+elements := []attr.Value{
+	types.StringValue("one"),
+	types.BoolValue(true),
+	types.Int64Value(123),
+}
+
+tupleValue, diags := types.TupleValue(elementTypes, elements)
+```

--- a/website/docs/plugin/framework/handling-data/types/tuple.mdx
+++ b/website/docs/plugin/framework/handling-data/types/tuple.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 <Note>
-The tuple type intentionally includes less functionality than other types in the type system as it has limited real world application and therefore is not exposed to provider developers.
+The tuple type intentionally includes less functionality than other types in the type system as it has limited real world application and therefore is not exposed to provider developers except when working with dynamic values.
 </Note>
 
 # Tuple Type


### PR DESCRIPTION
Ref: #54 

This PR introduces `basetypes.TupleType`, `basetypes.TupleValue`, and tuple helper functions/aliases in the `types` package. This PR **does not** introduce any accompanying `TupleAttribute` implementations, so currently there is no way to describe this schema to Terraform core.

Eventually when #147 is implemented, the `TupleType` will be necessary to fully handle dynamic attributes, as then Terraform core could possible send a [tuple](https://developer.hashicorp.com/terraform/language/expressions/type-constraints#tuple) to Plugin Framework.

### Notes
- I updated the reflection rules to create an explicit message describing that reflection from Go slices into `types.Tuple` is not supported. Also added tests around the code that was refactored relating to sets/lists
   - There weren't explicit tests for `Into` and `FromValue`, so I created table tests for them and added tests for just what I refactored. We can continually update the tests as we make changes to `internal/reflect`
- I wasn't 100% sure if we needed to implement `(TupleType).ApplyTerraform5AttributePathStep` for dynamic attributes, so I can update the implementation to return an error if that's not needed.