### PR TITLE
fix: remove incorrect code in `Diagnostics.Append` - fixes #932

### DIFF
--- a/diag/diagnostics.go
+++ b/diag/diagnostics.go
@@ -43,12 +43,7 @@ func (diags *Diagnostics) Append(in ...Diagnostic) {
 		if diags.Contains(diag) {
 			continue
 		}
-
-		if diags == nil {
-			*diags = Diagnostics{diag}
-		} else {
-			*diags = append(*diags, diag)
-		}
+		*diags = append(*diags, diag)
 	}
 }
 


### PR DESCRIPTION
fixes #932 