### PR TITLE
internal/fwserver: Skip automatic object state conversion and nested attributes plan modification if object is null or unknown

### DIFF
--- a/.changes/unreleased/BUG FIXES-20240429-165853.yaml
+++ b/.changes/unreleased/BUG FIXES-20240429-165853.yaml
@@ -1,0 +1,6 @@
+kind: BUG FIXES
+body: 'resource: Prevented errant collection-based nested object conversion from null/unknown
+  object to known object'
+time: 2024-04-29T16:58:53.593467-04:00
+custom:
+  Issue: "995"

--- a/.changes/unreleased/NOTES-20240429-170035.yaml
+++ b/.changes/unreleased/NOTES-20240429-170035.yaml
@@ -1,0 +1,7 @@
+kind: NOTES
+body: 'resource: If plan modification was dependent on nested attribute plan modification
+  automatically running when the nested object was null/unknown, it may be necessary to
+  add object-level plan modification to convert the nested object to a known object first.'
+time: 2024-04-29T17:00:35.374624-04:00
+custom:
+  Issue: "995"

--- a/internal/fwserver/attribute_plan_modification.go
+++ b/internal/fwserver/attribute_plan_modification.go
@@ -2325,6 +2325,17 @@ func NestedAttributeObjectPlanModify(ctx context.Context, o fwschema.NestedAttri
 		}
 	}
 
