### PR TITLE
resource: Initial MoveResourceState RPC support

### DIFF
--- a/.changes/unreleased/FEATURES-20240201-173428.yaml
+++ b/.changes/unreleased/FEATURES-20240201-173428.yaml
@@ -1,0 +1,6 @@
+kind: FEATURES
+body: 'resource: Added the `ResourceWithMoveState` interface, which enables state
+  moves across resource types with Terraform 1.8 and later'
+time: 2024-02-01T17:34:28.190047-05:00
+custom:
+  Issue: "917"

--- a/internal/fromproto5/moveresourcestate.go
+++ b/internal/fromproto5/moveresourcestate.go
@@ -1,0 +1,57 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package fromproto5
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
+	"github.com/hashicorp/terraform-plugin-framework/internal/privatestate"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+)
+
+// MoveResourceStateRequest returns the *fwserver.MoveResourceStateRequest
+// equivalent of a *tfprotov5.MoveResourceStateRequest.
+func MoveResourceStateRequest(ctx context.Context, proto5 *tfprotov5.MoveResourceStateRequest, resource resource.Resource, resourceSchema fwschema.Schema) (*fwserver.MoveResourceStateRequest, diag.Diagnostics) {
+	if proto5 == nil {
+		return nil, nil
+	}
+
+	var diags diag.Diagnostics
+
+	// Panic prevention here to simplify the calling implementations.
+	// This should not happen, but just in case.
+	if resourceSchema == nil {
+		diags.AddError(
+			"Framework Implementation Error",
+			"An unexpected issue was encountered when converting the MoveResourceState RPC request information from the protocol type to the framework type. "+
+				"The resource schema was missing. "+
+				"This is always an issue in terraform-plugin-framework used to implement the provider and should be reported to the provider developers.",
+		)
+
+		return nil, diags
+	}
+
+	fw := &fwserver.MoveResourceStateRequest{
+		SourceProviderAddress: proto5.SourceProviderAddress,
+		SourceRawState:        (*tfprotov6.RawState)(proto5.SourceState),
+		SourceSchemaVersion:   proto5.SourceSchemaVersion,
+		SourceTypeName:        proto5.SourceTypeName,
+		TargetResource:        resource,
+		TargetResourceSchema:  resourceSchema,
+		TargetTypeName:        proto5.TargetTypeName,
+	}
+
+	sourcePrivate, sourcePrivateDiags := privatestate.NewData(ctx, proto5.SourcePrivate)
+
+	diags.Append(sourcePrivateDiags...)
+
+	fw.SourcePrivate = sourcePrivate
+
+	return fw, diags
+}

--- a/internal/fromproto5/moveresourcestate_test.go
+++ b/internal/fromproto5/moveresourcestate_test.go
@@ -1,0 +1,184 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package fromproto5_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fromproto5"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
+	"github.com/hashicorp/terraform-plugin-framework/internal/privatestate"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+)
+
+func TestMoveResourceStateRequest(t *testing.T) {
+	t.Parallel()
+
+	testFwSchema := schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"test_attribute": schema.StringAttribute{
+				Required: true,
+			},
+		},
+	}
+
+	testCases := map[string]struct {
+		input               *tfprotov5.MoveResourceStateRequest
+		resourceSchema      fwschema.Schema
+		resource            resource.Resource
+		expected            *fwserver.MoveResourceStateRequest
+		expectedDiagnostics diag.Diagnostics
+	}{
+		"nil": {
+			input:    nil,
+			expected: nil,
+		},
+		"SourcePrivate": {
+			input: &tfprotov5.MoveResourceStateRequest{
+				SourcePrivate: privatestate.MustMarshalToJson(map[string][]byte{
+					".frameworkKey":  []byte(`{"fKeyOne": {"k0": "zero", "k1": 1}}`),
+					"providerKeyOne": []byte(`{"pKeyOne": {"k0": "zero", "k1": 1}}`),
+				}),
+			},
+			resourceSchema: testFwSchema,
+			expected: &fwserver.MoveResourceStateRequest{
+				SourcePrivate: &privatestate.Data{
+					Framework: map[string][]byte{
+						".frameworkKey": []byte(`{"fKeyOne": {"k0": "zero", "k1": 1}}`),
+					},
+					Provider: privatestate.MustProviderData(context.Background(), privatestate.MustMarshalToJson(map[string][]byte{
+						"providerKeyOne": []byte(`{"pKeyOne": {"k0": "zero", "k1": 1}}`),
+					})),
+				},
+				TargetResourceSchema: testFwSchema,
+			},
+		},
+		"SourcePrivate-malformed-json": {
+			input: &tfprotov5.MoveResourceStateRequest{
+				SourcePrivate: []byte(`{`),
+			},
+			resourceSchema: testFwSchema,
+			expected: &fwserver.MoveResourceStateRequest{
+				TargetResourceSchema: testFwSchema,
+			},
+			expectedDiagnostics: diag.Diagnostics{
+				diag.NewErrorDiagnostic(
+					"Error Decoding Private State",
+					"An error was encountered when decoding private state: unexpected end of JSON input.\n\n"+
+						"This is always a problem with Terraform or terraform-plugin-framework. Please report this to the provider developer.",
+				),
+			},
+		},
+		"SourcePrivate-empty-json": {
+			input: &tfprotov5.MoveResourceStateRequest{
+				SourcePrivate: []byte("{}"),
+			},
+			resourceSchema: testFwSchema,
+			expected: &fwserver.MoveResourceStateRequest{
+				SourcePrivate: &privatestate.Data{
+					Framework: map[string][]byte{},
+					Provider:  privatestate.EmptyProviderData(context.Background()),
+				},
+				TargetResourceSchema: testFwSchema,
+			},
+		},
+		"SourceProviderAddress": {
+			input: &tfprotov5.MoveResourceStateRequest{
+				SourceProviderAddress: "example.com/namespace/type",
+			},
+			resourceSchema: testFwSchema,
+			expected: &fwserver.MoveResourceStateRequest{
+				SourceProviderAddress: "example.com/namespace/type",
+				TargetResourceSchema:  testFwSchema,
+			},
+		},
+		"SourceRawState": {
+			input: &tfprotov5.MoveResourceStateRequest{
+				SourceState: testNewTfprotov5RawState(t, map[string]interface{}{
+					"test_attribute": "test-value",
+				}),
+			},
+			resourceSchema: testFwSchema,
+			expected: &fwserver.MoveResourceStateRequest{
+				SourceRawState: testNewTfprotov6RawState(t, map[string]interface{}{
+					"test_attribute": "test-value",
+				}),
+				TargetResourceSchema: testFwSchema,
+			},
+		},
+		"SourceSchemaVersion": {
+			input: &tfprotov5.MoveResourceStateRequest{
+				SourceSchemaVersion: 123,
+			},
+			resourceSchema: testFwSchema,
+			expected: &fwserver.MoveResourceStateRequest{
+				SourceSchemaVersion:  123,
+				TargetResourceSchema: testFwSchema,
+			},
+		},
+		"SourceTypeName": {
+			input: &tfprotov5.MoveResourceStateRequest{
+				SourceTypeName: "examplecloud_thing",
+			},
+			resourceSchema: testFwSchema,
+			expected: &fwserver.MoveResourceStateRequest{
+				SourceTypeName:       "examplecloud_thing",
+				TargetResourceSchema: testFwSchema,
+			},
+		},
+		"TargetResourceSchema": {
+			input:          &tfprotov5.MoveResourceStateRequest{},
+			resourceSchema: testFwSchema,
+			expected: &fwserver.MoveResourceStateRequest{
+				TargetResourceSchema: testFwSchema,
+			},
+		},
+		"TargetResourceSchema-missing": {
+			input:    &tfprotov5.MoveResourceStateRequest{},
+			expected: nil,
+			expectedDiagnostics: diag.Diagnostics{
+				diag.NewErrorDiagnostic(
+					"Framework Implementation Error",
+					"An unexpected issue was encountered when converting the MoveResourceState RPC request information from the protocol type to the framework type. "+
+						"The resource schema was missing. "+
+						"This is always an issue in terraform-plugin-framework used to implement the provider and should be reported to the provider developers.",
+				),
+			},
+		},
+		"TargetTypeName": {
+			input: &tfprotov5.MoveResourceStateRequest{
+				TargetTypeName: "examplecloud_thing",
+			},
+			resourceSchema: testFwSchema,
+			expected: &fwserver.MoveResourceStateRequest{
+				TargetResourceSchema: testFwSchema,
+				TargetTypeName:       "examplecloud_thing",
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, diags := fromproto5.MoveResourceStateRequest(context.Background(), testCase.input, testCase.resource, testCase.resourceSchema)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+
+			if diff := cmp.Diff(diags, testCase.expectedDiagnostics); diff != "" {
+				t.Errorf("unexpected diagnostics difference: %s", diff)
+			}
+		})
+	}
+}

--- a/internal/fromproto6/moveresourcestate.go
+++ b/internal/fromproto6/moveresourcestate.go
@@ -1,0 +1,56 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package fromproto6
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
+	"github.com/hashicorp/terraform-plugin-framework/internal/privatestate"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+)
+
+// MoveResourceStateRequest returns the *fwserver.MoveResourceStateRequest
+// equivalent of a *tfprotov6.MoveResourceStateRequest.
+func MoveResourceStateRequest(ctx context.Context, proto6 *tfprotov6.MoveResourceStateRequest, resource resource.Resource, resourceSchema fwschema.Schema) (*fwserver.MoveResourceStateRequest, diag.Diagnostics) {
+	if proto6 == nil {
+		return nil, nil
+	}
+
+	var diags diag.Diagnostics
+
+	// Panic prevention here to simplify the calling implementations.
+	// This should not happen, but just in case.
+	if resourceSchema == nil {
+		diags.AddError(
+			"Framework Implementation Error",
+			"An unexpected issue was encountered when converting the MoveResourceState RPC request information from the protocol type to the framework type. "+
+				"The resource schema was missing. "+
+				"This is always an issue in terraform-plugin-framework used to implement the provider and should be reported to the provider developers.",
+		)
+
+		return nil, diags
+	}
+
+	fw := &fwserver.MoveResourceStateRequest{
+		SourceProviderAddress: proto6.SourceProviderAddress,
+		SourceRawState:        proto6.SourceState,
+		SourceSchemaVersion:   proto6.SourceSchemaVersion,
+		SourceTypeName:        proto6.SourceTypeName,
+		TargetResource:        resource,
+		TargetResourceSchema:  resourceSchema,
+		TargetTypeName:        proto6.TargetTypeName,
+	}
+
+	sourcePrivate, sourcePrivateDiags := privatestate.NewData(ctx, proto6.SourcePrivate)
+
+	diags.Append(sourcePrivateDiags...)
+
+	fw.SourcePrivate = sourcePrivate
+
+	return fw, diags
+}

--- a/internal/fromproto6/moveresourcestate_test.go
+++ b/internal/fromproto6/moveresourcestate_test.go
@@ -1,0 +1,184 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package fromproto6_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fromproto6"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
+	"github.com/hashicorp/terraform-plugin-framework/internal/privatestate"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+)
+
+func TestMoveResourceStateRequest(t *testing.T) {
+	t.Parallel()
+
+	testFwSchema := schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"test_attribute": schema.StringAttribute{
+				Required: true,
+			},
+		},
+	}
+
+	testCases := map[string]struct {
+		input               *tfprotov6.MoveResourceStateRequest
+		resourceSchema      fwschema.Schema
+		resource            resource.Resource
+		expected            *fwserver.MoveResourceStateRequest
+		expectedDiagnostics diag.Diagnostics
+	}{
+		"nil": {
+			input:    nil,
+			expected: nil,
+		},
+		"SourcePrivate": {
+			input: &tfprotov6.MoveResourceStateRequest{
+				SourcePrivate: privatestate.MustMarshalToJson(map[string][]byte{
+					".frameworkKey":  []byte(`{"fKeyOne": {"k0": "zero", "k1": 1}}`),
+					"providerKeyOne": []byte(`{"pKeyOne": {"k0": "zero", "k1": 1}}`),
+				}),
+			},
+			resourceSchema: testFwSchema,
+			expected: &fwserver.MoveResourceStateRequest{
+				SourcePrivate: &privatestate.Data{
+					Framework: map[string][]byte{
+						".frameworkKey": []byte(`{"fKeyOne": {"k0": "zero", "k1": 1}}`),
+					},
+					Provider: privatestate.MustProviderData(context.Background(), privatestate.MustMarshalToJson(map[string][]byte{
+						"providerKeyOne": []byte(`{"pKeyOne": {"k0": "zero", "k1": 1}}`),
+					})),
+				},
+				TargetResourceSchema: testFwSchema,
+			},
+		},
+		"SourcePrivate-malformed-json": {
+			input: &tfprotov6.MoveResourceStateRequest{
+				SourcePrivate: []byte(`{`),
+			},
+			resourceSchema: testFwSchema,
+			expected: &fwserver.MoveResourceStateRequest{
+				TargetResourceSchema: testFwSchema,
+			},
+			expectedDiagnostics: diag.Diagnostics{
+				diag.NewErrorDiagnostic(
+					"Error Decoding Private State",
+					"An error was encountered when decoding private state: unexpected end of JSON input.\n\n"+
+						"This is always a problem with Terraform or terraform-plugin-framework. Please report this to the provider developer.",
+				),
+			},
+		},
+		"SourcePrivate-empty-json": {
+			input: &tfprotov6.MoveResourceStateRequest{
+				SourcePrivate: []byte("{}"),
+			},
+			resourceSchema: testFwSchema,
+			expected: &fwserver.MoveResourceStateRequest{
+				SourcePrivate: &privatestate.Data{
+					Framework: map[string][]byte{},
+					Provider:  privatestate.EmptyProviderData(context.Background()),
+				},
+				TargetResourceSchema: testFwSchema,
+			},
+		},
+		"SourceProviderAddress": {
+			input: &tfprotov6.MoveResourceStateRequest{
+				SourceProviderAddress: "example.com/namespace/type",
+			},
+			resourceSchema: testFwSchema,
+			expected: &fwserver.MoveResourceStateRequest{
+				SourceProviderAddress: "example.com/namespace/type",
+				TargetResourceSchema:  testFwSchema,
+			},
+		},
+		"SourceRawState": {
+			input: &tfprotov6.MoveResourceStateRequest{
+				SourceState: testNewRawState(t, map[string]interface{}{
+					"test_attribute": "test-value",
+				}),
+			},
+			resourceSchema: testFwSchema,
+			expected: &fwserver.MoveResourceStateRequest{
+				SourceRawState: testNewRawState(t, map[string]interface{}{
+					"test_attribute": "test-value",
+				}),
+				TargetResourceSchema: testFwSchema,
+			},
+		},
+		"SourceSchemaVersion": {
+			input: &tfprotov6.MoveResourceStateRequest{
+				SourceSchemaVersion: 123,
+			},
+			resourceSchema: testFwSchema,
+			expected: &fwserver.MoveResourceStateRequest{
+				SourceSchemaVersion:  123,
+				TargetResourceSchema: testFwSchema,
+			},
+		},
+		"SourceTypeName": {
+			input: &tfprotov6.MoveResourceStateRequest{
+				SourceTypeName: "examplecloud_thing",
+			},
+			resourceSchema: testFwSchema,
+			expected: &fwserver.MoveResourceStateRequest{
+				SourceTypeName:       "examplecloud_thing",
+				TargetResourceSchema: testFwSchema,
+			},
+		},
+		"TargetResourceSchema": {
+			input:          &tfprotov6.MoveResourceStateRequest{},
+			resourceSchema: testFwSchema,
+			expected: &fwserver.MoveResourceStateRequest{
+				TargetResourceSchema: testFwSchema,
+			},
+		},
+		"TargetResourceSchema-missing": {
+			input:    &tfprotov6.MoveResourceStateRequest{},
+			expected: nil,
+			expectedDiagnostics: diag.Diagnostics{
+				diag.NewErrorDiagnostic(
+					"Framework Implementation Error",
+					"An unexpected issue was encountered when converting the MoveResourceState RPC request information from the protocol type to the framework type. "+
+						"The resource schema was missing. "+
+						"This is always an issue in terraform-plugin-framework used to implement the provider and should be reported to the provider developers.",
+				),
+			},
+		},
+		"TargetTypeName": {
+			input: &tfprotov6.MoveResourceStateRequest{
+				TargetTypeName: "examplecloud_thing",
+			},
+			resourceSchema: testFwSchema,
+			expected: &fwserver.MoveResourceStateRequest{
+				TargetResourceSchema: testFwSchema,
+				TargetTypeName:       "examplecloud_thing",
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, diags := fromproto6.MoveResourceStateRequest(context.Background(), testCase.input, testCase.resource, testCase.resourceSchema)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+
+			if diff := cmp.Diff(diags, testCase.expectedDiagnostics); diff != "" {
+				t.Errorf("unexpected diagnostics difference: %s", diff)
+			}
+		})
+	}
+}

--- a/internal/fwserver/server_capabilities.go
+++ b/internal/fwserver/server_capabilities.go
@@ -15,6 +15,13 @@ type ServerCapabilities struct {
 	// Terraform 1.6 or later.
 	GetProviderSchemaOptional bool
 
+	// MoveResourceState signals that the provider is ready for the
+	// MoveResourceState RPC.
+	//
+	// This should always be enabled in framework providers and requires
+	// Terraform 1.8 or later.
+	MoveResourceState bool
+
 	// PlanDestroy signals that the provider is ready for the
 	// PlanResourceChange RPC on resource destruction.
 	//
@@ -27,6 +34,7 @@ type ServerCapabilities struct {
 func (s *Server) ServerCapabilities() *ServerCapabilities {
 	return &ServerCapabilities{
 		GetProviderSchemaOptional: true,
+		MoveResourceState:         true,
 		PlanDestroy:               true,
 	}
 }

--- a/internal/fwserver/server_getmetadata_test.go
+++ b/internal/fwserver/server_getmetadata_test.go
@@ -37,6 +37,7 @@ func TestServerGetMetadata(t *testing.T) {
 				Resources:   []fwserver.ResourceMetadata{},
 				ServerCapabilities: &fwserver.ServerCapabilities{
 					GetProviderSchemaOptional: true,
+					MoveResourceState:         true,
 					PlanDestroy:               true,
 				},
 			},
@@ -78,6 +79,7 @@ func TestServerGetMetadata(t *testing.T) {
 				Resources: []fwserver.ResourceMetadata{},
 				ServerCapabilities: &fwserver.ServerCapabilities{
 					GetProviderSchemaOptional: true,
+					MoveResourceState:         true,
 					PlanDestroy:               true,
 				},
 			},
@@ -120,6 +122,7 @@ func TestServerGetMetadata(t *testing.T) {
 				Resources: []fwserver.ResourceMetadata{},
 				ServerCapabilities: &fwserver.ServerCapabilities{
 					GetProviderSchemaOptional: true,
+					MoveResourceState:         true,
 					PlanDestroy:               true,
 				},
 			},
@@ -154,6 +157,7 @@ func TestServerGetMetadata(t *testing.T) {
 				Resources: []fwserver.ResourceMetadata{},
 				ServerCapabilities: &fwserver.ServerCapabilities{
 					GetProviderSchemaOptional: true,
+					MoveResourceState:         true,
 					PlanDestroy:               true,
 				},
 			},
@@ -188,6 +192,7 @@ func TestServerGetMetadata(t *testing.T) {
 				Resources: []fwserver.ResourceMetadata{},
 				ServerCapabilities: &fwserver.ServerCapabilities{
 					GetProviderSchemaOptional: true,
+					MoveResourceState:         true,
 					PlanDestroy:               true,
 				},
 			},
@@ -229,6 +234,7 @@ func TestServerGetMetadata(t *testing.T) {
 				Resources: []fwserver.ResourceMetadata{},
 				ServerCapabilities: &fwserver.ServerCapabilities{
 					GetProviderSchemaOptional: true,
+					MoveResourceState:         true,
 					PlanDestroy:               true,
 				},
 			},
@@ -271,6 +277,7 @@ func TestServerGetMetadata(t *testing.T) {
 				Resources: []fwserver.ResourceMetadata{},
 				ServerCapabilities: &fwserver.ServerCapabilities{
 					GetProviderSchemaOptional: true,
+					MoveResourceState:         true,
 					PlanDestroy:               true,
 				},
 			},
@@ -305,6 +312,7 @@ func TestServerGetMetadata(t *testing.T) {
 				Resources: []fwserver.ResourceMetadata{},
 				ServerCapabilities: &fwserver.ServerCapabilities{
 					GetProviderSchemaOptional: true,
+					MoveResourceState:         true,
 					PlanDestroy:               true,
 				},
 			},
@@ -346,6 +354,7 @@ func TestServerGetMetadata(t *testing.T) {
 				},
 				ServerCapabilities: &fwserver.ServerCapabilities{
 					GetProviderSchemaOptional: true,
+					MoveResourceState:         true,
 					PlanDestroy:               true,
 				},
 			},
@@ -388,6 +397,7 @@ func TestServerGetMetadata(t *testing.T) {
 				Resources: []fwserver.ResourceMetadata{},
 				ServerCapabilities: &fwserver.ServerCapabilities{
 					GetProviderSchemaOptional: true,
+					MoveResourceState:         true,
 					PlanDestroy:               true,
 				},
 			},
@@ -422,6 +432,7 @@ func TestServerGetMetadata(t *testing.T) {
 				Resources: []fwserver.ResourceMetadata{},
 				ServerCapabilities: &fwserver.ServerCapabilities{
 					GetProviderSchemaOptional: true,
+					MoveResourceState:         true,
 					PlanDestroy:               true,
 				},
 			},
@@ -456,6 +467,7 @@ func TestServerGetMetadata(t *testing.T) {
 				},
 				ServerCapabilities: &fwserver.ServerCapabilities{
 					GetProviderSchemaOptional: true,
+					MoveResourceState:         true,
 					PlanDestroy:               true,
 				},
 			},

