### PR TITLE
resource/schema: Ensure invalid attribute default value errors are raised

### DIFF
--- a/.changes/unreleased/BUG FIXES-20240228-103338.yaml
+++ b/.changes/unreleased/BUG FIXES-20240228-103338.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'resource/schema: Ensured invalid attribute default value errors are raised'
+time: 2024-02-28T10:33:38.517635-05:00
+custom:
+  Issue: "930"

--- a/internal/fwschema/diagnostics.go
+++ b/internal/fwschema/diagnostics.go
@@ -6,6 +6,7 @@ package fwschema
 import (
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 )
@@ -41,5 +42,25 @@ func AttributeMissingElementTypeDiag(attributePath path.Path) diag.Diagnostic {
 			"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
 			fmt.Sprintf("%q is missing the CustomType or ElementType field on a collection Attribute. ", attributePath)+
 			"One of these fields is required to prevent other unexpected errors or panics.",
+	)
+}
+
+func AttributeDefaultElementTypeMismatchDiag(attributePath path.Path, expectedElementType attr.Type, actualElementType attr.Type) diag.Diagnostic {
+	return diag.NewErrorDiagnostic(
+		"Invalid Attribute Implementation",
+		"When validating the schema, an implementation issue was found. "+
+			"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+			fmt.Sprintf("%q has a default value of element type %q, but the schema expects a type of %q. ", attributePath, actualElementType, expectedElementType)+
+			"The default value must match the type of the schema.",
+	)
+}
+
+func AttributeDefaultTypeMismatchDiag(attributePath path.Path, expectedType attr.Type, actualType attr.Type) diag.Diagnostic {
+	return diag.NewErrorDiagnostic(
+		"Invalid Attribute Implementation",
+		"When validating the schema, an implementation issue was found. "+
+			"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+			fmt.Sprintf("%q has a default value of type %q, but the schema expects a type of %q. ", attributePath, actualType, expectedType)+
+			"The default value must match the type of the schema.",
 	)
 }

--- a/internal/fwschemadata/data_default_test.go
+++ b/internal/fwschemadata/data_default_test.go
@@ -1496,6 +1496,104 @@ func TestDataDefault(t *testing.T) {
 				),
 			},
 		},
+		// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/930
+		"list-attribute-null-invalid-default": {
+			data: &fwschemadata.Data{
+				Description: fwschemadata.DataDescriptionState,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"list_attribute": testschema.AttributeWithListDefaultValue{
+							Optional:    true,
+							ElementType: types.StringType,
+							Default: listdefault.StaticValue(
+								types.ListValueMust(
+									// intentionally incorrect element type
+									types.BoolType,
+									[]attr.Value{
+										types.BoolValue(true),
+									},
+								),
+							),
+						},
+					},
+				},
+				TerraformValue: tftypes.NewValue(
+					tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"list_attribute": tftypes.List{
+								ElementType: tftypes.String,
+							},
+						},
+					},
+					map[string]tftypes.Value{
+						"list_attribute": tftypes.NewValue(tftypes.List{
+							ElementType: tftypes.String,
+						}, []tftypes.Value{
+							tftypes.NewValue(tftypes.String, "one"),
+						}),
+					},
+				),
+			},
+			rawConfig: tftypes.NewValue(
+				tftypes.Object{
+					AttributeTypes: map[string]tftypes.Type{
+						"list_attribute": tftypes.List{
+							ElementType: tftypes.String,
+						},
+					},
+				},
+				map[string]tftypes.Value{
+					"list_attribute": tftypes.NewValue(tftypes.List{
+						ElementType: tftypes.String,
+					}, nil,
+					),
+				},
+			),
+			expected: &fwschemadata.Data{
+				Description: fwschemadata.DataDescriptionState,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"list_attribute": testschema.AttributeWithListDefaultValue{
+							Optional:    true,
+							ElementType: types.StringType,
+							Default: listdefault.StaticValue(
+								types.ListValueMust(
+									// intentionally incorrect element type
+									types.BoolType,
+									[]attr.Value{
+										types.BoolValue(true),
+									},
+								),
+							),
+						},
+					},
+				},
+				TerraformValue: tftypes.NewValue(
+					tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"list_attribute": tftypes.List{
+								ElementType: tftypes.String,
+							},
+						},
+					},
+					map[string]tftypes.Value{
+						"list_attribute": tftypes.NewValue(tftypes.List{
+							ElementType: tftypes.String,
+						}, []tftypes.Value{
+							tftypes.NewValue(tftypes.String, "one"),
+						}),
+					},
+				),
+			},
+			expectedDiags: diag.Diagnostics{
+				diag.NewErrorDiagnostic(
+					"Error Handling Schema Defaults",
+					"An unexpected error occurred while handling schema default values. "+
+						"Please report the following to the provider developer:\n\n"+
+						"Error: AttributeName(\"list_attribute\"): can't use tftypes.List[tftypes.Bool] as tftypes.List[tftypes.String]",
+				),
+			},
+		},
 		"list-attribute-null-unmodified-default-nil": {
 			data: &fwschemadata.Data{
 				Description: fwschemadata.DataDescriptionState,
@@ -1961,6 +2059,104 @@ func TestDataDefault(t *testing.T) {
 				),
 			},
 		},
+		// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/930
+		"map-attribute-null-invalid-default": {
+			data: &fwschemadata.Data{
+				Description: fwschemadata.DataDescriptionState,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"map_attribute": testschema.AttributeWithMapDefaultValue{
+							Optional:    true,
+							ElementType: types.StringType,
+							Default: mapdefault.StaticValue(
+								types.MapValueMust(
+									// intentionally incorrect element type
+									types.BoolType,
+									map[string]attr.Value{
+										"b": types.BoolValue(true),
+									},
+								),
+							),
+						},
+					},
+				},
+				TerraformValue: tftypes.NewValue(
+					tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"map_attribute": tftypes.Map{
+								ElementType: tftypes.String,
+							},
+						},
+					},
+					map[string]tftypes.Value{
+						"map_attribute": tftypes.NewValue(tftypes.Map{
+							ElementType: tftypes.String,
+						}, map[string]tftypes.Value{
+							"a": tftypes.NewValue(tftypes.String, "one"),
+						}),
+					},
+				),
+			},
+			rawConfig: tftypes.NewValue(
+				tftypes.Object{
+					AttributeTypes: map[string]tftypes.Type{
+						"map_attribute": tftypes.Map{
+							ElementType: tftypes.String,
+						},
+					},
+				},
+				map[string]tftypes.Value{
+					"map_attribute": tftypes.NewValue(tftypes.Map{
+						ElementType: tftypes.String,
+					}, nil,
+					),
+				},
+			),
+			expected: &fwschemadata.Data{
+				Description: fwschemadata.DataDescriptionState,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"map_attribute": testschema.AttributeWithMapDefaultValue{
+							Optional:    true,
+							ElementType: types.StringType,
+							Default: mapdefault.StaticValue(
+								types.MapValueMust(
+									// intentionally incorrect element type
+									types.BoolType,
+									map[string]attr.Value{
+										"b": types.BoolValue(true),
+									},
+								),
+							),
+						},
+					},
+				},
+				TerraformValue: tftypes.NewValue(
+					tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"map_attribute": tftypes.Map{
+								ElementType: tftypes.String,
+							},
+						},
+					},
+					map[string]tftypes.Value{
+						"map_attribute": tftypes.NewValue(tftypes.Map{
+							ElementType: tftypes.String,
+						}, map[string]tftypes.Value{
+							"a": tftypes.NewValue(tftypes.String, "one"),
+						}),
+					},
+				),
+			},
+			expectedDiags: diag.Diagnostics{
+				diag.NewErrorDiagnostic(
+					"Error Handling Schema Defaults",
+					"An unexpected error occurred while handling schema default values. "+
+						"Please report the following to the provider developer:\n\n"+
+						"Error: AttributeName(\"map_attribute\"): can't use tftypes.Map[tftypes.Bool] as tftypes.Map[tftypes.String]",
+				),
+			},
+		},
 		"map-attribute-null-unmodified-default-nil": {
 			data: &fwschemadata.Data{
 				Description: fwschemadata.DataDescriptionState,
@@ -2407,6 +2603,13 @@ func TestDataDefault(t *testing.T) {
 											fmt.Sprintf("expected %s, got: %s", path.Root("object_attribute"), req.Path),
 										)
 									}
+
+									// Response value type must conform to the schema or an error will be returned.
+									resp.PlanValue = types.ObjectNull(
+										map[string]attr.Type{
+											"test_attribute": types.StringType,
+										},
+									)
 								},
 							},
 						},