+	// If the nested object itself is null or unknown, skip calling nested
+	// attribute plan modifiers. Any plan modification from a null or unknown
+	// object into a known object must occur at the object level to prevent
+	// the framework from errantly sending a known object when it should remain
+	// a null/unknown object.
+	//
+	// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/993
+	if req.PlanValue.IsNull() || req.PlanValue.IsUnknown() {
+		return
+	}
+
 	newPlanValueAttributes := req.PlanValue.Attributes()
 
 	for nestedName, nestedAttr := range o.GetAttributes() {


### PR DESCRIPTION
Closes #993

By data definition, a null or unknown object has no underlying data where nested attributes should run plan modification. By Terraform data consistency rules, a null or unknown object should be preserved as-is (unless it is an unknown value being refined into a more known value), however this was not the case where a collection-based nested attribute had a null or unknown object, such as this example configuration:

```
resource "examplecloud_thing" "example" {
  nested_map = {
    examplekey = null # this was previously problematic
  }
}
```

Previously, a null or unknown object would be errantly transformed by the framework plan modification logic into a known object with null/unknown attributes. This could be seen in human-readable Terraform plans, such as (`{}` below):

```
  # examplecloud_thing.example will be created
  + resource "examplecloud_thing" "example" {
      + nested_map = {
          + "examplekey" = {},
        }
    }
```

Following new unit test creation, failures could be seen from the PlanResourceChange RPC:

```
--- FAIL: TestServerPlanResourceChange_AttributeRoundtrip (0.00s)
    --- FAIL: TestServerPlanResourceChange_AttributeRoundtrip/create-list-nested-optional-and-computed-unknown-element (0.00s)
        /Users/bflad/src/github.com/hashicorp/terraform-plugin-framework/internal/fwserver/server_planresourcechange_test.go:15072: unexpected difference:   &fwserver.PlanResourceChangeResponse{
              	Diagnostics:    nil,
              	PlannedPrivate: &{Provider: &{data: {}}},
              	PlannedState: &tfsdk.State{
            - 		Raw:    s`tftypes.Object["list_nested_attribute":tftypes.List[tftypes.Object["string_attribute":tftypes.String]]]<"list_nested_attribute":tftypes.List[tftypes.Object["string_attribute":tftypes.String]]<tftypes.Object["string_attribute":tftypes.String]<"string_attrib`...,
            + 		Raw:    s`tftypes.Object["list_nested_attribute":tftypes.List[tftypes.Object["string_attribute":tftypes.String]]]<"list_nested_attribute":tftypes.List[tftypes.Object["string_attribute":tftypes.String]]<tftypes.Object["string_attribute":tftypes.String]<unknown>>>`,
              		Schema: schema.Schema{Attributes: {"list_nested_attribute": schema.ListNestedAttribute{NestedObject: {...}, Optional: true, Computed: true}}},
              	},
              	RequiresReplace: s"[]",
              }
    --- FAIL: TestServerPlanResourceChange_AttributeRoundtrip/create-list-nested-optional-null-element (0.00s)
        /Users/bflad/src/github.com/hashicorp/terraform-plugin-framework/internal/fwserver/server_planresourcechange_test.go:15072: unexpected difference:   &fwserver.PlanResourceChangeResponse{
              	Diagnostics:    nil,
              	PlannedPrivate: &{Provider: &{data: {}}},
              	PlannedState: &tfsdk.State{
            - 		Raw:    s`tftypes.Object["list_nested_attribute":tftypes.List[tftypes.Object["string_attribute":tftypes.String]]]<"list_nested_attribute":tftypes.List[tftypes.Object["string_attribute":tftypes.String]]<tftypes.Object["string_attribute":tftypes.String]<"string_attrib`...,
            + 		Raw:    s`tftypes.Object["list_nested_attribute":tftypes.List[tftypes.Object["string_attribute":tftypes.String]]]<"list_nested_attribute":tftypes.List[tftypes.Object["string_attribute":tftypes.String]]<tftypes.Object["string_attribute":tftypes.String]<null>>>`,
              		Schema: schema.Schema{Attributes: {"list_nested_attribute": schema.ListNestedAttribute{NestedObject: {...}, Optional: true}}},
              	},
              	RequiresReplace: s"[]",
              }
    --- FAIL: TestServerPlanResourceChange_AttributeRoundtrip/create-list-nested-optional-and-computed-null-element (0.00s)
        /Users/bflad/src/github.com/hashicorp/terraform-plugin-framework/internal/fwserver/server_planresourcechange_test.go:15072: unexpected difference:   &fwserver.PlanResourceChangeResponse{
              	Diagnostics:    nil,
              	PlannedPrivate: &{Provider: &{data: {}}},
              	PlannedState: &tfsdk.State{
            - 		Raw:    s`tftypes.Object["list_nested_attribute":tftypes.List[tftypes.Object["string_attribute":tftypes.String]]]<"list_nested_attribute":tftypes.List[tftypes.Object["string_attribute":tftypes.String]]<tftypes.Object["string_attribute":tftypes.String]<"string_attrib`...,
            + 		Raw:    s`tftypes.Object["list_nested_attribute":tftypes.List[tftypes.Object["string_attribute":tftypes.String]]]<"list_nested_attribute":tftypes.List[tftypes.Object["string_attribute":tftypes.String]]<tftypes.Object["string_attribute":tftypes.String]<unknown>>>`,
              		Schema: schema.Schema{Attributes: {"list_nested_attribute": schema.ListNestedAttribute{NestedObject: {...}, Optional: true, Computed: true}}},
              	},
              	RequiresReplace: s"[]",
              }
    --- FAIL: TestServerPlanResourceChange_AttributeRoundtrip/create-map-nested-optional-and-computed-null-element (0.00s)
        /Users/bflad/src/github.com/hashicorp/terraform-plugin-framework/internal/fwserver/server_planresourcechange_test.go:15072: unexpected difference:   &fwserver.PlanResourceChangeResponse{
              	Diagnostics:    nil,
              	PlannedPrivate: &{Provider: &{data: {}}},
              	PlannedState: &tfsdk.State{
            - 		Raw:    s`tftypes.Object["map_nested_attribute":tftypes.Map[tftypes.Object["string_attribute":tftypes.String]]]<"map_nested_attribute":tftypes.Map[tftypes.Object["string_attribute":tftypes.String]]<"null":tftypes.Object["string_attribute":tftypes.String]<"string_att`...,
            + 		Raw:    s`tftypes.Object["map_nested_attribute":tftypes.Map[tftypes.Object["string_attribute":tftypes.String]]]<"map_nested_attribute":tftypes.Map[tftypes.Object["string_attribute":tftypes.String]]<"null":tftypes.Object["string_attribute":tftypes.String]<unknown>>>`,
              		Schema: schema.Schema{Attributes: {"map_nested_attribute": schema.MapNestedAttribute{NestedObject: {...}, Optional: true, Computed: true}}},
              	},
              	RequiresReplace: s"[]",
              }
    --- FAIL: TestServerPlanResourceChange_AttributeRoundtrip/create-map-nested-optional-unknown-element (0.00s)
        /Users/bflad/src/github.com/hashicorp/terraform-plugin-framework/internal/fwserver/server_planresourcechange_test.go:15072: unexpected difference:   &fwserver.PlanResourceChangeResponse{
              	Diagnostics:    nil,
              	PlannedPrivate: &{Provider: &{data: {}}},
              	PlannedState: &tfsdk.State{
            - 		Raw:    s`tftypes.Object["map_nested_attribute":tftypes.Map[tftypes.Object["string_attribute":tftypes.String]]]<"map_nested_attribute":tftypes.Map[tftypes.Object["string_attribute":tftypes.String]]<"null":tftypes.Object["string_attribute":tftypes.String]<"string_att`...,
            + 		Raw:    s`tftypes.Object["map_nested_attribute":tftypes.Map[tftypes.Object["string_attribute":tftypes.String]]]<"map_nested_attribute":tftypes.Map[tftypes.Object["string_attribute":tftypes.String]]<"null":tftypes.Object["string_attribute":tftypes.String]<unknown>>>`,
              		Schema: schema.Schema{Attributes: {"map_nested_attribute": schema.MapNestedAttribute{NestedObject: {...}, Optional: true}}},
              	},
              	RequiresReplace: s"[]",
              }
    --- FAIL: TestServerPlanResourceChange_AttributeRoundtrip/create-set-nested-optional-unknown-element (0.00s)
        /Users/bflad/src/github.com/hashicorp/terraform-plugin-framework/internal/fwserver/server_planresourcechange_test.go:15072: unexpected difference:   &fwserver.PlanResourceChangeResponse{
              	Diagnostics:    nil,
              	PlannedPrivate: &{Provider: &{data: {}}},
              	PlannedState: &tfsdk.State{
            - 		Raw:    s`tftypes.Object["set_nested_attribute":tftypes.Set[tftypes.Object["string_attribute":tftypes.String]]]<"set_nested_attribute":tftypes.Set[tftypes.Object["string_attribute":tftypes.String]]<tftypes.Object["string_attribute":tftypes.String]<"string_attribute"`...,
            + 		Raw:    s`tftypes.Object["set_nested_attribute":tftypes.Set[tftypes.Object["string_attribute":tftypes.String]]]<"set_nested_attribute":tftypes.Set[tftypes.Object["string_attribute":tftypes.String]]<tftypes.Object["string_attribute":tftypes.String]<unknown>>>`,
              		Schema: schema.Schema{Attributes: {"set_nested_attribute": schema.SetNestedAttribute{NestedObject: {...}, Optional: true}}},
              	},
              	RequiresReplace: s"[]",
              }
    --- FAIL: TestServerPlanResourceChange_AttributeRoundtrip/create-set-nested-optional-null-element (0.00s)
        /Users/bflad/src/github.com/hashicorp/terraform-plugin-framework/internal/fwserver/server_planresourcechange_test.go:15072: unexpected difference:   &fwserver.PlanResourceChangeResponse{
              	Diagnostics:    nil,
              	PlannedPrivate: &{Provider: &{data: {}}},
              	PlannedState: &tfsdk.State{
            - 		Raw:    s`tftypes.Object["set_nested_attribute":tftypes.Set[tftypes.Object["string_attribute":tftypes.String]]]<"set_nested_attribute":tftypes.Set[tftypes.Object["string_attribute":tftypes.String]]<tftypes.Object["string_attribute":tftypes.String]<"string_attribute"`...,
            + 		Raw:    s`tftypes.Object["set_nested_attribute":tftypes.Set[tftypes.Object["string_attribute":tftypes.String]]]<"set_nested_attribute":tftypes.Set[tftypes.Object["string_attribute":tftypes.String]]<tftypes.Object["string_attribute":tftypes.String]<null>>>`,
              		Schema: schema.Schema{Attributes: {"set_nested_attribute": schema.SetNestedAttribute{NestedObject: {...}, Optional: true}}},
              	},
              	RequiresReplace: s"[]",
              }
    --- FAIL: TestServerPlanResourceChange_AttributeRoundtrip/create-set-nested-optional-and-computed-null-element (0.00s)
        /Users/bflad/src/github.com/hashicorp/terraform-plugin-framework/internal/fwserver/server_planresourcechange_test.go:15072: unexpected difference:   &fwserver.PlanResourceChangeResponse{
              	Diagnostics:    nil,
              	PlannedPrivate: &{Provider: &{data: {}}},
              	PlannedState: &tfsdk.State{
            - 		Raw:    s`tftypes.Object["set_nested_attribute":tftypes.Set[tftypes.Object["string_attribute":tftypes.String]]]<"set_nested_attribute":tftypes.Set[tftypes.Object["string_attribute":tftypes.String]]<tftypes.Object["string_attribute":tftypes.String]<"string_attribute"`...,
            + 		Raw:    s`tftypes.Object["set_nested_attribute":tftypes.Set[tftypes.Object["string_attribute":tftypes.String]]]<"set_nested_attribute":tftypes.Set[tftypes.Object["string_attribute":tftypes.String]]<tftypes.Object["string_attribute":tftypes.String]<unknown>>>`,
              		Schema: schema.Schema{Attributes: {"set_nested_attribute": schema.SetNestedAttribute{NestedObject: {...}, Optional: true, Computed: true}}},
              	},
              	RequiresReplace: s"[]",
              }
    --- FAIL: TestServerPlanResourceChange_AttributeRoundtrip/create-map-nested-optional-null-element (0.00s)
        /Users/bflad/src/github.com/hashicorp/terraform-plugin-framework/internal/fwserver/server_planresourcechange_test.go:15072: unexpected difference:   &fwserver.PlanResourceChangeResponse{
              	Diagnostics:    nil,
              	PlannedPrivate: &{Provider: &{data: {}}},
              	PlannedState: &tfsdk.State{
            - 		Raw:    s`tftypes.Object["map_nested_attribute":tftypes.Map[tftypes.Object["string_attribute":tftypes.String]]]<"map_nested_attribute":tftypes.Map[tftypes.Object["string_attribute":tftypes.String]]<"null":tftypes.Object["string_attribute":tftypes.String]<"string_att`...,
            + 		Raw:    s`tftypes.Object["map_nested_attribute":tftypes.Map[tftypes.Object["string_attribute":tftypes.String]]]<"map_nested_attribute":tftypes.Map[tftypes.Object["string_attribute":tftypes.String]]<"null":tftypes.Object["string_attribute":tftypes.String]<null>>>`,
              		Schema: schema.Schema{Attributes: {"map_nested_attribute": schema.MapNestedAttribute{NestedObject: {...}, Optional: true}}},
              	},
              	RequiresReplace: s"[]",
              }
    --- FAIL: TestServerPlanResourceChange_AttributeRoundtrip/create-set-nested-optional-and-computed-unknown-element (0.00s)
        /Users/bflad/src/github.com/hashicorp/terraform-plugin-framework/internal/fwserver/server_planresourcechange_test.go:15072: unexpected difference:   &fwserver.PlanResourceChangeResponse{
              	Diagnostics:    nil,
              	PlannedPrivate: &{Provider: &{data: {}}},
              	PlannedState: &tfsdk.State{
            - 		Raw:    s`tftypes.Object["set_nested_attribute":tftypes.Set[tftypes.Object["string_attribute":tftypes.String]]]<"set_nested_attribute":tftypes.Set[tftypes.Object["string_attribute":tftypes.String]]<tftypes.Object["string_attribute":tftypes.String]<"string_attribute"`...,
            + 		Raw:    s`tftypes.Object["set_nested_attribute":tftypes.Set[tftypes.Object["string_attribute":tftypes.String]]]<"set_nested_attribute":tftypes.Set[tftypes.Object["string_attribute":tftypes.String]]<tftypes.Object["string_attribute":tftypes.String]<unknown>>>`,
              		Schema: schema.Schema{Attributes: {"set_nested_attribute": schema.SetNestedAttribute{NestedObject: {...}, Optional: true, Computed: true}}},
              	},
              	RequiresReplace: s"[]",
              }
    --- FAIL: TestServerPlanResourceChange_AttributeRoundtrip/create-map-nested-optional-and-computed-unknown-element (0.00s)
        /Users/bflad/src/github.com/hashicorp/terraform-plugin-framework/internal/fwserver/server_planresourcechange_test.go:15072: unexpected difference:   &fwserver.PlanResourceChangeResponse{
              	Diagnostics:    nil,
              	PlannedPrivate: &{Provider: &{data: {}}},
              	PlannedState: &tfsdk.State{
            - 		Raw:    s`tftypes.Object["map_nested_attribute":tftypes.Map[tftypes.Object["string_attribute":tftypes.String]]]<"map_nested_attribute":tftypes.Map[tftypes.Object["string_attribute":tftypes.String]]<"null":tftypes.Object["string_attribute":tftypes.String]<"string_att`...,
            + 		Raw:    s`tftypes.Object["map_nested_attribute":tftypes.Map[tftypes.Object["string_attribute":tftypes.String]]]<"map_nested_attribute":tftypes.Map[tftypes.Object["string_attribute":tftypes.String]]<"null":tftypes.Object["string_attribute":tftypes.String]<unknown>>>`,
              		Schema: schema.Schema{Attributes: {"map_nested_attribute": schema.MapNestedAttribute{NestedObject: {...}, Optional: true, Computed: true}}},
              	},
              	RequiresReplace: s"[]",
              }
    --- FAIL: TestServerPlanResourceChange_AttributeRoundtrip/create-list-nested-optional-unknown-element (0.00s)
        /Users/bflad/src/github.com/hashicorp/terraform-plugin-framework/internal/fwserver/server_planresourcechange_test.go:15072: unexpected difference:   &fwserver.PlanResourceChangeResponse{
              	Diagnostics:    nil,
              	PlannedPrivate: &{Provider: &{data: {}}},
              	PlannedState: &tfsdk.State{
            - 		Raw:    s`tftypes.Object["list_nested_attribute":tftypes.List[tftypes.Object["string_attribute":tftypes.String]]]<"list_nested_attribute":tftypes.List[tftypes.Object["string_attribute":tftypes.String]]<tftypes.Object["string_attribute":tftypes.String]<"string_attrib`...,
            + 		Raw:    s`tftypes.Object["list_nested_attribute":tftypes.List[tftypes.Object["string_attribute":tftypes.String]]]<"list_nested_attribute":tftypes.List[tftypes.Object["string_attribute":tftypes.String]]<tftypes.Object["string_attribute":tftypes.String]<unknown>>>`,
              		Schema: schema.Schema{Attributes: {"list_nested_attribute": schema.ListNestedAttribute{NestedObject: {...}, Optional: true}}},
              	},
              	RequiresReplace: s"[]",
              }
```

The plan modification logic was updated to return a null/unknown object early, but only after the object plan modifiers have run. This ensures that provider developers still have an escape hatch to run logic before the framework skips the nested attributes.

If provider developers need to override this logic change, object-level plan modifiers can convert a null/unknown object into a known object will all null/unknown attributes, which then the framework will run nested attribute plan modification on those attributes. If this is a common use case, a feature request can be submitted to consider including this type of object plan modifier in the framework.