### PR TITLE
Fix `PlanModifiers` usage in code-snippet

### DIFF
--- a/website/docs/plugin/framework/resources/create.mdx
+++ b/website/docs/plugin/framework/resources/create.mdx
@@ -59,7 +59,7 @@ func (r ThingResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 			"id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "Service generated identifier for the thing.",
-				PlanModifiers: planmodifier.String{
+				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},


### PR DESCRIPTION
The example seems to be missing `[]` in `PlanModifiers` field.