@@ -2793,6 +2996,104 @@ func TestDataDefault(t *testing.T) {
 							"a": tftypes.NewValue(tftypes.String, "two"),
 						}),
 					},
+				),
+			},
+		},
+		// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/930
+		"object-attribute-null-invalid-default": {
+			data: &fwschemadata.Data{
+				Description: fwschemadata.DataDescriptionState,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"object_attribute": testschema.AttributeWithObjectDefaultValue{
+							Optional:       true,
+							AttributeTypes: map[string]attr.Type{"a": types.StringType},
+							Default: objectdefault.StaticValue(
+								types.ObjectValueMust(
+									// intentionally invalid attribute types
+									map[string]attr.Type{"invalid": types.BoolType},
+									map[string]attr.Value{
+										"invalid": types.BoolValue(true),
+									},
+								),
+							),
+						},
+					},
+				},
+				TerraformValue: tftypes.NewValue(
+					tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"object_attribute": tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{"a": tftypes.String},
+							},
+						},
+					},
+					map[string]tftypes.Value{
+						"object_attribute": tftypes.NewValue(tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{"a": tftypes.String},
+						}, map[string]tftypes.Value{
+							"a": tftypes.NewValue(tftypes.String, "one"),
+						}),
+					},
+				),
+			},
+			rawConfig: tftypes.NewValue(
+				tftypes.Object{
+					AttributeTypes: map[string]tftypes.Type{
+						"object_attribute": tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{"a": tftypes.String},
+						},
+					},
+				},
+				map[string]tftypes.Value{
+					"object_attribute": tftypes.NewValue(tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{"a": tftypes.String},
+					}, nil,
+					),
+				},
+			),
+			expected: &fwschemadata.Data{
+				Description: fwschemadata.DataDescriptionState,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"object_attribute": testschema.AttributeWithObjectDefaultValue{
+							Optional:       true,
+							AttributeTypes: map[string]attr.Type{"a": types.StringType},
+							Default: objectdefault.StaticValue(
+								types.ObjectValueMust(
+									// intentionally invalid attribute types
+									map[string]attr.Type{"invalid": types.BoolType},
+									map[string]attr.Value{
+										"invalid": types.BoolValue(true),
+									},
+								),
+							),
+						},
+					},
+				},
+				TerraformValue: tftypes.NewValue(
+					tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"object_attribute": tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{"a": tftypes.String},
+							},
+						},
+					},
+					map[string]tftypes.Value{
+						"object_attribute": tftypes.NewValue(tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{"a": tftypes.String},
+						}, map[string]tftypes.Value{
+							"a": tftypes.NewValue(tftypes.String, "one"),
+						}),
+					},
+				),
+			},
+			expectedDiags: diag.Diagnostics{
+				diag.NewErrorDiagnostic(
+					"Error Handling Schema Defaults",
+					"An unexpected error occurred while handling schema default values. "+
+						"Please report the following to the provider developer:\n\n"+
+						"Error: AttributeName(\"object_attribute\"): can't use tftypes.Object[\"invalid\":tftypes.Bool] as tftypes.Object[\"a\":tftypes.String]",
 				),
 			},
 		},
@@ -3258,6 +3559,104 @@ func TestDataDefault(t *testing.T) {
 							tftypes.NewValue(tftypes.String, "two"),
 						}),
 					},
+				),
+			},
+		},
+		// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/930
+		"set-attribute-null-invalid-default": {
+			data: &fwschemadata.Data{
+				Description: fwschemadata.DataDescriptionState,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"set_attribute": testschema.AttributeWithSetDefaultValue{
+							Optional:    true,
+							ElementType: types.StringType,
+							Default: setdefault.StaticValue(
+								types.SetValueMust(
+									// intentionally invalid element type
+									types.BoolType,
+									[]attr.Value{
+										types.BoolValue(true),
+									},
+								),
+							),
+						},
+					},
+				},
+				TerraformValue: tftypes.NewValue(
+					tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"set_attribute": tftypes.Set{
+								ElementType: tftypes.String,
+							},
+						},
+					},
+					map[string]tftypes.Value{
+						"set_attribute": tftypes.NewValue(tftypes.Set{
+							ElementType: tftypes.String,
+						}, []tftypes.Value{
+							tftypes.NewValue(tftypes.String, "one"),
+						}),
+					},
+				),
+			},
+			rawConfig: tftypes.NewValue(
+				tftypes.Object{
+					AttributeTypes: map[string]tftypes.Type{
+						"set_attribute": tftypes.Set{
+							ElementType: tftypes.String,
+						},
+					},
+				},
+				map[string]tftypes.Value{
+					"set_attribute": tftypes.NewValue(tftypes.Set{
+						ElementType: tftypes.String,
+					}, nil,
+					),
+				},
+			),
+			expected: &fwschemadata.Data{
+				Description: fwschemadata.DataDescriptionState,
+				Schema: testschema.Schema{
+					Attributes: map[string]fwschema.Attribute{
+						"set_attribute": testschema.AttributeWithSetDefaultValue{
+							Optional:    true,
+							ElementType: types.StringType,
+							Default: setdefault.StaticValue(
+								types.SetValueMust(
+									// intentionally invalid element type
+									types.BoolType,
+									[]attr.Value{
+										types.BoolValue(true),
+									},
+								),
+							),
+						},
+					},
+				},
+				TerraformValue: tftypes.NewValue(
+					tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"set_attribute": tftypes.Set{
+								ElementType: tftypes.String,
+							},
+						},
+					},
+					map[string]tftypes.Value{
+						"set_attribute": tftypes.NewValue(tftypes.Set{
+							ElementType: tftypes.String,
+						}, []tftypes.Value{
+							tftypes.NewValue(tftypes.String, "one"),
+						}),
+					},
+				),
+			},
+			expectedDiags: diag.Diagnostics{
+				diag.NewErrorDiagnostic(
+					"Error Handling Schema Defaults",
+					"An unexpected error occurred while handling schema default values. "+
+						"Please report the following to the provider developer:\n\n"+
+						"Error: AttributeName(\"set_attribute\"): can't use tftypes.Set[tftypes.Bool] as tftypes.Set[tftypes.String]",
 				),
 			},
 		},
@@ -4167,6 +4566,168 @@ func TestDataDefault(t *testing.T) {
 							},
 						),
 					},
