### PR TITLE
docs: Include tfversion checking in function acceptance testing

### DIFF
--- a/website/docs/plugin/framework/functions/testing.mdx
+++ b/website/docs/plugin/framework/functions/testing.mdx
@@ -43,12 +43,16 @@ import (
     "github.com/hashicorp/terraform-plugin-framework/providerserver"
     "github.com/hashicorp/terraform-plugin-go/tfprotov6"
     "github.com/hashicorp/terraform-plugin-testing/helper/resource"
+    "github.com/hashicorp/terraform-plugin-testing/tfversion"
 )
 
 func TestEchoFunction_Valid(t *testing.T) {
     t.Parallel()
 
     resource.UnitTest(t, resource.TestCase{
+        TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+            tfversion.SkipBelow(tfversion.Version1_8_0),
+        },
         ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error) {
             "example": providerserver.NewProtocol6WithError(provider.New()),
         },
@@ -71,6 +75,9 @@ func TestEchoFunction_Invalid(t *testing.T) {
     t.Parallel()
 
     resource.UnitTest(t, resource.TestCase{
+        TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+            tfversion.SkipBelow(tfversion.Version1_8_0),
+        },
         ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error) {
             "example": providerserver.NewProtocol6WithError(provider.New()),
         },
@@ -93,6 +100,9 @@ func TestEchoFunction_Null(t *testing.T) {
     t.Parallel()
 
     resource.UnitTest(t, resource.TestCase{
+        TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+            tfversion.SkipBelow(tfversion.Version1_8_0),
+        },
         ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error) {
             "example": providerserver.NewProtocol6WithError(provider.New()),
         },
@@ -113,6 +123,9 @@ output "test" {
 // acceptance test shows how to verify the behavior.
 func TestEchoFunction_Unknown(t *testing.T) {
     resource.UnitTest(t, resource.TestCase{
+        TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+            tfversion.SkipBelow(tfversion.Version1_8_0),
+        },
         ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error) {
             "example": providerserver.NewProtocol6WithError(provider.New()),
         },


### PR DESCRIPTION
Provider-defined functions are only supported in Terraform 1.8 and later. Provider developers that run acceptance testing across multiple Terraform versions will likely want to know how to setup their tests to avoid test failures in earlier versions of Terraform.

The terraform-plugin-testing v1.7.0 release earlier this week contains the `tfversion.Version1_8_0` variable which makes this setup easier. Other recent terraform-plugin-testing versions support the `TerraformVersionChecks` handling, although developers would need to "manually" create the version with `go-version` via `version.Must(version.NewVersion("1.8.0"))`.