--- a/internal/fwserver/server_getproviderschema_test.go
+++ b/internal/fwserver/server_getproviderschema_test.go
@@ -42,6 +42,7 @@ func TestServerGetProviderSchema(t *testing.T) {
 				ResourceSchemas:     map[string]fwschema.Schema{},
 				ServerCapabilities: &fwserver.ServerCapabilities{
 					GetProviderSchemaOptional: true,
+					MoveResourceState:         true,
 					PlanDestroy:               true,
 				},
 			},
@@ -110,6 +111,7 @@ func TestServerGetProviderSchema(t *testing.T) {
 				ResourceSchemas:     map[string]fwschema.Schema{},
 				ServerCapabilities: &fwserver.ServerCapabilities{
 					GetProviderSchemaOptional: true,
+					MoveResourceState:         true,
 					PlanDestroy:               true,
 				},
 			},
@@ -161,6 +163,7 @@ func TestServerGetProviderSchema(t *testing.T) {
 				ResourceSchemas: map[string]fwschema.Schema{},
 				ServerCapabilities: &fwserver.ServerCapabilities{
 					GetProviderSchemaOptional: true,
+					MoveResourceState:         true,
 					PlanDestroy:               true,
 				},
 				Diagnostics: diag.Diagnostics{
@@ -230,6 +233,7 @@ func TestServerGetProviderSchema(t *testing.T) {
 				ResourceSchemas: map[string]fwschema.Schema{},
 				ServerCapabilities: &fwserver.ServerCapabilities{
 					GetProviderSchemaOptional: true,
+					MoveResourceState:         true,
 					PlanDestroy:               true,
 				},
 			},
@@ -264,6 +268,7 @@ func TestServerGetProviderSchema(t *testing.T) {
 				ResourceSchemas: map[string]fwschema.Schema{},
 				ServerCapabilities: &fwserver.ServerCapabilities{
 					GetProviderSchemaOptional: true,
+					MoveResourceState:         true,
 					PlanDestroy:               true,
 				},
 			},
@@ -312,6 +317,7 @@ func TestServerGetProviderSchema(t *testing.T) {
 				ResourceSchemas:     map[string]fwschema.Schema{},
 				ServerCapabilities: &fwserver.ServerCapabilities{
 					GetProviderSchemaOptional: true,
+					MoveResourceState:         true,
 					PlanDestroy:               true,
 				},
 			},
@@ -364,6 +370,7 @@ func TestServerGetProviderSchema(t *testing.T) {
 				ResourceSchemas: map[string]fwschema.Schema{},
 				ServerCapabilities: &fwserver.ServerCapabilities{
 					GetProviderSchemaOptional: true,
+					MoveResourceState:         true,
 					PlanDestroy:               true,
 				},
 			},
@@ -417,6 +424,7 @@ func TestServerGetProviderSchema(t *testing.T) {
 				ResourceSchemas:     map[string]fwschema.Schema{},
 				ServerCapabilities: &fwserver.ServerCapabilities{
 					GetProviderSchemaOptional: true,
+					MoveResourceState:         true,
 					PlanDestroy:               true,
 				},
 			},
@@ -470,6 +478,7 @@ func TestServerGetProviderSchema(t *testing.T) {
 				ResourceSchemas:     map[string]fwschema.Schema{},
 				ServerCapabilities: &fwserver.ServerCapabilities{
 					GetProviderSchemaOptional: true,
+					MoveResourceState:         true,
 					PlanDestroy:               true,
 				},
 			},
@@ -505,6 +514,7 @@ func TestServerGetProviderSchema(t *testing.T) {
 				ResourceSchemas:     map[string]fwschema.Schema{},
 				ServerCapabilities: &fwserver.ServerCapabilities{
 					GetProviderSchemaOptional: true,
+					MoveResourceState:         true,
 					PlanDestroy:               true,
 				},
 			},
@@ -537,6 +547,7 @@ func TestServerGetProviderSchema(t *testing.T) {
 				ResourceSchemas: map[string]fwschema.Schema{},
 				ServerCapabilities: &fwserver.ServerCapabilities{
 					GetProviderSchemaOptional: true,
+					MoveResourceState:         true,
 					PlanDestroy:               true,
 				},
 			},
@@ -559,6 +570,7 @@ func TestServerGetProviderSchema(t *testing.T) {
 			expectedResponse: &fwserver.GetProviderSchemaResponse{
 				ServerCapabilities: &fwserver.ServerCapabilities{
 					GetProviderSchemaOptional: true,
+					MoveResourceState:         true,
 					PlanDestroy:               true,
 				},
 				Diagnostics: diag.Diagnostics{
@@ -602,6 +614,7 @@ func TestServerGetProviderSchema(t *testing.T) {
 				ResourceSchemas: map[string]fwschema.Schema{},
 				ServerCapabilities: &fwserver.ServerCapabilities{
 					GetProviderSchemaOptional: true,
+					MoveResourceState:         true,
 					PlanDestroy:               true,
 				},
 			},
@@ -626,6 +639,7 @@ func TestServerGetProviderSchema(t *testing.T) {
 				Provider: providerschema.Schema{},
 				ServerCapabilities: &fwserver.ServerCapabilities{
 					GetProviderSchemaOptional: true,
+					MoveResourceState:         true,
 					PlanDestroy:               true,
 				},
 				Diagnostics: diag.Diagnostics{
@@ -703,6 +717,7 @@ func TestServerGetProviderSchema(t *testing.T) {
 				},
 				ServerCapabilities: &fwserver.ServerCapabilities{
 					GetProviderSchemaOptional: true,
+					MoveResourceState:         true,
 					PlanDestroy:               true,
 				},
 			},
@@ -753,6 +768,7 @@ func TestServerGetProviderSchema(t *testing.T) {
 				Provider: providerschema.Schema{},
 				ServerCapabilities: &fwserver.ServerCapabilities{
 					GetProviderSchemaOptional: true,
+					MoveResourceState:         true,
 					PlanDestroy:               true,
 				},
 				Diagnostics: diag.Diagnostics{
@@ -822,6 +838,7 @@ func TestServerGetProviderSchema(t *testing.T) {
 				ResourceSchemas: nil,
 				ServerCapabilities: &fwserver.ServerCapabilities{
 					GetProviderSchemaOptional: true,
+					MoveResourceState:         true,
 					PlanDestroy:               true,
 				},
 			},
@@ -856,6 +873,7 @@ func TestServerGetProviderSchema(t *testing.T) {
 				ResourceSchemas: nil,
 				ServerCapabilities: &fwserver.ServerCapabilities{
 					GetProviderSchemaOptional: true,
+					MoveResourceState:         true,
 					PlanDestroy:               true,
 				},
 			},
@@ -904,6 +922,7 @@ func TestServerGetProviderSchema(t *testing.T) {
 				},
 				ServerCapabilities: &fwserver.ServerCapabilities{
 					GetProviderSchemaOptional: true,
+					MoveResourceState:         true,
 					PlanDestroy:               true,
 				},
 			},

--- a/internal/fwserver/server_moveresourcestate.go
+++ b/internal/fwserver/server_moveresourcestate.go
@@ -163,6 +163,14 @@ func (s *Server) MoveResourceState(ctx context.Context, req *MoveResourceStateRe
 			// since both the developer and calling practitioner cannot avoid
 			// the situation. Instead, developers will still have a nil
 			// SourceState and they can investigate any error as logged here.
+			//
+			// It is also important to note that the error generally only occurs
+			// if the source schema declared incompatible types. The
+			// IgnoreUndefinedAttributes option above can cause the error to be
+			// nil and the SourceState to be populated with null values. It is
+			// always recommended for StateMover implementations to check the
+			// other request fields (SourceTypeName, SourceProviderAddress,
+			// etc.) instead of relying on SourceState to be populated or not.
 			if err != nil {
 				logging.FrameworkDebug(
 					ctx,

--- a/internal/fwserver/server_moveresourcestate.go
+++ b/internal/fwserver/server_moveresourcestate.go
@@ -1,0 +1,187 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package fwserver
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/logging"
+	"github.com/hashicorp/terraform-plugin-framework/internal/privatestate"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+)
+
+// MoveResourceStateRequest is the framework server request for the
+// MoveResourceState RPC.
+type MoveResourceStateRequest struct {
+	SourcePrivate         *privatestate.Data
+	SourceProviderAddress string
+	SourceSchemaVersion   int64
+	SourceRawState        *tfprotov6.RawState
+	SourceTypeName        string
+
+	TargetResource       resource.Resource
+	TargetResourceSchema fwschema.Schema
+	TargetTypeName       string
+}
+
+// MoveResourceStateResponse is the framework server response for the
+// MoveResourceState RPC.
+type MoveResourceStateResponse struct {
+	Diagnostics   diag.Diagnostics
+	TargetPrivate *privatestate.Data
+	TargetState   *tfsdk.State
+}
+
+// MoveResourceState implements the framework server MoveResourceState RPC.
+func (s *Server) MoveResourceState(ctx context.Context, req *MoveResourceStateRequest, resp *MoveResourceStateResponse) {
+	if req == nil {
+		return
+	}
+
+	if req.SourceRawState == nil {
+		resp.Diagnostics.AddError(
+			"Missing Source Resource State",
+			"The source resource state was not provided to the provider for the MoveResourceState operation. "+
+				"This is always an issue in Terraform and should be reported to the Terraform maintainers.",
+		)
+
+		return
+	}
+
+	resourceWithMoveState, ok := req.TargetResource.(resource.ResourceWithMoveState)
+
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unable to Move Resource State",
+			"The target resource implementation does not include move resource state support. "+
+				"The resource implementation can be updated by the provider developers to include this support with the ResourceWithMoveState interface.\n\n"+
+				"Source Provider Address: "+req.SourceProviderAddress+"\n"+
+				"Source Resource Type: "+req.SourceTypeName+"\n"+
+				"Source Resource Schema Version: "+strconv.FormatInt(req.SourceSchemaVersion, 10)+"\n"+
+				"Target Resource Type: "+req.TargetTypeName,
+		)
+
+		return
+	}
+
+	logging.FrameworkTrace(ctx, "Resource implements ResourceWithMoveState")
+
+	logging.FrameworkTrace(ctx, "Calling provider defined Resource MoveState")
+	resourceStateMovers := resourceWithMoveState.MoveState(ctx)
+	logging.FrameworkTrace(ctx, "Called provider defined Resource MoveState")
+
+	sourcePrivate := privatestate.EmptyProviderData(ctx)
+
+	if req.SourcePrivate != nil && req.SourcePrivate.Provider != nil {
+		sourcePrivate = req.SourcePrivate.Provider
+	}
+
+	if resp.TargetPrivate == nil {
+		resp.TargetPrivate = privatestate.EmptyData(ctx)
+	}
+
+	for _, resourceStateMover := range resourceStateMovers {
+		moveStateReq := resource.MoveStateRequest{
+			SourcePrivate:         sourcePrivate,
+			SourceProviderAddress: req.SourceProviderAddress,
+			SourceRawState:        req.SourceRawState,
+			SourceSchemaVersion:   req.SourceSchemaVersion,
+			SourceTypeName:        req.SourceTypeName,
+		}
+		moveStateResp := resource.MoveStateResponse{
+			TargetPrivate: privatestate.EmptyProviderData(ctx),
+			TargetState: tfsdk.State{
+				Schema: req.TargetResourceSchema,
+				Raw:    tftypes.NewValue(req.TargetResourceSchema.Type().TerraformType(ctx), nil),
+			},
+		}
+
+		if resourceStateMover.SourceSchema != nil {
+			logging.FrameworkTrace(ctx, "Attempting to populate MoveResourceStateRequest SourceState from provider defined SourceSchema")
+
+			sourceSchemaType := resourceStateMover.SourceSchema.Type().TerraformType(ctx)
+			unmarshalOpts := tfprotov6.UnmarshalOpts{
+				ValueFromJSONOpts: tftypes.ValueFromJSONOpts{
+					// IgnoreUndefinedAttributes will silently skip over fields
+					// in the JSON that do not have a matching definition in the
+					// given schema. The purpose of this is to allow for
+					// additive changes to the source resource schema without
+					// breaking target resource state moves. It also enables
+					// simplified implementations, if certain source data is not
+					// needed anyways.
+					IgnoreUndefinedAttributes: true,
+				},
+			}
+
+			rawStateValue, err := req.SourceRawState.UnmarshalWithOpts(sourceSchemaType, unmarshalOpts)
+
+			// Resources may support multiple source resources, so returning the
+			// error here as an error or warning diagnostic is not appropriate
+			// since both the developer and calling practitioner cannot avoid
+			// the situation. Instead, developers will still have a nil
+			// SourceState and they can investigate any error as logged here.
+			if err != nil {
+				logging.FrameworkDebug(
+					ctx,
+					"Error unmarshalling SourceRawState using the provided SourceSchema for source "+
+						req.SourceProviderAddress+" resource type "+
+						req.SourceTypeName+" with schema version "+
+						strconv.FormatInt(req.SourceSchemaVersion, 10)+". "+
+						"This is not a fatal error since resources can support multiple source resources which cause this type of error to be unavoidable, "+
+						"but due to this error the SourceState will not be populated for the implementation.",
+					map[string]any{
+						logging.KeyError: err,
+					},
+				)
+			} else {
+				moveStateReq.SourceState = &tfsdk.State{
+					Raw:    rawStateValue,
+					Schema: *resourceStateMover.SourceSchema,
+				}
+			}
+		}
+
+		logging.FrameworkTrace(ctx, "Calling provider defined Resource StateMover")
+		resourceStateMover.StateMover(ctx, moveStateReq, &moveStateResp)
+		logging.FrameworkTrace(ctx, "Called provider defined Resource StateMover")
+
+		resp.Diagnostics.Append(moveStateResp.Diagnostics...)
+
+		// If the implementation has error diagnostics, return the diagnostics.
+		if moveStateResp.Diagnostics.HasError() {
+			resp.Diagnostics = moveStateResp.Diagnostics
+
+			return
+		}
+
+		// If the implement has set the state in any way, return the response.
+		if !moveStateResp.TargetState.Raw.Equal(tftypes.NewValue(req.TargetResourceSchema.Type().TerraformType(ctx), nil)) {
+			resp.Diagnostics = moveStateResp.Diagnostics
+			resp.TargetState = &moveStateResp.TargetState
+
+			if moveStateResp.TargetPrivate != nil {
+				resp.TargetPrivate.Provider = moveStateResp.TargetPrivate
+			}
+
+			return
+		}
+	}
+
+	resp.Diagnostics.AddError(
+		"Unable to Move Resource State",
+		"The target resource implementation does not include support for the given source resource. "+
+			"The resource implementation can be updated by the provider developers to include this support by returning the moved state when the request matches this source.\n\n"+
+			"Source Provider Address: "+req.SourceProviderAddress+"\n"+
+			"Source Resource Type: "+req.SourceTypeName+"\n"+
+			"Source Resource Schema Version: "+strconv.FormatInt(req.SourceSchemaVersion, 10)+"\n"+
+			"Target Resource Type: "+req.TargetTypeName,
+	)
+}

--- a/internal/fwserver/server_moveresourcestate.go
+++ b/internal/fwserver/server_moveresourcestate.go
@@ -21,15 +21,50 @@ import (
 // MoveResourceStateRequest is the framework server request for the
 // MoveResourceState RPC.
 type MoveResourceStateRequest struct {
-	SourcePrivate         *privatestate.Data
-	SourceProviderAddress string
-	SourceSchemaVersion   int64
-	SourceRawState        *tfprotov6.RawState
-	SourceTypeName        string
+	// SourcePrivate is the private state of the source resource as given by
+	// Terraform across the protocol.
+	SourcePrivate *privatestate.Data
 
-	TargetResource       resource.Resource
+	// SourceProviderAddress is the address of the source provider as given by
+	// Terraform across the protocol.
+	SourceProviderAddress string
+
+	// SourceSchemaVersion is the version of the source resource schema as given
+	// by Terraform across the protocol.
+	SourceSchemaVersion int64
+
+	// SourceRawState is the raw state of the source resource as given by
+	// Terraform across the protocol.
+	//
+	// Using the tfprotov6 type here was a pragmatic effort decision around when
+	// the framework introduced compatibility promises. This type was chosen as
+	// it was readily available and trivial to convert between tfprotov5.
+	//
+	// Using a terraform-plugin-go type is not ideal for the framework as almost
+	// all terraform-plugin-go types have framework abstractions, but if there
+	// is ever a time where it makes sense to re-evaluate this decision, such as
+	// a major version bump, it could be changed then.
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/340
+	SourceRawState *tfprotov6.RawState
+
+	// SourceTypeName is the type name of the source resource as given by
+	// Terraform across the protocol.
+	SourceTypeName string
+
+	// TargetResource is the provider-defined resource implementation as
+	// determined by the framework looking up the resource name from the
+	// provider.Provider implementation Resources method defined by the
+	// provider developer.
+	TargetResource resource.Resource
+
+	// TargetResourceSchema is the evaluated schema definition of the target
+	// resource as determined by the framework calling the resource.Resource
+	// implementation Schema method defined by the provider developer.
 	TargetResourceSchema fwschema.Schema
-	TargetTypeName       string
+
+	// TargetTypeName is the type name of the target resource as given by
+	// Terraform across the protocol.
+	TargetTypeName string
 }
 
 // MoveResourceStateResponse is the framework server response for the

--- a/internal/fwserver/server_moveresourcestate_test.go
+++ b/internal/fwserver/server_moveresourcestate_test.go
@@ -1,0 +1,547 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package fwserver_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
+	"github.com/hashicorp/terraform-plugin-framework/internal/privatestate"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testprovider"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func TestServerMoveResourceState(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	testSchema := schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+			},
+			"optional_attribute": schema.StringAttribute{
+				Optional: true,
+			},
+			"required_attribute": schema.StringAttribute{
+				Required: true,
+			},
+		},
+	}
+	schemaType := testSchema.Type().TerraformType(ctx)
+
+	testCases := map[string]struct {
+		server           *fwserver.Server
+		request          *fwserver.MoveResourceStateRequest
+		expectedResponse *fwserver.MoveResourceStateResponse
+	}{
+		"nil": {
+			server: &fwserver.Server{
+				Provider: &testprovider.Provider{},
+			},
+			request:          nil,
+			expectedResponse: &fwserver.MoveResourceStateResponse{},
+		},
+		"request-SourcePrivate": {
+			server: &fwserver.Server{
+				Provider: &testprovider.Provider{},
+			},
+			request: &fwserver.MoveResourceStateRequest{
+				SourcePrivate: &privatestate.Data{
+					Framework: map[string][]byte{
+						".frameworkKey": []byte(`{"fKeyOne": {"k0": "zero", "k1": 1}}`),
+					},
+					Provider: privatestate.MustProviderData(ctx, privatestate.MustMarshalToJson(map[string][]byte{
+						"providerKey": []byte(`{"pKeyOne": {"k0": "zero", "k1": 1}}`),
+					})),
+				},
+				// SourceRawState required to prevent error
+				SourceRawState: testNewRawState(t, map[string]interface{}{
+					"id":                 "test-id-value",
+					"required_attribute": true,
+				}),
+				TargetResource: &testprovider.ResourceWithMoveState{
+					MoveStateMethod: func(ctx context.Context) []resource.StateMover {
+						return []resource.StateMover{
+							{
+								StateMover: func(_ context.Context, req resource.MoveStateRequest, resp *resource.MoveStateResponse) {
+									expected := `{"pKeyOne": {"k0": "zero", "k1": 1}}`
+									got, diags := req.SourcePrivate.GetKey(ctx, "providerKey")
+
+									resp.Diagnostics.Append(diags...)
+
+									if string(got) != expected {
+										resp.Diagnostics.AddError(
+											"Unexpected req.SourcePrivate Value",
+											fmt.Sprintf("expected %q, got %q", expected, got),
+										)
+									}
+
+									// Prevent missing implementation error, the values do not matter except for response assertion
+									resp.Diagnostics.Append(resp.TargetState.SetAttribute(ctx, path.Root("id"), "test-id-value")...)
+									resp.Diagnostics.Append(resp.TargetState.SetAttribute(ctx, path.Root("required_attribute"), "true")...)
+								},
+							},
+						}
+					},
+				},
+				TargetResourceSchema: testSchema,
+				TargetTypeName:       "test_resource",
+			},
+			expectedResponse: &fwserver.MoveResourceStateResponse{
+				// TargetPrivate intentionally not set by the framework
+				TargetPrivate: privatestate.EmptyData(ctx),
+				TargetState: &tfsdk.State{
+					Raw: tftypes.NewValue(schemaType, map[string]tftypes.Value{
+						"id":                 tftypes.NewValue(tftypes.String, "test-id-value"),
+						"optional_attribute": tftypes.NewValue(tftypes.String, nil),
+						"required_attribute": tftypes.NewValue(tftypes.String, "true"),
+					}),
+					Schema: testSchema,
+				},
+			},
+		},
+		"request-SourceProviderAddress": {
+			server: &fwserver.Server{
+				Provider: &testprovider.Provider{},
+			},
+			request: &fwserver.MoveResourceStateRequest{
+				SourceProviderAddress: "example.com/namespace/type",
+				// SourceRawState required to prevent error
+				SourceRawState: testNewRawState(t, map[string]interface{}{
+					"id":                 "test-id-value",
+					"required_attribute": true,
+				}),
+				TargetResource: &testprovider.ResourceWithMoveState{
+					MoveStateMethod: func(ctx context.Context) []resource.StateMover {
+						return []resource.StateMover{
+							{
+								StateMover: func(_ context.Context, req resource.MoveStateRequest, resp *resource.MoveStateResponse) {
+									expected := `example.com/namespace/type`
+
+									if diff := cmp.Diff(req.SourceProviderAddress, expected); diff != "" {
+										resp.Diagnostics.AddError("Unexpected req.SourceProviderAddress difference", diff)
+									}
+
+									// Prevent missing implementation error, the values do not matter except for response assertion
+									resp.Diagnostics.Append(resp.TargetState.SetAttribute(ctx, path.Root("id"), "test-id-value")...)
+									resp.Diagnostics.Append(resp.TargetState.SetAttribute(ctx, path.Root("required_attribute"), "true")...)
+								},
+							},
+						}
+					},
+				},
+				TargetResourceSchema: testSchema,
+				TargetTypeName:       "test_resource",
+			},
+			expectedResponse: &fwserver.MoveResourceStateResponse{
+				TargetPrivate: privatestate.EmptyData(ctx),
+				TargetState: &tfsdk.State{
+					Raw: tftypes.NewValue(schemaType, map[string]tftypes.Value{
+						"id":                 tftypes.NewValue(tftypes.String, "test-id-value"),
+						"optional_attribute": tftypes.NewValue(tftypes.String, nil),
+						"required_attribute": tftypes.NewValue(tftypes.String, "true"),
+					}),
+					Schema: testSchema,
+				},
+			},
+		},
+		"request-SourceSchemaVersion": {
+			server: &fwserver.Server{
+				Provider: &testprovider.Provider{},
+			},
+			request: &fwserver.MoveResourceStateRequest{
+				SourceSchemaVersion: 123,
+				// SourceRawState required to prevent error
+				SourceRawState: testNewRawState(t, map[string]interface{}{
+					"id":                 "test-id-value",
+					"required_attribute": true,
+				}),
+				TargetResource: &testprovider.ResourceWithMoveState{
+					MoveStateMethod: func(ctx context.Context) []resource.StateMover {
+						return []resource.StateMover{
+							{
+								StateMover: func(_ context.Context, req resource.MoveStateRequest, resp *resource.MoveStateResponse) {
+									expected := int64(123)
+
+									if diff := cmp.Diff(req.SourceSchemaVersion, expected); diff != "" {
+										resp.Diagnostics.AddError("Unexpected req.SourceSchemaVersion difference", diff)
+									}
+
+									// Prevent missing implementation error, the values do not matter except for response assertion
+									resp.Diagnostics.Append(resp.TargetState.SetAttribute(ctx, path.Root("id"), "test-id-value")...)
+									resp.Diagnostics.Append(resp.TargetState.SetAttribute(ctx, path.Root("required_attribute"), "true")...)
+								},
+							},
+						}
+					},
+				},
+				TargetResourceSchema: testSchema,
+				TargetTypeName:       "test_resource",
+			},
+			expectedResponse: &fwserver.MoveResourceStateResponse{
+				TargetPrivate: privatestate.EmptyData(ctx),
+				TargetState: &tfsdk.State{
+					Raw: tftypes.NewValue(schemaType, map[string]tftypes.Value{
+						"id":                 tftypes.NewValue(tftypes.String, "test-id-value"),
+						"optional_attribute": tftypes.NewValue(tftypes.String, nil),
+						"required_attribute": tftypes.NewValue(tftypes.String, "true"),
+					}),
+					Schema: testSchema,
+				},
+			},
+		},
+		"request-SourceRawState": {
+			server: &fwserver.Server{
+				Provider: &testprovider.Provider{},
+			},
+			request: &fwserver.MoveResourceStateRequest{
+				SourceRawState: testNewRawState(t, map[string]interface{}{
+					"id":                 "test-id-value",
+					"required_attribute": true,
+				}),
+				TargetResource: &testprovider.ResourceWithMoveState{
+					MoveStateMethod: func(ctx context.Context) []resource.StateMover {
+						return []resource.StateMover{
+							{
+								StateMover: func(_ context.Context, req resource.MoveStateRequest, resp *resource.MoveStateResponse) {
+									expectedSourceRawState := testNewRawState(t, map[string]interface{}{
+										"id":                 "test-id-value",
+										"required_attribute": true,
+									})
+
+									if diff := cmp.Diff(req.SourceRawState, expectedSourceRawState); diff != "" {
+										resp.Diagnostics.AddError("Unexpected req.SourceRawState difference", diff)
+									}
+
+									// Prevent missing implementation error, the values do not matter except for response assertion
+									resp.Diagnostics.Append(resp.TargetState.SetAttribute(ctx, path.Root("id"), "test-id-value")...)
+									resp.Diagnostics.Append(resp.TargetState.SetAttribute(ctx, path.Root("required_attribute"), "true")...)
+								},
+							},
+						}
+					},
+				},
+				TargetResourceSchema: testSchema,
+				TargetTypeName:       "test_resource",
+			},
+			expectedResponse: &fwserver.MoveResourceStateResponse{
+				TargetPrivate: privatestate.EmptyData(ctx),
+				TargetState: &tfsdk.State{
+					Raw: tftypes.NewValue(schemaType, map[string]tftypes.Value{
+						"id":                 tftypes.NewValue(tftypes.String, "test-id-value"),
+						"optional_attribute": tftypes.NewValue(tftypes.String, nil),
+						"required_attribute": tftypes.NewValue(tftypes.String, "true"),
+					}),
+					Schema: testSchema,
+				},
+			},
+		},
+		"request-SourceState": {
+			server: &fwserver.Server{
+				Provider: &testprovider.Provider{},
+			},
+			request: &fwserver.MoveResourceStateRequest{
+				SourceRawState: testNewRawState(t, map[string]interface{}{
+					"id":                 "test-id-value",
+					"required_attribute": true,
+				}),
+				TargetResource: &testprovider.ResourceWithMoveState{
+					MoveStateMethod: func(ctx context.Context) []resource.StateMover {
+						return []resource.StateMover{
+							{
+								SourceSchema: &testSchema,
+								StateMover: func(_ context.Context, req resource.MoveStateRequest, resp *resource.MoveStateResponse) {
+									var id, requiredAttribute types.String
+
+									resp.Diagnostics.Append(req.SourceState.GetAttribute(ctx, path.Root("id"), &id)...)
+									resp.Diagnostics.Append(req.SourceState.GetAttribute(ctx, path.Root("required_attribute"), &requiredAttribute)...)
+
+									if diff := cmp.Diff(id, types.StringValue("test-id-value")); diff != "" {
+										resp.Diagnostics.AddError("Unexpected req.SourceState difference", diff)
+									}
+
+									if diff := cmp.Diff(requiredAttribute, types.StringValue("true")); diff != "" {
+										resp.Diagnostics.AddError("Unexpected req.SourceState difference", diff)
+									}
+
+									// Prevent missing implementation error, the values do not matter except for response assertion
+									resp.Diagnostics.Append(resp.TargetState.SetAttribute(ctx, path.Root("id"), "test-id-value")...)
+									resp.Diagnostics.Append(resp.TargetState.SetAttribute(ctx, path.Root("required_attribute"), "true")...)
+								},
+							},
+						}
+					},
+				},
+				TargetResourceSchema: testSchema,
+				TargetTypeName:       "test_resource",
+			},
+			expectedResponse: &fwserver.MoveResourceStateResponse{
+				TargetPrivate: privatestate.EmptyData(ctx),
+				TargetState: &tfsdk.State{
+					Raw: tftypes.NewValue(schemaType, map[string]tftypes.Value{
+						"id":                 tftypes.NewValue(tftypes.String, "test-id-value"),
+						"optional_attribute": tftypes.NewValue(tftypes.String, nil),
+						"required_attribute": tftypes.NewValue(tftypes.String, "true"),
+					}),
+					Schema: testSchema,
+				},
+			},
+		},
+		"request-SourceTypeName": {
+			server: &fwserver.Server{
+				Provider: &testprovider.Provider{},
+			},
+			request: &fwserver.MoveResourceStateRequest{
+				// SourceRawState required to prevent error
+				SourceRawState: testNewRawState(t, map[string]interface{}{
+					"id":                 "test-id-value",
+					"required_attribute": true,
+				}),
+				SourceTypeName: "test_source_resource",
+				TargetResource: &testprovider.ResourceWithMoveState{
+					MoveStateMethod: func(ctx context.Context) []resource.StateMover {
+						return []resource.StateMover{
+							{
+								StateMover: func(_ context.Context, req resource.MoveStateRequest, resp *resource.MoveStateResponse) {
+									expected := `test_source_resource`
+
+									if diff := cmp.Diff(req.SourceTypeName, expected); diff != "" {
+										resp.Diagnostics.AddError("Unexpected req.SourceTypeName difference", diff)
+									}
+
+									// Prevent missing implementation error, the values do not matter except for response assertion
+									resp.Diagnostics.Append(resp.TargetState.SetAttribute(ctx, path.Root("id"), "test-id-value")...)
+									resp.Diagnostics.Append(resp.TargetState.SetAttribute(ctx, path.Root("required_attribute"), "true")...)
+								},
+							},
+						}
+					},
+				},
+				TargetResourceSchema: testSchema,
+				TargetTypeName:       "test_resource",
+			},
+			expectedResponse: &fwserver.MoveResourceStateResponse{
+				TargetPrivate: privatestate.EmptyData(ctx),
+				TargetState: &tfsdk.State{
+					Raw: tftypes.NewValue(schemaType, map[string]tftypes.Value{
+						"id":                 tftypes.NewValue(tftypes.String, "test-id-value"),
+						"optional_attribute": tftypes.NewValue(tftypes.String, nil),
+						"required_attribute": tftypes.NewValue(tftypes.String, "true"),
+					}),
+					Schema: testSchema,
+				},
+			},
+		},
+		"request-TargetTypeName-unimplemented-interface": {
+			server: &fwserver.Server{
+				Provider: &testprovider.Provider{},
+			},
+			request: &fwserver.MoveResourceStateRequest{
+				SourceProviderAddress: "example.com/namespace/type",
+				// SourceRawState required to prevent error
+				SourceRawState: testNewRawState(t, map[string]interface{}{
+					"id":                 "test-id-value",
+					"required_attribute": true,
+				}),
+				SourceTypeName:       "test_source_resource",
+				TargetResource:       &testprovider.Resource{},
+				TargetResourceSchema: testSchema,
+				TargetTypeName:       "test_resource",
+			},
+			expectedResponse: &fwserver.MoveResourceStateResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic(
+						"Unable to Move Resource State",
+						"The target resource implementation does not include move resource state support. "+
+							"The resource implementation can be updated by the provider developers to include this support with the ResourceWithMoveState interface.\n\n"+
+							"Source Provider Address: example.com/namespace/type\n"+
+							"Source Resource Type: test_source_resource\n"+
+							"Source Resource Schema Version: 0\n"+
+							"Target Resource Type: test_resource",
+					),
+				},
+			},
+		},
+		"request-TargetTypeName-unimplemented-no-responses": {
+			server: &fwserver.Server{
+				Provider: &testprovider.Provider{},
+			},
+			request: &fwserver.MoveResourceStateRequest{
+				SourceProviderAddress: "example.com/namespace/type",
+				// SourceRawState required to prevent error
+				SourceRawState: testNewRawState(t, map[string]interface{}{
+					"id":                 "test-id-value",
+					"required_attribute": true,
+				}),
+				SourceTypeName: "test_source_resource",
+				TargetResource: &testprovider.ResourceWithMoveState{
+					MoveStateMethod: func(ctx context.Context) []resource.StateMover {
+						return []resource.StateMover{}
+					},
+				},
+				TargetResourceSchema: testSchema,
+				TargetTypeName:       "test_resource",
+			},
+			expectedResponse: &fwserver.MoveResourceStateResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic(
+						"Unable to Move Resource State",
+						"The target resource implementation does not include support for the given source resource. "+
+							"The resource implementation can be updated by the provider developers to include this support by returning the moved state when the request matches this source.\n\n"+
+							"Source Provider Address: example.com/namespace/type\n"+
+							"Source Resource Type: test_source_resource\n"+
+							"Source Resource Schema Version: 0\n"+
+							"Target Resource Type: test_resource",
+					),
+				},
+				TargetPrivate: privatestate.EmptyData(ctx),
+			},
+		},
+		"response-Diagnostics": {
+			server: &fwserver.Server{
+				Provider: &testprovider.Provider{},
+			},
+			request: &fwserver.MoveResourceStateRequest{
+				// SourceRawState required to prevent error
+				SourceRawState: testNewRawState(t, map[string]interface{}{
+					"id":                 "test-id-value",
+					"required_attribute": true,
+				}),
+				TargetResource: &testprovider.ResourceWithMoveState{
+					MoveStateMethod: func(ctx context.Context) []resource.StateMover {
+						return []resource.StateMover{
+							{
+								StateMover: func(_ context.Context, req resource.MoveStateRequest, resp *resource.MoveStateResponse) {
+									resp.Diagnostics.AddWarning("warning summary", "warning detail")
+									resp.Diagnostics.AddError("error summary", "error detail")
+								},
+							},
+						}
+					},
+				},
+				TargetResourceSchema: testSchema,
+				TargetTypeName:       "test_resource",
+			},
+			expectedResponse: &fwserver.MoveResourceStateResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewWarningDiagnostic(
+						"warning summary",
+						"warning detail",
+					),
+					diag.NewErrorDiagnostic(
+						"error summary",
+						"error detail",
+					),
+				},
+				TargetPrivate: privatestate.EmptyData(ctx),
+			},
+		},
+		"response-TargetPrivate": {
+			server: &fwserver.Server{
+				Provider: &testprovider.Provider{},
+			},
+			request: &fwserver.MoveResourceStateRequest{
+				// SourceRawState required to prevent error
+				SourceRawState: testNewRawState(t, map[string]interface{}{
+					"id":                 "test-id-value",
+					"required_attribute": true,
+				}),
+				TargetResource: &testprovider.ResourceWithMoveState{
+					MoveStateMethod: func(ctx context.Context) []resource.StateMover {
+						return []resource.StateMover{
+							{
+								StateMover: func(_ context.Context, req resource.MoveStateRequest, resp *resource.MoveStateResponse) {
+									resp.Diagnostics.Append(resp.TargetPrivate.SetKey(ctx, "providerKey", []byte(`{"key": "value"}`))...)
+
+									// Prevent missing implementation error, the values do not matter except for response assertion
+									resp.Diagnostics.Append(resp.TargetState.SetAttribute(ctx, path.Root("id"), "test-id-value")...)
+									resp.Diagnostics.Append(resp.TargetState.SetAttribute(ctx, path.Root("required_attribute"), "true")...)
+								},
+							},
+						}
+					},
+				},
+				TargetResourceSchema: testSchema,
+				TargetTypeName:       "test_resource",
+			},
+			expectedResponse: &fwserver.MoveResourceStateResponse{
+				TargetPrivate: &privatestate.Data{
+					Provider: privatestate.MustProviderData(ctx, privatestate.MustMarshalToJson(map[string][]byte{
+						"providerKey": []byte(`{"key": "value"}`),
+					})),
+				},
+				TargetState: &tfsdk.State{
+					Raw: tftypes.NewValue(schemaType, map[string]tftypes.Value{
+						"id":                 tftypes.NewValue(tftypes.String, "test-id-value"),
+						"optional_attribute": tftypes.NewValue(tftypes.String, nil),
+						"required_attribute": tftypes.NewValue(tftypes.String, "true"),
+					}),
+					Schema: testSchema,
+				},
+			},
+		},
+		"response-TargetState": {
+			server: &fwserver.Server{
+				Provider: &testprovider.Provider{},
+			},
+			request: &fwserver.MoveResourceStateRequest{
+				SourceRawState: testNewRawState(t, map[string]interface{}{
+					"id":                 "test-id-value",
+					"required_attribute": true,
+				}),
+				TargetResource: &testprovider.ResourceWithMoveState{
+					MoveStateMethod: func(ctx context.Context) []resource.StateMover {
+						return []resource.StateMover{
+							{
+								StateMover: func(_ context.Context, req resource.MoveStateRequest, resp *resource.MoveStateResponse) {
+									resp.Diagnostics.Append(resp.TargetState.SetAttribute(ctx, path.Root("id"), "test-id-value")...)
+									resp.Diagnostics.Append(resp.TargetState.SetAttribute(ctx, path.Root("required_attribute"), "true")...)
+								},
+							},
+						}
+					},
+				},
+				TargetResourceSchema: testSchema,
+				TargetTypeName:       "test_resource",
+			},
+			expectedResponse: &fwserver.MoveResourceStateResponse{
+				TargetPrivate: privatestate.EmptyData(ctx),
+				TargetState: &tfsdk.State{
+					Raw: tftypes.NewValue(schemaType, map[string]tftypes.Value{
+						"id":                 tftypes.NewValue(tftypes.String, "test-id-value"),
+						"optional_attribute": tftypes.NewValue(tftypes.String, nil),
+						"required_attribute": tftypes.NewValue(tftypes.String, "true"),
+					}),
+					Schema: testSchema,
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			response := &fwserver.MoveResourceStateResponse{}
+
+			testCase.server.MoveResourceState(context.Background(), testCase.request, response)
+
+			if diff := cmp.Diff(testCase.expectedResponse, response, cmp.AllowUnexported(privatestate.ProviderData{})); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}

--- a/internal/fwserver/server_upgraderesourcestate.go
+++ b/internal/fwserver/server_upgraderesourcestate.go
@@ -20,7 +20,14 @@ import (
 // UpgradeResourceStateRequest is the framework server request for the
 // UpgradeResourceState RPC.
 type UpgradeResourceStateRequest struct {
-	// TODO: Create framework defined type that is not protocol specific.
+	// Using the tfprotov6 type here was a pragmatic effort decision around when
+	// the framework introduced compatibility promises. This type was chosen as
+	// it was readily available and trivial to convert between tfprotov5.
+	//
+	// Using a terraform-plugin-go type is not ideal for the framework as almost
+	// all terraform-plugin-go types have framework abstractions, but if there
+	// is ever a time where it makes sense to re-evaluate this decision, such as
+	// a major version bump, it could be changed then.
 	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/340
 	RawState *tfprotov6.RawState
 

--- a/internal/proto5server/server_moveresourcestate.go
+++ b/internal/proto5server/server_moveresourcestate.go
@@ -1,0 +1,54 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package proto5server
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/internal/fromproto5"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
+	"github.com/hashicorp/terraform-plugin-framework/internal/logging"
+	"github.com/hashicorp/terraform-plugin-framework/internal/toproto5"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+)
+
+// MoveResourceState satisfies the tfprotov5.ProviderServer interface.
+func (s *Server) MoveResourceState(ctx context.Context, proto5Req *tfprotov5.MoveResourceStateRequest) (*tfprotov5.MoveResourceStateResponse, error) {
+	ctx = s.registerContext(ctx)
+	ctx = logging.InitContext(ctx)
+
+	fwResp := &fwserver.MoveResourceStateResponse{}
+
+	if proto5Req == nil {
+		return toproto5.MoveResourceStateResponse(ctx, fwResp), nil
+	}
+
+	resource, diags := s.FrameworkServer.Resource(ctx, proto5Req.TargetTypeName)
+
+	fwResp.Diagnostics.Append(diags...)
+
+	if fwResp.Diagnostics.HasError() {
+		return toproto5.MoveResourceStateResponse(ctx, fwResp), nil
+	}
+
+	resourceSchema, diags := s.FrameworkServer.ResourceSchema(ctx, proto5Req.TargetTypeName)
+
+	fwResp.Diagnostics.Append(diags...)
+
+	if fwResp.Diagnostics.HasError() {
+		return toproto5.MoveResourceStateResponse(ctx, fwResp), nil
+	}
+
+	fwReq, diags := fromproto5.MoveResourceStateRequest(ctx, proto5Req, resource, resourceSchema)
+
+	fwResp.Diagnostics.Append(diags...)
+
+	if fwResp.Diagnostics.HasError() {
+		return toproto5.MoveResourceStateResponse(ctx, fwResp), nil
+	}
+
+	s.FrameworkServer.MoveResourceState(ctx, fwReq, fwResp)
+
+	return toproto5.MoveResourceStateResponse(ctx, fwResp), nil
+}

--- a/internal/proto5server/server_moveresourcestate_test.go
+++ b/internal/proto5server/server_moveresourcestate_test.go
@@ -1,0 +1,727 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package proto5server
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
+	"github.com/hashicorp/terraform-plugin-framework/internal/privatestate"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testprovider"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func TestServerMoveResourceState(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	testSchema := schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+			},
+			"optional_attribute": schema.StringAttribute{
+				Optional: true,
+			},
+			"required_attribute": schema.StringAttribute{
+				Required: true,
+			},
+		},
+	}
+	schemaType := testSchema.Type().TerraformType(ctx)
+
+	testCases := map[string]struct {
+		server           *Server
+		request          *tfprotov5.MoveResourceStateRequest
+		expectedResponse *tfprotov5.MoveResourceStateResponse
+		expectedError    error
+	}{
+		"nil": {
+			server: &Server{
+				FrameworkServer: fwserver.Server{
+					Provider: &testprovider.Provider{},
+				},
+			},
+			request:          nil,
+			expectedResponse: &tfprotov5.MoveResourceStateResponse{},
+		},
+		"request-SourcePrivate": {
+			server: &Server{
+				FrameworkServer: fwserver.Server{
+					Provider: &testprovider.Provider{
+						ResourcesMethod: func(_ context.Context) []func() resource.Resource {
+							return []func() resource.Resource{
+								func() resource.Resource {
+									return &testprovider.ResourceWithMoveState{
+										Resource: &testprovider.Resource{
+											SchemaMethod: func(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+												resp.Schema = testSchema
+											},
+											MetadataMethod: func(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
+												resp.TypeName = "test_resource"
+											},
+										},
+										MoveStateMethod: func(ctx context.Context) []resource.StateMover {
+											return []resource.StateMover{
+												{
+													StateMover: func(_ context.Context, req resource.MoveStateRequest, resp *resource.MoveStateResponse) {
+														expected := `{"pKeyOne": {"k0": "zero", "k1": 1}}`
+														got, diags := req.SourcePrivate.GetKey(ctx, "providerKey")
+
+														resp.Diagnostics.Append(diags...)
+
+														if string(got) != expected {
+															resp.Diagnostics.AddError(
+																"Unexpected req.SourcePrivate Value",
+																fmt.Sprintf("expected %q, got %q", expected, got),
+															)
+														}
+
+														// Prevent missing implementation error, the values do not matter except for response assertion
+														resp.Diagnostics.Append(resp.TargetState.SetAttribute(ctx, path.Root("id"), "test-id-value")...)
+														resp.Diagnostics.Append(resp.TargetState.SetAttribute(ctx, path.Root("required_attribute"), "true")...)
+													},
+												},
+											}
+										},
+									}
+								},
+							}
+						},
+					},
+				},
+			},
+			request: &tfprotov5.MoveResourceStateRequest{
+				SourcePrivate: privatestate.MustMarshalToJson(map[string][]byte{
+					".frameworkKey": []byte(`{"fKeyOne": {"k0": "zero", "k1": 1}}`),
+					"providerKey":   []byte(`{"pKeyOne": {"k0": "zero", "k1": 1}}`),
+				}),
+				// SourceState required to prevent error
+				SourceState: testNewTfprotov5RawState(t, map[string]interface{}{
+					"id":                 "test-id-value",
+					"required_attribute": true,
+				}),
+				TargetTypeName: "test_resource",
+			},
+			expectedResponse: &tfprotov5.MoveResourceStateResponse{
+				// TargetPrivate intentionally not set by the framework
+				TargetState: testNewDynamicValue(t, schemaType, map[string]tftypes.Value{
+					"id":                 tftypes.NewValue(tftypes.String, "test-id-value"),
+					"optional_attribute": tftypes.NewValue(tftypes.String, nil),
+					"required_attribute": tftypes.NewValue(tftypes.String, "true"),
+				}),
+			},
+		},
+		"request-SourceProviderAddress": {
+			server: &Server{
+				FrameworkServer: fwserver.Server{
+					Provider: &testprovider.Provider{
+						ResourcesMethod: func(_ context.Context) []func() resource.Resource {
+							return []func() resource.Resource{
+								func() resource.Resource {
+									return &testprovider.ResourceWithMoveState{
+										Resource: &testprovider.Resource{
+											SchemaMethod: func(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+												resp.Schema = testSchema
+											},
+											MetadataMethod: func(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
+												resp.TypeName = "test_resource"
+											},
+										},
+										MoveStateMethod: func(ctx context.Context) []resource.StateMover {
+											return []resource.StateMover{
+												{
+													StateMover: func(_ context.Context, req resource.MoveStateRequest, resp *resource.MoveStateResponse) {
+														expected := `example.com/namespace/type`
+
+														if diff := cmp.Diff(req.SourceProviderAddress, expected); diff != "" {
+															resp.Diagnostics.AddError("Unexpected req.SourceProviderAddress difference", diff)
+														}
+
+														// Prevent missing implementation error, the values do not matter except for response assertion
+														resp.Diagnostics.Append(resp.TargetState.SetAttribute(ctx, path.Root("id"), "test-id-value")...)
+														resp.Diagnostics.Append(resp.TargetState.SetAttribute(ctx, path.Root("required_attribute"), "true")...)
+													},
+												},
+											}
+										},
+									}
+								},
+							}
+						},
+					},
+				},
+			},
+			request: &tfprotov5.MoveResourceStateRequest{
+				SourceProviderAddress: "example.com/namespace/type",
+				// SourceState required to prevent error
+				SourceState: testNewTfprotov5RawState(t, map[string]interface{}{
+					"id":                 "test-id-value",
+					"required_attribute": true,
+				}),
+				TargetTypeName: "test_resource",
+			},
+			expectedResponse: &tfprotov5.MoveResourceStateResponse{
+				TargetState: testNewDynamicValue(t, schemaType, map[string]tftypes.Value{
+					"id":                 tftypes.NewValue(tftypes.String, "test-id-value"),
+					"optional_attribute": tftypes.NewValue(tftypes.String, nil),
+					"required_attribute": tftypes.NewValue(tftypes.String, "true"),
+				}),
+			},
+		},
+		"request-SourceSchemaVersion": {
+			server: &Server{
+				FrameworkServer: fwserver.Server{
+					Provider: &testprovider.Provider{
+						ResourcesMethod: func(_ context.Context) []func() resource.Resource {
+							return []func() resource.Resource{
+								func() resource.Resource {
+									return &testprovider.ResourceWithMoveState{
+										Resource: &testprovider.Resource{
+											SchemaMethod: func(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+												resp.Schema = testSchema
+											},
+											MetadataMethod: func(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
+												resp.TypeName = "test_resource"
+											},
+										},
+										MoveStateMethod: func(ctx context.Context) []resource.StateMover {
+											return []resource.StateMover{
+												{
+													StateMover: func(_ context.Context, req resource.MoveStateRequest, resp *resource.MoveStateResponse) {
+														expected := int64(123)
+
+														if diff := cmp.Diff(req.SourceSchemaVersion, expected); diff != "" {
+															resp.Diagnostics.AddError("Unexpected req.SourceSchemaVersion difference", diff)
+														}
+
+														// Prevent missing implementation error, the values do not matter except for response assertion
+														resp.Diagnostics.Append(resp.TargetState.SetAttribute(ctx, path.Root("id"), "test-id-value")...)
+														resp.Diagnostics.Append(resp.TargetState.SetAttribute(ctx, path.Root("required_attribute"), "true")...)
+													},
+												},
+											}
+										},
+									}
+								},
+							}
+						},
+					},
+				},
+			},
+			request: &tfprotov5.MoveResourceStateRequest{
+				SourceSchemaVersion: 123,
+				// SourceState required to prevent error
+				SourceState: testNewTfprotov5RawState(t, map[string]interface{}{
+					"id":                 "test-id-value",
+					"required_attribute": true,
+				}),
+				TargetTypeName: "test_resource",
+			},
+			expectedResponse: &tfprotov5.MoveResourceStateResponse{
+				TargetState: testNewDynamicValue(t, schemaType, map[string]tftypes.Value{
+					"id":                 tftypes.NewValue(tftypes.String, "test-id-value"),
+					"optional_attribute": tftypes.NewValue(tftypes.String, nil),
+					"required_attribute": tftypes.NewValue(tftypes.String, "true"),
+				}),
+			},
+		},
+		"request-SourceRawState": {
+			server: &Server{
+				FrameworkServer: fwserver.Server{
+					Provider: &testprovider.Provider{
+						ResourcesMethod: func(_ context.Context) []func() resource.Resource {
+							return []func() resource.Resource{
+								func() resource.Resource {
+									return &testprovider.ResourceWithMoveState{
+										Resource: &testprovider.Resource{
+											SchemaMethod: func(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+												resp.Schema = testSchema
+											},
+											MetadataMethod: func(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
+												resp.TypeName = "test_resource"
+											},
+										},
+										MoveStateMethod: func(ctx context.Context) []resource.StateMover {
+											return []resource.StateMover{
+												{
+													StateMover: func(_ context.Context, req resource.MoveStateRequest, resp *resource.MoveStateResponse) {
+														expectedSourceRawState := testNewTfprotov6RawState(t, map[string]interface{}{
+															"id":                 "test-id-value",
+															"required_attribute": true,
+														})
+
+														if diff := cmp.Diff(req.SourceRawState, expectedSourceRawState); diff != "" {
+															resp.Diagnostics.AddError("Unexpected req.SourceRawState difference", diff)
+														}
+
+														// Prevent missing implementation error, the values do not matter except for response assertion
+														resp.Diagnostics.Append(resp.TargetState.SetAttribute(ctx, path.Root("id"), "test-id-value")...)
+														resp.Diagnostics.Append(resp.TargetState.SetAttribute(ctx, path.Root("required_attribute"), "true")...)
+													},
+												},
+											}
+										},
+									}
+								},
+							}
+						},
+					},
+				},
+			},
+			request: &tfprotov5.MoveResourceStateRequest{
+				SourceState: testNewTfprotov5RawState(t, map[string]interface{}{
+					"id":                 "test-id-value",
+					"required_attribute": true,
+				}),
+				TargetTypeName: "test_resource",
+			},
+			expectedResponse: &tfprotov5.MoveResourceStateResponse{
+				TargetState: testNewDynamicValue(t, schemaType, map[string]tftypes.Value{
+					"id":                 tftypes.NewValue(tftypes.String, "test-id-value"),
+					"optional_attribute": tftypes.NewValue(tftypes.String, nil),
+					"required_attribute": tftypes.NewValue(tftypes.String, "true"),
+				}),
+			},
+		},
+		"request-SourceState": {
+			server: &Server{
+				FrameworkServer: fwserver.Server{
+					Provider: &testprovider.Provider{
+						ResourcesMethod: func(_ context.Context) []func() resource.Resource {
+							return []func() resource.Resource{
+								func() resource.Resource {
+									return &testprovider.ResourceWithMoveState{
+										Resource: &testprovider.Resource{
+											SchemaMethod: func(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+												resp.Schema = testSchema
+											},
+											MetadataMethod: func(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
+												resp.TypeName = "test_resource"
+											},
+										},
+										MoveStateMethod: func(ctx context.Context) []resource.StateMover {
+											return []resource.StateMover{
+												{
+													SourceSchema: &testSchema,
+													StateMover: func(_ context.Context, req resource.MoveStateRequest, resp *resource.MoveStateResponse) {
+														var id, requiredAttribute types.String
+
+														resp.Diagnostics.Append(req.SourceState.GetAttribute(ctx, path.Root("id"), &id)...)
+														resp.Diagnostics.Append(req.SourceState.GetAttribute(ctx, path.Root("required_attribute"), &requiredAttribute)...)
+
+														if diff := cmp.Diff(id, types.StringValue("test-id-value")); diff != "" {
+															resp.Diagnostics.AddError("Unexpected req.SourceState difference", diff)
+														}
+
+														if diff := cmp.Diff(requiredAttribute, types.StringValue("true")); diff != "" {
+															resp.Diagnostics.AddError("Unexpected req.SourceState difference", diff)
+														}
+
+														// Prevent missing implementation error, the values do not matter except for response assertion
+														resp.Diagnostics.Append(resp.TargetState.SetAttribute(ctx, path.Root("id"), "test-id-value")...)
+														resp.Diagnostics.Append(resp.TargetState.SetAttribute(ctx, path.Root("required_attribute"), "true")...)
+													},
+												},
+											}
+										},
+									}
+								},
+							}
+						},
+					},
+				},
+			},
+			request: &tfprotov5.MoveResourceStateRequest{
+				SourceState: testNewTfprotov5RawState(t, map[string]interface{}{
+					"id":                 "test-id-value",
+					"required_attribute": true,
+				}),
+				TargetTypeName: "test_resource",
+			},
+			expectedResponse: &tfprotov5.MoveResourceStateResponse{
+				TargetState: testNewDynamicValue(t, schemaType, map[string]tftypes.Value{
+					"id":                 tftypes.NewValue(tftypes.String, "test-id-value"),
+					"optional_attribute": tftypes.NewValue(tftypes.String, nil),
+					"required_attribute": tftypes.NewValue(tftypes.String, "true"),
+				}),
+			},
+		},
+		"request-SourceTypeName": {
+			server: &Server{
+				FrameworkServer: fwserver.Server{
+					Provider: &testprovider.Provider{
+						ResourcesMethod: func(_ context.Context) []func() resource.Resource {
+							return []func() resource.Resource{
+								func() resource.Resource {
+									return &testprovider.ResourceWithMoveState{
+										Resource: &testprovider.Resource{
+											SchemaMethod: func(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+												resp.Schema = testSchema
+											},
+											MetadataMethod: func(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
+												resp.TypeName = "test_resource"
+											},
+										},
+										MoveStateMethod: func(ctx context.Context) []resource.StateMover {
+											return []resource.StateMover{
+												{
+													StateMover: func(_ context.Context, req resource.MoveStateRequest, resp *resource.MoveStateResponse) {
+														expected := `test_source_resource`
+
+														if diff := cmp.Diff(req.SourceTypeName, expected); diff != "" {
+															resp.Diagnostics.AddError("Unexpected req.SourceTypeName difference", diff)
+														}
+
+														// Prevent missing implementation error, the values do not matter except for response assertion
+														resp.Diagnostics.Append(resp.TargetState.SetAttribute(ctx, path.Root("id"), "test-id-value")...)
+														resp.Diagnostics.Append(resp.TargetState.SetAttribute(ctx, path.Root("required_attribute"), "true")...)
+													},
+												},
+											}
+										},
+									}
+								},
+							}
+						},
+					},
+				},
+			},
+			request: &tfprotov5.MoveResourceStateRequest{
+				// SourceState required to prevent error
+				SourceState: testNewTfprotov5RawState(t, map[string]interface{}{
+					"id":                 "test-id-value",
+					"required_attribute": true,
+				}),
+				SourceTypeName: "test_source_resource",
+				TargetTypeName: "test_resource",
+			},
+			expectedResponse: &tfprotov5.MoveResourceStateResponse{
+				TargetState: testNewDynamicValue(t, schemaType, map[string]tftypes.Value{
+					"id":                 tftypes.NewValue(tftypes.String, "test-id-value"),
+					"optional_attribute": tftypes.NewValue(tftypes.String, nil),
+					"required_attribute": tftypes.NewValue(tftypes.String, "true"),
+				}),
+			},
+		},
+		"request-TargetTypeName-missing": {
+			server: &Server{
+				FrameworkServer: fwserver.Server{
+					Provider: &testprovider.Provider{},
+				},
+			},
+			request: &tfprotov5.MoveResourceStateRequest{},
+			expectedResponse: &tfprotov5.MoveResourceStateResponse{
+				Diagnostics: []*tfprotov5.Diagnostic{
+					{
+						Severity: tfprotov5.DiagnosticSeverityError,
+						Summary:  "Resource Type Not Found",
+						Detail:   "No resource type named \"\" was found in the provider.",
+					},
+				},
+			},
+		},
+		"request-TargetTypeName-unknown": {
+			server: &Server{
+				FrameworkServer: fwserver.Server{
+					Provider: &testprovider.Provider{},
+				},
+			},
+			request: &tfprotov5.MoveResourceStateRequest{
+				TargetTypeName: "unknown",
+			},
+			expectedResponse: &tfprotov5.MoveResourceStateResponse{
+				Diagnostics: []*tfprotov5.Diagnostic{
+					{
+						Severity: tfprotov5.DiagnosticSeverityError,
+						Summary:  "Resource Type Not Found",
+						Detail:   "No resource type named \"unknown\" was found in the provider.",
+					},
+				},
+			},
+		},
+		"request-TargetTypeName-unimplemented-interface": {
+			server: &Server{
+				FrameworkServer: fwserver.Server{
+					Provider: &testprovider.Provider{
+						ResourcesMethod: func(_ context.Context) []func() resource.Resource {
+							return []func() resource.Resource{
+								func() resource.Resource {
+									return &testprovider.Resource{
+										SchemaMethod: func(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+											resp.Schema = testSchema
+										},
+										MetadataMethod: func(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
+											resp.TypeName = "test_resource"
+										},
+									}
+								},
+							}
+						},
+					},
+				},
+			},
+			request: &tfprotov5.MoveResourceStateRequest{
+				SourceProviderAddress: "example.com/namespace/type",
+				// SourceState required to prevent error
+				SourceState: testNewTfprotov5RawState(t, map[string]interface{}{
+					"id":                 "test-id-value",
+					"required_attribute": true,
+				}),
+				SourceTypeName: "test_source_resource",
+				TargetTypeName: "test_resource",
+			},
+			expectedResponse: &tfprotov5.MoveResourceStateResponse{
+				Diagnostics: []*tfprotov5.Diagnostic{
+					{
+						Severity: tfprotov5.DiagnosticSeverityError,
+						Summary:  "Unable to Move Resource State",
+						Detail: "The target resource implementation does not include move resource state support. " +
+							"The resource implementation can be updated by the provider developers to include this support with the ResourceWithMoveState interface.\n\n" +
+							"Source Provider Address: example.com/namespace/type\n" +
+							"Source Resource Type: test_source_resource\n" +
+							"Source Resource Schema Version: 0\n" +
+							"Target Resource Type: test_resource",
+					},
+				},
+			},
+		},
+		"request-TargetTypeName-unimplemented-no-responses": {
+			server: &Server{
+				FrameworkServer: fwserver.Server{
+					Provider: &testprovider.Provider{
+						ResourcesMethod: func(_ context.Context) []func() resource.Resource {
+							return []func() resource.Resource{
+								func() resource.Resource {
+									return &testprovider.ResourceWithMoveState{
+										Resource: &testprovider.Resource{
+											SchemaMethod: func(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+												resp.Schema = testSchema
+											},
+											MetadataMethod: func(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
+												resp.TypeName = "test_resource"
+											},
+										},
+										MoveStateMethod: func(ctx context.Context) []resource.StateMover {
+											return []resource.StateMover{}
+										},
+									}
+								},
+							}
+						},
+					},
+				},
+			},
+			request: &tfprotov5.MoveResourceStateRequest{
+				SourceProviderAddress: "example.com/namespace/type",
+				// SourceState required to prevent error
+				SourceState: testNewTfprotov5RawState(t, map[string]interface{}{
+					"id":                 "test-id-value",
+					"required_attribute": true,
+				}),
+				SourceTypeName: "test_source_resource",
+				TargetTypeName: "test_resource",
+			},
+			expectedResponse: &tfprotov5.MoveResourceStateResponse{
+				Diagnostics: []*tfprotov5.Diagnostic{
+					{
+						Severity: tfprotov5.DiagnosticSeverityError,
+						Summary:  "Unable to Move Resource State",
+						Detail: "The target resource implementation does not include support for the given source resource. " +
+							"The resource implementation can be updated by the provider developers to include this support by returning the moved state when the request matches this source.\n\n" +
+							"Source Provider Address: example.com/namespace/type\n" +
+							"Source Resource Type: test_source_resource\n" +
+							"Source Resource Schema Version: 0\n" +
+							"Target Resource Type: test_resource",
+					},
+				},
+			},
+		},
+		"response-Diagnostics": {
+			server: &Server{
+				FrameworkServer: fwserver.Server{
+					Provider: &testprovider.Provider{
+						ResourcesMethod: func(_ context.Context) []func() resource.Resource {
+							return []func() resource.Resource{
+								func() resource.Resource {
+									return &testprovider.ResourceWithMoveState{
+										Resource: &testprovider.Resource{
+											SchemaMethod: func(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+												resp.Schema = testSchema
+											},
+											MetadataMethod: func(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
+												resp.TypeName = "test_resource"
+											},
+										},
+										MoveStateMethod: func(ctx context.Context) []resource.StateMover {
+											return []resource.StateMover{
+												{
+													StateMover: func(_ context.Context, req resource.MoveStateRequest, resp *resource.MoveStateResponse) {
+														resp.Diagnostics.AddWarning("warning summary", "warning detail")
+														resp.Diagnostics.AddError("error summary", "error detail")
+													},
+												},
+											}
+										},
+									}
+								},
+							}
+						},
+					},
+				},
+			},
+			request: &tfprotov5.MoveResourceStateRequest{
+				// SourceState required to prevent error
+				SourceState: testNewTfprotov5RawState(t, map[string]interface{}{
+					"id":                 "test-id-value",
+					"required_attribute": true,
+				}),
+				TargetTypeName: "test_resource",
+			},
+			expectedResponse: &tfprotov5.MoveResourceStateResponse{
+				Diagnostics: []*tfprotov5.Diagnostic{
+					{
+						Severity: tfprotov5.DiagnosticSeverityWarning,
+						Summary:  "warning summary",
+						Detail:   "warning detail",
+					},
+					{
+						Severity: tfprotov5.DiagnosticSeverityError,
+						Summary:  "error summary",
+						Detail:   "error detail",
+					},
+				},
+			},
+		},
+		"response-TargetPrivate": {
+			server: &Server{
+				FrameworkServer: fwserver.Server{
+					Provider: &testprovider.Provider{
+						ResourcesMethod: func(_ context.Context) []func() resource.Resource {
+							return []func() resource.Resource{
+								func() resource.Resource {
+									return &testprovider.ResourceWithMoveState{
+										Resource: &testprovider.Resource{
+											SchemaMethod: func(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+												resp.Schema = testSchema
+											},
+											MetadataMethod: func(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
+												resp.TypeName = "test_resource"
+											},
+										},
+										MoveStateMethod: func(ctx context.Context) []resource.StateMover {
+											return []resource.StateMover{
+												{
+													StateMover: func(_ context.Context, req resource.MoveStateRequest, resp *resource.MoveStateResponse) {
+														resp.Diagnostics.Append(resp.TargetPrivate.SetKey(ctx, "providerKey", []byte(`{"key": "value"}`))...)
+
+														// Prevent missing implementation error, the values do not matter except for response assertion
+														resp.Diagnostics.Append(resp.TargetState.SetAttribute(ctx, path.Root("id"), "test-id-value")...)
+														resp.Diagnostics.Append(resp.TargetState.SetAttribute(ctx, path.Root("required_attribute"), "true")...)
+													},
+												},
+											}
+										},
+									}
+								},
+							}
+						},
+					},
+				},
+			},
+			request: &tfprotov5.MoveResourceStateRequest{
+				// SourceState required to prevent error
+				SourceState: testNewTfprotov5RawState(t, map[string]interface{}{
+					"id":                 "test-id-value",
+					"required_attribute": true,
+				}),
+				TargetTypeName: "test_resource",
+			},
+			expectedResponse: &tfprotov5.MoveResourceStateResponse{
+				TargetPrivate: privatestate.MustMarshalToJson(map[string][]byte{
+					"providerKey": []byte(`{"key": "value"}`),
+				}),
+				TargetState: testNewDynamicValue(t, schemaType, map[string]tftypes.Value{
+					"id":                 tftypes.NewValue(tftypes.String, "test-id-value"),
+					"optional_attribute": tftypes.NewValue(tftypes.String, nil),
+					"required_attribute": tftypes.NewValue(tftypes.String, "true"),
+				}),
+			},
+		},
+		"response-TargetState": {
+			server: &Server{
+				FrameworkServer: fwserver.Server{
+					Provider: &testprovider.Provider{
+						ResourcesMethod: func(_ context.Context) []func() resource.Resource {
+							return []func() resource.Resource{
+								func() resource.Resource {
+									return &testprovider.ResourceWithMoveState{
+										Resource: &testprovider.Resource{
+											SchemaMethod: func(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+												resp.Schema = testSchema
+											},
+											MetadataMethod: func(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
+												resp.TypeName = "test_resource"
+											},
+										},
+										MoveStateMethod: func(ctx context.Context) []resource.StateMover {
+											return []resource.StateMover{
+												{
+													StateMover: func(_ context.Context, req resource.MoveStateRequest, resp *resource.MoveStateResponse) {
+														resp.Diagnostics.Append(resp.TargetState.SetAttribute(ctx, path.Root("id"), "test-id-value")...)
+														resp.Diagnostics.Append(resp.TargetState.SetAttribute(ctx, path.Root("required_attribute"), "true")...)
+													},
+												},
+											}
+										},
+									}
+								},
+							}
+						},
+					},
+				},
+			},
+			request: &tfprotov5.MoveResourceStateRequest{
+				SourceState: testNewTfprotov5RawState(t, map[string]interface{}{
+					"id":                 "test-id-value",
+					"required_attribute": true,
+				}),
+				TargetTypeName: "test_resource",
+			},
+			expectedResponse: &tfprotov5.MoveResourceStateResponse{
+				TargetState: testNewDynamicValue(t, schemaType, map[string]tftypes.Value{
+					"id":                 tftypes.NewValue(tftypes.String, "test-id-value"),
+					"optional_attribute": tftypes.NewValue(tftypes.String, nil),
+					"required_attribute": tftypes.NewValue(tftypes.String, "true"),
+				}),
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := testCase.server.MoveResourceState(context.Background(), testCase.request)
+
+			if diff := cmp.Diff(testCase.expectedError, err); diff != "" {
+				t.Errorf("unexpected error difference: %s", diff)
+			}
+
+			if diff := cmp.Diff(testCase.expectedResponse, got); diff != "" {
+				t.Errorf("unexpected response difference: %s", diff)
+			}
+		})
+	}
+}

--- a/internal/proto6server/server_moveresourcestate.go
+++ b/internal/proto6server/server_moveresourcestate.go
@@ -1,0 +1,54 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package proto6server
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/internal/fromproto6"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
+	"github.com/hashicorp/terraform-plugin-framework/internal/logging"
+	"github.com/hashicorp/terraform-plugin-framework/internal/toproto6"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+)
+
+// MoveResourceState satisfies the tfprotov6.ProviderServer interface.
+func (s *Server) MoveResourceState(ctx context.Context, proto6Req *tfprotov6.MoveResourceStateRequest) (*tfprotov6.MoveResourceStateResponse, error) {
+	ctx = s.registerContext(ctx)
+	ctx = logging.InitContext(ctx)
+
+	fwResp := &fwserver.MoveResourceStateResponse{}
+
+	if proto6Req == nil {
+		return toproto6.MoveResourceStateResponse(ctx, fwResp), nil
+	}
+
+	resource, diags := s.FrameworkServer.Resource(ctx, proto6Req.TargetTypeName)
+
+	fwResp.Diagnostics.Append(diags...)
+
+	if fwResp.Diagnostics.HasError() {
+		return toproto6.MoveResourceStateResponse(ctx, fwResp), nil
+	}
+
+	resourceSchema, diags := s.FrameworkServer.ResourceSchema(ctx, proto6Req.TargetTypeName)
+
+	fwResp.Diagnostics.Append(diags...)
+
+	if fwResp.Diagnostics.HasError() {
+		return toproto6.MoveResourceStateResponse(ctx, fwResp), nil
+	}
+
+	fwReq, diags := fromproto6.MoveResourceStateRequest(ctx, proto6Req, resource, resourceSchema)
+
+	fwResp.Diagnostics.Append(diags...)
+
+	if fwResp.Diagnostics.HasError() {
+		return toproto6.MoveResourceStateResponse(ctx, fwResp), nil
+	}
+
+	s.FrameworkServer.MoveResourceState(ctx, fwReq, fwResp)
+
+	return toproto6.MoveResourceStateResponse(ctx, fwResp), nil
+}

