### PR TITLE
internal/fwserver: Ensure computed dynamic values are marked as dynamic type during plan modification

### DIFF
--- a/.changes/unreleased/BUG FIXES-20240325-101108.yaml
+++ b/.changes/unreleased/BUG FIXES-20240325-101108.yaml
@@ -1,0 +1,6 @@
+kind: BUG FIXES
+body: 'internal/fwserver: Ensure computed dynamic values are marked as dynamic type
+  during plan modification.'
+time: 2024-03-25T10:11:08.813527-04:00
+custom:
+  Issue: "969"

--- a/.changes/unreleased/BUG FIXES-20240325-101108.yaml
+++ b/.changes/unreleased/BUG FIXES-20240325-101108.yaml
@@ -1,6 +1,6 @@
 kind: BUG FIXES
-body: 'internal/fwserver: Ensure computed dynamic values are marked as dynamic type
-  during plan modification.'
+body: 'resource: Ensured computed-only dynamic attributes will not cause `wrong final
+  value type` errors during planning'
 time: 2024-03-25T10:11:08.813527-04:00
 custom:
   Issue: "969"

--- a/internal/fwserver/server_planresourcechange_test.go
+++ b/internal/fwserver/server_planresourcechange_test.go
@@ -78,7 +78,7 @@ func TestMarkComputedNilsAsUnknown(t *testing.T) {
 			"dynamic-nil-computed": schema.DynamicAttribute{
 				Computed: true,
 			},
-			// underlying nil computed values should be turned into unknown, preserving the original type
+			// underlying nil computed values should be turned into unknown, this should not preserve the original type
 			"dynamic-underlying-string-nil-computed": schema.DynamicAttribute{
 				Computed: true,
 			},
@@ -274,7 +274,7 @@ func TestMarkComputedNilsAsUnknown(t *testing.T) {
 		"dynamic-value":                          tftypes.NewValue(tftypes.String, "hello, world"),
 		"dynamic-nil":                            tftypes.NewValue(tftypes.DynamicPseudoType, nil),
 		"dynamic-nil-computed":                   tftypes.NewValue(tftypes.DynamicPseudoType, tftypes.UnknownValue),
-		"dynamic-underlying-string-nil-computed": tftypes.NewValue(tftypes.String, tftypes.UnknownValue), // Preserves the underlying string type
+		"dynamic-underlying-string-nil-computed": tftypes.NewValue(tftypes.DynamicPseudoType, tftypes.UnknownValue), // doesn't preserve original type
 		"dynamic-nil-optional-computed":          tftypes.NewValue(tftypes.DynamicPseudoType, tftypes.UnknownValue),
 		"dynamic-value-optional-computed":        tftypes.NewValue(tftypes.String, "hello, world"),
 		"dynamic-value-with-underlying-list-optional-computed": tftypes.NewValue(


### PR DESCRIPTION
Closes #969 

If a computed dynamic attribute is going to be marked as unknown, we need to ensure we don't use the planned state value to create the unknown value, as it could create the unknown with a concrete type. (assuming the. eventual type will be the same as prior state)

This fix, like all other dynamic changes, is intentionally pessimistic 🙂 