+				),
+			},
+		},
+		// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/930
+		"list-nested-attribute-null-invalid-default": {
+			data: &fwschemadata.Data{
+				Description: fwschemadata.DataDescriptionState,
+				Schema: schema.Schema{
+					Attributes: map[string]schema.Attribute{
+						"list_nested": testschema.NestedAttributeWithListDefaultValue{
+							Computed: true,
+							NestedObject: schema.NestedAttributeObject{
+								Attributes: map[string]schema.Attribute{
+									"string_attribute": testschema.Attribute{
+										Computed: true,
+										Type:     types.StringType,
+									},
+								},
+							},
+							Default: listdefault.StaticValue(
+								types.ListValueMust(
+									// intentionally invalid element type
+									types.StringType,
+									[]attr.Value{
+										types.StringValue("invalid"),
+									},
+								),
+							),
+						},
+					},
+				},
+				TerraformValue: tftypes.NewValue(
+					tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"list_nested": tftypes.List{
+								ElementType: tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"string_attribute": tftypes.String,
+									},
+								},
+							},
+						},
+					},
+					map[string]tftypes.Value{
+						"list_nested": tftypes.NewValue(
+							tftypes.List{
+								ElementType: tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"string_attribute": tftypes.String,
+									},
+								},
+							},
+							[]tftypes.Value{
+								tftypes.NewValue(
+									tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"string_attribute": tftypes.String,
+										},
+									},
+									map[string]tftypes.Value{
+										"string_attribute": tftypes.NewValue(tftypes.String, "one"),
+									},
+								),
+							},
+						),
+					},
+				),
+			},
+			rawConfig: tftypes.NewValue(
+				tftypes.Object{
+					AttributeTypes: map[string]tftypes.Type{
+						"list_nested": tftypes.List{
+							ElementType: tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"string_attribute": tftypes.String,
+								},
+							},
+						},
+					},
+				},
+				map[string]tftypes.Value{
+					"list_nested": tftypes.NewValue(
+						tftypes.List{
+							ElementType: tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"string_attribute": tftypes.String,
+								},
+							},
+						},
+						nil,
+					),
+				},
+			),
+			expected: &fwschemadata.Data{
+				Description: fwschemadata.DataDescriptionState,
+				Schema: schema.Schema{
+					Attributes: map[string]schema.Attribute{
+						"list_nested": testschema.NestedAttributeWithListDefaultValue{
+							Computed: true,
+							NestedObject: schema.NestedAttributeObject{
+								Attributes: map[string]schema.Attribute{
+									"string_attribute": testschema.Attribute{
+										Computed: true,
+										Type:     types.StringType,
+									},
+								},
+							},
+							Default: listdefault.StaticValue(
+								types.ListValueMust(
+									// intentionally invalid element type
+									types.StringType,
+									[]attr.Value{
+										types.StringValue("invalid"),
+									},
+								),
+							),
+						},
+					},
+				},
+				TerraformValue: tftypes.NewValue(
+					tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"list_nested": tftypes.List{
+								ElementType: tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"string_attribute": tftypes.String,
+									},
+								},
+							},
+						},
+					},
+					map[string]tftypes.Value{
+						"list_nested": tftypes.NewValue(
+							tftypes.List{
+								ElementType: tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"string_attribute": tftypes.String,
+									},
+								},
+							},
+							[]tftypes.Value{
+								tftypes.NewValue(
+									tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"string_attribute": tftypes.String,
+										},
+									},
+									map[string]tftypes.Value{
+										"string_attribute": tftypes.NewValue(tftypes.String, "one"),
+									},
+								),
+							},
+						),
+					},
+				),
+			},
+			expectedDiags: diag.Diagnostics{
+				diag.NewErrorDiagnostic(
+					"Error Handling Schema Defaults",
+					"An unexpected error occurred while handling schema default values. "+
+						"Please report the following to the provider developer:\n\n"+
+						"Error: AttributeName(\"list_nested\"): can't use tftypes.List[tftypes.String] as tftypes.List[tftypes.Object[\"string_attribute\":tftypes.String]]",
 				),
 			},
 		},
@@ -5363,6 +5924,168 @@ func TestDataDefault(t *testing.T) {
 				),
 			},
 		},
+		// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/930
+		"map-nested-attribute-null-invalid-default": {
+			data: &fwschemadata.Data{
+				Description: fwschemadata.DataDescriptionState,
+				Schema: schema.Schema{
+					Attributes: map[string]schema.Attribute{
+						"map_nested": testschema.NestedAttributeWithMapDefaultValue{
+							Computed: true,
+							NestedObject: schema.NestedAttributeObject{
+								Attributes: map[string]schema.Attribute{
+									"string_attribute": testschema.Attribute{
+										Computed: true,
+										Type:     types.StringType,
+									},
+								},
+							},
+							Default: mapdefault.StaticValue(
+								types.MapValueMust(
+									// intentionally invalid element type
+									types.StringType,
+									map[string]attr.Value{
+										"test-key": types.StringValue("invalid"),
+									},
+								),
+							),
+						},
+					},
+				},
+				TerraformValue: tftypes.NewValue(
+					tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"map_nested": tftypes.Map{
+								ElementType: tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"string_attribute": tftypes.String,
+									},
+								},
+							},
+						},
+					},
+					map[string]tftypes.Value{
+						"map_nested": tftypes.NewValue(
+							tftypes.Map{
+								ElementType: tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"string_attribute": tftypes.String,
+									},
+								},
+							},
+							map[string]tftypes.Value{
+								"test-key": tftypes.NewValue(
+									tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"string_attribute": tftypes.String,
+										},
+									},
+									map[string]tftypes.Value{
+										"string_attribute": tftypes.NewValue(tftypes.String, "one"),
+									},
+								),
+							},
+						),
+					},
+				),
+			},
+			rawConfig: tftypes.NewValue(
+				tftypes.Object{
+					AttributeTypes: map[string]tftypes.Type{
+						"map_nested": tftypes.Map{
+							ElementType: tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"string_attribute": tftypes.String,
+								},
+							},
+						},
+					},
+				},
+				map[string]tftypes.Value{
+					"map_nested": tftypes.NewValue(
+						tftypes.Map{
+							ElementType: tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"string_attribute": tftypes.String,
+								},
+							},
+						},
+						nil,
+					),
+				},
+			),
+			expected: &fwschemadata.Data{
+				Description: fwschemadata.DataDescriptionState,
+				Schema: schema.Schema{
+					Attributes: map[string]schema.Attribute{
+						"map_nested": testschema.NestedAttributeWithMapDefaultValue{
+							Computed: true,
+							NestedObject: schema.NestedAttributeObject{
+								Attributes: map[string]schema.Attribute{
+									"string_attribute": testschema.Attribute{
+										Computed: true,
+										Type:     types.StringType,
+									},
+								},
+							},
+							Default: mapdefault.StaticValue(
+								types.MapValueMust(
+									// intentionally invalid element type
+									types.StringType,
+									map[string]attr.Value{
+										"test-key": types.StringValue("invalid"),
+									},
+								),
+							),
+						},
+					},
+				},
+				TerraformValue: tftypes.NewValue(
+					tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"map_nested": tftypes.Map{
+								ElementType: tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"string_attribute": tftypes.String,
+									},
+								},
+							},
+						},
+					},
+					map[string]tftypes.Value{
+						"map_nested": tftypes.NewValue(
+							tftypes.Map{
+								ElementType: tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"string_attribute": tftypes.String,
+									},
+								},
+							},
+							map[string]tftypes.Value{
+								"test-key": tftypes.NewValue(
+									tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"string_attribute": tftypes.String,
+										},
+									},
+									map[string]tftypes.Value{
+										"string_attribute": tftypes.NewValue(tftypes.String, "one"),
+									},
+								),
+							},
+						),
+					},
+				),
+			},
+			expectedDiags: diag.Diagnostics{
+				diag.NewErrorDiagnostic(
+					"Error Handling Schema Defaults",
+					"An unexpected error occurred while handling schema default values. "+
+						"Please report the following to the provider developer:\n\n"+
+						"Error: AttributeName(\"map_nested\"): can't use tftypes.Map[tftypes.String] as tftypes.Map[tftypes.Object[\"string_attribute\":tftypes.String]]",
+				),
+			},
+		},
 		"map-nested-attribute-null-unmodified-default-nil": {
 			data: &fwschemadata.Data{
 				Description: fwschemadata.DataDescriptionState,
@@ -6556,6 +7279,168 @@ func TestDataDefault(t *testing.T) {
 				),
 			},
 		},
