### PR TITLE
reflect: Use `float64` string representation for `float32` reflection equivalency

### DIFF
--- a/internal/reflect/number.go
+++ b/internal/reflect/number.go
@@ -132,9 +132,9 @@ func Number(ctx context.Context, typ attr.Type, val tftypes.Value, target reflec
 			return reflect.ValueOf(uintResult), diags
 		}
 	case reflect.Float32:
-		floatResult, _ := result.Float32()
+		float64Result, _ := result.Float64()
 
-		bf := big.NewFloat(float64(floatResult))
+		bf := big.NewFloat(float64Result)
 
 		if result.Text('f', -1) != bf.Text('f', -1) {
 			diags.Append(roundingErrorDiag)
@@ -142,7 +142,25 @@ func Number(ctx context.Context, typ attr.Type, val tftypes.Value, target reflec
 			return target, diags
 		}
 
-		return reflect.ValueOf(floatResult), diags
+		float32Result, accuracy := result.Float32()
+
+		// Underflow
+		// Reference: https://pkg.go.dev/math/big#Float.Float32
+		if float32Result == 0 && accuracy != big.Exact {
+			diags.Append(roundingErrorDiag)
+
+			return target, diags
+		}
+
+		// Overflow
+		// Reference: https://pkg.go.dev/math/big#Float.Float32
+		if math.IsInf(float64(float32Result), 0) {
+			diags.Append(roundingErrorDiag)
+
+			return target, diags
+		}
+
+		return reflect.ValueOf(float32Result), diags
 	case reflect.Float64:
 		floatResult, _ := result.Float64()
 

--- a/internal/reflect/number_test.go
+++ b/internal/reflect/number_test.go
@@ -623,6 +623,25 @@ func TestNumber_float32OverflowError(t *testing.T) {
 	}
 }
 
