### PR TITLE
Add clarification for nil check of ProviderData in data source and resource Configure() method

### DIFF
--- a/website/docs/plugin/framework/data-sources/configure.mdx
+++ b/website/docs/plugin/framework/data-sources/configure.mdx
@@ -66,7 +66,8 @@ type ThingDataSource struct {
 }
 
 func (d *ThingDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
-  // Prevent panic if the provider has not been configured.
+  // A nil check should always be performed when handling ProviderData as it
+  // is only set after the ConfigureProvider RPC has been called by Terraform.
   if req.ProviderData == nil {
     return
   }

--- a/website/docs/plugin/framework/resources/configure.mdx
+++ b/website/docs/plugin/framework/resources/configure.mdx
@@ -66,7 +66,8 @@ type ThingResource struct {
 }
 
 func (r *ThingResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
-  // Prevent panic if the provider has not been configured.
+  // A nil check should always be performed when handling ProviderData as it
+  // is only set after the ConfigureProvider RPC has been called by Terraform.
   if req.ProviderData == nil {
     return
   }


### PR DESCRIPTION
Reference: https://github.com/hashicorp/tutorials/issues/1944

Updating documentation to clarify that a `nil` check of `ProviderData` should always be performed in the `Configure()` method of data sources and resources.