### PR TITLE
docs: Fix note tag with link

### DIFF
--- a/website/docs/plugin/framework/functions/index.mdx
+++ b/website/docs/plugin/framework/functions/index.mdx
@@ -17,7 +17,9 @@ Provider-defined function support is in technical preview and offered without co
 Functions are an abstraction that allow providers to expose computational logic beyond Terraform's [built-in functions](/terraform/language/functions) and simplify practitioner configurations. Provider-defined functions are supported in Terraform 1.8 and later.
 
 <Note>
+
 It is possible to add functions to an existing provider. If you do not have an existing provider, you will need to create your own provider to contain the functions. Please see [Getting Started - Code Walkthrough](/terraform/plugin/framework/getting-started/code-walkthrough) to learn how to create your first provider.
+
 </Note>
 
 ## Concepts


### PR DESCRIPTION
Stumbled across this when I was writing some docs, follow-up to #946

### Before
![Screenshot 2024-03-13 at 9 54 48 AM](https://github.com/hashicorp/terraform-plugin-framework/assets/8650838/47e30f48-1047-4c4d-8b7c-9e7b4e3001ce)

### After
![Screenshot 2024-03-13 at 9 55 13 AM](https://github.com/hashicorp/terraform-plugin-framework/assets/8650838/c9a6bf5e-ceba-43fe-9bf2-7c3c93c1ad60)