--- a/internal/proto6server/server_moveresourcestate_test.go
+++ b/internal/proto6server/server_moveresourcestate_test.go
@@ -1,0 +1,727 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package proto6server
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
+	"github.com/hashicorp/terraform-plugin-framework/internal/privatestate"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testprovider"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func TestServerMoveResourceState(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	testSchema := schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+			},
+			"optional_attribute": schema.StringAttribute{
+				Optional: true,
+			},
+			"required_attribute": schema.StringAttribute{
+				Required: true,
+			},
+		},
+	}
+	schemaType := testSchema.Type().TerraformType(ctx)
+
+	testCases := map[string]struct {
+		server           *Server
+		request          *tfprotov6.MoveResourceStateRequest
+		expectedResponse *tfprotov6.MoveResourceStateResponse
+		expectedError    error
+	}{
+		"nil": {
+			server: &Server{
+				FrameworkServer: fwserver.Server{
+					Provider: &testprovider.Provider{},
+				},
+			},
+			request:          nil,
+			expectedResponse: &tfprotov6.MoveResourceStateResponse{},
+		},
+		"request-SourcePrivate": {
+			server: &Server{
+				FrameworkServer: fwserver.Server{
+					Provider: &testprovider.Provider{
+						ResourcesMethod: func(_ context.Context) []func() resource.Resource {
+							return []func() resource.Resource{
+								func() resource.Resource {
+									return &testprovider.ResourceWithMoveState{
+										Resource: &testprovider.Resource{
+											SchemaMethod: func(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+												resp.Schema = testSchema
+											},
+											MetadataMethod: func(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
+												resp.TypeName = "test_resource"
+											},
+										},
+										MoveStateMethod: func(ctx context.Context) []resource.StateMover {
+											return []resource.StateMover{
+												{
+													StateMover: func(_ context.Context, req resource.MoveStateRequest, resp *resource.MoveStateResponse) {
+														expected := `{"pKeyOne": {"k0": "zero", "k1": 1}}`
+														got, diags := req.SourcePrivate.GetKey(ctx, "providerKey")
+
+														resp.Diagnostics.Append(diags...)
+
+														if string(got) != expected {
+															resp.Diagnostics.AddError(
+																"Unexpected req.SourcePrivate Value",
+																fmt.Sprintf("expected %q, got %q", expected, got),
+															)
+														}
+
+														// Prevent missing implementation error, the values do not matter except for response assertion
+														resp.Diagnostics.Append(resp.TargetState.SetAttribute(ctx, path.Root("id"), "test-id-value")...)
+														resp.Diagnostics.Append(resp.TargetState.SetAttribute(ctx, path.Root("required_attribute"), "true")...)
+													},
+												},
+											}
+										},
+									}
+								},
+							}
+						},
+					},
+				},
+			},
+			request: &tfprotov6.MoveResourceStateRequest{
+				SourcePrivate: privatestate.MustMarshalToJson(map[string][]byte{
+					".frameworkKey": []byte(`{"fKeyOne": {"k0": "zero", "k1": 1}}`),
+					"providerKey":   []byte(`{"pKeyOne": {"k0": "zero", "k1": 1}}`),
+				}),
+				// SourceState required to prevent error
+				SourceState: testNewRawState(t, map[string]interface{}{
+					"id":                 "test-id-value",
+					"required_attribute": true,
+				}),
+				TargetTypeName: "test_resource",
+			},
+			expectedResponse: &tfprotov6.MoveResourceStateResponse{
+				// TargetPrivate intentionally not set by the framework
+				TargetState: testNewDynamicValue(t, schemaType, map[string]tftypes.Value{
+					"id":                 tftypes.NewValue(tftypes.String, "test-id-value"),
+					"optional_attribute": tftypes.NewValue(tftypes.String, nil),
+					"required_attribute": tftypes.NewValue(tftypes.String, "true"),
+				}),
+			},
+		},
+		"request-SourceProviderAddress": {
+			server: &Server{
+				FrameworkServer: fwserver.Server{
+					Provider: &testprovider.Provider{
+						ResourcesMethod: func(_ context.Context) []func() resource.Resource {
+							return []func() resource.Resource{
+								func() resource.Resource {
+									return &testprovider.ResourceWithMoveState{
+										Resource: &testprovider.Resource{
+											SchemaMethod: func(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+												resp.Schema = testSchema
+											},
+											MetadataMethod: func(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
+												resp.TypeName = "test_resource"
+											},
+										},
+										MoveStateMethod: func(ctx context.Context) []resource.StateMover {
+											return []resource.StateMover{
+												{
+													StateMover: func(_ context.Context, req resource.MoveStateRequest, resp *resource.MoveStateResponse) {
+														expected := `example.com/namespace/type`
+
+														if diff := cmp.Diff(req.SourceProviderAddress, expected); diff != "" {
+															resp.Diagnostics.AddError("Unexpected req.SourceProviderAddress difference", diff)
+														}
+
+														// Prevent missing implementation error, the values do not matter except for response assertion
+														resp.Diagnostics.Append(resp.TargetState.SetAttribute(ctx, path.Root("id"), "test-id-value")...)
+														resp.Diagnostics.Append(resp.TargetState.SetAttribute(ctx, path.Root("required_attribute"), "true")...)
+													},
+												},
+											}
+										},
+									}
+								},
+							}
+						},
+					},
+				},
+			},
+			request: &tfprotov6.MoveResourceStateRequest{
+				SourceProviderAddress: "example.com/namespace/type",
+				// SourceState required to prevent error
+				SourceState: testNewRawState(t, map[string]interface{}{
+					"id":                 "test-id-value",
+					"required_attribute": true,
+				}),
+				TargetTypeName: "test_resource",
+			},
+			expectedResponse: &tfprotov6.MoveResourceStateResponse{
+				TargetState: testNewDynamicValue(t, schemaType, map[string]tftypes.Value{
+					"id":                 tftypes.NewValue(tftypes.String, "test-id-value"),
+					"optional_attribute": tftypes.NewValue(tftypes.String, nil),
+					"required_attribute": tftypes.NewValue(tftypes.String, "true"),
+				}),
+			},
+		},
+		"request-SourceSchemaVersion": {
+			server: &Server{
+				FrameworkServer: fwserver.Server{
+					Provider: &testprovider.Provider{
+						ResourcesMethod: func(_ context.Context) []func() resource.Resource {
+							return []func() resource.Resource{
+								func() resource.Resource {
+									return &testprovider.ResourceWithMoveState{
+										Resource: &testprovider.Resource{
+											SchemaMethod: func(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+												resp.Schema = testSchema
+											},
+											MetadataMethod: func(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
+												resp.TypeName = "test_resource"
+											},
+										},
+										MoveStateMethod: func(ctx context.Context) []resource.StateMover {
+											return []resource.StateMover{
+												{
+													StateMover: func(_ context.Context, req resource.MoveStateRequest, resp *resource.MoveStateResponse) {
+														expected := int64(123)
+
+														if diff := cmp.Diff(req.SourceSchemaVersion, expected); diff != "" {
+															resp.Diagnostics.AddError("Unexpected req.SourceSchemaVersion difference", diff)
+														}
+
+														// Prevent missing implementation error, the values do not matter except for response assertion
+														resp.Diagnostics.Append(resp.TargetState.SetAttribute(ctx, path.Root("id"), "test-id-value")...)
+														resp.Diagnostics.Append(resp.TargetState.SetAttribute(ctx, path.Root("required_attribute"), "true")...)
+													},
+												},
+											}
+										},
+									}
+								},
+							}
+						},
+					},
+				},
+			},
+			request: &tfprotov6.MoveResourceStateRequest{
+				SourceSchemaVersion: 123,
+				// SourceState required to prevent error
+				SourceState: testNewRawState(t, map[string]interface{}{
+					"id":                 "test-id-value",
+					"required_attribute": true,
+				}),
+				TargetTypeName: "test_resource",
+			},
+			expectedResponse: &tfprotov6.MoveResourceStateResponse{
+				TargetState: testNewDynamicValue(t, schemaType, map[string]tftypes.Value{
+					"id":                 tftypes.NewValue(tftypes.String, "test-id-value"),
+					"optional_attribute": tftypes.NewValue(tftypes.String, nil),
+					"required_attribute": tftypes.NewValue(tftypes.String, "true"),
+				}),
+			},
+		},
+		"request-SourceRawState": {
+			server: &Server{
+				FrameworkServer: fwserver.Server{
+					Provider: &testprovider.Provider{
+						ResourcesMethod: func(_ context.Context) []func() resource.Resource {
+							return []func() resource.Resource{
+								func() resource.Resource {
+									return &testprovider.ResourceWithMoveState{
+										Resource: &testprovider.Resource{
+											SchemaMethod: func(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+												resp.Schema = testSchema
+											},
+											MetadataMethod: func(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
+												resp.TypeName = "test_resource"
+											},
+										},
+										MoveStateMethod: func(ctx context.Context) []resource.StateMover {
+											return []resource.StateMover{
+												{
+													StateMover: func(_ context.Context, req resource.MoveStateRequest, resp *resource.MoveStateResponse) {
+														expectedSourceRawState := testNewRawState(t, map[string]interface{}{
+															"id":                 "test-id-value",
+															"required_attribute": true,
+														})
+
+														if diff := cmp.Diff(req.SourceRawState, expectedSourceRawState); diff != "" {
+															resp.Diagnostics.AddError("Unexpected req.SourceRawState difference", diff)
+														}
+
+														// Prevent missing implementation error, the values do not matter except for response assertion
+														resp.Diagnostics.Append(resp.TargetState.SetAttribute(ctx, path.Root("id"), "test-id-value")...)
+														resp.Diagnostics.Append(resp.TargetState.SetAttribute(ctx, path.Root("required_attribute"), "true")...)
+													},
+												},
+											}
+										},
+									}
+								},
+							}
+						},
+					},
+				},
+			},
+			request: &tfprotov6.MoveResourceStateRequest{
+				SourceState: testNewRawState(t, map[string]interface{}{
+					"id":                 "test-id-value",
+					"required_attribute": true,
+				}),
+				TargetTypeName: "test_resource",
+			},
+			expectedResponse: &tfprotov6.MoveResourceStateResponse{
+				TargetState: testNewDynamicValue(t, schemaType, map[string]tftypes.Value{
+					"id":                 tftypes.NewValue(tftypes.String, "test-id-value"),
+					"optional_attribute": tftypes.NewValue(tftypes.String, nil),
+					"required_attribute": tftypes.NewValue(tftypes.String, "true"),
+				}),
+			},
+		},
+		"request-SourceState": {
+			server: &Server{
+				FrameworkServer: fwserver.Server{
+					Provider: &testprovider.Provider{
+						ResourcesMethod: func(_ context.Context) []func() resource.Resource {
+							return []func() resource.Resource{
+								func() resource.Resource {
+									return &testprovider.ResourceWithMoveState{
+										Resource: &testprovider.Resource{
+											SchemaMethod: func(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+												resp.Schema = testSchema
+											},
+											MetadataMethod: func(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
+												resp.TypeName = "test_resource"
+											},
+										},
+										MoveStateMethod: func(ctx context.Context) []resource.StateMover {
+											return []resource.StateMover{
+												{
+													SourceSchema: &testSchema,
+													StateMover: func(_ context.Context, req resource.MoveStateRequest, resp *resource.MoveStateResponse) {
+														var id, requiredAttribute types.String
+
+														resp.Diagnostics.Append(req.SourceState.GetAttribute(ctx, path.Root("id"), &id)...)
+														resp.Diagnostics.Append(req.SourceState.GetAttribute(ctx, path.Root("required_attribute"), &requiredAttribute)...)
+
+														if diff := cmp.Diff(id, types.StringValue("test-id-value")); diff != "" {
+															resp.Diagnostics.AddError("Unexpected req.SourceState difference", diff)
+														}
+
+														if diff := cmp.Diff(requiredAttribute, types.StringValue("true")); diff != "" {
+															resp.Diagnostics.AddError("Unexpected req.SourceState difference", diff)
+														}
+
+														// Prevent missing implementation error, the values do not matter except for response assertion
+														resp.Diagnostics.Append(resp.TargetState.SetAttribute(ctx, path.Root("id"), "test-id-value")...)
+														resp.Diagnostics.Append(resp.TargetState.SetAttribute(ctx, path.Root("required_attribute"), "true")...)
+													},
+												},
+											}
+										},
+									}
+								},
+							}
+						},
+					},
+				},
+			},
+			request: &tfprotov6.MoveResourceStateRequest{
+				SourceState: testNewRawState(t, map[string]interface{}{
+					"id":                 "test-id-value",
+					"required_attribute": true,
+				}),
+				TargetTypeName: "test_resource",
+			},
+			expectedResponse: &tfprotov6.MoveResourceStateResponse{
+				TargetState: testNewDynamicValue(t, schemaType, map[string]tftypes.Value{
+					"id":                 tftypes.NewValue(tftypes.String, "test-id-value"),
+					"optional_attribute": tftypes.NewValue(tftypes.String, nil),
+					"required_attribute": tftypes.NewValue(tftypes.String, "true"),
+				}),
+			},
+		},
+		"request-SourceTypeName": {
+			server: &Server{
+				FrameworkServer: fwserver.Server{
+					Provider: &testprovider.Provider{
+						ResourcesMethod: func(_ context.Context) []func() resource.Resource {
+							return []func() resource.Resource{
+								func() resource.Resource {
+									return &testprovider.ResourceWithMoveState{
+										Resource: &testprovider.Resource{
+											SchemaMethod: func(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+												resp.Schema = testSchema
+											},
+											MetadataMethod: func(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
+												resp.TypeName = "test_resource"
+											},
+										},
+										MoveStateMethod: func(ctx context.Context) []resource.StateMover {
+											return []resource.StateMover{
+												{
+													StateMover: func(_ context.Context, req resource.MoveStateRequest, resp *resource.MoveStateResponse) {
+														expected := `test_source_resource`
+
+														if diff := cmp.Diff(req.SourceTypeName, expected); diff != "" {
+															resp.Diagnostics.AddError("Unexpected req.SourceTypeName difference", diff)
+														}
+
+														// Prevent missing implementation error, the values do not matter except for response assertion
+														resp.Diagnostics.Append(resp.TargetState.SetAttribute(ctx, path.Root("id"), "test-id-value")...)
+														resp.Diagnostics.Append(resp.TargetState.SetAttribute(ctx, path.Root("required_attribute"), "true")...)
+													},
+												},
+											}
+										},
+									}
+								},
+							}
+						},
+					},
+				},
+			},
+			request: &tfprotov6.MoveResourceStateRequest{
+				// SourceState required to prevent error
+				SourceState: testNewRawState(t, map[string]interface{}{
+					"id":                 "test-id-value",
+					"required_attribute": true,
+				}),
+				SourceTypeName: "test_source_resource",
+				TargetTypeName: "test_resource",
+			},
+			expectedResponse: &tfprotov6.MoveResourceStateResponse{
+				TargetState: testNewDynamicValue(t, schemaType, map[string]tftypes.Value{
+					"id":                 tftypes.NewValue(tftypes.String, "test-id-value"),
+					"optional_attribute": tftypes.NewValue(tftypes.String, nil),
+					"required_attribute": tftypes.NewValue(tftypes.String, "true"),
+				}),
+			},
+		},
+		"request-TargetTypeName-missing": {
+			server: &Server{
+				FrameworkServer: fwserver.Server{
+					Provider: &testprovider.Provider{},
+				},
+			},
+			request: &tfprotov6.MoveResourceStateRequest{},
+			expectedResponse: &tfprotov6.MoveResourceStateResponse{
+				Diagnostics: []*tfprotov6.Diagnostic{
+					{
+						Severity: tfprotov6.DiagnosticSeverityError,
+						Summary:  "Resource Type Not Found",
+						Detail:   "No resource type named \"\" was found in the provider.",
+					},
+				},
+			},
+		},
+		"request-TargetTypeName-unknown": {
+			server: &Server{
+				FrameworkServer: fwserver.Server{
+					Provider: &testprovider.Provider{},
+				},
+			},
+			request: &tfprotov6.MoveResourceStateRequest{
+				TargetTypeName: "unknown",
+			},
+			expectedResponse: &tfprotov6.MoveResourceStateResponse{
+				Diagnostics: []*tfprotov6.Diagnostic{
+					{
+						Severity: tfprotov6.DiagnosticSeverityError,
+						Summary:  "Resource Type Not Found",
+						Detail:   "No resource type named \"unknown\" was found in the provider.",
+					},
+				},
+			},
+		},
+		"request-TargetTypeName-unimplemented-interface": {
+			server: &Server{
+				FrameworkServer: fwserver.Server{
+					Provider: &testprovider.Provider{
+						ResourcesMethod: func(_ context.Context) []func() resource.Resource {
+							return []func() resource.Resource{
+								func() resource.Resource {
+									return &testprovider.Resource{
+										SchemaMethod: func(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+											resp.Schema = testSchema
+										},
+										MetadataMethod: func(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
+											resp.TypeName = "test_resource"
+										},
+									}
+								},
+							}
+						},
+					},
+				},
+			},
+			request: &tfprotov6.MoveResourceStateRequest{
+				SourceProviderAddress: "example.com/namespace/type",
+				// SourceState required to prevent error
+				SourceState: testNewRawState(t, map[string]interface{}{
+					"id":                 "test-id-value",
+					"required_attribute": true,
+				}),
+				SourceTypeName: "test_source_resource",
+				TargetTypeName: "test_resource",
+			},
+			expectedResponse: &tfprotov6.MoveResourceStateResponse{
+				Diagnostics: []*tfprotov6.Diagnostic{
+					{
+						Severity: tfprotov6.DiagnosticSeverityError,
+						Summary:  "Unable to Move Resource State",
+						Detail: "The target resource implementation does not include move resource state support. " +
+							"The resource implementation can be updated by the provider developers to include this support with the ResourceWithMoveState interface.\n\n" +
+							"Source Provider Address: example.com/namespace/type\n" +
+							"Source Resource Type: test_source_resource\n" +
+							"Source Resource Schema Version: 0\n" +
+							"Target Resource Type: test_resource",
+					},
+				},
+			},
+		},
+		"request-TargetTypeName-unimplemented-no-responses": {
+			server: &Server{
+				FrameworkServer: fwserver.Server{
+					Provider: &testprovider.Provider{
+						ResourcesMethod: func(_ context.Context) []func() resource.Resource {
+							return []func() resource.Resource{
+								func() resource.Resource {
+									return &testprovider.ResourceWithMoveState{
+										Resource: &testprovider.Resource{
+											SchemaMethod: func(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+												resp.Schema = testSchema
+											},
+											MetadataMethod: func(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
+												resp.TypeName = "test_resource"
+											},
+										},
+										MoveStateMethod: func(ctx context.Context) []resource.StateMover {
+											return []resource.StateMover{}
+										},
+									}
+								},
+							}
+						},
+					},
+				},
+			},
+			request: &tfprotov6.MoveResourceStateRequest{
+				SourceProviderAddress: "example.com/namespace/type",
+				// SourceState required to prevent error
+				SourceState: testNewRawState(t, map[string]interface{}{
+					"id":                 "test-id-value",
+					"required_attribute": true,
+				}),
+				SourceTypeName: "test_source_resource",
+				TargetTypeName: "test_resource",
+			},
+			expectedResponse: &tfprotov6.MoveResourceStateResponse{
+				Diagnostics: []*tfprotov6.Diagnostic{
+					{
+						Severity: tfprotov6.DiagnosticSeverityError,
+						Summary:  "Unable to Move Resource State",
+						Detail: "The target resource implementation does not include support for the given source resource. " +
+							"The resource implementation can be updated by the provider developers to include this support by returning the moved state when the request matches this source.\n\n" +
+							"Source Provider Address: example.com/namespace/type\n" +
+							"Source Resource Type: test_source_resource\n" +
+							"Source Resource Schema Version: 0\n" +
+							"Target Resource Type: test_resource",
+					},
+				},
+			},
+		},
+		"response-Diagnostics": {
+			server: &Server{
+				FrameworkServer: fwserver.Server{
+					Provider: &testprovider.Provider{
+						ResourcesMethod: func(_ context.Context) []func() resource.Resource {
+							return []func() resource.Resource{
+								func() resource.Resource {
+									return &testprovider.ResourceWithMoveState{
+										Resource: &testprovider.Resource{
+											SchemaMethod: func(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+												resp.Schema = testSchema
+											},
+											MetadataMethod: func(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
+												resp.TypeName = "test_resource"
+											},
+										},
+										MoveStateMethod: func(ctx context.Context) []resource.StateMover {
+											return []resource.StateMover{
+												{
+													StateMover: func(_ context.Context, req resource.MoveStateRequest, resp *resource.MoveStateResponse) {
+														resp.Diagnostics.AddWarning("warning summary", "warning detail")
+														resp.Diagnostics.AddError("error summary", "error detail")
+													},
+												},
+											}
+										},
+									}
+								},
+							}
+						},
+					},
+				},
+			},
+			request: &tfprotov6.MoveResourceStateRequest{
+				// SourceState required to prevent error
+				SourceState: testNewRawState(t, map[string]interface{}{
+					"id":                 "test-id-value",
+					"required_attribute": true,
+				}),
+				TargetTypeName: "test_resource",
+			},
+			expectedResponse: &tfprotov6.MoveResourceStateResponse{
+				Diagnostics: []*tfprotov6.Diagnostic{
+					{
+						Severity: tfprotov6.DiagnosticSeverityWarning,
+						Summary:  "warning summary",
+						Detail:   "warning detail",
+					},
+					{
+						Severity: tfprotov6.DiagnosticSeverityError,
+						Summary:  "error summary",
+						Detail:   "error detail",
+					},
+				},
+			},
+		},
+		"response-TargetPrivate": {
+			server: &Server{
+				FrameworkServer: fwserver.Server{
+					Provider: &testprovider.Provider{
+						ResourcesMethod: func(_ context.Context) []func() resource.Resource {
+							return []func() resource.Resource{
+								func() resource.Resource {
+									return &testprovider.ResourceWithMoveState{
+										Resource: &testprovider.Resource{
+											SchemaMethod: func(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+												resp.Schema = testSchema
+											},
+											MetadataMethod: func(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
+												resp.TypeName = "test_resource"
+											},
+										},
+										MoveStateMethod: func(ctx context.Context) []resource.StateMover {
+											return []resource.StateMover{
+												{
+													StateMover: func(_ context.Context, req resource.MoveStateRequest, resp *resource.MoveStateResponse) {
+														resp.Diagnostics.Append(resp.TargetPrivate.SetKey(ctx, "providerKey", []byte(`{"key": "value"}`))...)
+
+														// Prevent missing implementation error, the values do not matter except for response assertion
+														resp.Diagnostics.Append(resp.TargetState.SetAttribute(ctx, path.Root("id"), "test-id-value")...)
+														resp.Diagnostics.Append(resp.TargetState.SetAttribute(ctx, path.Root("required_attribute"), "true")...)
+													},
+												},
+											}
+										},
+									}
+								},
+							}
+						},
+					},
+				},
+			},
+			request: &tfprotov6.MoveResourceStateRequest{
+				// SourceState required to prevent error
+				SourceState: testNewRawState(t, map[string]interface{}{
+					"id":                 "test-id-value",
+					"required_attribute": true,
+				}),
+				TargetTypeName: "test_resource",
+			},
+			expectedResponse: &tfprotov6.MoveResourceStateResponse{
+				TargetPrivate: privatestate.MustMarshalToJson(map[string][]byte{
+					"providerKey": []byte(`{"key": "value"}`),
+				}),
+				TargetState: testNewDynamicValue(t, schemaType, map[string]tftypes.Value{
+					"id":                 tftypes.NewValue(tftypes.String, "test-id-value"),
+					"optional_attribute": tftypes.NewValue(tftypes.String, nil),
+					"required_attribute": tftypes.NewValue(tftypes.String, "true"),
+				}),
+			},
+		},
+		"response-TargetState": {
+			server: &Server{
+				FrameworkServer: fwserver.Server{
+					Provider: &testprovider.Provider{
+						ResourcesMethod: func(_ context.Context) []func() resource.Resource {
+							return []func() resource.Resource{
+								func() resource.Resource {
+									return &testprovider.ResourceWithMoveState{
+										Resource: &testprovider.Resource{
+											SchemaMethod: func(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+												resp.Schema = testSchema
+											},
+											MetadataMethod: func(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
+												resp.TypeName = "test_resource"
+											},
+										},
+										MoveStateMethod: func(ctx context.Context) []resource.StateMover {
+											return []resource.StateMover{
+												{
+													StateMover: func(_ context.Context, req resource.MoveStateRequest, resp *resource.MoveStateResponse) {
+														resp.Diagnostics.Append(resp.TargetState.SetAttribute(ctx, path.Root("id"), "test-id-value")...)
+														resp.Diagnostics.Append(resp.TargetState.SetAttribute(ctx, path.Root("required_attribute"), "true")...)
+													},
+												},
+											}
+										},
+									}
+								},
+							}
+						},
+					},
+				},
+			},
+			request: &tfprotov6.MoveResourceStateRequest{
+				SourceState: testNewRawState(t, map[string]interface{}{
+					"id":                 "test-id-value",
+					"required_attribute": true,
+				}),
+				TargetTypeName: "test_resource",
+			},
+			expectedResponse: &tfprotov6.MoveResourceStateResponse{
+				TargetState: testNewDynamicValue(t, schemaType, map[string]tftypes.Value{
+					"id":                 tftypes.NewValue(tftypes.String, "test-id-value"),
+					"optional_attribute": tftypes.NewValue(tftypes.String, nil),
+					"required_attribute": tftypes.NewValue(tftypes.String, "true"),
+				}),
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := testCase.server.MoveResourceState(context.Background(), testCase.request)
+
+			if diff := cmp.Diff(testCase.expectedError, err); diff != "" {
+				t.Errorf("unexpected error difference: %s", diff)
+			}
+
+			if diff := cmp.Diff(testCase.expectedResponse, got); diff != "" {
+				t.Errorf("unexpected response difference: %s", diff)
+			}
+		})
+	}
+}

