### PR TITLE
privatestate: Support nil or zero-length value in SetKey to remove key

### DIFF
--- a/.changes/unreleased/ENHANCEMENTS-20240126-073810.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20240126-073810.yaml
@@ -1,6 +1,6 @@
 kind: ENHANCEMENTS
-body: 'privatestate: Added `nil` or zero-length value in `SetKey()` method to fully
-  remove key'
+body: 'privatestate: Added support for `SetKey()` method to fully remove key with
+  `nil` or zero-length value'
 time: 2024-01-26T07:38:10.644333-05:00
 custom:
   Issue: "910"

--- a/.changes/unreleased/ENHANCEMENTS-20240126-073810.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20240126-073810.yaml
@@ -1,0 +1,6 @@
+kind: ENHANCEMENTS
+body: 'privatestate: Added `nil` or zero-length value in `SetKey()` method to fully
+  remove key'
+time: 2024-01-26T07:38:10.644333-05:00
+custom:
+  Issue: "910"

--- a/internal/privatestate/data.go
+++ b/internal/privatestate/data.go
@@ -327,6 +327,13 @@ func (d *ProviderData) SetKey(ctx context.Context, key string, value []byte) dia
 		return diags
 	}
 
+	// Support removing keys by setting them to nil or zero-length value.
+	if len(value) == 0 {
+		delete(d.data, key)
+
+		return diags
+	}
+
 	if !utf8.Valid(value) {
 		tflog.Error(ctx, "invalid UTF-8 value", map[string]interface{}{"key": key, "value": value})
 

--- a/internal/privatestate/data_test.go
+++ b/internal/privatestate/data_test.go
@@ -877,6 +877,64 @@ func TestProviderData_SetKey(t *testing.T) {
 				},
 			},
 		},
+		"key-value-null": {
+			providerData: &ProviderData{
+				data: map[string][]byte{
+					"keyOne": []byte(`{"foo": "bar"}`),
+				},
+			},
+			key:   "keyOne",
+			value: []byte(`null`),
+			expected: &ProviderData{
+				data: map[string][]byte{
+					"keyOne": []byte(`null`),
+				},
+			},
+		},
+		"key-value-nil": {
+			providerData: &ProviderData{
+				data: map[string][]byte{
+					"keyOne": []byte(`{"foo": "bar"}`),
+				},
+			},
+			key:   "keyOne",
+			value: nil,
+			expected: &ProviderData{
+				data: map[string][]byte{},
+			},
+		},
+		"key-value-nil-no-key": {
+			providerData: &ProviderData{
+				data: map[string][]byte{},
+			},
+			key:   "nonexistent",
+			value: nil,
+			expected: &ProviderData{
+				data: map[string][]byte{},
+			},
+		},
+		"key-value-zero-bytes": {
+			providerData: &ProviderData{
+				data: map[string][]byte{
+					"keyOne": []byte(`{"foo": "bar"}`),
+				},
+			},
+			key:   "keyOne",
+			value: []byte{},
+			expected: &ProviderData{
+				data: map[string][]byte{},
+			},
+		},
+		"key-value-zero-bytes-no-key": {
+			providerData: &ProviderData{
+				data: map[string][]byte{},
+			},
+			key:   "nonexistent",
+			value: []byte{},
+			expected: &ProviderData{
+				data: map[string][]byte{},
+			},
+		},
 	}
 
 	for name, testCase := range testCases {

--- a/website/docs/plugin/framework/resources/private-state.mdx
+++ b/website/docs/plugin/framework/resources/private-state.mdx
@@ -18,14 +18,11 @@ Example uses in the framework include:
 
 ## Concepts
 
-Private state data is byte data stored in the Terraform state and is intended for provider usage only (i.e., it is only
-used by the Framework and provider code). Providers have the ability to save this data during create, import, planning, 
-read, and update operations and the ability to read this data during delete, planning, read, and update operations.
+Private state data is byte data stored in the Terraform state and is intended for provider usage only (i.e., it is only used by the Framework and provider code). Providers have the ability to save this data during create, import, planning, read, and update operations and the ability to read this data during delete, planning, read, and update operations.
 
 ## Accessing Private State Data
 
-Private state data can be read from a [privatestate.ProviderData](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/internal/privatestate#ProviderData) 
-type in the `Private` field present in the _request_ that is passed into:
+Private state data can be read from a [privatestate.ProviderData](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/internal/privatestate#ProviderData) type in the `Private` field present in the _request_ that is passed into:
 
 | Resource Operation | Private State Data |
 | --- | --- |
@@ -35,8 +32,7 @@ type in the `Private` field present in the _request_ that is passed into:
 | Read | [resource.ReadRequest.Private](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#ReadRequest.Private) |
 | Update | [resource.UpdateRequest.Private](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#UpdateRequest.Private)
 
-Private state data can be saved to a [privatestate.ProviderData](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/internal/privatestate#ProviderData) 
-type in the `Private` field present in the _response_ that is returned from:
+Private state data can be saved to a [privatestate.ProviderData](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/internal/privatestate#ProviderData) type in the `Private` field present in the _response_ that is returned from:
 
 | Resource Operation | Private State Data |
 | --- | --- |
@@ -89,6 +85,8 @@ func (r *resourceExample) Read(ctx context.Context, req resource.ReadRequest, re
 If the key supplied is [reserved](#reserved-keys) for framework usage, an error diagnostic will be returned.
 
 If the value is not valid JSON and UTF-8 safe, an error diagnostic will be returned.
+
+To remove a key and its associated value, use `nil` or a zero-length value such as `[]byte{}`.
 
 ### Reserved Keys
 


### PR DESCRIPTION
Closes #910

This change ensures that developers can fully remove private state keys by setting the value to `nil` or `[]byte{}`. Attempting to set the value to either value would previously generate an error. The closest available workaround was to set keys to the literal JSON `null` and handle that value during unmarshaling, rather than purely checking existence via `GetKey()` returning `nil`.