### PR TITLE
Correct resource State Move documentation

### DIFF
--- a/website/docs/plugin/framework/resources/state-move.mdx
+++ b/website/docs/plugin/framework/resources/state-move.mdx
@@ -37,9 +37,9 @@ The framework implementation does the following:
 
 ## Implementation
 
-Implement the [`resource.ResourceWithMoveState` interface](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#ResourceWithMoveState) for the [`resource.Resource`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#Resource). That interface requires the `StateMove` method, which enables individual source resource criteria and logic for each source resource type to support.
+Implement the [`resource.ResourceWithMoveState` interface](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#ResourceWithMoveState) for the [`resource.Resource`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#Resource). That interface requires the `MoveState` method, which enables individual source resource criteria and logic for each source resource type to support.
 
-This example shows a `Resource` with the necessary `StateMove` method to implement the `ResourceWithMoveState` interface:
+This example shows a `Resource` with the necessary `MoveState` method to implement the `ResourceWithMoveState` interface:
 
 ```go
 // Other Resource methods are omitted in this example

--- a/website/docs/plugin/framework/resources/state-move.mdx
+++ b/website/docs/plugin/framework/resources/state-move.mdx
@@ -37,9 +37,9 @@ The framework implementation does the following:
 
 ## Implementation
 
-Implement the [`resource.ResourceWithStateMove` interface](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#ResourceWithStateMove) for the [`resource.Resource`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#Resource). That interface requires the `StateMove` method, which enables individual source resource criteria and logic for each source resource type to support.
+Implement the [`resource.ResourceWithMoveState` interface](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#ResourceWithMoveState) for the [`resource.Resource`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#Resource). That interface requires the `StateMove` method, which enables individual source resource criteria and logic for each source resource type to support.
 
-This example shows a `Resource` with the necessary `StateMove` method to implement the `ResourceWithStateMove` interface:
+This example shows a `Resource` with the necessary `StateMove` method to implement the `ResourceWithMoveState` interface:
 
 ```go
 // Other Resource methods are omitted in this example


### PR DESCRIPTION
The [_Resource State Move_ documentation](https://developer.hashicorp.com/terraform/plugin/framework/resources/state-move#implementation) states that a resource should implement a `StateMove` method, satisfying the `resource.ResourceWithStateMove` interface.
The interface is actually named `resource.ResourceWithMoveState`, and the method `MoveState`.
This PR corrects the documentation.