--- a/internal/testing/testprovider/resourcewithmovestate.go
+++ b/internal/testing/testprovider/resourcewithmovestate.go
@@ -1,0 +1,30 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package testprovider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+)
+
+var _ resource.Resource = &ResourceWithMoveState{}
+var _ resource.ResourceWithMoveState = &ResourceWithMoveState{}
+
+// Declarative resource.ResourceWithMoveState for unit testing.
+type ResourceWithMoveState struct {
+	*Resource
+
+	// ResourceWithMoveState interface methods
+	MoveStateMethod func(context.Context) []resource.StateMover
+}
+
+// MoveState satisfies the resource.ResourceWithMoveState interface.
+func (p *ResourceWithMoveState) MoveState(ctx context.Context) []resource.StateMover {
+	if p.MoveStateMethod == nil {
+		return nil
+	}
+
+	return p.MoveStateMethod(ctx)
+}

--- a/internal/toproto5/moveresourcestate.go
+++ b/internal/toproto5/moveresourcestate.go
@@ -1,0 +1,36 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package toproto5
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
+)
+
+// MoveResourceStateResponse returns the *tfprotov5.MoveResourceStateResponse
+// equivalent of a *fwserver.MoveResourceStateResponse.
+func MoveResourceStateResponse(ctx context.Context, fw *fwserver.MoveResourceStateResponse) *tfprotov5.MoveResourceStateResponse {
+	if fw == nil {
+		return nil
+	}
+
+	proto5 := &tfprotov5.MoveResourceStateResponse{
+		Diagnostics: Diagnostics(ctx, fw.Diagnostics),
+	}
+
+	targetPrivate, diags := fw.TargetPrivate.Bytes(ctx)
+
+	proto5.Diagnostics = append(proto5.Diagnostics, Diagnostics(ctx, diags)...)
+	proto5.TargetPrivate = targetPrivate
+
+	targetState, diags := State(ctx, fw.TargetState)
+
+	proto5.Diagnostics = append(proto5.Diagnostics, Diagnostics(ctx, diags)...)
+	proto5.TargetState = targetState
+
+	return proto5
+}

