### PR TITLE
function: Mention that return documentation is expected in definition documentation

### DIFF
--- a/function/bool_return.go
+++ b/function/bool_return.go
@@ -19,6 +19,8 @@ var _ Return = BoolReturn{}
 //
 // - If CustomType is set, use its associated value type.
 // - Otherwise, use [types.Bool], *bool, or bool.
+//
+// Return documentation is expected in the function [Definition] documentation.
 type BoolReturn struct {
 	// CustomType enables the use of a custom data type in place of the
 	// default [basetypes.BoolType]. When setting data, the

--- a/function/dynamic_return.go
+++ b/function/dynamic_return.go
@@ -22,6 +22,8 @@ var _ Return = DynamicReturn{}
 //
 // - If CustomType is set, use its associated value type.
 // - Otherwise, use the [types.Dynamic] value type.
+//
+// Return documentation is expected in the function [Definition] documentation.
 type DynamicReturn struct {
 	// CustomType enables the use of a custom data type in place of the
 	// default [basetypes.DynamicType]. When setting data, the

--- a/function/float64_return.go
+++ b/function/float64_return.go
@@ -20,6 +20,8 @@ var _ Return = Float64Return{}
 //
 // - If CustomType is set, use its associated value type.
 // - Otherwise, use [types.Float64], *float64, or float64.
+//
+// Return documentation is expected in the function [Definition] documentation.
 type Float64Return struct {
 	// CustomType enables the use of a custom data type in place of the
 	// default [basetypes.Float64Type]. When setting data, the

--- a/function/int64_return.go
+++ b/function/int64_return.go
@@ -19,6 +19,8 @@ var _ Return = Int64Return{}
 //
 // - If CustomType is set, use its associated value type.
 // - Otherwise, use [types.Int64], *int64, or int64.
+//
+// Return documentation is expected in the function [Definition] documentation.
 type Int64Return struct {
 	// CustomType enables the use of a custom data type in place of the
 	// default [basetypes.Int64Type]. When setting data, the

--- a/function/list_return.go
+++ b/function/list_return.go
@@ -26,6 +26,8 @@ var (
 //   - If CustomType is set, use its associated value type.
 //   - Otherwise, use [types.List] or a Go slice value type compatible with the
 //     element type.
+//
+// Return documentation is expected in the function [Definition] documentation.
 type ListReturn struct {
 	// ElementType is the type for all elements of the list. This field must be
 	// set.

--- a/function/map_return.go
+++ b/function/map_return.go
@@ -26,6 +26,8 @@ var (
 //   - If CustomType is set, use its associated value type.
 //   - Otherwise, use [types.Map] or a Go map value type compatible with the
 //     element type.
+//
+// Return documentation is expected in the function [Definition] documentation.
 type MapReturn struct {
 	// ElementType is the type for all elements of the map. This field must be
 	// set.

--- a/function/number_return.go
+++ b/function/number_return.go
@@ -20,6 +20,8 @@ var _ Return = NumberReturn{}
 //
 // - If CustomType is set, use its associated value type.
 // - Otherwise, use [types.Number] or *big.Float.
+//
+// Return documentation is expected in the function [Definition] documentation.
 type NumberReturn struct {
 	// CustomType enables the use of a custom data type in place of the
 	// default [basetypes.NumberType]. When setting data, the

--- a/function/object_return.go
+++ b/function/object_return.go
@@ -22,6 +22,8 @@ var (
 // attribute names to values. When setting the value for this return, use
 // [types.Object] or a compatible Go struct as the value type unless the
 // CustomType field is set. The AttributeTypes field must be set.
+//
+// Return documentation is expected in the function [Definition] documentation.
 type ObjectReturn struct {
 	// AttributeTypes is the mapping of underlying attribute names to attribute
 	// types. This field must be set.

--- a/function/set_return.go
+++ b/function/set_return.go
@@ -26,6 +26,8 @@ var (
 //   - If CustomType is set, use its associated value type.
 //   - Otherwise, use [types.Set] or a Go slice value type compatible with the
 //     element type.
+//
+// Return documentation is expected in the function [Definition] documentation.
 type SetReturn struct {
 	// ElementType is the type for all elements of the set. This field must be
 	// set.

--- a/function/string_return.go
+++ b/function/string_return.go
@@ -19,6 +19,8 @@ var _ Return = StringReturn{}
 //
 // - If CustomType is set, use its associated value type.
 // - Otherwise, use [types.String], *string, or string.
+//
+// Return documentation is expected in the function [Definition] documentation.
 type StringReturn struct {
 	// CustomType enables the use of a custom data type in place of the
 	// default [basetypes.StringType]. When setting data, the


### PR DESCRIPTION
Followup from an out-of-band conversation. The website documentation for returns already mentions this, but it was missing from the Go package documentation.