### PR TITLE
Fixing Documentation for Defining Type Validation

### DIFF
--- a/website/docs/plugin/framework/validation.mdx
+++ b/website/docs/plugin/framework/validation.mdx
@@ -264,7 +264,7 @@ func (t computeInstanceIdentifierType) Validate(ctx context.Context, tfValue tft
         diags.AddAttributeError(
             path,
             "Compute Instance Type Validation Error",
-            fmt.Sprintf("Expected String value, received %T with value: %v", in, in),
+            fmt.Sprintf("Expected String value, received %T with value: %v", tfValue, tfValue),
         )
         return diags
     }


### PR DESCRIPTION
Fixing documentation in code sample used for [Defining Type Validation](https://developer.hashicorp.com/terraform/plugin/framework/validation#defining-type-validation).

**Before**:
```go
func (t computeInstanceIdentifierType) Validate(ctx context.Context, tfValue tftypes.Value, path path.Path) diag.Diagnostics {
    var diags diag.Diagnostics

    if !tfValue.Type().Equal(tftypes.String) {
        diags.AddAttributeError(
            path,
            "Compute Instance Type Validation Error",
            fmt.Sprintf("Expected String value, received %T with value: %v", in, in),
            /* ... */
```

**After**:
```go
func (t computeInstanceIdentifierType) Validate(ctx context.Context, tfValue tftypes.Value, path path.Path) diag.Diagnostics {
    var diags diag.Diagnostics

    if !tfValue.Type().Equal(tftypes.String) {
        diags.AddAttributeError(
            path,
            "Compute Instance Type Validation Error",
            fmt.Sprintf("Expected String value, received %T with value: %v", tfValue, tfValue),
            /* ... */
```
