### PR TITLE
Remove extra unaccepted comma in the example code

### DIFF
--- a/website/docs/plugin/framework/migrating/mux.mdx
+++ b/website/docs/plugin/framework/migrating/mux.mdx
@@ -234,7 +234,7 @@ func TestMuxServer(t *testing.T) {
                 providers := []func() tfprotov6.ProviderServer{
                     providerserver.NewProtocol6(New()), // Example terraform-plugin-framework provider
                     func() tfprotov6.ProviderServer {
-                        return upgradedSdkServer,
+                        return upgradedSdkServer
                     },
                 }
 


### PR DESCRIPTION
The comma in the example code is unexpected in the context and causes a parsing error