--- a/internal/toproto5/moveresourcestate_test.go
+++ b/internal/toproto5/moveresourcestate_test.go
@@ -1,0 +1,170 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package toproto5_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
+	"github.com/hashicorp/terraform-plugin-framework/internal/privatestate"
+	"github.com/hashicorp/terraform-plugin-framework/internal/toproto5"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+)
+
+func TestMoveResourceStateResponse(t *testing.T) {
+	t.Parallel()
+
+	testProto5Value := tftypes.NewValue(
+		tftypes.Object{
+			AttributeTypes: map[string]tftypes.Type{
+				"test_attribute": tftypes.String,
+			},
+		},
+		map[string]tftypes.Value{
+			"test_attribute": tftypes.NewValue(tftypes.String, "test-value"),
+		},
+	)
+
+	testCases := map[string]struct {
+		input    *fwserver.MoveResourceStateResponse
+		expected *tfprotov5.MoveResourceStateResponse
+	}{
+		"nil": {
+			input:    nil,
+			expected: nil,
+		},
+		"empty": {
+			input:    &fwserver.MoveResourceStateResponse{},
+			expected: &tfprotov5.MoveResourceStateResponse{},
+		},
+		"Diagnostics": {
+			input: &fwserver.MoveResourceStateResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewWarningDiagnostic("test warning summary", "test warning details"),
+					diag.NewErrorDiagnostic("test error summary", "test error details"),
+				},
+			},
+			expected: &tfprotov5.MoveResourceStateResponse{
+				Diagnostics: []*tfprotov5.Diagnostic{
+					{
+						Severity: tfprotov5.DiagnosticSeverityWarning,
+						Summary:  "test warning summary",
+						Detail:   "test warning details",
+					},
+					{
+						Severity: tfprotov5.DiagnosticSeverityError,
+						Summary:  "test error summary",
+						Detail:   "test error details",
+					},
+				},
+			},
+		},
+		"TargetPrivate": {
+			input: &fwserver.MoveResourceStateResponse{
+				TargetPrivate: &privatestate.Data{
+					Framework: map[string][]byte{
+						".frameworkKey": []byte(`{"fKeyOne": {"k0": "zero", "k1": 1}}`)},
+					Provider: privatestate.MustProviderData(context.Background(), privatestate.MustMarshalToJson(map[string][]byte{
+						"providerKeyOne": []byte(`{"pKeyOne": {"k0": "zero", "k1": 1}}`),
+					})),
+				},
+			},
+			expected: &tfprotov5.MoveResourceStateResponse{
+				TargetPrivate: privatestate.MustMarshalToJson(map[string][]byte{
+					".frameworkKey":  []byte(`{"fKeyOne": {"k0": "zero", "k1": 1}}`),
+					"providerKeyOne": []byte(`{"pKeyOne": {"k0": "zero", "k1": 1}}`),
+				}),
+			},
+		},
+		"TargetPrivate-empty": {
+			input: &fwserver.MoveResourceStateResponse{
+				TargetPrivate: &privatestate.Data{
+					Framework: map[string][]byte{},
+					Provider:  privatestate.EmptyProviderData(context.Background()),
+				},
+			},
+			expected: &tfprotov5.MoveResourceStateResponse{
+				TargetPrivate: nil,
+			},
+		},
+		"TargetState": {
+			input: &fwserver.MoveResourceStateResponse{
+				TargetState: &tfsdk.State{
+					Raw: testProto5Value,
+					Schema: schema.Schema{
+						Attributes: map[string]schema.Attribute{
+							"test_attribute": schema.StringAttribute{
+								Required: true,
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov5.MoveResourceStateResponse{
+				TargetState: DynamicValueMust(testProto5Value),
+			},
+		},
+		"TargetState-invalid": {
+			input: &fwserver.MoveResourceStateResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewWarningDiagnostic("test warning summary", "test warning details"),
+					diag.NewErrorDiagnostic("test error summary", "test error details"),
+				},
+				TargetState: &tfsdk.State{
+					Raw: testProto5Value,
+					Schema: schema.Schema{
+						Attributes: map[string]schema.Attribute{
+							"test_attribute": schema.BoolAttribute{
+								Required: true,
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov5.MoveResourceStateResponse{
+				Diagnostics: []*tfprotov5.Diagnostic{
+					{
+						Severity: tfprotov5.DiagnosticSeverityWarning,
+						Summary:  "test warning summary",
+						Detail:   "test warning details",
+					},
+					{
+						Severity: tfprotov5.DiagnosticSeverityError,
+						Summary:  "test error summary",
+						Detail:   "test error details",
+					},
+					{
+						Severity: tfprotov5.DiagnosticSeverityError,
+						Summary:  "Unable to Convert State",
+						Detail: "An unexpected error was encountered when converting the state to the protocol type. " +
+							"This is always an issue in terraform-plugin-framework used to implement the provider and should be reported to the provider developers.\n\n" +
+							"Please report this to the provider developer:\n\n" +
+							"Unable to create DynamicValue: AttributeName(\"test_attribute\"): unexpected value type string, tftypes.Bool values must be of type bool",
+					},
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := toproto5.MoveResourceStateResponse(context.Background(), testCase.input)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}

--- a/internal/toproto6/moveresourcestate.go
+++ b/internal/toproto6/moveresourcestate.go
@@ -1,0 +1,36 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package toproto6
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
+)
+
+// MoveResourceStateResponse returns the *tfprotov6.MoveResourceStateResponse
+// equivalent of a *fwserver.MoveResourceStateResponse.
+func MoveResourceStateResponse(ctx context.Context, fw *fwserver.MoveResourceStateResponse) *tfprotov6.MoveResourceStateResponse {
+	if fw == nil {
+		return nil
+	}
+
+	proto5 := &tfprotov6.MoveResourceStateResponse{
+		Diagnostics: Diagnostics(ctx, fw.Diagnostics),
+	}
+
+	targetPrivate, diags := fw.TargetPrivate.Bytes(ctx)
+
+	proto5.Diagnostics = append(proto5.Diagnostics, Diagnostics(ctx, diags)...)
+	proto5.TargetPrivate = targetPrivate
+
+	targetState, diags := State(ctx, fw.TargetState)
+
+	proto5.Diagnostics = append(proto5.Diagnostics, Diagnostics(ctx, diags)...)
+	proto5.TargetState = targetState
+
+	return proto5
+}

--- a/internal/toproto6/moveresourcestate.go
+++ b/internal/toproto6/moveresourcestate.go
@@ -18,19 +18,19 @@ func MoveResourceStateResponse(ctx context.Context, fw *fwserver.MoveResourceSta
 		return nil
 	}
 
-	proto5 := &tfprotov6.MoveResourceStateResponse{
+	proto6 := &tfprotov6.MoveResourceStateResponse{
 		Diagnostics: Diagnostics(ctx, fw.Diagnostics),
 	}
 
 	targetPrivate, diags := fw.TargetPrivate.Bytes(ctx)
 
-	proto5.Diagnostics = append(proto5.Diagnostics, Diagnostics(ctx, diags)...)
-	proto5.TargetPrivate = targetPrivate
+	proto6.Diagnostics = append(proto6.Diagnostics, Diagnostics(ctx, diags)...)
+	proto6.TargetPrivate = targetPrivate
 
 	targetState, diags := State(ctx, fw.TargetState)
 
-	proto5.Diagnostics = append(proto5.Diagnostics, Diagnostics(ctx, diags)...)
-	proto5.TargetState = targetState
+	proto6.Diagnostics = append(proto6.Diagnostics, Diagnostics(ctx, diags)...)
+	proto6.TargetState = targetState
 
-	return proto5
+	return proto6
 }

--- a/internal/toproto6/moveresourcestate_test.go
+++ b/internal/toproto6/moveresourcestate_test.go
@@ -1,0 +1,170 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package toproto6_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
+	"github.com/hashicorp/terraform-plugin-framework/internal/privatestate"
+	"github.com/hashicorp/terraform-plugin-framework/internal/toproto6"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+)
+
+func TestMoveResourceStateResponse(t *testing.T) {
+	t.Parallel()
+
+	testProto6Value := tftypes.NewValue(
+		tftypes.Object{
+			AttributeTypes: map[string]tftypes.Type{
+				"test_attribute": tftypes.String,
+			},
+		},
+		map[string]tftypes.Value{
+			"test_attribute": tftypes.NewValue(tftypes.String, "test-value"),
+		},
+	)
+
+	testCases := map[string]struct {
+		input    *fwserver.MoveResourceStateResponse
+		expected *tfprotov6.MoveResourceStateResponse
+	}{
+		"nil": {
+			input:    nil,
+			expected: nil,
+		},
+		"empty": {
+			input:    &fwserver.MoveResourceStateResponse{},
+			expected: &tfprotov6.MoveResourceStateResponse{},
+		},
+		"Diagnostics": {
+			input: &fwserver.MoveResourceStateResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewWarningDiagnostic("test warning summary", "test warning details"),
+					diag.NewErrorDiagnostic("test error summary", "test error details"),
+				},
+			},
+			expected: &tfprotov6.MoveResourceStateResponse{
+				Diagnostics: []*tfprotov6.Diagnostic{
+					{
+						Severity: tfprotov6.DiagnosticSeverityWarning,
+						Summary:  "test warning summary",
+						Detail:   "test warning details",
+					},
+					{
+						Severity: tfprotov6.DiagnosticSeverityError,
+						Summary:  "test error summary",
+						Detail:   "test error details",
+					},
+				},
+			},
+		},
+		"TargetPrivate": {
+			input: &fwserver.MoveResourceStateResponse{
+				TargetPrivate: &privatestate.Data{
+					Framework: map[string][]byte{
+						".frameworkKey": []byte(`{"fKeyOne": {"k0": "zero", "k1": 1}}`)},
+					Provider: privatestate.MustProviderData(context.Background(), privatestate.MustMarshalToJson(map[string][]byte{
+						"providerKeyOne": []byte(`{"pKeyOne": {"k0": "zero", "k1": 1}}`),
+					})),
+				},
+			},
+			expected: &tfprotov6.MoveResourceStateResponse{
+				TargetPrivate: privatestate.MustMarshalToJson(map[string][]byte{
+					".frameworkKey":  []byte(`{"fKeyOne": {"k0": "zero", "k1": 1}}`),
+					"providerKeyOne": []byte(`{"pKeyOne": {"k0": "zero", "k1": 1}}`),
+				}),
+			},
+		},
+		"TargetPrivate-empty": {
+			input: &fwserver.MoveResourceStateResponse{
+				TargetPrivate: &privatestate.Data{
+					Framework: map[string][]byte{},
+					Provider:  privatestate.EmptyProviderData(context.Background()),
+				},
+			},
+			expected: &tfprotov6.MoveResourceStateResponse{
+				TargetPrivate: nil,
+			},
+		},
+		"TargetState": {
+			input: &fwserver.MoveResourceStateResponse{
+				TargetState: &tfsdk.State{
+					Raw: testProto6Value,
+					Schema: schema.Schema{
+						Attributes: map[string]schema.Attribute{
+							"test_attribute": schema.StringAttribute{
+								Required: true,
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.MoveResourceStateResponse{
+				TargetState: DynamicValueMust(testProto6Value),
+			},
+		},
+		"TargetState-invalid": {
+			input: &fwserver.MoveResourceStateResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewWarningDiagnostic("test warning summary", "test warning details"),
+					diag.NewErrorDiagnostic("test error summary", "test error details"),
+				},
+				TargetState: &tfsdk.State{
+					Raw: testProto6Value,
+					Schema: schema.Schema{
+						Attributes: map[string]schema.Attribute{
+							"test_attribute": schema.BoolAttribute{
+								Required: true,
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.MoveResourceStateResponse{
+				Diagnostics: []*tfprotov6.Diagnostic{
+					{
+						Severity: tfprotov6.DiagnosticSeverityWarning,
+						Summary:  "test warning summary",
+						Detail:   "test warning details",
+					},
+					{
+						Severity: tfprotov6.DiagnosticSeverityError,
+						Summary:  "test error summary",
+						Detail:   "test error details",
+					},
+					{
+						Severity: tfprotov6.DiagnosticSeverityError,
+						Summary:  "Unable to Convert State",
+						Detail: "An unexpected error was encountered when converting the state to the protocol type. " +
+							"This is always an issue in terraform-plugin-framework used to implement the provider and should be reported to the provider developers.\n\n" +
+							"Please report this to the provider developer:\n\n" +
+							"Unable to create DynamicValue: AttributeName(\"test_attribute\"): unexpected value type string, tftypes.Bool values must be of type bool",
+					},
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := toproto6.MoveResourceStateResponse(context.Background(), testCase.input)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}

--- a/resource/move_state.go
+++ b/resource/move_state.go
@@ -43,9 +43,6 @@ type MoveStateRequest struct {
 	// redeclaration of source schemas and instead use lower level handlers to
 	// transform data. A typical implementation for working with this data will
 	// call the Unmarshal() method.
-	//
-	// TODO: Create framework defined type that is not protocol specific.
-	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/340
 	SourceRawState *tfprotov6.RawState
 
 	// SourceSchemaVersion is the schema version of the source resource. It is
@@ -61,6 +58,16 @@ type MoveStateRequest struct {
 	// If this request matches the intended implementation, the implementation
 	// logic must set [MoveStateResponse.TargetState] as it is intentionally not
 	// copied automatically.
+	//
+	// State conversion errors based on [StateMover.SourceSchema] not matching
+	// the source state are only intentionally logged at DEBUG level as there
+	// may be multiple [StateMover] implementations on the same target resource
+	// for differing source resources. In these cases, this value will be nil,
+	// and the [StateMover] implementation will still be called to enable
+	// fallback logic, such as using SourceRawState. If that fallback logic is
+	// not desired, implementations can check this value for nil and return
+	// early without errors or setting the target state to signal that the
+	// [StateMover] was skipped.
 	SourceState *tfsdk.State
 
 	// SourceTypeName is the type name of the source resource. For example,

--- a/resource/move_state.go
+++ b/resource/move_state.go
@@ -62,12 +62,10 @@ type MoveStateRequest struct {
 	// State conversion errors based on [StateMover.SourceSchema] not matching
 	// the source state are only intentionally logged at DEBUG level as there
 	// may be multiple [StateMover] implementations on the same target resource
-	// for differing source resources. In these cases, this value will be nil,
-	// and the [StateMover] implementation will still be called to enable
-	// fallback logic, such as using SourceRawState. If that fallback logic is
-	// not desired, implementations can check this value for nil and return
-	// early without errors or setting the target state to signal that the
-	// [StateMover] was skipped.
+	// for differing source resources. The [StateMover] implementation will
+	// still be called even with these errors, so it is important that
+	// implementations verify the request via the SourceTypeName and other
+	// fields before attempting to use this data.
 	SourceState *tfsdk.State
 
 	// SourceTypeName is the type name of the source resource. For example,

--- a/resource/move_state.go
+++ b/resource/move_state.go
@@ -1,0 +1,105 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package resource
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/internal/privatestate"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+)
+
+// MoveStateRequest represents a request for the provider to move a source
+// resource state into the target resource state with any necessary data
+// transformation logic. An instance of this request struct is supplied as an
+// argument to each [StateMover.StateMover].
+type MoveStateRequest struct {
+	// SourcePrivate is the source resource private state data. If this source
+	// data is important for the target resource, the implementation should set
+	// the data via [MoveStateResponse.TargetPrivate] as it is intentionally not
+	// copied automatically.
+	SourcePrivate *privatestate.ProviderData
+
+	// SourceProviderAddress is the address of the provider for the source
+	// resource type. It is the full address in HOSTNAME/NAMESPACE/TYPE format.
+	// For example, registry.terraform.io/hashicorp/random.
+	//
+	// Implementations should consider using this value to determine whether the
+	// request should be handled by this particular implementation. It is
+	// recommended to ignore the hostname unless necessary for disambiguation.
+	SourceProviderAddress string
+
+	// SourceRawState is the raw state of the source resource. This data is
+	// always available, regardless whether the [StateMover.SourceSchema] field
+	// was set. If SourceSchema is present, the [SourceState] field will be
+	// populated and it is recommended to use that field instead.
+	//
+	// If this request matches the intended implementation, the implementation
+	// logic must set [MoveStateResponse.State] as it is intentionally not
+	// copied automatically.
+	//
+	// This is advanced functionality for providers wanting to skip the full
+	// redeclaration of source schemas and instead use lower level handlers to
+	// transform data. A typical implementation for working with this data will
+	// call the Unmarshal() method.
+	//
+	// TODO: Create framework defined type that is not protocol specific.
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/340
+	SourceRawState *tfprotov6.RawState
+
+	// SourceSchemaVersion is the schema version of the source resource. It is
+	// important for implementations to account for the schema version when
+	// handling the source state data, since differing schema versions typically
+	// have differing data structures and types.
+	SourceSchemaVersion int64
+
+	// SourceState is the source resource state if the [StateMover.SourceSchema]
+	// was set. When available, this allows for easier data handling such as
+	// calling Get() or GetAttribute().
+	//
+	// If this request matches the intended implementation, the implementation
+	// logic must set [MoveStateResponse.TargetState] as it is intentionally not
+	// copied automatically.
+	SourceState *tfsdk.State
+
+	// SourceTypeName is the type name of the source resource. For example,
+	// aws_vpc or random_string.
+	//
+	// Implementations should always use this value, in addition to potentially
+	// other request fields, to determine whether the request should be handled
+	// by this particular implementation.
+	SourceTypeName string
+}
+
+// MoveStateResponse represents a response to a MoveStateRequest.
+// An instance of this response struct is supplied as an argument to
+// [StateMover] implementations. The provider should set response values only
+// within the implementation that aligns with a supported request, or put
+// differently, a response that contains no error diagnostics nor state is
+// considered as skipped by the framework. Any fulfilling response, whether via
+// error diagnostics or state data, will cause the framework to not call other
+// implementations and immediately return that response. The framework will
+// return an implementation not found error if all implementations return
+// responses without error diagnostics and state.
+type MoveStateResponse struct {
+	// Diagnostics report errors or warnings related to moving the resource.
+	// An unset or empty value indicates a successful operation or skipped
+	// implementation if [TargetState] is also not set.
+	Diagnostics diag.Diagnostics
+
+	// TargetState is the resource state following the move operation. This
+	// value is intentionally not pre-populated by the framework. The provider
+	// must set state values to indicate a successful move operation.
+	//
+	// If this value is unset and there are no diagnostics, the framework will
+	// consider this implementation to have not matched the request and move on
+	// to the next implementation, if any. If no implementation returns a state
+	// then the framework will return an implementation not found error.
+	TargetState tfsdk.State
+
+	// TargetPrivate is the resource private state data following the move
+	// operation. This field is not pre-populated as it is up to implementations
+	// whether the source private data is relevant for the target resource.
+	TargetPrivate *privatestate.ProviderData
+}

--- a/resource/state_mover.go
+++ b/resource/state_mover.go
@@ -1,0 +1,63 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package resource
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+)
+
+// Implementation handler for a state move operation. After determining the
+// source resource is supported, this should encapsulate all data transformation
+// logic from a source resource to the current schema version of this
+// [Resource]. The [Resource] is connected to these implementations by
+// implementing the [ResourceWithMoveState] interface.
+//
+// This functionality is only available in Terraform 1.8 or later. It is invoked
+// when a configuration contains a `moved` configuration block where the source
+// resource type in the `from` argument differs from the target resource type in
+// the `to` argument, causing Terraform to call this provider operation and the
+// framework to route the request to this [Resource] as the target.
+//
+// Each implementation is responsible for determining whether the request should
+// be handled or skipped. The implementation is considered skipped by the
+// framework when the response contains no error diagnostics or state.
+// Otherwise, any error diagnostics or state data, will cause the framework to
+// consider the request completed and not call other [StateMover]
+// implementations. The framework will return an implementation not found error
+// if all implementations return responses without error diagnostics or state.
+type StateMover struct {
+	// SourceSchema is an optional schema for the intended source resource state
+	// and schema version. While not required, setting this will populate
+	// [MoveStateRequest.SourceState] when possible similar to other [Resource]
+	// types. State conversion errors based on this schema are only logged at
+	// DEBUG level as there may be multiple [StateMover] implementations on the
+	// same target resource for differing source resources.
+	//
+	// If not set, source state data is only available in
+	// [MoveStateRequest.SourceRawState].
+	SourceSchema *schema.Schema
+
+	// StateMove defines the logic for determining whether the request source
+	// resource information should match this implementation, and if so, the
+	// data transformation of the source resource state to the current schema
+	// version state of this [Resource].
+	//
+	// The [context.Context] parameter contains framework-defined loggers and
+	// supports request cancellation.
+	//
+	// The [MoveStateRequest] parameter contains source resource information.
+	// If [SourceSchema] was set, the [MoveStateRequest.SourceState] field will
+	// be available. Otherwise, the [MoveStateRequest.SourceRawState] must be
+	// used.
+	//
+	// The [MoveStateResponse] parameter can either remain unmodified to signal
+	// to the framework that this implementation should be considered skipped or
+	// must contain the transformed state data to signal a successful move. Any
+	// returned error diagnostics will cause the framework to immediately
+	// respond with those errors and without calling other [StateMover]
+	// implementations.
+	StateMover func(context.Context, MoveStateRequest, *MoveStateResponse)
+}

--- a/resource/state_mover.go
+++ b/resource/state_mover.go
@@ -32,14 +32,15 @@ type StateMover struct {
 	// SourceSchema is an optional schema for the intended source resource state
 	// and schema version. While not required, setting this will populate
 	// [MoveStateRequest.SourceState] when possible similar to other [Resource]
-	// types. State conversion errors based on this schema are only logged at
-	// DEBUG level as there may be multiple [StateMover] implementations on the
-	// same target resource for differing source resources. The [StateMover]
-	// implementation will still be called to enable fallback logic, such as
-	// using [MoveStateRequest.SourceRawState]. If that fallback logic is not
-	// desired, implementations can check [MoveStateRequest.SourceState] for nil
-	// and return early without error or setting the target state to signal that
-	// the [StateMover] was skipped.
+	// types.
+	//
+	// State conversion errors based on this schema are only logged at DEBUG
+	// level as there may be multiple [StateMover] implementations on the same
+	// target resource for differing source resources. The [StateMover]
+	// implementation will still be called even with these errors, so it is
+	// important that implementations verify the request via the
+	// [MoveStateRequest.SourceTypeName] and other fields before attempting
+	// to use [MoveStateRequest.SourceState].
 	//
 	// If not set, source state data is only available in
 	// [MoveStateRequest.SourceRawState].

--- a/resource/state_mover.go
+++ b/resource/state_mover.go
@@ -34,7 +34,12 @@ type StateMover struct {
 	// [MoveStateRequest.SourceState] when possible similar to other [Resource]
 	// types. State conversion errors based on this schema are only logged at
 	// DEBUG level as there may be multiple [StateMover] implementations on the
-	// same target resource for differing source resources.
+	// same target resource for differing source resources. The [StateMover]
+	// implementation will still be called to enable fallback logic, such as
+	// using [MoveStateRequest.SourceRawState]. If that fallback logic is not
+	// desired, implementations can check [MoveStateRequest.SourceState] for nil
+	// and return early without error or setting the target state to signal that
+	// the [StateMover] was skipped.
 	//
 	// If not set, source state data is only available in
 	// [MoveStateRequest.SourceRawState].

--- a/website/data/plugin-framework-nav-data.json
+++ b/website/data/plugin-framework-nav-data.json
@@ -84,6 +84,10 @@
         "path": "resources/import"
       },
       {
+        "title": "Move State",
+        "path": "resources/state-move"
+      },
+      {
         "title": "Upgrade State",
         "path": "resources/state-upgrade"
       },

--- a/website/docs/plugin/framework/resources/state-move.mdx
+++ b/website/docs/plugin/framework/resources/state-move.mdx
@@ -108,6 +108,7 @@ func (r *TargetResource) MoveState(ctx context.Context) []resource.StateMover {
                 },
             },
             StateMover: func(ctx context.Context, req resource.MoveStateRequest, resp *resource.MoveStateResponse) {
+                // Always verify the expected source before working with the data.
                 if req.SourceTypeName != "examplecloud_source" {
                     return
                 }
@@ -175,6 +176,7 @@ func (r *TargetResource) MoveState(ctx context.Context) []resource.StateMover {
     return []resource.StateMover{
         {
             StateMover: func(ctx context.Context, req resource.MoveStateRequest, resp *resource.MoveStateResponse) {
+                // Always verify the expected source before working with the data.
                 if req.SourceTypeName != "examplecloud_source" {
                     return
                 }
@@ -260,5 +262,6 @@ func (r *TargetResource) MoveState(ctx context.Context) []resource.StateMover {
 
 Note these caveats when implementing the `MoveState` method:
 
+* The `SourceState` will not always be `nil` if the schema does not match the source state. Always verify the implementation matches other request fields (`SourceTypeName`, etc.) beforehand.
 * An error is returned if the response state contains unknown values. Set all attributes to either null or known values in the response.
 * Any response errors will cause Terraform to keep the source resource state.

--- a/website/docs/plugin/framework/resources/state-move.mdx
+++ b/website/docs/plugin/framework/resources/state-move.mdx
@@ -1,0 +1,264 @@
+---
+page_title: 'Plugin Development - Framework: State Move'
+description: >-
+  How to move state data across managed resource types using the provider
+  development framework.
+---
+
+# State Move
+
+<Tip>
+
+State move across managed resource types is supported in Terraform 1.8 and later.
+
+</Tip>
+
+Terraform is designed with each managed resource type being distinguished from all other types. To prevent data loss or unexpected data issues, Terraform will raise an error when practitioners attempt to refactor existing resource usage across resource types via the [`moved` configuration block](/terraform/language/modules/develop/refactoring) since data compatibility is not guaranteed. Provider developers can opt into explicitly enabling Terraform to allow these refactoring operations for a target resource type based on source resource type criteria. This criteria can include the source provider address, resource type name, and schema version.
+
+## Use Cases
+
+Example use cases include:
+
+* Renaming a resource type, such as API service name changes or for Terraform resource naming consistency.
+* Splitting a resource type, into separate resource types for practitioner ease, such as a compute resource into Linux and Windows variants.
+* Handing a resource type with API versioning quirks, such as multiple resource types representing the same real world resources with partially different configuration data/concepts.
+
+## Concepts
+
+A managed resource type has an associated [state](/terraform/language/state), which captures the structure and types of data for the resource type. Enabling state move support requires the provider to handle data transformation logic which takes in source resource type state as an input and outputs the equivalent target resource type state.
+
+When a plan is generated with a `moved` configuration block, Terraform will send a request to the provider with all the source resource state information (provider address, resource type, schema version) and target resource type. The framework will check the target resource to see if it defines state move support.
+
+The framework implementation does the following:
+
+* If no state move support is defined for the resource, an error diagnostic is returned.
+* If state move support is defined for the resource, each provider defined implementation is called until one responds with error diagnostics or state data.
+* If all implementations return without error diagnostics and state data, an error diagnostic is returned.
+
+## Implementation
+
+Implement the [`resource.ResourceWithStateMove` interface](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#ResourceWithStateMove) for the [`resource.Resource`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#Resource). That interface requires the `StateMove` method, which enables individual source resource criteria and logic for each source resource type to support.
+
+This example shows a `Resource` with the necessary `StateMove` method to implement the `ResourceWithStateMove` interface:
+
+```go
+// Other Resource methods are omitted in this example
+var _ resource.ResourceWithMoveState = &TargetResource{}
+
+type TargetResource struct{/* ... */}
+
+func (r *TargetResource) MoveState(ctx context.Context) []resource.StateMover {
+    return []resource.StateMover{
+        {
+            // Optionally, the SourceSchema field can be defined.
+            StateMover: func(ctx context.Context, req resource.MoveStateRequest, resp *resource.MoveStateResponse) { /* ... */ },
+        },
+        // ... potentially more StateMover for each compatible source ...
+    }
+}
+```
+
+Each [`resource.StateMover`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#StateMover) implementation is expected to:
+
+* Check the [`resource.MoveStateRequest`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#MoveStateRequest) for whether this implementation matches a known source resource. It is always recommended to check the `SourceTypeName`, `SourceSchemaVersion`, and `SourceProviderAddress` (without the hostname, unless needed for disambiguation).
+* If not matching, return early without diagnostics or setting state data in the [`resource.MoveStateResponse`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#MoveStateResponse). The framework will try the next implementation.
+* If matching, wholly set the resource state from the source state. All state data must be populated in the [`resource.MoveStateResponse`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#MoveStateResponse). The framework does not copy any source state data from the [`resource.MoveStateRequest`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#MoveStateRequest).
+
+There are two approaches to implementing the provider logic for state moves in `StateMover`. The recommended approach is defining the source schema matching the source resource state, which allows for source state access similar to other parts of the framework. The second, more advanced, approach is accessing the source resource state using lower level data handlers.
+
+### StateMover With SourceSchema
+
+Implement the [`StateMover` type `SourceSchema` field](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#StateMover.SourceSchema) to enable the framework to populate the [`resource.MoveStateRequest` type `SourceState` field](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#MoveStateRequest.SourceState) for the provider defined state move logic. Access the request `SourceState` using methods such as [`Get()`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/tfsdk#State.Get) or [`GetAttribute()`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/tfsdk#State.GetAttribute). Write the [`resource.MoveStateResponse` type `TargetState` field](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#MoveStateResponse.TargetState) using methods such as [`Set()`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/tfsdk#State.Set) or [`SetAttribute()`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/tfsdk#State.SetAttribute).
+
+This example shows a target resource that supports moving state from a source resource, using the `SourceSchema` approach:
+
+```go
+// Other Resource methods are omitted in this example
+var _ resource.Resource = &TargetResource{}
+var _ resource.ResourceWithMoveState = &TargetResource{}
+
+type TargetResource struct{/* ... */}
+
+type TargetResourceModel struct {
+    Id              types.String `tfsdk:"id"`
+    TargetAttribute types.Bool   `tfsdk:"target_attribute"`
+}
+
+type SourceResourceModel struct {
+    Id              types.String `tfsdk:"id"`
+    SourceAttribute types.Bool   `tfsdk:"source_attribute"`
+}
+
+func (r *TargetResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+    resp.Schema = schema.Schema{
+        Attributes: map[string]schema.Attribute{
+            "id": schema.StringAttribute{ /* ... */ },
+            "target_attribute": schema.BoolAttribute{ /* ... */ },
+        },
+    }
+}
+
+func (r *TargetResource) MoveState(ctx context.Context) []resource.StateMover {
+    return []resource.StateMover{
+        {
+            SourceSchema: &schema.Schema{
+                Attributes: map[string]schema.Attribute{
+                    "id": schema.StringAttribute{},
+                    "source_attribute": schema.BoolAttribute{},
+                },
+            },
+            StateMover: func(ctx context.Context, req resource.MoveStateRequest, resp *resource.MoveStateResponse) {
+                if req.SourceTypeName != "examplecloud_source" {
+                    return
+                }
+
+                if req.SourceSchemaVersion != 0 {
+                    return
+                }
+
+                // This only checks the provider address namespace and type
+                // since practitioners may use differing hostnames for the same
+                // provider, such as a network mirror. If necessary though, the
+                // hostname can be used for disambiguation.
+                if !strings.HasSuffix(req.SourceProviderAddress, "examplecorp/examplecloud") {
+                    return
+                }
+
+                var sourceStateData SourceResourceModel
+
+                resp.Diagnostics.Append(req.SourceState.Get(ctx, &sourceStateData)...)
+
+                if resp.Diagnostics.HasError() {
+                    return
+                }
+
+                targetStateData := TargetResourceModel{
+                    Id:              sourceStateData.Id,
+                    TargetAttribute: sourceStateData.SourceAttribute,
+                }
+
+                resp.Diagnostics.Append(resp.TargetState.Set(ctx, targetStateData)...)
+            },
+        },
+    }
+}
+```
+
+### StateMover Without SourceSchema
+
+Read source state data from the [`resource.MoveStateRequest` type `SourceRawState` field](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#MoveStateRequest.SourceRawState). Write the [`resource.MoveStateResponse` type `TargetState` field](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#MoveStateResponse.TargetState) using methods such as [`Set()`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/tfsdk#State.Set) or [`SetAttribute()`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/tfsdk#State.SetAttribute).
+
+This example shows a target resource that supports moving state from a source resource, using the `SourceRawState` approach for the request:
+
+```go
+// Other Resource methods are omitted in this example
+var _ resource.Resource = &TargetResource{}
+var _ resource.ResourceWithMoveState = &TargetResource{}
+
+type TargetResource struct{/* ... */}
+
+type TargetResourceModel struct {
+    Id              types.String `tfsdk:"id"`
+    TargetAttribute types.Bool   `tfsdk:"target_attribute"`
+}
+
+func (r *TargetResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+    resp.Schema = schema.Schema{
+        Attributes: map[string]schema.Attribute{
+            "id": schema.StringAttribute{ /* ... */ },
+            "target_attribute": schema.BoolAttribute{ /* ... */ },
+        },
+    }
+}
+
+func (r *TargetResource) MoveState(ctx context.Context) []resource.StateMover {
+    return []resource.StateMover{
+        {
+            StateMover: func(ctx context.Context, req resource.MoveStateRequest, resp *resource.MoveStateResponse) {
+                if req.SourceTypeName != "examplecloud_source" {
+                    return
+                }
+
+                if req.SourceSchemaVersion != 0 {
+                    return
+                }
+
+                // This only checks the provider address namespace and type
+                // since practitioners may use differing hostnames for the same
+                // provider, such as a network mirror. If necessary though, the
+                // hostname can be used for disambiguation.
+                if !strings.HasSuffix(req.SourceProviderAddress, "examplecorp/examplecloud") {
+                    return
+                }
+
+                // Refer also to the RawState type JSON field which can be used
+                // with json.Unmarshal()
+                rawStateValue, err := req.SourceRawState.Unmarshal(tftypes.Object{
+                    AttributeTypes: map[string]tftypes.Type{
+                        "id":               tftypes.String,
+                        "source_attribute": tftypes.Bool,
+                    },
+                })
+
+                if err != nil {
+                    resp.Diagnostics.AddError(
+                        "Unable to Unmarshal Source State",
+                        err.Error(),
+                    )
+
+                    return
+                }
+
+                var rawState map[string]tftypes.Value
+
+                if err := rawStateValue.As(&rawState); err != nil {
+                    resp.Diagnostics.AddError(
+                        "Unable to Convert Source State",
+                        err.Error(),
+                    )
+
+                    return
+                }
+
+                var id *string
+
+                if err := rawState["id"].As(&id); err != nil {
+                    resp.Diagnostics.AddAttributeError(
+                        path.Root("id"),
+                        "Unable to Convert Source State",
+                        err.Error(),
+                    )
+
+                    return
+                }
+
+                var sourceAttribute *bool
+
+                if err := rawState["source_attribute"].As(&sourceAttribute); err != nil {
+                    resp.Diagnostics.AddAttributeError(
+                        path.Root("source_attribute"),
+                        "Unable to Convert Source State",
+                        err.Error(),
+                    )
+
+                    return
+                }
+
+                targetStateData := TargetResourceModel{
+                    Id:              types.StringPointerValue(id),
+                    TargetAttribute: types.BoolPointerValue(sourceAttribute),
+                }
+
+                resp.Diagnostics.Append(resp.TargetState.Set(ctx, targetStateData)...)
+            },
+        },
+    }
+}
+```
+
+## Caveats
+
+Note these caveats when implementing the `MoveState` method:
+
+* An error is returned if the response state contains unknown values. Set all attributes to either null or known values in the response.
+* Any response errors will cause Terraform to keep the source resource state.


### PR DESCRIPTION
This change adds initial support for the `MoveResourceState` RPC to the framework, including:

* Adding the framework shared server implementation for the new RPC
* Adding the protocol version 5 and 6 server implementations for the new RPC
* Adding the type conversion logic for the framework types to/from the protocol types
* Exposing a new `resource.ResourceWithMoveState` interface that providers can implement to support the new RPC
* Adding a website documentation page for the new functionality

A state move using the new RPC occurs when a Terraform 1.8 and later configuration includes a `moved` configuration block such as the following:

```terraform
moved {
    from = "examplecloud_source.XXX"
    to   = "examplecloud_target.XXX"
}
```

There are no restrictions on the source resource types, but target resource types must opt into support to prevent data loss. Target resources can support moves from multiple, differing source resources, so the framework implementation is exposed as an ordered list to developers.

The framework implementation for the new RPC is as follows:

* If no state move support is defined for the resource, the framework returns an error diagnostic.
* If state move support is defined for the resource, each provider-defined state move implementation is called until one responds with error diagnostics or state data.
* If all provider-defined state move implementations return without error diagnostics and state data, the framework returns an error diagnostic.

The protocol server unit testing shows the end-to-end handling of the new RPC, including the provider-defined resource implementations, the type conversion logic, and the framework shared server implementation. The exposed `resource.ResourceWithMoveState` implementation is intentionally similar to the existing `resource.ResourceWithUpgradeState` handling, both in internal details and the exposed API. This is to provide a smoother experience for provider developers familiar with the other functionality and maintainers of the framework.

This initial implementation exposes a lot of the request/response handling as-is, however there is likely potential for introducing native helper functionality for developers, such as implementing one to simplify "aliasing"/"renaming" an existing `resource.Resource` within the same provider codebase.