+		// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/930
+		"set-nested-attribute-null-invalid-default": {
+			data: &fwschemadata.Data{
+				Description: fwschemadata.DataDescriptionState,
+				Schema: schema.Schema{
+					Attributes: map[string]schema.Attribute{
+						"set_nested": testschema.NestedAttributeWithSetDefaultValue{
+							Computed: true,
+							NestedObject: schema.NestedAttributeObject{
+								Attributes: map[string]schema.Attribute{
+									"string_attribute": testschema.Attribute{
+										Computed: true,
+										Type:     types.StringType,
+									},
+								},
+							},
+							Default: setdefault.StaticValue(
+								types.SetValueMust(
+									// intentionally invalid element type
+									types.StringType,
+									[]attr.Value{
+										types.StringValue("invalid"),
+									},
+								),
+							),
+						},
+					},
+				},
+				TerraformValue: tftypes.NewValue(
+					tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"set_nested": tftypes.Set{
+								ElementType: tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"string_attribute": tftypes.String,
+									},
+								},
+							},
+						},
+					},
+					map[string]tftypes.Value{
+						"set_nested": tftypes.NewValue(
+							tftypes.Set{
+								ElementType: tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"string_attribute": tftypes.String,
+									},
+								},
+							},
+							[]tftypes.Value{
+								tftypes.NewValue(
+									tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"string_attribute": tftypes.String,
+										},
+									},
+									map[string]tftypes.Value{
+										"string_attribute": tftypes.NewValue(tftypes.String, "one"),
+									},
+								),
+							},
+						),
+					},
+				),
+			},
+			rawConfig: tftypes.NewValue(
+				tftypes.Object{
+					AttributeTypes: map[string]tftypes.Type{
+						"set_nested": tftypes.Set{
+							ElementType: tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"string_attribute": tftypes.String,
+								},
+							},
+						},
+					},
+				},
+				map[string]tftypes.Value{
+					"set_nested": tftypes.NewValue(
+						tftypes.Set{
+							ElementType: tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"string_attribute": tftypes.String,
+								},
+							},
+						},
+						nil,
+					),
+				},
+			),
+			expected: &fwschemadata.Data{
+				Description: fwschemadata.DataDescriptionState,
+				Schema: schema.Schema{
+					Attributes: map[string]schema.Attribute{
+						"set_nested": testschema.NestedAttributeWithSetDefaultValue{
+							Computed: true,
+							NestedObject: schema.NestedAttributeObject{
+								Attributes: map[string]schema.Attribute{
+									"string_attribute": testschema.Attribute{
+										Computed: true,
+										Type:     types.StringType,
+									},
+								},
+							},
+							Default: setdefault.StaticValue(
+								types.SetValueMust(
+									// intentionally invalid element type
+									types.StringType,
+									[]attr.Value{
+										types.StringValue("invalid"),
+									},
+								),
+							),
+						},
+					},
+				},
+				TerraformValue: tftypes.NewValue(
+					tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"set_nested": tftypes.Set{
+								ElementType: tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"string_attribute": tftypes.String,
+									},
+								},
+							},
+						},
+					},
+					map[string]tftypes.Value{
+						"set_nested": tftypes.NewValue(
+							tftypes.Set{
+								ElementType: tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"string_attribute": tftypes.String,
+									},
+								},
+							},
+							[]tftypes.Value{
+								tftypes.NewValue(
+									tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"string_attribute": tftypes.String,
+										},
+									},
+									map[string]tftypes.Value{
+										"string_attribute": tftypes.NewValue(tftypes.String, "one"),
+									},
+								),
+							},
+						),
+					},
+				),
+			},
+			expectedDiags: diag.Diagnostics{
+				diag.NewErrorDiagnostic(
+					"Error Handling Schema Defaults",
+					"An unexpected error occurred while handling schema default values. "+
+						"Please report the following to the provider developer:\n\n"+
+						"Error: AttributeName(\"set_nested\"): can't use tftypes.Set[tftypes.String] as tftypes.Set[tftypes.Object[\"string_attribute\":tftypes.String]]",
+				),
+			},
+		},
 		"set-nested-attribute-null-unmodified-default-nil": {
 			data: &fwschemadata.Data{
 				Description: fwschemadata.DataDescriptionState,
@@ -7599,6 +8484,134 @@ func TestDataDefault(t *testing.T) {
 							},
 						),
 					},
+				),
+			},
+		},
+		// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/930
+		"single-nested-attribute-null-invalid-default": {
+			data: &fwschemadata.Data{
+				Description: fwschemadata.DataDescriptionState,
+				Schema: schema.Schema{
+					Attributes: map[string]schema.Attribute{
+						"single_nested": testschema.NestedAttributeWithObjectDefaultValue{
+							Computed: true,
+							Attributes: map[string]schema.Attribute{
+								"string_attribute": schema.StringAttribute{
+									Computed: true,
+								},
+							},
+							Default: objectdefault.StaticValue(
+								types.ObjectValueMust(
+									// intentionally invalid attribute types
+									map[string]attr.Type{
+										"invalid": types.BoolType,
+									},
+									map[string]attr.Value{
+										"invalid": types.BoolValue(true),
+									}),
+							),
+						},
+					},
+				},
+				TerraformValue: tftypes.NewValue(
+					tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"single_nested": tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"string_attribute": tftypes.String,
+								},
+							},
+						},
+					},
+					map[string]tftypes.Value{
+						"single_nested": tftypes.NewValue(
+							tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"string_attribute": tftypes.String,
+								},
+							},
+							map[string]tftypes.Value{
+								"string_attribute": tftypes.NewValue(tftypes.String, "one"),
+							},
+						),
+					},
+				),
+			},
+			rawConfig: tftypes.NewValue(
+				tftypes.Object{
+					AttributeTypes: map[string]tftypes.Type{
+						"single_nested": tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"string_attribute": tftypes.String,
+							},
+						},
+					},
+				},
+				map[string]tftypes.Value{
+					"single_nested": tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"string_attribute": tftypes.String,
+							},
+						},
+						nil,
+					),
+				},
+			),
+			expected: &fwschemadata.Data{
+				Description: fwschemadata.DataDescriptionState,
+				Schema: schema.Schema{
+					Attributes: map[string]schema.Attribute{
+						"single_nested": testschema.NestedAttributeWithObjectDefaultValue{
+							Computed: true,
+							Attributes: map[string]schema.Attribute{
+								"string_attribute": schema.StringAttribute{
+									Computed: true,
+								},
+							},
+							Default: objectdefault.StaticValue(
+								types.ObjectValueMust(
+									// intentionally invalid attribute types
+									map[string]attr.Type{
+										"invalid": types.BoolType,
+									},
+									map[string]attr.Value{
+										"invalid": types.BoolValue(true),
+									}),
+							),
+						},
+					},
+				},
+				TerraformValue: tftypes.NewValue(
+					tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"single_nested": tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"string_attribute": tftypes.String,
+								},
+							},
+						},
+					},
+					map[string]tftypes.Value{
+						"single_nested": tftypes.NewValue(
+							tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"string_attribute": tftypes.String,
+								},
+							},
+							map[string]tftypes.Value{
+								"string_attribute": tftypes.NewValue(tftypes.String, "one"),
+							},
+						),
+					},
+				),
+			},
+			expectedDiags: diag.Diagnostics{
+				diag.NewErrorDiagnostic(
+					"Error Handling Schema Defaults",
+					"An unexpected error occurred while handling schema default values. "+
+						"Please report the following to the provider developer:\n\n"+
+						"Error: AttributeName(\"single_nested\"): can't use tftypes.Object[\"invalid\":tftypes.Bool] as tftypes.Object[\"string_attribute\":tftypes.String]",
 				),
 			},
 		},