+func TestNumber_float32OverflowNegativeError(t *testing.T) {
+	t.Parallel()
+
+	var n float32
+	expectedDiags := diag.Diagnostics{
+		diag.NewAttributeErrorDiagnostic(
+			path.Empty(),
+			"Value Conversion Error",
+			"An unexpected error was encountered trying to convert to number. This is always an error in the provider. Please report the following to the provider developer:\n\ncannot store -3.402823466e+39 in float32",
+		),
+	}
+
+	_, diags := refl.Number(context.Background(), types.NumberType, tftypes.NewValue(tftypes.Number, overflowNegativeFloat32), reflect.ValueOf(n), refl.Options{}, path.Empty())
+
+	if diff := cmp.Diff(diags, expectedDiags); diff != "" {
+		t.Errorf("unexpected diagnostics (+wanted, -got): %s", diff)
+	}
+}
+
 func TestNumber_float32UnderflowError(t *testing.T) {
 	t.Parallel()
 
@@ -636,6 +655,25 @@ func TestNumber_float32UnderflowError(t *testing.T) {
 	}
 
 	_, diags := refl.Number(context.Background(), types.NumberType, tftypes.NewValue(tftypes.Number, underflowFloat32), reflect.ValueOf(n), refl.Options{}, path.Empty())
+
+	if diff := cmp.Diff(diags, expectedDiags); diff != "" {
+		t.Errorf("unexpected diagnostics (+wanted, -got): %s", diff)
+	}
+}
+
+func TestNumber_float32UnderflowNegativeError(t *testing.T) {
+	t.Parallel()
+
+	var n float32
+	expectedDiags := diag.Diagnostics{
+		diag.NewAttributeErrorDiagnostic(
+			path.Empty(),
+			"Value Conversion Error",
+			"An unexpected error was encountered trying to convert to number. This is always an error in the provider. Please report the following to the provider developer:\n\ncannot store -1.401298464e-46 in float32",
+		),
+	}
+
+	_, diags := refl.Number(context.Background(), types.NumberType, tftypes.NewValue(tftypes.Number, underflowNegativeFloat32), reflect.ValueOf(n), refl.Options{}, path.Empty())
 
 	if diff := cmp.Diff(diags, expectedDiags); diff != "" {
 		t.Errorf("unexpected diagnostics (+wanted, -got): %s", diff)

--- a/internal/reflect/number_test.go
+++ b/internal/reflect/number_test.go
@@ -22,13 +22,17 @@ import (
 )
 
 var (
-	overflowInt, _, _            = big.ParseFloat("9223372036854775808", 10, 53, big.ToPositiveInf)
-	overflowUint, _, _           = big.ParseFloat("18446744073709551616", 10, 53, big.ToPositiveInf)
-	overflowFloat, _, _          = big.ParseFloat("1e10000", 10, 53, big.ToPositiveInf)
-	overflowNegativeFloat, _, _  = big.ParseFloat("-1e10000", 10, 53, big.ToPositiveInf)
-	underflowInt, _, _           = big.ParseFloat("-9223372036854775809", 10, 53, big.ToNegativeInf)
-	underflowFloat, _, _         = big.ParseFloat("1e-1000", 10, 0, big.ToNegativeInf)
-	underflowNegativeFloat, _, _ = big.ParseFloat("-1e-1000", 10, 0, big.ToNegativeInf)
+	overflowInt, _, _              = big.ParseFloat("9223372036854775808", 10, 53, big.ToPositiveInf)
+	overflowUint, _, _             = big.ParseFloat("18446744073709551616", 10, 53, big.ToPositiveInf)
+	overflowFloat32, _, _          = big.ParseFloat("3.40282346638528859811704183484516925440e+39", 10, 24, big.ToPositiveInf)
+	overflowFloat64, _, _          = big.ParseFloat("1e10000", 10, 53, big.ToPositiveInf)
+	overflowNegativeFloat32, _, _  = big.ParseFloat("-3.40282346638528859811704183484516925440e+39", 10, 53, big.ToPositiveInf)
+	overflowNegativeFloat64, _, _  = big.ParseFloat("-1e10000", 10, 53, big.ToPositiveInf)
+	underflowInt, _, _             = big.ParseFloat("-9223372036854775809", 10, 53, big.ToNegativeInf)
+	underflowFloat32, _, _         = big.ParseFloat("1.401298464324817070923729583289916131280e-46", 10, 0, big.ToNegativeInf)
+	underflowFloat64, _, _         = big.ParseFloat("1e-1000", 10, 0, big.ToNegativeInf)
+	underflowNegativeFloat32, _, _ = big.ParseFloat("-1.401298464324817070923729583289916131280e-46", 10, 0, big.ToNegativeInf)
+	underflowNegativeFloat64, _, _ = big.ParseFloat("-1e-1000", 10, 0, big.ToNegativeInf)
 )
 
 func TestNumber_bigFloat(t *testing.T) {
@@ -590,13 +594,13 @@ func TestNumber_float32(t *testing.T) {
 
 	var n float32
 
-	result, diags := refl.Number(context.Background(), types.NumberType, tftypes.NewValue(tftypes.Number, 123), reflect.ValueOf(n), refl.Options{}, path.Empty())
+	result, diags := refl.Number(context.Background(), types.NumberType, tftypes.NewValue(tftypes.Number, 1.23), reflect.ValueOf(n), refl.Options{}, path.Empty())
 	if diags.HasError() {
 		t.Errorf("Unexpected error: %v", diags)
 	}
 	reflect.ValueOf(&n).Elem().Set(result)
-	if n != 123 {
-		t.Errorf("Expected %v, got %v", 123, n)
+	if n != 1.23 {
+		t.Errorf("Expected %v, got %v", 1.23, n)
 	}
 }
 
@@ -608,11 +612,11 @@ func TestNumber_float32OverflowError(t *testing.T) {
 		diag.NewAttributeErrorDiagnostic(
 			path.Empty(),
 			"Value Conversion Error",
-			"An unexpected error was encountered trying to convert to number. This is always an error in the provider. Please report the following to the provider developer:\n\ncannot store 1.797693135e+308 in float32",
+			"An unexpected error was encountered trying to convert to number. This is always an error in the provider. Please report the following to the provider developer:\n\ncannot store 3.402823669e+39 in float32",
 		),
 	}
 
-	_, diags := refl.Number(context.Background(), types.NumberType, tftypes.NewValue(tftypes.Number, math.MaxFloat64), reflect.ValueOf(n), refl.Options{}, path.Empty())
+	_, diags := refl.Number(context.Background(), types.NumberType, tftypes.NewValue(tftypes.Number, overflowFloat32), reflect.ValueOf(n), refl.Options{}, path.Empty())
 
 	if diff := cmp.Diff(diags, expectedDiags); diff != "" {
 		t.Errorf("unexpected diagnostics (+wanted, -got): %s", diff)
@@ -627,11 +631,11 @@ func TestNumber_float32UnderflowError(t *testing.T) {
 		diag.NewAttributeErrorDiagnostic(
 			path.Empty(),
 			"Value Conversion Error",
-			"An unexpected error was encountered trying to convert to number. This is always an error in the provider. Please report the following to the provider developer:\n\ncannot store 4.940656458e-324 in float32",
+			"An unexpected error was encountered trying to convert to number. This is always an error in the provider. Please report the following to the provider developer:\n\ncannot store 1.401298464e-46 in float32",
 		),
 	}
 
-	_, diags := refl.Number(context.Background(), types.NumberType, tftypes.NewValue(tftypes.Number, math.SmallestNonzeroFloat64), reflect.ValueOf(n), refl.Options{}, path.Empty())
+	_, diags := refl.Number(context.Background(), types.NumberType, tftypes.NewValue(tftypes.Number, underflowFloat32), reflect.ValueOf(n), refl.Options{}, path.Empty())
 
 	if diff := cmp.Diff(diags, expectedDiags); diff != "" {
 		t.Errorf("unexpected diagnostics (+wanted, -got): %s", diff)
@@ -643,13 +647,13 @@ func TestNumber_float64(t *testing.T) {
 
 	var n float64
 
-	result, diags := refl.Number(context.Background(), types.NumberType, tftypes.NewValue(tftypes.Number, 123), reflect.ValueOf(n), refl.Options{}, path.Empty())
+	result, diags := refl.Number(context.Background(), types.NumberType, tftypes.NewValue(tftypes.Number, 1.23), reflect.ValueOf(n), refl.Options{}, path.Empty())
 	if diags.HasError() {
 		t.Errorf("Unexpected error: %v", diags)
 	}
 	reflect.ValueOf(&n).Elem().Set(result)
-	if n != 123 {
-		t.Errorf("Expected %v, got %v", 123, n)
+	if n != 1.23 {
+		t.Errorf("Expected %v, got %v", 1.23, n)
 	}
 }
 
@@ -665,7 +669,7 @@ func TestNumber_float64OverflowError(t *testing.T) {
 		),
 	}
 
-	_, diags := refl.Number(context.Background(), types.NumberType, tftypes.NewValue(tftypes.Number, overflowFloat), reflect.ValueOf(n), refl.Options{}, path.Empty())
+	_, diags := refl.Number(context.Background(), types.NumberType, tftypes.NewValue(tftypes.Number, overflowFloat64), reflect.ValueOf(n), refl.Options{}, path.Empty())
 
 	if diff := cmp.Diff(diags, expectedDiags); diff != "" {
 		t.Errorf("unexpected diagnostics (+wanted, -got): %s", diff)
@@ -684,7 +688,7 @@ func TestNumber_float64OverflowNegativeError(t *testing.T) {
 		),
 	}
 
-	_, diags := refl.Number(context.Background(), types.NumberType, tftypes.NewValue(tftypes.Number, overflowNegativeFloat), reflect.ValueOf(n), refl.Options{}, path.Empty())
+	_, diags := refl.Number(context.Background(), types.NumberType, tftypes.NewValue(tftypes.Number, overflowNegativeFloat64), reflect.ValueOf(n), refl.Options{}, path.Empty())
 
 	if diff := cmp.Diff(diags, expectedDiags); diff != "" {
 		t.Errorf("unexpected diagnostics (+wanted, -got): %s", diff)
@@ -703,7 +707,7 @@ func TestNumber_float64UnderflowError(t *testing.T) {
 		),
 	}
 
-	_, diags := refl.Number(context.Background(), types.NumberType, tftypes.NewValue(tftypes.Number, underflowFloat), reflect.ValueOf(n), refl.Options{}, path.Empty())
+	_, diags := refl.Number(context.Background(), types.NumberType, tftypes.NewValue(tftypes.Number, underflowFloat64), reflect.ValueOf(n), refl.Options{}, path.Empty())
 
 	if diff := cmp.Diff(diags, expectedDiags); diff != "" {
 		t.Errorf("unexpected diagnostics (+wanted, -got): %s", diff)
@@ -722,7 +726,7 @@ func TestNumber_float64UnderflowNegativeError(t *testing.T) {
 		),
 	}
 
-	_, diags := refl.Number(context.Background(), types.NumberType, tftypes.NewValue(tftypes.Number, underflowNegativeFloat), reflect.ValueOf(n), refl.Options{}, path.Empty())
+	_, diags := refl.Number(context.Background(), types.NumberType, tftypes.NewValue(tftypes.Number, underflowNegativeFloat64), reflect.ValueOf(n), refl.Options{}, path.Empty())
 
 	if diff := cmp.Diff(diags, expectedDiags); diff != "" {
 		t.Errorf("unexpected diagnostics (+wanted, -got): %s", diff)


### PR DESCRIPTION
Relates: #1014 

This fixes a bug encountered when using `function.Float32Parameter` in a provider defined function, similar to issue #914:
```go
=== RUN   TestFloat32Function_known
    float32_function_test.go:20: Step 1/1 error: Error running pre-apply plan: exit status 1
        
        Error: Error in function call
        
          on terraform_plugin_test.tf line 13, in output "test":
          13: 					value = provider::framework::float32(1.23)
            ├────────────────
            │ while calling provider::framework::float32(float32_param)
        
        Call to function "provider::framework::float32" failed: Value Conversion
        Error: An unexpected error was encountered trying to convert to number. This
        is always an error in the provider. Please report the following to the
        provider developer:
        
        cannot store 1.23 in float32.
--- FAIL: TestFloat32Function_known (0.36s)
```

The current reflection logic for `float32` compares the reflection target's string representation of the `float32` value with the string representation of that same value in a new `big.Float` object and throws an error if the representations differ. Creating a new `big.Float` object requires a conversion from `float32` to `float64` resulting in precision loss and differing string representations. 

This PR switches the string comparisons to `float64` and adds overflow and underflow checks for `float32`. 