### PR TITLE
basetypes: fix equality for values with nil elementType

### DIFF
--- a/.changes/unreleased/BUG FIXES-20240319-085739.yaml
+++ b/.changes/unreleased/BUG FIXES-20240319-085739.yaml
@@ -1,0 +1,6 @@
+kind: BUG FIXES
+body: 'types/basetypes: Prevented panic in the `MapValue` types `Equal` method when
+  the receiver has a nil `elementType`'
+time: 2024-03-19T08:57:39.837509-04:00
+custom:
+  Issue: "961"

--- a/.changes/unreleased/BUG FIXES-20240319-085908.yaml
+++ b/.changes/unreleased/BUG FIXES-20240319-085908.yaml
@@ -1,0 +1,6 @@
+kind: BUG FIXES
+body: 'types/basetypes: Prevented panic in the `ListValue` types `Equal` method when
+  the receiver has a nil `elementType`'
+time: 2024-03-19T08:59:08.576502-04:00
+custom:
+  Issue: "961"

--- a/.changes/unreleased/BUG FIXES-20240319-085928.yaml
+++ b/.changes/unreleased/BUG FIXES-20240319-085928.yaml
@@ -1,0 +1,6 @@
+kind: BUG FIXES
+body: 'types/basetypes: Prevented panic in the `SetValue` types `Equal` method when
+  the receiver has a nil `elementType`'
+time: 2024-03-19T08:59:28.116063-04:00
+custom:
+  Issue: "961"

--- a/types/basetypes/list_value.go
+++ b/types/basetypes/list_value.go
@@ -258,6 +258,11 @@ func (l ListValue) Equal(o attr.Value) bool {
 		return false
 	}
 
+	// A list with no elementType is an invalid state
+	if l.elementType == nil || other.elementType == nil {
+		return false
+	}
+
 	if !l.elementType.Equal(other.elementType) {
 		return false
 	}

--- a/types/basetypes/list_value_test.go
+++ b/types/basetypes/list_value_test.go
@@ -618,6 +618,21 @@ func TestListValueEqual(t *testing.T) {
 			input:    nil,
 			expected: false,
 		},
+		"zero-null": {
+			receiver: ListValue{},
+			input:    NewListNull(StringType{}),
+			expected: false,
+		},
+		"zero-zero": {
+			receiver: ListValue{},
+			input:    ListValue{},
+			expected: false,
+		},
+		"null-zero": {
+			receiver: NewListNull(StringType{}),
+			input:    ListValue{},
+			expected: false,
+		},
 	}
 	for name, test := range tests {
 		name, test := name, test

--- a/types/basetypes/map_value.go
+++ b/types/basetypes/map_value.go
@@ -265,6 +265,11 @@ func (m MapValue) Equal(o attr.Value) bool {
 		return false
 	}
 
+	// A map with no elementType is an invalid state
+	if m.elementType == nil || other.elementType == nil {
+		return false
+	}
+
 	if !m.elementType.Equal(other.elementType) {
 		return false
 	}

--- a/types/basetypes/map_value_test.go
+++ b/types/basetypes/map_value_test.go
@@ -621,6 +621,21 @@ func TestMapValueEqual(t *testing.T) {
 			input:    nil,
 			expected: false,
 		},
+		"zero-null": {
+			receiver: MapValue{},
+			input:    NewMapNull(StringType{}),
+			expected: false,
+		},
+		"zero-zero": {
+			receiver: MapValue{},
+			input:    MapValue{},
+			expected: false,
+		},
+		"null-zero": {
+			receiver: NewMapNull(StringType{}),
+			input:    MapValue{},
+			expected: false,
+		},
 	}
 	for name, test := range tests {
 		name, test := name, test

--- a/types/basetypes/set_value.go
+++ b/types/basetypes/set_value.go
@@ -258,6 +258,11 @@ func (s SetValue) Equal(o attr.Value) bool {
 		return false
 	}
 
+	// A set with no elementType is an invalid state
+	if s.elementType == nil || other.elementType == nil {
+		return false
+	}
+
 	if !s.elementType.Equal(other.elementType) {
 		return false
 	}

--- a/types/basetypes/set_value_test.go
+++ b/types/basetypes/set_value_test.go
@@ -871,6 +871,21 @@ func TestSetValueEqual(t *testing.T) {
 			input:    nil,
 			expected: false,
 		},
+		"zero-null": {
+			receiver: SetValue{},
+			input:    NewSetNull(StringType{}),
+			expected: false,
+		},
+		"zero-zero": {
+			receiver: SetValue{},
+			input:    SetValue{},
+			expected: false,
+		},
+		"null-zero": {
+			receiver: NewSetNull(StringType{}),
+			input:    SetValue{},
+			expected: false,
+		},
 	}
 	for name, test := range tests {
 		name, test := name, test


### PR DESCRIPTION
A `MapValue`, `ListValue`, or `SetValue` with a nil `elementType` is an invalid state, and therefore cannot verify equality with another value. These changes to the `Equal` method now returns `false` if either the receiver or argument have a nil `elementType`.

Closes #959 