--- a/resource/schema/list_attribute.go
+++ b/resource/schema/list_attribute.go
@@ -269,6 +269,10 @@ func (a ListAttribute) ValidateImplementation(ctx context.Context, req fwschema.
 
 		resp.Diagnostics.Append(defaultResp.Diagnostics...)
 
+		if defaultResp.Diagnostics.HasError() {
+			return
+		}
+
 		if a.ElementType != nil && !a.ElementType.Equal(defaultResp.PlanValue.ElementType(ctx)) {
 			resp.Diagnostics.Append(fwschema.AttributeDefaultElementTypeMismatchDiag(req.Path, a.ElementType, defaultResp.PlanValue.ElementType(ctx)))
 		}

--- a/resource/schema/list_attribute.go
+++ b/resource/schema/list_attribute.go
@@ -251,7 +251,26 @@ func (a ListAttribute) ValidateImplementation(ctx context.Context, req fwschema.
 		resp.Diagnostics.Append(fwschema.AttributeMissingElementTypeDiag(req.Path))
 	}
 
-	if !a.IsComputed() && a.ListDefaultValue() != nil {
-		resp.Diagnostics.Append(nonComputedAttributeWithDefaultDiag(req.Path))
+	if a.ListDefaultValue() != nil {
+		if !a.IsComputed() {
+			resp.Diagnostics.Append(nonComputedAttributeWithDefaultDiag(req.Path))
+		}
+
+		// Validate Default implementation. This is safe unless the framework
+		// ever allows more dynamic Default implementations at which the
+		// implementation would be required to be validated at runtime.
+		// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/930
+		defaultReq := defaults.ListRequest{
+			Path: req.Path,
+		}
+		defaultResp := &defaults.ListResponse{}
+
+		a.ListDefaultValue().DefaultList(ctx, defaultReq, defaultResp)
+
+		resp.Diagnostics.Append(defaultResp.Diagnostics...)
+
+		if a.ElementType != nil && !a.ElementType.Equal(defaultResp.PlanValue.ElementType(ctx)) {
+			resp.Diagnostics.Append(fwschema.AttributeDefaultElementTypeMismatchDiag(req.Path, a.ElementType, defaultResp.PlanValue.ElementType(ctx)))
+		}
 	}
 }

--- a/resource/schema/list_attribute_test.go
+++ b/resource/schema/list_attribute_test.go
@@ -606,6 +606,36 @@ func TestListAttributeValidateImplementation(t *testing.T) {
 			},
 			expected: &fwschema.ValidateImplementationResponse{},
 		},
