### PR TITLE
website: Fixed function doc links in parameter/return sections

### DIFF
--- a/website/docs/plugin/framework/functions/parameters/index.mdx
+++ b/website/docs/plugin/framework/functions/parameters/index.mdx
@@ -23,11 +23,11 @@ Parameter types that accepts a single data value, such as a boolean, number, or 
 
 | Parameter Type | Use Case |
 |----------------|----------|
-| [Bool](/terraform/plugin/framework/parameters/bool) | Boolean true or false |
-| [Float64](/terraform/plugin/framework/parameters/float64) | 64-bit floating point number |
-| [Int64](/terraform/plugin/framework/parameters/int64) | 64-bit integer number |
-| [Number](/terraform/plugin/framework/parameters/number) | Arbitrary precision (generally over 64-bit, up to 512-bit) number |
-| [String](/terraform/plugin/framework/parameters/string) | Collection of UTF-8 encoded characters |
+| [Bool](/terraform/plugin/framework/functions/parameters/bool) | Boolean true or false |
+| [Float64](/terraform/plugin/framework/functions/parameters/float64) | 64-bit floating point number |
+| [Int64](/terraform/plugin/framework/functions/parameters/int64) | 64-bit integer number |
+| [Number](/terraform/plugin/framework/functions/parameters/number) | Arbitrary precision (generally over 64-bit, up to 512-bit) number |
+| [String](/terraform/plugin/framework/functions/parameters/string) | Collection of UTF-8 encoded characters |
 
 #### Collection Parameter Types
 
@@ -35,9 +35,9 @@ Parameter types that accepts multiple values of a single element type, such as a
 
 | Parameter Type | Use Case |
 |----------------|----------|
-| [List](/terraform/plugin/framework/parameters/list) | Ordered collection of single element type |
-| [Map](/terraform/plugin/framework/parameters/map) | Mapping of arbitrary string keys to values of single element type |
-| [Set](/terraform/plugin/framework/parameters/set) | Unordered, unique collection of single element type |
+| [List](/terraform/plugin/framework/functions/parameters/list) | Ordered collection of single element type |
+| [Map](/terraform/plugin/framework/functions/parameters/map) | Mapping of arbitrary string keys to values of single element type |
+| [Set](/terraform/plugin/framework/functions/parameters/set) | Unordered, unique collection of single element type |
 
 #### Object Parameter Type
 
@@ -45,4 +45,4 @@ Parameter type that accepts a structure of explicit attribute names.
 
 | Parameter Type | Use Case |
 |----------------|----------|
-| [Object](/terraform/plugin/framework/parameters/object) | Single structure mapping explicit attribute names |
+| [Object](/terraform/plugin/framework/functions/parameters/object) | Single structure mapping explicit attribute names |

--- a/website/docs/plugin/framework/functions/returns/index.mdx
+++ b/website/docs/plugin/framework/functions/returns/index.mdx
@@ -23,11 +23,11 @@ Return types that expect a single data value, such as a boolean, number, or stri
 
 | Return Type | Use Case |
 |----------------|----------|
-| [Bool](/terraform/plugin/framework/returns/bool) | Boolean true or false |
-| [Float64](/terraform/plugin/framework/returns/float64) | 64-bit floating point number |
-| [Int64](/terraform/plugin/framework/returns/int64) | 64-bit integer number |
-| [Number](/terraform/plugin/framework/returns/number) | Arbitrary precision (generally over 64-bit, up to 512-bit) number |
-| [String](/terraform/plugin/framework/returns/string) | Collection of UTF-8 encoded characters |
+| [Bool](/terraform/plugin/framework/functions/returns/bool) | Boolean true or false |
+| [Float64](/terraform/plugin/framework/functions/returns/float64) | 64-bit floating point number |
+| [Int64](/terraform/plugin/framework/functions/returns/int64) | 64-bit integer number |
+| [Number](/terraform/plugin/framework/functions/returns/number) | Arbitrary precision (generally over 64-bit, up to 512-bit) number |
+| [String](/terraform/plugin/framework/functions/returns/string) | Collection of UTF-8 encoded characters |
 
 #### Collection Return Types
 
@@ -35,9 +35,9 @@ Return types that expect multiple values of a single element type, such as a lis
 
 | Return Type | Use Case |
 |----------------|----------|
-| [List](/terraform/plugin/framework/returns/list) | Ordered collection of single element type |
-| [Map](/terraform/plugin/framework/returns/map) | Mapping of arbitrary string keys to values of single element type |
-| [Set](/terraform/plugin/framework/returns/set) | Unordered, unique collection of single element type |
+| [List](/terraform/plugin/framework/functions/returns/list) | Ordered collection of single element type |
+| [Map](/terraform/plugin/framework/functions/returns/map) | Mapping of arbitrary string keys to values of single element type |
+| [Set](/terraform/plugin/framework/functions/returns/set) | Unordered, unique collection of single element type |
 
 #### Object Return Type
 
@@ -45,4 +45,4 @@ Return type that expects a structure of explicit attribute names.
 
 | Return Type | Use Case |
 |----------------|----------|
-| [Object](/terraform/plugin/framework/returns/object) | Single structure mapping explicit attribute names |
+| [Object](/terraform/plugin/framework/functions/returns/object) | Single structure mapping explicit attribute names |


### PR DESCRIPTION
Apparently the issue I recreated locally was not the caching problem, but actual broken links 😆  