+		"default-with-invalid-elementtype": {
+			attribute: schema.ListAttribute{
+				Computed: true,
+				Default: listdefault.StaticValue(
+					types.ListValueMust(
+						// intentionally invalid element type
+						types.BoolType,
+						[]attr.Value{
+							types.BoolValue(true),
+						},
+					),
+				),
+				ElementType: types.StringType,
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic(
+						"Invalid Attribute Implementation",
+						"When validating the schema, an implementation issue was found. "+
+							"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+							"\"test\" has a default value of element type \"basetypes.BoolType\", but the schema expects a type of \"basetypes.StringType\". "+
+							"The default value must match the type of the schema.",
+					),
+				},
+			},
+		},
 		"elementtype": {
 			attribute: schema.ListAttribute{
 				Computed:    true,

--- a/resource/schema/list_attribute_test.go
+++ b/resource/schema/list_attribute_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testdefaults"
 	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testtypes"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -605,6 +606,27 @@ func TestListAttributeValidateImplementation(t *testing.T) {
 				Path: path.Root("test"),
 			},
 			expected: &fwschema.ValidateImplementationResponse{},
+		},
+		"default-with-error-diagnostic": {
+			attribute: schema.ListAttribute{
+				Computed: true,
+				Default: testdefaults.List{
+					DefaultListMethod: func(ctx context.Context, req defaults.ListRequest, resp *defaults.ListResponse) {
+						resp.Diagnostics.AddError("error summary", "error detail")
+					},
+				},
+				ElementType: types.StringType,
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{
+				Diagnostics: diag.Diagnostics{
+					// Only the Default error should be returned, not type validation errors.
+					diag.NewErrorDiagnostic("error summary", "error detail"),
+				},
+			},
 		},
 		"default-with-invalid-elementtype": {
 			attribute: schema.ListAttribute{

--- a/resource/schema/list_nested_attribute.go
+++ b/resource/schema/list_nested_attribute.go
@@ -293,6 +293,10 @@ func (a ListNestedAttribute) ValidateImplementation(ctx context.Context, req fws
 
 		resp.Diagnostics.Append(defaultResp.Diagnostics...)
 
+		if defaultResp.Diagnostics.HasError() {
+			return
+		}
+
 		if a.CustomType == nil && a.NestedObject.CustomType == nil && !a.NestedObject.Type().Equal(defaultResp.PlanValue.ElementType(ctx)) {
 			resp.Diagnostics.Append(fwschema.AttributeDefaultElementTypeMismatchDiag(req.Path, a.NestedObject.Type(), defaultResp.PlanValue.ElementType(ctx)))
 		}

--- a/resource/schema/list_nested_attribute.go
+++ b/resource/schema/list_nested_attribute.go
@@ -275,7 +275,26 @@ func (a ListNestedAttribute) ListValidators() []validator.List {
 // errors or panics. This logic runs during the GetProviderSchema RPC and
 // should never include false positives.
 func (a ListNestedAttribute) ValidateImplementation(ctx context.Context, req fwschema.ValidateImplementationRequest, resp *fwschema.ValidateImplementationResponse) {
-	if !a.IsComputed() && a.ListDefaultValue() != nil {
-		resp.Diagnostics.Append(nonComputedAttributeWithDefaultDiag(req.Path))
+	if a.ListDefaultValue() != nil {
+		if !a.IsComputed() {
+			resp.Diagnostics.Append(nonComputedAttributeWithDefaultDiag(req.Path))
+		}
+
+		// Validate Default implementation. This is safe unless the framework
+		// ever allows more dynamic Default implementations at which the
+		// implementation would be required to be validated at runtime.
+		// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/930
+		defaultReq := defaults.ListRequest{
+			Path: req.Path,
+		}
+		defaultResp := &defaults.ListResponse{}
+
+		a.ListDefaultValue().DefaultList(ctx, defaultReq, defaultResp)
+
+		resp.Diagnostics.Append(defaultResp.Diagnostics...)
+
+		if a.CustomType == nil && a.NestedObject.CustomType == nil && !a.NestedObject.Type().Equal(defaultResp.PlanValue.ElementType(ctx)) {
+			resp.Diagnostics.Append(fwschema.AttributeDefaultElementTypeMismatchDiag(req.Path, a.NestedObject.Type(), defaultResp.PlanValue.ElementType(ctx)))
+		}
 	}
 }

--- a/resource/schema/list_nested_attribute_test.go
+++ b/resource/schema/list_nested_attribute_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testdefaults"
 	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -816,6 +817,33 @@ func TestListNestedAttributeValidateImplementation(t *testing.T) {
 				Path: path.Root("test"),
 			},
 			expected: &fwschema.ValidateImplementationResponse{},
+		},
+		"default-with-error-diagnostic": {
+			attribute: schema.ListNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"test_attr": schema.StringAttribute{
+							Computed: true,
+						},
+					},
+				},
+				Computed: true,
+				Default: testdefaults.List{
+					DefaultListMethod: func(ctx context.Context, req defaults.ListRequest, resp *defaults.ListResponse) {
+						resp.Diagnostics.AddError("error summary", "error detail")
+					},
+				},
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{
+				Diagnostics: diag.Diagnostics{
+					// Only the Default error should be returned, not type validation errors.
+					diag.NewErrorDiagnostic("error summary", "error detail"),
+				},
+			},
 		},
 		"default-with-invalid-elementtype": {
 			attribute: schema.ListNestedAttribute{

--- a/resource/schema/map_attribute.go
+++ b/resource/schema/map_attribute.go
@@ -272,6 +272,10 @@ func (a MapAttribute) ValidateImplementation(ctx context.Context, req fwschema.V
 
 		resp.Diagnostics.Append(defaultResp.Diagnostics...)
 
+		if defaultResp.Diagnostics.HasError() {
+			return
+		}
+
 		if a.ElementType != nil && !a.ElementType.Equal(defaultResp.PlanValue.ElementType(ctx)) {
 			resp.Diagnostics.Append(fwschema.AttributeDefaultElementTypeMismatchDiag(req.Path, a.ElementType, defaultResp.PlanValue.ElementType(ctx)))
 		}

--- a/resource/schema/map_attribute.go
+++ b/resource/schema/map_attribute.go
@@ -254,7 +254,26 @@ func (a MapAttribute) ValidateImplementation(ctx context.Context, req fwschema.V
 		resp.Diagnostics.Append(fwschema.AttributeMissingElementTypeDiag(req.Path))
 	}
 
-	if !a.IsComputed() && a.MapDefaultValue() != nil {
-		resp.Diagnostics.Append(nonComputedAttributeWithDefaultDiag(req.Path))
+	if a.MapDefaultValue() != nil {
+		if !a.IsComputed() {
+			resp.Diagnostics.Append(nonComputedAttributeWithDefaultDiag(req.Path))
+		}
+
+		// Validate Default implementation. This is safe unless the framework
+		// ever allows more dynamic Default implementations at which the
+		// implementation would be required to be validated at runtime.
+		// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/930
+		defaultReq := defaults.MapRequest{
+			Path: req.Path,
+		}
+		defaultResp := &defaults.MapResponse{}
+
+		a.MapDefaultValue().DefaultMap(ctx, defaultReq, defaultResp)
+
+		resp.Diagnostics.Append(defaultResp.Diagnostics...)
+
+		if a.ElementType != nil && !a.ElementType.Equal(defaultResp.PlanValue.ElementType(ctx)) {
+			resp.Diagnostics.Append(fwschema.AttributeDefaultElementTypeMismatchDiag(req.Path, a.ElementType, defaultResp.PlanValue.ElementType(ctx)))
+		}
 	}
 }

--- a/resource/schema/map_attribute_test.go
+++ b/resource/schema/map_attribute_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testdefaults"
 	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testtypes"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -604,6 +605,27 @@ func TestMapAttributeValidateImplementation(t *testing.T) {
 				Path: path.Root("test"),
 			},
 			expected: &fwschema.ValidateImplementationResponse{},
+		},
+		"default-with-error-diagnostic": {
+			attribute: schema.MapAttribute{
+				Computed: true,
+				Default: testdefaults.Map{
+					DefaultMapMethod: func(ctx context.Context, req defaults.MapRequest, resp *defaults.MapResponse) {
+						resp.Diagnostics.AddError("error summary", "error detail")
+					},
+				},
+				ElementType: types.StringType,
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{
+				Diagnostics: diag.Diagnostics{
+					// Only the Default error should be returned, not type validation errors.
+					diag.NewErrorDiagnostic("error summary", "error detail"),
+				},
+			},
 		},
 		"default-with-invalid-elementtype": {
 			attribute: schema.MapAttribute{

--- a/resource/schema/map_attribute_test.go
+++ b/resource/schema/map_attribute_test.go
@@ -605,6 +605,36 @@ func TestMapAttributeValidateImplementation(t *testing.T) {
 			},
 			expected: &fwschema.ValidateImplementationResponse{},
 		},
+		"default-with-invalid-elementtype": {
+			attribute: schema.MapAttribute{
+				Computed: true,
+				Default: mapdefault.StaticValue(
+					types.MapValueMust(
+						// intentionally invalid element type
+						types.BoolType,
+						map[string]attr.Value{
+							"testkey": types.BoolValue(true),
+						},
+					),
+				),
+				ElementType: types.StringType,
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic(
+						"Invalid Attribute Implementation",
+						"When validating the schema, an implementation issue was found. "+
+							"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+							"\"test\" has a default value of element type \"basetypes.BoolType\", but the schema expects a type of \"basetypes.StringType\". "+
+							"The default value must match the type of the schema.",
+					),
+				},
+			},
+		},
 		"elementtype": {
 			attribute: schema.MapAttribute{
 				Computed:    true,

--- a/resource/schema/map_nested_attribute.go
+++ b/resource/schema/map_nested_attribute.go
@@ -293,6 +293,10 @@ func (a MapNestedAttribute) ValidateImplementation(ctx context.Context, req fwsc
 
 		resp.Diagnostics.Append(defaultResp.Diagnostics...)
 
+		if defaultResp.Diagnostics.HasError() {
+			return
+		}
+
 		if a.CustomType == nil && a.NestedObject.CustomType == nil && !a.NestedObject.Type().Equal(defaultResp.PlanValue.ElementType(ctx)) {
 			resp.Diagnostics.Append(fwschema.AttributeDefaultElementTypeMismatchDiag(req.Path, a.NestedObject.Type(), defaultResp.PlanValue.ElementType(ctx)))
 		}

--- a/resource/schema/map_nested_attribute.go
+++ b/resource/schema/map_nested_attribute.go
@@ -275,7 +275,26 @@ func (a MapNestedAttribute) MapValidators() []validator.Map {
 // errors or panics. This logic runs during the GetProviderSchema RPC and
 // should never include false positives.
 func (a MapNestedAttribute) ValidateImplementation(ctx context.Context, req fwschema.ValidateImplementationRequest, resp *fwschema.ValidateImplementationResponse) {
-	if !a.IsComputed() && a.MapDefaultValue() != nil {
-		resp.Diagnostics.Append(nonComputedAttributeWithDefaultDiag(req.Path))
+	if a.MapDefaultValue() != nil {
+		if !a.IsComputed() {
+			resp.Diagnostics.Append(nonComputedAttributeWithDefaultDiag(req.Path))
+		}
+
+		// Validate Default implementation. This is safe unless the framework
+		// ever allows more dynamic Default implementations at which the
+		// implementation would be required to be validated at runtime.
+		// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/930
+		defaultReq := defaults.MapRequest{
+			Path: req.Path,
+		}
+		defaultResp := &defaults.MapResponse{}
+
+		a.MapDefaultValue().DefaultMap(ctx, defaultReq, defaultResp)
+
+		resp.Diagnostics.Append(defaultResp.Diagnostics...)
+
+		if a.CustomType == nil && a.NestedObject.CustomType == nil && !a.NestedObject.Type().Equal(defaultResp.PlanValue.ElementType(ctx)) {
+			resp.Diagnostics.Append(fwschema.AttributeDefaultElementTypeMismatchDiag(req.Path, a.NestedObject.Type(), defaultResp.PlanValue.ElementType(ctx)))
+		}
 	}
 }

--- a/resource/schema/map_nested_attribute_test.go
+++ b/resource/schema/map_nested_attribute_test.go
@@ -817,6 +817,42 @@ func TestMapNestedAttributeValidateImplementation(t *testing.T) {
 			},
 			expected: &fwschema.ValidateImplementationResponse{},
 		},
+		"default-with-invalid-elementtype": {
+			attribute: schema.MapNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"test_attr": schema.StringAttribute{
+							Computed: true,
+						},
+					},
+				},
+				Computed: true,
+				Default: mapdefault.StaticValue(
+					types.MapValueMust(
+						// intentionally invalid element type
+						types.BoolType,
+						map[string]attr.Value{
+							"testkey": types.BoolValue(true),
+						},
+					),
+				),
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic(
+						"Invalid Attribute Implementation",
+						"When validating the schema, an implementation issue was found. "+
+							"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+							"\"test\" has a default value of element type \"basetypes.BoolType\", but the schema expects a type of \"types.ObjectType[\\\"test_attr\\\":basetypes.StringType]\". "+
+							"The default value must match the type of the schema.",
+					),
+				},
+			},
+		},
 	}
 
 	for name, testCase := range testCases {

--- a/resource/schema/map_nested_attribute_test.go
+++ b/resource/schema/map_nested_attribute_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testdefaults"
 	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -816,6 +817,33 @@ func TestMapNestedAttributeValidateImplementation(t *testing.T) {
 				Path: path.Root("test"),
 			},
 			expected: &fwschema.ValidateImplementationResponse{},
+		},
+		"default-with-error-diagnostic": {
+			attribute: schema.MapNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"test_attr": schema.StringAttribute{
+							Computed: true,
+						},
+					},
+				},
+				Computed: true,
+				Default: testdefaults.Map{
+					DefaultMapMethod: func(ctx context.Context, req defaults.MapRequest, resp *defaults.MapResponse) {
+						resp.Diagnostics.AddError("error summary", "error detail")
+					},
+				},
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{
+				Diagnostics: diag.Diagnostics{
+					// Only the Default error should be returned, not type validation errors.
+					diag.NewErrorDiagnostic("error summary", "error detail"),
+				},
+			},
 		},
 		"default-with-invalid-elementtype": {
 			attribute: schema.MapNestedAttribute{

--- a/resource/schema/object_attribute.go
+++ b/resource/schema/object_attribute.go
@@ -271,6 +271,10 @@ func (a ObjectAttribute) ValidateImplementation(ctx context.Context, req fwschem
 
 		resp.Diagnostics.Append(defaultResp.Diagnostics...)
 
+		if defaultResp.Diagnostics.HasError() {
+			return
+		}
+
 		if a.AttributeTypes != nil && !a.GetType().Equal(defaultResp.PlanValue.Type(ctx)) {
 			resp.Diagnostics.Append(fwschema.AttributeDefaultTypeMismatchDiag(req.Path, a.GetType(), defaultResp.PlanValue.Type(ctx)))
 		}

--- a/resource/schema/object_attribute.go
+++ b/resource/schema/object_attribute.go
@@ -253,7 +253,26 @@ func (a ObjectAttribute) ValidateImplementation(ctx context.Context, req fwschem
 		resp.Diagnostics.Append(fwschema.AttributeMissingAttributeTypesDiag(req.Path))
 	}
 
-	if !a.IsComputed() && a.ObjectDefaultValue() != nil {
-		resp.Diagnostics.Append(nonComputedAttributeWithDefaultDiag(req.Path))
+	if a.ObjectDefaultValue() != nil {
+		if !a.IsComputed() {
+			resp.Diagnostics.Append(nonComputedAttributeWithDefaultDiag(req.Path))
+		}
+
+		// Validate Default implementation. This is safe unless the framework
+		// ever allows more dynamic Default implementations at which the
+		// implementation would be required to be validated at runtime.
+		// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/930
+		defaultReq := defaults.ObjectRequest{
+			Path: req.Path,
+		}
+		defaultResp := &defaults.ObjectResponse{}
+
+		a.ObjectDefaultValue().DefaultObject(ctx, defaultReq, defaultResp)
+
+		resp.Diagnostics.Append(defaultResp.Diagnostics...)
+
+		if a.AttributeTypes != nil && !a.GetType().Equal(defaultResp.PlanValue.Type(ctx)) {
+			resp.Diagnostics.Append(fwschema.AttributeDefaultTypeMismatchDiag(req.Path, a.GetType(), defaultResp.PlanValue.Type(ctx)))
+		}
 	}
 }

--- a/resource/schema/set_attribute.go
+++ b/resource/schema/set_attribute.go
@@ -267,6 +267,10 @@ func (a SetAttribute) ValidateImplementation(ctx context.Context, req fwschema.V
 
 		resp.Diagnostics.Append(defaultResp.Diagnostics...)
 
+		if defaultResp.Diagnostics.HasError() {
+			return
+		}
+
 		if a.ElementType != nil && !a.ElementType.Equal(defaultResp.PlanValue.ElementType(ctx)) {
 			resp.Diagnostics.Append(fwschema.AttributeDefaultElementTypeMismatchDiag(req.Path, a.ElementType, defaultResp.PlanValue.ElementType(ctx)))
 		}

--- a/resource/schema/set_attribute.go
+++ b/resource/schema/set_attribute.go
@@ -249,7 +249,26 @@ func (a SetAttribute) ValidateImplementation(ctx context.Context, req fwschema.V
 		resp.Diagnostics.Append(fwschema.AttributeMissingElementTypeDiag(req.Path))
 	}
 
-	if !a.IsComputed() && a.SetDefaultValue() != nil {
-		resp.Diagnostics.Append(nonComputedAttributeWithDefaultDiag(req.Path))
+	if a.SetDefaultValue() != nil {
+		if !a.IsComputed() {
+			resp.Diagnostics.Append(nonComputedAttributeWithDefaultDiag(req.Path))
+		}
+
+		// Validate Default implementation. This is safe unless the framework
+		// ever allows more dynamic Default implementations at which the
+		// implementation would be required to be validated at runtime.
+		// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/930
+		defaultReq := defaults.SetRequest{
+			Path: req.Path,
+		}
+		defaultResp := &defaults.SetResponse{}
+
+		a.SetDefaultValue().DefaultSet(ctx, defaultReq, defaultResp)
+
+		resp.Diagnostics.Append(defaultResp.Diagnostics...)
+
+		if a.ElementType != nil && !a.ElementType.Equal(defaultResp.PlanValue.ElementType(ctx)) {
+			resp.Diagnostics.Append(fwschema.AttributeDefaultElementTypeMismatchDiag(req.Path, a.ElementType, defaultResp.PlanValue.ElementType(ctx)))
+		}
 	}
 }

--- a/resource/schema/set_attribute_test.go
+++ b/resource/schema/set_attribute_test.go
@@ -594,6 +594,36 @@ func TestSetAttributeValidateImplementation(t *testing.T) {
 			},
 			expected: &fwschema.ValidateImplementationResponse{},
 		},
+		"default-with-invalid-elementtype": {
+			attribute: schema.SetAttribute{
+				Computed: true,
+				Default: setdefault.StaticValue(
+					types.SetValueMust(
+						// intentionally invalid element type
+						types.BoolType,
+						[]attr.Value{
+							types.BoolValue(true),
+						},
+					),
+				),
+				ElementType: types.StringType,
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic(
+						"Invalid Attribute Implementation",
+						"When validating the schema, an implementation issue was found. "+
+							"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+							"\"test\" has a default value of element type \"basetypes.BoolType\", but the schema expects a type of \"basetypes.StringType\". "+
+							"The default value must match the type of the schema.",
+					),
+				},
+			},
+		},
 		"elementtype": {
 			attribute: schema.SetAttribute{
 				Computed:    true,

--- a/resource/schema/set_nested_attribute.go
+++ b/resource/schema/set_nested_attribute.go
@@ -270,7 +270,26 @@ func (a SetNestedAttribute) SetValidators() []validator.Set {
 // errors or panics. This logic runs during the GetProviderSchema RPC and
 // should never include false positives.
 func (a SetNestedAttribute) ValidateImplementation(ctx context.Context, req fwschema.ValidateImplementationRequest, resp *fwschema.ValidateImplementationResponse) {
-	if !a.IsComputed() && a.SetDefaultValue() != nil {
-		resp.Diagnostics.Append(nonComputedAttributeWithDefaultDiag(req.Path))
+	if a.SetDefaultValue() != nil {
+		if !a.IsComputed() {
+			resp.Diagnostics.Append(nonComputedAttributeWithDefaultDiag(req.Path))
+		}
+
+		// Validate Default implementation. This is safe unless the framework
+		// ever allows more dynamic Default implementations at which the
+		// implementation would be required to be validated at runtime.
+		// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/930
+		defaultReq := defaults.SetRequest{
+			Path: req.Path,
+		}
+		defaultResp := &defaults.SetResponse{}
+
+		a.SetDefaultValue().DefaultSet(ctx, defaultReq, defaultResp)
+
+		resp.Diagnostics.Append(defaultResp.Diagnostics...)
+
+		if a.CustomType == nil && a.NestedObject.CustomType == nil && !a.NestedObject.Type().Equal(defaultResp.PlanValue.ElementType(ctx)) {
+			resp.Diagnostics.Append(fwschema.AttributeDefaultElementTypeMismatchDiag(req.Path, a.NestedObject.Type(), defaultResp.PlanValue.ElementType(ctx)))
+		}
 	}
 }

--- a/resource/schema/set_nested_attribute.go
+++ b/resource/schema/set_nested_attribute.go
@@ -288,6 +288,10 @@ func (a SetNestedAttribute) ValidateImplementation(ctx context.Context, req fwsc
 
 		resp.Diagnostics.Append(defaultResp.Diagnostics...)
 
+		if defaultResp.Diagnostics.HasError() {
+			return
+		}
+
 		if a.CustomType == nil && a.NestedObject.CustomType == nil && !a.NestedObject.Type().Equal(defaultResp.PlanValue.ElementType(ctx)) {
 			resp.Diagnostics.Append(fwschema.AttributeDefaultElementTypeMismatchDiag(req.Path, a.NestedObject.Type(), defaultResp.PlanValue.ElementType(ctx)))
 		}

--- a/resource/schema/set_nested_attribute_test.go
+++ b/resource/schema/set_nested_attribute_test.go
@@ -817,6 +817,42 @@ func TestSetNestedAttributeValidateImplementation(t *testing.T) {
 			},
 			expected: &fwschema.ValidateImplementationResponse{},
 		},
+		"default-with-invalid-elementtype": {
+			attribute: schema.SetNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"test_attr": schema.StringAttribute{
+							Computed: true,
+						},
+					},
+				},
+				Computed: true,
+				Default: setdefault.StaticValue(
+					types.SetValueMust(
+						// intentionally invalid element type
+						types.BoolType,
+						[]attr.Value{
+							types.BoolValue(true),
+						},
+					),
+				),
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic(
+						"Invalid Attribute Implementation",
+						"When validating the schema, an implementation issue was found. "+
+							"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+							"\"test\" has a default value of element type \"basetypes.BoolType\", but the schema expects a type of \"types.ObjectType[\\\"test_attr\\\":basetypes.StringType]\". "+
+							"The default value must match the type of the schema.",
+					),
+				},
+			},
+		},
 	}
 
 	for name, testCase := range testCases {

--- a/resource/schema/set_nested_attribute_test.go
+++ b/resource/schema/set_nested_attribute_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testdefaults"
 	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -816,6 +817,33 @@ func TestSetNestedAttributeValidateImplementation(t *testing.T) {
 				Path: path.Root("test"),
 			},
 			expected: &fwschema.ValidateImplementationResponse{},
+		},
+		"default-with-error-diagnostic": {
+			attribute: schema.SetNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"test_attr": schema.StringAttribute{
+							Computed: true,
+						},
+					},
+				},
+				Computed: true,
+				Default: testdefaults.Set{
+					DefaultSetMethod: func(ctx context.Context, req defaults.SetRequest, resp *defaults.SetResponse) {
+						resp.Diagnostics.AddError("error summary", "error detail")
+					},
+				},
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{
+				Diagnostics: diag.Diagnostics{
+					// Only the Default error should be returned, not type validation errors.
+					diag.NewErrorDiagnostic("error summary", "error detail"),
+				},
+			},
 		},
 		"default-with-invalid-elementtype": {
 			attribute: schema.SetNestedAttribute{

--- a/resource/schema/single_nested_attribute.go
+++ b/resource/schema/single_nested_attribute.go
@@ -294,4 +294,27 @@ func (a SingleNestedAttribute) ValidateImplementation(ctx context.Context, req f
 	if !a.IsComputed() && a.ObjectDefaultValue() != nil {
 		resp.Diagnostics.Append(nonComputedAttributeWithDefaultDiag(req.Path))
 	}
+
+	if a.ObjectDefaultValue() != nil {
+		if !a.IsComputed() {
+			resp.Diagnostics.Append(nonComputedAttributeWithDefaultDiag(req.Path))
+		}
+
+		// Validate Default implementation. This is safe unless the framework
+		// ever allows more dynamic Default implementations at which the
+		// implementation would be required to be validated at runtime.
+		// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/930
+		defaultReq := defaults.ObjectRequest{
+			Path: req.Path,
+		}
+		defaultResp := &defaults.ObjectResponse{}
+
+		a.ObjectDefaultValue().DefaultObject(ctx, defaultReq, defaultResp)
+
+		resp.Diagnostics.Append(defaultResp.Diagnostics...)
+
+		if a.CustomType == nil && !a.GetType().Equal(defaultResp.PlanValue.Type(ctx)) {
+			resp.Diagnostics.Append(fwschema.AttributeDefaultTypeMismatchDiag(req.Path, a.GetType(), defaultResp.PlanValue.Type(ctx)))
+		}
+	}
 }

--- a/resource/schema/single_nested_attribute.go
+++ b/resource/schema/single_nested_attribute.go
@@ -313,6 +313,10 @@ func (a SingleNestedAttribute) ValidateImplementation(ctx context.Context, req f
 
 		resp.Diagnostics.Append(defaultResp.Diagnostics...)
 
+		if defaultResp.Diagnostics.HasError() {
+			return
+		}
+
 		if a.CustomType == nil && !a.GetType().Equal(defaultResp.PlanValue.Type(ctx)) {
 			resp.Diagnostics.Append(fwschema.AttributeDefaultTypeMismatchDiag(req.Path, a.GetType(), defaultResp.PlanValue.Type(ctx)))
 		}

--- a/resource/schema/single_nested_attribute_test.go
+++ b/resource/schema/single_nested_attribute_test.go
@@ -757,6 +757,41 @@ func TestSingleNestedAttributeValidateImplementation(t *testing.T) {
 			},
 			expected: &fwschema.ValidateImplementationResponse{},
 		},
+		"default-with-invalid-attributetypes": {
+			attribute: schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"test_attr": schema.StringAttribute{
+						Computed: true,
+					},
+				},
+				Computed: true,
+				Default: objectdefault.StaticValue(
+					types.ObjectValueMust(
+						map[string]attr.Type{
+							"invalid": types.BoolType,
+						},
+						map[string]attr.Value{
+							"invalid": types.BoolValue(true),
+						},
+					),
+				),
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic(
+						"Invalid Attribute Implementation",
+						"When validating the schema, an implementation issue was found. "+
+							"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+							"\"test\" has a default value of type \"types.ObjectType[\\\"invalid\\\":basetypes.BoolType]\", but the schema expects a type of \"types.ObjectType[\\\"test_attr\\\":basetypes.StringType]\". "+
+							"The default value must match the type of the schema.",
+					),
+				},
+			},
+		},
 	}
 
 	for name, testCase := range testCases {

--- a/resource/schema/single_nested_attribute_test.go
+++ b/resource/schema/single_nested_attribute_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testdefaults"
 	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -756,6 +757,31 @@ func TestSingleNestedAttributeValidateImplementation(t *testing.T) {
 				Path: path.Root("test"),
 			},
 			expected: &fwschema.ValidateImplementationResponse{},
+		},
+		"default-with-error-diagnostic": {
+			attribute: schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"test_attr": schema.StringAttribute{
+						Computed: true,
+					},
+				},
+				Computed: true,
+				Default: testdefaults.Object{
+					DefaultObjectMethod: func(ctx context.Context, req defaults.ObjectRequest, resp *defaults.ObjectResponse) {
+						resp.Diagnostics.AddError("error summary", "error detail")
+					},
+				},
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{
+				Diagnostics: diag.Diagnostics{
+					// Only the Default error should be returned, not type validation errors.
+					diag.NewErrorDiagnostic("error summary", "error detail"),
+				},
+			},
 		},
 		"default-with-invalid-attributetypes": {
 			attribute: schema.SingleNestedAttribute{


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/590
Closes #930

Previously the logic handling attribute `Default` values would silently ignore any type errors, which would lead to confusing planning data behaviors. This updates the logic to raise those error properly and adds covering unit testing.

These error messages are using the underlying `tftypes` type system errors which is currently a pragmatic compromise throughout various parts of the framework logic that bridges between both type systems to save additional type assertion logic and potential bugs relating to those conversions. In the future if the internal `tftypes` handling and exported fields are replaced with the framework type system types, this logic would instead return error messaging based on the framework type system errors.

This also will enhance the schema validation logic to check any `Default` response value and compare its type to the schema, which will raise framework type system errors during the `GetProviderSchema` RPC, or during schema unit testing if provider developers have implemented that additional testing.