### PR TITLE
all: Add support for embedded struct types in object conversions

### DIFF
--- a/.changes/unreleased/ENHANCEMENTS-20240722-175116.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20240722-175116.yaml
@@ -1,0 +1,6 @@
+kind: ENHANCEMENTS
+body: 'all: Added embedded struct support for object to struct conversions with `tfsdk`
+  tags'
+time: 2024-07-22T17:51:16.833264-04:00
+custom:
+  Issue: "1021"

--- a/.changes/unreleased/NOTES-20240801-171654.yaml
+++ b/.changes/unreleased/NOTES-20240801-171654.yaml
@@ -1,0 +1,40 @@
+kind: NOTES
+body: |
+  Framework reflection logic (`Config.Get`, `Plan.Get`, etc.) for structs with
+  `tfsdk` field tags has been updated to support embedded structs that promote exported
+  fields. For existing structs that embed unexported structs with exported fields, a tfsdk
+  ignore tag (``tfsdk:"-"``) can be added to ignore all promoted fields.  
+
+  For example, the following struct will now return an error diagnostic:
+  ```go
+  type thingResourceModel struct {
+  	Attr1 types.String `tfsdk:"attr_1"`
+  	Attr2 types.Bool   `tfsdk:"attr_2"`
+  
+  	// Previously, this embedded struct was ignored, will now promote underlying fields
+  	embeddedModel
+  }
+  
+  type embeddedModel struct {
+  	// No `tfsdk` tag
+  	ExportedField string
+  }
+  ```
+  
+  To preserve the original behavior, a tfsdk ignore tag can be added to ignore the entire embedded struct:
+  ```go
+  type thingResourceModel struct {
+  	Attr1 types.String `tfsdk:"attr_1"`
+  	Attr2 types.Bool   `tfsdk:"attr_2"`
+  
+  	// This embedded struct will now be ignored
+  	embeddedModel      `tfsdk:"-"`
+  }
+  
+  type embeddedModel struct {
+  	ExportedField string
+  }
+  ```
+time: 2024-08-01T17:16:54.043432-04:00
+custom:
+  Issue: "1021"

--- a/internal/reflect/helpers.go
+++ b/internal/reflect/helpers.go
@@ -46,35 +46,77 @@ func commaSeparatedString(in []string) string {
 }
 
 // getStructTags returns a map of Terraform field names to their position in
-// the tags of the struct `in`. `in` must be a struct.
-func getStructTags(_ context.Context, in reflect.Value, path path.Path) (map[string]int, error) {
-	tags := map[string]int{}
-	typ := trueReflectValue(in).Type()
-	if typ.Kind() != reflect.Struct {
-		return nil, fmt.Errorf("%s: can't get struct tags of %s, is not a struct", path, in.Type())
+// the fields of the struct `in`. `in` must be a struct.
+//
+// The position of the field in a struct is represented as an index sequence to support type embedding
+// in structs. This index sequence can be used to retrieve the field with the Go "reflect" package FieldByIndex methods:
+//   - https://pkg.go.dev/reflect#Type.FieldByIndex
+//   - https://pkg.go.dev/reflect#Value.FieldByIndex
+//
+// The following are not supported and will return an error if detected in a struct (including embedded structs):
+//   - Duplicate "tfsdk" tags
+//   - Exported fields without a "tfsdk" tag
+//   - Exported fields with an invalid "tfsdk" tag (must be a valid Terraform identifier)
+func getStructTags(ctx context.Context, typ reflect.Type, path path.Path) (map[string][]int, error) { //nolint:unparam // False positive, ctx is used below.
+	tags := make(map[string][]int, 0)
+
+	if typ.Kind() == reflect.Pointer {
+		typ = typ.Elem()
 	}
+	if typ.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("%s: can't get struct tags of %s, is not a struct", path, typ)
+	}
+
 	for i := 0; i < typ.NumField(); i++ {
 		field := typ.Field(i)
-		if field.PkgPath != "" {
-			// skip unexported fields
+		if !field.IsExported() {
+			// skip all unexported fields
 			continue
 		}
+
+		// This index sequence is the location of the field within the struct.
+		// For embedded structs, the length of this sequence will be > 1
+		fieldIndexSequence := []int{i}
 		tag := field.Tag.Get(`tfsdk`)
-		if tag == "-" {
-			// skip explicitly excluded fields
-			continue
-		}
-		if tag == "" {
+
+		switch tag {
+		// "tfsdk" tags can only be omitted on embedded structs
+		case "":
+			if field.Anonymous {
+				embeddedTags, err := getStructTags(ctx, field.Type, path)
+				if err != nil {
+					return nil, fmt.Errorf(`error retrieving embedded struct %q field tags: %w`, field.Name, err)
+				}
+				for k, v := range embeddedTags {
+					if other, ok := tags[k]; ok {
+						otherField := typ.FieldByIndex(other)
+						return nil, fmt.Errorf("embedded struct %q contains a duplicate field name %q", field.Name, otherField.Name)
+					}
+
+					tags[k] = append(fieldIndexSequence, v...)
+				}
+				continue
+			}
+
 			return nil, fmt.Errorf(`%s: need a struct tag for "tfsdk" on %s`, path, field.Name)
+
+		// "tfsdk" tags with "-" are being explicitly excluded
+		case "-":
+			continue
+
+		// validate the "tfsdk" tag and ensure there are no duplicates before storing
+		default:
+			path := path.AtName(tag)
+			if !isValidFieldName(tag) {
+				return nil, fmt.Errorf("%s: invalid field name, must only use lowercase letters, underscores, and numbers, and must start with a letter", path)
+			}
+			if other, ok := tags[tag]; ok {
+				otherField := typ.FieldByIndex(other)
+				return nil, fmt.Errorf("%s: can't use field name for both %s and %s", path, otherField.Name, field.Name)
+			}
+
+			tags[tag] = fieldIndexSequence
 		}
-		path := path.AtName(tag)
-		if !isValidFieldName(tag) {
-			return nil, fmt.Errorf("%s: invalid field name, must only use lowercase letters, underscores, and numbers, and must start with a letter", path)
-		}
-		if other, ok := tags[tag]; ok {
-			return nil, fmt.Errorf("%s: can't use field name for both %s and %s", path, typ.Field(other).Name, field.Name)
-		}
-		tags[tag] = i
 	}
 	return tags, nil
 }

--- a/internal/reflect/helpers.go
+++ b/internal/reflect/helpers.go
@@ -71,7 +71,7 @@ func getStructTags(ctx context.Context, typ reflect.Type, path path.Path) (map[s
 	for i := 0; i < typ.NumField(); i++ {
 		field := typ.Field(i)
 		if !field.IsExported() && !field.Anonymous {
-			// Skip unexported fields. Embedded structs (anonymous fields) are allowed because they may
+			// Skip unexported fields. Unexported embedded structs (anonymous fields) are allowed because they may
 			// contain exported fields that are promoted; which means they can be read/set.
 			continue
 		}

--- a/internal/reflect/helpers.go
+++ b/internal/reflect/helpers.go
@@ -52,6 +52,7 @@ func commaSeparatedString(in []string) string {
 // in structs. This index sequence can be used to retrieve the field with the Go "reflect" package FieldByIndex methods:
 //   - https://pkg.go.dev/reflect#Type.FieldByIndex
 //   - https://pkg.go.dev/reflect#Value.FieldByIndex
+//   - https://pkg.go.dev/reflect#Value.FieldByIndexErr
 //
 // The following are not supported and will return an error if detected in a struct (including embedded structs):
 //   - Duplicate "tfsdk" tags

--- a/internal/reflect/helpers_test.go
+++ b/internal/reflect/helpers_test.go
@@ -50,11 +50,11 @@ func TestGetStructTags(t *testing.T) {
 				StrField string `tfsdk:"str_field"`
 				IntField string `tfsdk:"str_field"`
 			}{},
-			expectedErr: errors.New(`str_field: can't use field name for both StrField and IntField`),
+			expectedErr: errors.New(`str_field: can't use tfsdk tag "str_field" for both StrField and IntField fields`),
 		},
 		"struct-err-invalid-field": {
 			in:          StructWithInvalidTag{},
-			expectedErr: errors.New(`*()-: invalid field name, must only use lowercase letters, underscores, and numbers, and must start with a letter`),
+			expectedErr: errors.New(`*()-: invalid tfsdk tag, must only use lowercase letters, underscores, and numbers, and must start with a letter`),
 		},
 		"embedded-struct": {
 			in: struct {
@@ -88,13 +88,13 @@ func TestGetStructTags(t *testing.T) {
 				StrField      string `tfsdk:"str_field"`
 				ExampleStruct        // Contains a `tfsdk:"str_field"`
 			}{},
-			expectedErr: errors.New(`embedded struct "ExampleStruct" contains a duplicate field name "StrField"`),
+			expectedErr: errors.New(`embedded struct "ExampleStruct" promotes a field with a duplicate tfsdk tag "str_field", conflicts with "StrField" tfsdk tag`),
 		},
 		"embedded-struct-err-invalid": {
 			in: struct {
 				StructWithInvalidTag // Contains an invalid "tfsdk" tag
 			}{},
-			expectedErr: errors.New(`error retrieving embedded struct "StructWithInvalidTag" field tags: *()-: invalid field name, must only use lowercase letters, underscores, and numbers, and must start with a letter`),
+			expectedErr: errors.New(`error retrieving embedded struct "StructWithInvalidTag" field tags: *()-: invalid tfsdk tag, must only use lowercase letters, underscores, and numbers, and must start with a letter`),
 		},
 		// Embedded struct pointers still produce a valid field index, but are later rejected when retrieving
 		"embedded-struct-ptr": {
@@ -130,13 +130,13 @@ func TestGetStructTags(t *testing.T) {
 				StrField       string `tfsdk:"str_field"`
 				*ExampleStruct        // Contains a `tfsdk:"str_field"`
 			}{},
-			expectedErr: errors.New(`embedded struct "ExampleStruct" contains a duplicate field name "StrField"`),
+			expectedErr: errors.New(`embedded struct "ExampleStruct" promotes a field with a duplicate tfsdk tag "str_field", conflicts with "StrField" tfsdk tag`),
 		},
 		"embedded-struct-ptr-err-invalid": {
 			in: struct {
 				*StructWithInvalidTag // Contains an invalid "tfsdk" tag
 			}{},
-			expectedErr: errors.New(`error retrieving embedded struct "StructWithInvalidTag" field tags: *()-: invalid field name, must only use lowercase letters, underscores, and numbers, and must start with a letter`),
+			expectedErr: errors.New(`error retrieving embedded struct "StructWithInvalidTag" field tags: *()-: invalid tfsdk tag, must only use lowercase letters, underscores, and numbers, and must start with a letter`),
 		},
 	}
 

--- a/internal/reflect/helpers_test.go
+++ b/internal/reflect/helpers_test.go
@@ -74,6 +74,15 @@ func TestGetStructTags(t *testing.T) {
 			in:          StructWithInvalidTag{},
 			expectedErr: errors.New(`*()-: invalid tfsdk tag, must only use lowercase letters, underscores, and numbers, and must start with a letter`),
 		},
+		"ignore-embedded-struct": {
+			in: struct {
+				ExampleStruct `tfsdk:"-"`
+				Field5        string `tfsdk:"field5"`
+			}{},
+			expectedTags: map[string][]int{
+				"field5": {1},
+			},
+		},
 		"embedded-struct": {
 			in: struct {
 				ExampleStruct
@@ -110,6 +119,15 @@ func TestGetStructTags(t *testing.T) {
 		// NOTE: The following tests are for embedded struct pointers, despite them not being explicitly supported by the framework reflect package.
 		// Embedded struct pointers still produce a valid field index, but are later rejected when retrieving them. These tests just ensure that there
 		// are no panics when retrieving the field index for an embedded struct pointer field
+		"ignore-embedded-struct-ptr": {
+			in: struct {
+				*ExampleStruct `tfsdk:"-"`
+				Field5         string `tfsdk:"field5"`
+			}{},
+			expectedTags: map[string][]int{
+				"field5": {1},
+			},
+		},
 		"embedded-struct-ptr": {
 			in: struct {
 				*ExampleStruct

--- a/internal/reflect/helpers_test.go
+++ b/internal/reflect/helpers_test.go
@@ -25,6 +25,16 @@ type ExampleStruct struct {
 	unexportedAndTagged string `tfsdk:"unexported_and_tagged"`
 }
 
+type NestedEmbed struct {
+	ListField []string `tfsdk:"list_field"`
+	DoubleNestedEmbed
+}
+
+type DoubleNestedEmbed struct {
+	Map map[string]string `tfsdk:"map_field"`
+	ExampleStruct
+}
+
 type EmbedWithDuplicates struct {
 	StrField1 string `tfsdk:"str_field"`
 	StrField2 string `tfsdk:"str_field"`
@@ -92,6 +102,20 @@ func TestGetStructTags(t *testing.T) {
 				"str_field":  {0, 0},
 				"int_field":  {0, 1},
 				"bool_field": {0, 2},
+				"field5":     {1},
+			},
+		},
+		"nested-embedded-struct": {
+			in: struct {
+				NestedEmbed
+				Field5 string `tfsdk:"field5"`
+			}{},
+			expectedTags: map[string][]int{
+				"list_field": {0, 0},
+				"map_field":  {0, 1, 0},
+				"str_field":  {0, 1, 1, 0},
+				"int_field":  {0, 1, 1, 1},
+				"bool_field": {0, 1, 1, 2},
 				"field5":     {1},
 			},
 		},

--- a/internal/reflect/helpers_test.go
+++ b/internal/reflect/helpers_test.go
@@ -84,6 +84,18 @@ func TestGetStructTags(t *testing.T) {
 			in:          StructWithInvalidTag{},
 			expectedErr: errors.New(`*()-: invalid tfsdk tag, must only use lowercase letters, underscores, and numbers, and must start with a letter`),
 		},
+		"struct-err-missing-tfsdk-tag": {
+			in: struct {
+				ExampleField string
+			}{},
+			expectedErr: errors.New(`: need a struct tag for "tfsdk" on ExampleField`),
+		},
+		"struct-err-empty-tfsdk-tag": {
+			in: struct {
+				ExampleField string `tfsdk:""`
+			}{},
+			expectedErr: errors.New(`: invalid tfsdk tag, must only use lowercase letters, underscores, and numbers, and must start with a letter`),
+		},
 		"ignore-embedded-struct": {
 			in: struct {
 				ExampleStruct `tfsdk:"-"`
@@ -133,6 +145,12 @@ func TestGetStructTags(t *testing.T) {
 				"bool_field": {0, 2},
 				"field5":     {1},
 			},
+		},
+		"embedded-struct-err-cannot-have-empty-tfsdk-tag": {
+			in: struct {
+				ExampleStruct `tfsdk:""` // Can't put a tfsdk tag here
+			}{},
+			expectedErr: errors.New(`: embedded struct field ExampleStruct cannot have tfsdk tag`),
 		},
 		"embedded-struct-err-cannot-have-tfsdk-tag": {
 			in: struct {
@@ -184,6 +202,12 @@ func TestGetStructTags(t *testing.T) {
 				"bool_field": {0, 2},
 				"field5":     {1},
 			},
+		},
+		"embedded-struct-ptr-err-cannot-have-empty-tfsdk-tag": {
+			in: struct {
+				*ExampleStruct `tfsdk:""` // Can't put a tfsdk tag here
+			}{},
+			expectedErr: errors.New(`: embedded struct field ExampleStruct cannot have tfsdk tag`),
 		},
 		"embedded-struct-ptr-err-cannot-have-tfsdk-tag": {
 			in: struct {

--- a/internal/reflect/helpers_test.go
+++ b/internal/reflect/helpers_test.go
@@ -134,6 +134,12 @@ func TestGetStructTags(t *testing.T) {
 				"field5":     {1},
 			},
 		},
+		"embedded-struct-err-cannot-have-tfsdk-tag": {
+			in: struct {
+				ExampleStruct `tfsdk:"example_field"` // Can't put a tfsdk tag here
+			}{},
+			expectedErr: errors.New(`example_field: embedded struct field ExampleStruct cannot have tfsdk tag`),
+		},
 		"embedded-struct-err-invalid": {
 			in: struct {
 				StructWithInvalidTag // Contains an invalid "tfsdk" tag
@@ -178,6 +184,12 @@ func TestGetStructTags(t *testing.T) {
 				"bool_field": {0, 2},
 				"field5":     {1},
 			},
+		},
+		"embedded-struct-ptr-err-cannot-have-tfsdk-tag": {
+			in: struct {
+				*ExampleStruct `tfsdk:"example_field"` // Can't put a tfsdk tag here
+			}{},
+			expectedErr: errors.New(`example_field: embedded struct field ExampleStruct cannot have tfsdk tag`),
 		},
 		"embedded-struct-ptr-err-duplicate-fields": {
 			in: struct {

--- a/internal/reflect/struct.go
+++ b/internal/reflect/struct.go
@@ -133,10 +133,10 @@ func Struct(ctx context.Context, typ attr.Type, object tftypes.Value, target ref
 
 		structField, err := result.FieldByIndexErr(fieldIndex)
 		if err != nil {
-			// The field index that triggered the error is in an embedded struct. The most likely cause for the error
-			// is because the embedded struct is a pointer, which we explicitly don't support. We'll create a more tailored
-			// error message to nudge provider developers to use a value embedded struct.
 			if len(fieldIndex) > 1 {
+				// The field index that triggered the error is in an embedded struct. The most likely cause for the error
+				// is because the embedded struct is a pointer, which we explicitly don't support. We'll create a more tailored
+				// error message to nudge provider developers to use a value embedded struct.
 				diags.Append(diag.WithPath(path, DiagIntoIncompatibleType{
 					Val:        object,
 					TargetType: target.Type(),

--- a/internal/reflect/struct_test.go
+++ b/internal/reflect/struct_test.go
@@ -817,8 +817,13 @@ func TestNewStruct_embedded_structtags_ignores(t *testing.T) {
 		ExportedAndExcluded string `tfsdk:"-"`
 	}
 
+	type s2 struct {
+		unexportedField string //nolint:structcheck,unused
+	}
+
 	var s struct {
 		s1
+		*s2 `tfsdk:"-"`
 	}
 	result, diags := refl.Struct(context.Background(), types.ObjectType{
 		AttrTypes: map[string]attr.Type{
@@ -2110,8 +2115,13 @@ func TestFromStruct_embedded_structtags_ignores(t *testing.T) {
 		ExportedAndExcluded string `tfsdk:"-"`
 	}
 
+	type s2 struct {
+		unexportedField string //nolint:structcheck,unused
+	}
+
 	type s struct {
 		s1
+		*s2 `tfsdk:"-"`
 	}
 	testStruct := s{
 		s1{
@@ -2120,6 +2130,7 @@ func TestFromStruct_embedded_structtags_ignores(t *testing.T) {
 			unexportedAndTagged: "shouldntcopy",
 			ExportedAndExcluded: "shouldntcopy",
 		},
+		&s2{},
 	}
 
 	actualVal, diags := refl.FromStruct(context.Background(), types.ObjectType{

--- a/internal/reflect/struct_test.go
+++ b/internal/reflect/struct_test.go
@@ -22,6 +22,20 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
+type embedSingleField struct {
+	Attr1 types.String `tfsdk:"attr_1"`
+}
+
+type embedNoFields struct{}
+
+type embedWithUntaggedExportedField struct {
+	ExportedAndUntagged types.String
+}
+
+type embedWithInvalidTag struct {
+	A types.String `tfsdk:"invalidTag"`
+}
+
 func TestNewStruct_errors(t *testing.T) {
 	t.Parallel()
 
@@ -62,6 +76,14 @@ func TestNewStruct_errors(t *testing.T) {
 			}{}),
 			expectedError: errors.New("mismatch between struct and object: Struct defines fields not found in object: a."),
 		},
+		"embedded-object-missing-fields": {
+			typ:    types.ObjectType{},
+			objVal: tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{}}, map[string]tftypes.Value{}),
+			targetVal: reflect.ValueOf(struct {
+				embedSingleField
+			}{}),
+			expectedError: errors.New("mismatch between struct and object: Struct defines fields not found in object: attr_1."),
+		},
 		"struct-missing-fields": {
 			typ: types.ObjectType{
 				AttrTypes: map[string]attr.Type{
@@ -78,10 +100,28 @@ func TestNewStruct_errors(t *testing.T) {
 			targetVal:     reflect.ValueOf(struct{}{}),
 			expectedError: errors.New("mismatch between struct and object: Object defines fields not found in struct: a."),
 		},
-		"object-and-struct-missing-fields": {
+		"embedded-struct-missing-fields": {
 			typ: types.ObjectType{
 				AttrTypes: map[string]attr.Type{
 					"a": types.StringType,
+				},
+			},
+			objVal: tftypes.NewValue(tftypes.Object{
+				AttributeTypes: map[string]tftypes.Type{
+					"a": tftypes.String,
+				},
+			}, map[string]tftypes.Value{
+				"a": tftypes.NewValue(tftypes.String, "hello"),
+			}),
+			targetVal: reflect.ValueOf(struct {
+				embedNoFields
+			}{}),
+			expectedError: errors.New("mismatch between struct and object: Object defines fields not found in struct: a."),
+		},
+		"object-and-struct-missing-fields": {
+			typ: types.ObjectType{
+				AttrTypes: map[string]attr.Type{
+					"b": types.StringType,
 				},
 			},
 			objVal: tftypes.NewValue(tftypes.Object{
@@ -95,6 +135,24 @@ func TestNewStruct_errors(t *testing.T) {
 				A string `tfsdk:"a"`
 			}{}),
 			expectedError: errors.New("mismatch between struct and object: Struct defines fields not found in object: a. Object defines fields not found in struct: b."),
+		},
+		"embedded-object-and-struct-missing-fields": {
+			typ: types.ObjectType{
+				AttrTypes: map[string]attr.Type{
+					"b": types.StringType,
+				},
+			},
+			objVal: tftypes.NewValue(tftypes.Object{
+				AttributeTypes: map[string]tftypes.Type{
+					"b": tftypes.String,
+				},
+			}, map[string]tftypes.Value{
+				"b": tftypes.NewValue(tftypes.String, "hello"),
+			}),
+			targetVal: reflect.ValueOf(struct {
+				embedSingleField
+			}{}),
+			expectedError: errors.New("mismatch between struct and object: Struct defines fields not found in object: attr_1. Object defines fields not found in struct: b."),
 		},
 		"struct-has-untagged-fields": {
 			typ: types.ObjectType{
@@ -117,6 +175,30 @@ func TestNewStruct_errors(t *testing.T) {
 				"error retrieving field names from struct tags: %w",
 				errors.New(`: need a struct tag for "tfsdk" on ExportedAndUntagged`)),
 		},
+		"embedded-struct-has-untagged-fields": {
+			typ: types.ObjectType{
+				AttrTypes: map[string]attr.Type{
+					"a": types.StringType,
+				},
+			},
+			objVal: tftypes.NewValue(tftypes.Object{
+				AttributeTypes: map[string]tftypes.Type{
+					"a": tftypes.String,
+				},
+			}, map[string]tftypes.Value{
+				"a": tftypes.NewValue(tftypes.String, "hello"),
+			}),
+			targetVal: reflect.ValueOf(struct {
+				A string `tfsdk:"a"`
+				embedWithUntaggedExportedField
+			}{}),
+			expectedError: fmt.Errorf(
+				"error retrieving field names from struct tags: %w",
+				fmt.Errorf(`error retrieving embedded struct "embedWithUntaggedExportedField" field tags: %w`,
+					errors.New(`: need a struct tag for "tfsdk" on ExportedAndUntagged`),
+				),
+			),
+		},
 		"struct-has-invalid-tags": {
 			typ: types.ObjectType{
 				AttrTypes: map[string]attr.Type{
@@ -135,7 +217,30 @@ func TestNewStruct_errors(t *testing.T) {
 			}{}),
 			expectedError: fmt.Errorf(
 				"error retrieving field names from struct tags: %w",
-				errors.New("invalidTag: invalid field name, must only use lowercase letters, underscores, and numbers, and must start with a letter")),
+				errors.New("invalidTag: invalid tfsdk tag, must only use lowercase letters, underscores, and numbers, and must start with a letter")),
+		},
+		"embedded-struct-has-invalid-tags": {
+			typ: types.ObjectType{
+				AttrTypes: map[string]attr.Type{
+					"a": types.StringType,
+				},
+			},
+			objVal: tftypes.NewValue(tftypes.Object{
+				AttributeTypes: map[string]tftypes.Type{
+					"a": tftypes.String,
+				},
+			}, map[string]tftypes.Value{
+				"a": tftypes.NewValue(tftypes.String, "hello"),
+			}),
+			targetVal: reflect.ValueOf(struct {
+				embedWithInvalidTag
+			}{}),
+			expectedError: fmt.Errorf(
+				"error retrieving field names from struct tags: %w",
+				fmt.Errorf(`error retrieving embedded struct "embedWithInvalidTag" field tags: %w`,
+					errors.New("invalidTag: invalid tfsdk tag, must only use lowercase letters, underscores, and numbers, and must start with a letter"),
+				),
+			),
 		},
 		"struct-has-duplicate-tags": {
 			typ: types.ObjectType{
@@ -156,7 +261,71 @@ func TestNewStruct_errors(t *testing.T) {
 			}{}),
 			expectedError: fmt.Errorf(
 				"error retrieving field names from struct tags: %w",
-				errors.New("a: can't use field name for both A and B")),
+				errors.New(`a: can't use tfsdk tag "a" for both A and B fields`)),
+		},
+		"embedded-struct-has-duplicate-tags": {
+			typ: types.ObjectType{
+				AttrTypes: map[string]attr.Type{
+					"a": types.StringType,
+				},
+			},
+			objVal: tftypes.NewValue(tftypes.Object{
+				AttributeTypes: map[string]tftypes.Type{
+					"a": tftypes.String,
+				},
+			}, map[string]tftypes.Value{
+				"a": tftypes.NewValue(tftypes.String, "hello"),
+			}),
+			targetVal: reflect.ValueOf(struct {
+				FirstAttr1 types.String `tfsdk:"attr_1"`
+				// Also contains an attr_1 tfsdk tag
+				embedSingleField
+			}{}),
+			expectedError: fmt.Errorf(
+				"error retrieving field names from struct tags: %w",
+				errors.New(`embedded struct "embedSingleField" promotes a field with a duplicate tfsdk tag "attr_1", conflicts with "FirstAttr1" tfsdk tag`),
+			),
+		},
+		"embedded-struct-with-pointer-not-supported": {
+			typ: types.ObjectType{
+				AttrTypes: map[string]attr.Type{
+					"attr_1": types.StringType,
+				},
+			},
+			objVal: tftypes.NewValue(tftypes.Object{
+				AttributeTypes: map[string]tftypes.Type{
+					"attr_1": tftypes.String,
+				},
+			}, map[string]tftypes.Value{
+				"attr_1": tftypes.NewValue(tftypes.String, "hello"),
+			}),
+			targetVal: reflect.ValueOf(struct {
+				*embedSingleField
+			}{}),
+			expectedError: errors.New(
+				"struct { *reflect_test.embedSingleField } contains a struct embedded by a pointer which is not supported. Switch any embedded structs to be embedded by value.\n\n" +
+					"Error: reflect: indirection through nil pointer to embedded struct field embedSingleField",
+			),
+		},
+		"embedded-struct-has-tfsdk-tag": {
+			typ: types.ObjectType{
+				AttrTypes: map[string]attr.Type{
+					"attr_1": types.StringType,
+				},
+			},
+			objVal: tftypes.NewValue(tftypes.Object{
+				AttributeTypes: map[string]tftypes.Type{
+					"attr_1": tftypes.String,
+				},
+			}, map[string]tftypes.Value{
+				"attr_1": tftypes.NewValue(tftypes.String, "hello"),
+			}),
+			targetVal: reflect.ValueOf(struct {
+				embedSingleField `tfsdk:"attr_2"`
+			}{}),
+			expectedError: errors.New(
+				"error retrieving field names from struct tags: attr_2: embedded struct field embedSingleField cannot have tfsdk tag",
+			),
 		},
 	}
 
@@ -194,6 +363,54 @@ func TestNewStruct_primitives(t *testing.T) {
 		B *big.Float `tfsdk:"b"`
 		C bool       `tfsdk:"c"`
 	}
+	result, diags := refl.Struct(context.Background(), types.ObjectType{
+		AttrTypes: map[string]attr.Type{
+			"a": types.StringType,
+			"b": types.NumberType,
+			"c": types.BoolType,
+		},
+	}, tftypes.NewValue(tftypes.Object{
+		AttributeTypes: map[string]tftypes.Type{
+			"a": tftypes.String,
+			"b": tftypes.Number,
+			"c": tftypes.Bool,
+		},
+	}, map[string]tftypes.Value{
+		"a": tftypes.NewValue(tftypes.String, "hello"),
+		"b": tftypes.NewValue(tftypes.Number, 123),
+		"c": tftypes.NewValue(tftypes.Bool, true),
+	}), reflect.ValueOf(s), refl.Options{}, path.Empty())
+	if diags.HasError() {
+		t.Errorf("Unexpected error: %v", diags)
+	}
+	reflect.ValueOf(&s).Elem().Set(result)
+	if s.A != "hello" {
+		t.Errorf("Expected s.A to be %q, was %q", "hello", s.A)
+	}
+	if s.B.Cmp(big.NewFloat(123)) != 0 {
+		t.Errorf("Expected s.B to be %v, was %v", big.NewFloat(123), s.B)
+	}
+	if s.C != true {
+		t.Errorf("Expected s.C to be %v, was %v", true, s.C)
+	}
+}
+
+func TestNewStruct_embedded_primitives(t *testing.T) {
+	t.Parallel()
+
+	type s3 struct {
+		C bool `tfsdk:"c"`
+	}
+	type s2 struct {
+		B *big.Float `tfsdk:"b"`
+		s3
+	}
+	type s1 struct {
+		A string `tfsdk:"a"`
+		s2
+	}
+	var s s1
+
 	result, diags := refl.Struct(context.Background(), types.ObjectType{
 		AttrTypes: map[string]attr.Type{
 			"a": types.StringType,
@@ -565,6 +782,51 @@ func TestNewStruct_structtags_ignores(t *testing.T) {
 	}
 }
 
+func TestNewStruct_embedded_structtags_ignores(t *testing.T) {
+	t.Parallel()
+
+	type s1 struct {
+		ExportedAndTagged   string `tfsdk:"exported_and_tagged"`
+		unexported          string //nolint:structcheck,unused
+		unexportedAndTagged string `tfsdk:"unexported_and_tagged"`
+		ExportedAndExcluded string `tfsdk:"-"`
+	}
+
+	var s struct {
+		s1
+	}
+	result, diags := refl.Struct(context.Background(), types.ObjectType{
+		AttrTypes: map[string]attr.Type{
+			"exported_and_tagged": types.StringType,
+		},
+	}, tftypes.NewValue(tftypes.Object{
+		AttributeTypes: map[string]tftypes.Type{
+			"exported_and_tagged": tftypes.String,
+		},
+	}, map[string]tftypes.Value{
+		"exported_and_tagged": tftypes.NewValue(tftypes.String, "hello"),
+	}), reflect.ValueOf(s), refl.Options{}, path.Empty())
+	if diags.HasError() {
+		t.Errorf("Unexpected error: %v", diags)
+	}
+	reflect.ValueOf(&s).Elem().Set(result)
+	if s.ExportedAndTagged != "hello" {
+		t.Errorf("Expected s.ExportedAndTagged to be %q, was %q", "hello", s.ExportedAndTagged)
+	}
+
+	if s.unexported != "" {
+		t.Errorf("Expected s.unexported to be empty, was %q", s.unexported)
+	}
+
+	if s.unexportedAndTagged != "" {
+		t.Errorf("Expected s.unexportedAndTagged to be empty, was %q", s.unexportedAndTagged)
+	}
+
+	if s.ExportedAndExcluded != "" {
+		t.Errorf("Expected s.ExportedAndExcluded to be empty, was %q", s.ExportedAndExcluded)
+	}
+}
+
 func TestFromStruct_primitives(t *testing.T) {
 	t.Parallel()
 
@@ -577,6 +839,55 @@ func TestFromStruct_primitives(t *testing.T) {
 		Name:    "myfirstdisk",
 		Age:     30,
 		OptedIn: true,
+	}
+
+	actualVal, diags := refl.FromStruct(context.Background(), types.ObjectType{
+		AttrTypes: map[string]attr.Type{
+			"name":     types.StringType,
+			"age":      types.NumberType,
+			"opted_in": types.BoolType,
+		},
+	}, reflect.ValueOf(disk1), path.Empty())
+	if diags.HasError() {
+		t.Fatalf("Unexpected error: %v", diags)
+	}
+
+	expectedVal := types.ObjectValueMust(
+		map[string]attr.Type{
+			"name":     types.StringType,
+			"age":      types.NumberType,
+			"opted_in": types.BoolType,
+		},
+		map[string]attr.Value{
+			"name":     types.StringValue("myfirstdisk"),
+			"age":      types.NumberValue(big.NewFloat(30)),
+			"opted_in": types.BoolValue(true),
+		},
+	)
+
+	if diff := cmp.Diff(expectedVal, actualVal); diff != "" {
+		t.Errorf("Unexpected diff (+wanted, -got): %s", diff)
+	}
+}
+
+func TestFromStruct_embedded_primitives(t *testing.T) {
+	t.Parallel()
+
+	type embedFields struct {
+		Name    string `tfsdk:"name"`
+		Age     int    `tfsdk:"age"`
+		OptedIn bool   `tfsdk:"opted_in"`
+	}
+
+	type disk struct {
+		embedFields
+	}
+	disk1 := disk{
+		embedFields{
+			Name:    "myfirstdisk",
+			Age:     30,
+			OptedIn: true,
+		},
 	}
 
 	actualVal, diags := refl.FromStruct(context.Background(), types.ObjectType{
@@ -970,6 +1281,29 @@ func TestFromStruct_errors(t *testing.T) {
 				),
 			},
 		},
+		"embedded-struct-field-mismatch": {
+			typ: types.ObjectType{
+				AttrTypes: map[string]attr.Type{
+					"test": types.StringType,
+				},
+			},
+			val: reflect.ValueOf(
+				struct {
+					embedSingleField
+				}{},
+			),
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("test"),
+					"Value Conversion Error",
+					"An unexpected error was encountered trying to convert from struct into an object. "+
+						"This is always an error in the provider. Please report the following to the provider developer:\n\n"+
+						"Mismatch between struct and object type: Struct defines fields not found in object: attr_1. Object defines fields not found in struct: test.\n"+
+						`Struct: struct { reflect_test.embedSingleField }`+"\n"+
+						`Object type: types.ObjectType["test":basetypes.StringType]`,
+				),
+			},
+		},
 		"struct-type-mismatch": {
 			typ: types.ObjectType{
 				AttrTypes: map[string]attr.Type{
@@ -993,6 +1327,29 @@ func TestFromStruct_errors(t *testing.T) {
 				),
 			},
 		},
+		"embedded-struct-type-mismatch": {
+			typ: types.ObjectType{
+				AttrTypes: map[string]attr.Type{
+					"attr_1": types.BoolType,
+				},
+			},
+			val: reflect.ValueOf(
+				struct {
+					embedSingleField // intentionally not types.Bool
+				}{},
+			),
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("test").AtName("attr_1"),
+					"Value Conversion Error",
+					"An unexpected error was encountered while verifying an attribute value matched its expected type to prevent unexpected behavior or panics. "+
+						"This is always an error in the provider. Please report the following to the provider developer:\n\n"+
+						"Expected framework type from provider logic: basetypes.BoolType / underlying type: tftypes.Bool\n"+
+						"Received framework type from provider logic: basetypes.StringType / underlying type: tftypes.String\n"+
+						"Path: test.attr_1",
+				),
+			},
+		},
 		"struct-validate-error": {
 			typ: testtypes.ObjectTypeWithValidateError{
 				ObjectType: types.ObjectType{
@@ -1004,6 +1361,27 @@ func TestFromStruct_errors(t *testing.T) {
 			val: reflect.ValueOf(
 				struct {
 					Test types.String `tfsdk:"test"`
+				}{},
+			),
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("test"),
+					"Error Diagnostic",
+					"This is an error.",
+				),
+			},
+		},
+		"embedded-struct-validate-error": {
+			typ: testtypes.ObjectTypeWithValidateError{
+				ObjectType: types.ObjectType{
+					AttrTypes: map[string]attr.Type{
+						"attr_1": types.StringType,
+					},
+				},
+			},
+			val: reflect.ValueOf(
+				struct {
+					embedSingleField
 				}{},
 			),
 			expectedDiags: diag.Diagnostics{
@@ -1035,6 +1413,27 @@ func TestFromStruct_errors(t *testing.T) {
 				),
 			},
 		},
+		"embedded-struct-validate-attribute-error": {
+			typ: testtypes.ObjectTypeWithValidateAttributeError{
+				ObjectType: types.ObjectType{
+					AttrTypes: map[string]attr.Type{
+						"attr_1": types.StringType,
+					},
+				},
+			},
+			val: reflect.ValueOf(
+				struct {
+					embedSingleField
+				}{},
+			),
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("test"),
+					"Error Diagnostic",
+					"This is an error.",
+				),
+			},
+		},
 		"struct-validate-warning": {
 			typ: testtypes.ObjectTypeWithValidateWarning{
 				ObjectType: types.ObjectType{
@@ -1056,6 +1455,39 @@ func TestFromStruct_errors(t *testing.T) {
 				},
 				map[string]attr.Value{
 					"test": types.StringValue("test"),
+				},
+			),
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeWarningDiagnostic(
+					path.Root("test"),
+					"Warning Diagnostic",
+					"This is a warning.",
+				),
+			},
+		},
+		"embedded-struct-validate-warning": {
+			typ: testtypes.ObjectTypeWithValidateWarning{
+				ObjectType: types.ObjectType{
+					AttrTypes: map[string]attr.Type{
+						"attr_1": types.StringType,
+					},
+				},
+			},
+			val: reflect.ValueOf(
+				struct {
+					embedSingleField
+				}{
+					embedSingleField{
+						Attr1: types.StringValue("test"),
+					},
+				},
+			),
+			expected: types.ObjectValueMust(
+				map[string]attr.Type{
+					"attr_1": types.StringType,
+				},
+				map[string]attr.Value{
+					"attr_1": types.StringValue("test"),
 				},
 			),
 			expectedDiags: diag.Diagnostics{
@@ -1099,6 +1531,41 @@ func TestFromStruct_errors(t *testing.T) {
 				),
 			},
 		},
+		"embedded-struct-validate-attribute-warning": {
+			typ: testtypes.ObjectTypeWithValidateAttributeWarning{
+				ObjectType: types.ObjectType{
+					AttrTypes: map[string]attr.Type{
+						"attr_1": types.StringType,
+					},
+				},
+			},
+			val: reflect.ValueOf(
+				struct {
+					embedSingleField
+				}{
+					embedSingleField: embedSingleField{
+						Attr1: types.StringValue("test"),
+					},
+				},
+			),
+			expected: testtypes.ObjectValueWithValidateAttributeWarning{
+				Object: types.ObjectValueMust(
+					map[string]attr.Type{
+						"attr_1": types.StringType,
+					},
+					map[string]attr.Value{
+						"attr_1": types.StringValue("test"),
+					},
+				),
+			},
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeWarningDiagnostic(
+					path.Root("test"),
+					"Warning Diagnostic",
+					"This is a warning.",
+				),
+			},
+		},
 		"struct-field-validate-error": {
 			typ: types.ObjectType{
 				AttrTypes: map[string]attr.Type{
@@ -1113,6 +1580,25 @@ func TestFromStruct_errors(t *testing.T) {
 			expectedDiags: diag.Diagnostics{
 				diag.NewAttributeErrorDiagnostic(
 					path.Root("test").AtName("test"),
+					"Error Diagnostic",
+					"This is an error.",
+				),
+			},
+		},
+		"embedded-struct-field-validate-error": {
+			typ: types.ObjectType{
+				AttrTypes: map[string]attr.Type{
+					"attr_1": testtypes.StringTypeWithValidateError{},
+				},
+			},
+			val: reflect.ValueOf(
+				struct {
+					embedSingleField
+				}{},
+			),
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("test").AtName("attr_1"),
 					"Error Diagnostic",
 					"This is an error.",
 				),
@@ -1237,6 +1723,29 @@ func TestFromStruct_errors(t *testing.T) {
 				),
 			},
 		},
+		"embedded-struct-has-untagged-fields": {
+			typ: types.ObjectType{
+				AttrTypes: map[string]attr.Type{
+					"test": types.StringType,
+				},
+			},
+			val: reflect.ValueOf(
+				struct {
+					Test types.String `tfsdk:"test"`
+					embedWithUntaggedExportedField
+				}{},
+			),
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("test"),
+					"Value Conversion Error",
+					"An unexpected error was encountered trying to convert from struct value. "+
+						"This is always an error in the provider. Please report the following to the provider developer:\n\n"+
+						"error retrieving field names from struct tags: error retrieving embedded struct \"embedWithUntaggedExportedField\" field tags: "+
+						"test: need a struct tag for \"tfsdk\" on ExportedAndUntagged",
+				),
+			},
+		},
 		"struct-has-invalid-tags": {
 			typ: types.ObjectType{
 				AttrTypes: map[string]attr.Type{
@@ -1254,7 +1763,29 @@ func TestFromStruct_errors(t *testing.T) {
 					"Value Conversion Error",
 					"An unexpected error was encountered trying to convert from struct value. "+
 						"This is always an error in the provider. Please report the following to the provider developer:\n\n"+
-						"error retrieving field names from struct tags: test.invalidTag: invalid field name, must only use lowercase letters, underscores, and numbers, and must start with a letter",
+						"error retrieving field names from struct tags: test.invalidTag: invalid tfsdk tag, must only use lowercase letters, underscores, and numbers, and must start with a letter",
+				),
+			},
+		},
+		"embedded-struct-has-invalid-tags": {
+			typ: types.ObjectType{
+				AttrTypes: map[string]attr.Type{
+					"test": types.StringType,
+				},
+			},
+			val: reflect.ValueOf(
+				struct {
+					embedWithInvalidTag
+				}{},
+			),
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("test"),
+					"Value Conversion Error",
+					"An unexpected error was encountered trying to convert from struct value. "+
+						"This is always an error in the provider. Please report the following to the provider developer:\n\n"+
+						"error retrieving field names from struct tags: error retrieving embedded struct \"embedWithInvalidTag\" field tags: "+
+						"test.invalidTag: invalid tfsdk tag, must only use lowercase letters, underscores, and numbers, and must start with a letter",
 				),
 			},
 		},
@@ -1276,7 +1807,29 @@ func TestFromStruct_errors(t *testing.T) {
 					"Value Conversion Error",
 					"An unexpected error was encountered trying to convert from struct value. "+
 						"This is always an error in the provider. Please report the following to the provider developer:\n\n"+
-						"error retrieving field names from struct tags: test.test: can't use field name for both Test and Test2",
+						"error retrieving field names from struct tags: test.test: can't use tfsdk tag \"test\" for both Test and Test2 fields",
+				),
+			},
+		},
+		"embedded-struct-has-duplicate-tags": {
+			typ: types.ObjectType{
+				AttrTypes: map[string]attr.Type{
+					"attr_1": types.StringType,
+				},
+			},
+			val: reflect.ValueOf(
+				struct {
+					Attr1 types.String `tfsdk:"attr_1"`
+					embedSingleField
+				}{},
+			),
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("test"),
+					"Value Conversion Error",
+					"An unexpected error was encountered trying to convert from struct value. "+
+						"This is always an error in the provider. Please report the following to the provider developer:\n\n"+
+						"error retrieving field names from struct tags: embedded struct \"embedSingleField\" promotes a field with a duplicate tfsdk tag \"attr_1\", conflicts with \"Attr1\" tfsdk tag",
 				),
 			},
 		},
@@ -1383,6 +1936,49 @@ func TestFromStruct_errors(t *testing.T) {
 				),
 			},
 		},
+		"embedded-struct-with-pointer-not-supported": {
+			typ: types.ObjectType{
+				AttrTypes: map[string]attr.Type{
+					"attr_1": types.StringType,
+				},
+			},
+			val: reflect.ValueOf(
+				struct {
+					*embedSingleField
+				}{},
+			),
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("test").AtName("attr_1"),
+					"Value Conversion Error",
+					"An unexpected error was encountered trying to convert from struct value. "+
+						"This is always an error in the provider. Please report the following to the provider developer:\n\n"+
+						"struct { *reflect_test.embedSingleField } contains a struct embedded by a pointer which is not supported. Switch any embedded structs to be embedded by value.\n\n"+
+						"Error: reflect: indirection through nil pointer to embedded struct field embedSingleField",
+				),
+			},
+		},
+		"embedded-struct-has-tfsdk-tag": {
+			typ: types.ObjectType{
+				AttrTypes: map[string]attr.Type{
+					"attr_1": types.StringType,
+				},
+			},
+			val: reflect.ValueOf(
+				struct {
+					embedSingleField `tfsdk:"attr_2"`
+				}{},
+			),
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("test"),
+					"Value Conversion Error",
+					"An unexpected error was encountered trying to convert from struct value. "+
+						"This is always an error in the provider. Please report the following to the provider developer:\n\n"+
+						"error retrieving field names from struct tags: test.attr_2: embedded struct field embedSingleField cannot have tfsdk tag",
+				),
+			},
+		},
 	}
 
 	for name, testCase := range testCases {
@@ -1426,6 +2022,51 @@ func TestFromStruct_structtags_ignores(t *testing.T) {
 		unexported:          "shouldntcopy",
 		unexportedAndTagged: "shouldntcopy",
 		ExportedAndExcluded: "shouldntcopy",
+	}
+
+	actualVal, diags := refl.FromStruct(context.Background(), types.ObjectType{
+		AttrTypes: map[string]attr.Type{
+			"exported_and_tagged": types.StringType,
+		},
+	}, reflect.ValueOf(testStruct), path.Empty())
+	if diags.HasError() {
+		t.Fatalf("Unexpected error: %v", diags)
+	}
+
+	expectedVal := types.ObjectValueMust(
+		map[string]attr.Type{
+			"exported_and_tagged": types.StringType,
+		},
+		map[string]attr.Value{
+			"exported_and_tagged": types.StringValue("thisshouldstay"),
+		},
+	)
+
+	if diff := cmp.Diff(expectedVal, actualVal); diff != "" {
+		t.Errorf("Unexpected diff (+wanted, -got): %s", diff)
+	}
+}
+
+func TestFromStruct_embedded_structtags_ignores(t *testing.T) {
+	t.Parallel()
+
+	type s1 struct {
+		ExportedAndTagged   string `tfsdk:"exported_and_tagged"`
+		unexported          string //nolint:structcheck,unused
+		unexportedAndTagged string `tfsdk:"unexported_and_tagged"`
+		ExportedAndExcluded string `tfsdk:"-"`
+	}
+
+	type s struct {
+		s1
+	}
+	testStruct := s{
+		s1{
+			ExportedAndTagged:   "thisshouldstay",
+			unexported:          "shouldntcopy",
+			unexportedAndTagged: "shouldntcopy",
+			ExportedAndExcluded: "shouldntcopy",
+		},
 	}
 
 	actualVal, diags := refl.FromStruct(context.Background(), types.ObjectType{

--- a/website/docs/plugin/framework/handling-data/types/object.mdx
+++ b/website/docs/plugin/framework/handling-data/types/object.mdx
@@ -121,10 +121,12 @@ Otherwise, for certain framework functionality that does not require `types` imp
 * [`types.ObjectValueFrom()`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/types#ObjectValueFrom)
 * [`types.SetValueFrom()`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/types#SetValueFrom)
 
-Objects can be automatically converted to any Go struct type that follows these constraints to prevent accidental data loss:
+## Automatic conversion with `tfsdk` struct tags
 
+Objects can be automatically converted to and from any Go struct type that follows these constraints to prevent accidental data loss:
+
+* Every struct field must have a `tfsdk` struct tag and every attribute in the object must have a corresponding struct tag. The `tfsdk` struct tag must name an attribute in the object that it is being mapped or be set to `-` to explicitly declare it does not map to an attribute in the object. Duplicate `tfsdk` struct tags are not allowed.
 * Every struct type must be an acceptable conversion type according to the type documentation, such as `*string` being acceptable for a string type. However, it is recommended to use framework types to simplify data modeling (one model type for accessing and setting data) and prevent errors when encountering unknown values from Terraform.
-* Every struct field must have a `tfsdk` struct tag and every attribute in the object must have a corresponding struct tag. The `tfsdk` struct tag must name an attribute in the object that it is being mapped or be set to `-` to explicitly declare it does not map to an attribute in the object.
 
 In this example, a struct is directly used to set an object attribute value:
 
@@ -163,6 +165,77 @@ value := ExampleAttributeModel{
 }
 
 objectValue, diags := types.ObjectValueFrom(ctx, value.AttributeTypes(), value)
+```
+
+### Struct Embedding
+
+Go struct types that utilize [struct embedding](https://go.dev/doc/effective_go#embedding) to promote fields with `tfsdk` tags are supported when converting to and from object types.
+
+In this example, a `types.Object` is created from a struct that embeds another struct type:
+
+```go
+type ExampleAttributeModel struct {
+	Attr1 types.String `tfsdk:"attr_1"`
+	Attr2 types.Bool   `tfsdk:"attr_2"`
+	CommonModel // This embedded struct type promotes the Attr3 field
+}
+
+type CommonModel struct {
+	Attr3 types.Int64 `tfsdk:"attr_3"`
+}
+
+func (m ExampleAttributeModel) AttributeTypes() map[string]attr.Type {
+    return map[string]attr.Type{
+        "attr_1":  types.StringType,
+        "attr_2":  types.BoolType,
+        "attr_3":  types.Int64Type,
+    }
+}
+
+value := ExampleAttributeModel{
+    Attr1: types.StringValue("example"),
+    Attr2: types.BoolValue(true),
+}
+// This field is promoted from CommonModel
+value.Attr3 = types.Int64Value(123)
+
+objectValue, diags := types.ObjectValueFrom(ctx, value.AttributeTypes(), value)
+```
+
+#### Restrictions
+
+In addition to the constraints [listed above for object conversions](#automatic-conversion-with-tfsdk-struct-tags) using `tfsdk` tagged fields, embedded struct types have these additional restrictions:
+
+* Promoted fields cannot have duplicate `tfsdk` struct tags that conflict with any fields of structs they are embedded within.
+```go
+type thingResourceModel struct {
+	Attr1 types.String `tfsdk:"attr_1"`
+	Attr2 types.Bool   `tfsdk:"attr_2"`
+	CommonModel
+}
+
+type CommonModel struct {
+    // This field has a duplicate tfsdk tag, conflicting with (thingResourceModel).Attr1
+    // and will raise an error diagnostic during conversion.
+	ConflictingAttr types.Int64 `tfsdk:"attr_1"`
+}
+```
+* Struct types embedded by pointers are not supported.
+```go
+type thingResourceModel struct {
+	Attr1 types.String `tfsdk:"attr_1"`
+	Attr2 types.Bool   `tfsdk:"attr_2"`
+    // This type of struct embedding is not supported and will raise
+    // an error diagnostic during conversion.
+    //
+    // Remove the pointer to embed the struct by value.
+	*CommonModel
+}
+
+type CommonModel struct {
+	Attr3 types.Int64 `tfsdk:"attr_3"`
+	Attr4 types.List  `tfsdk:"attr_4"`
+}
 ```
 
 ## Extending


### PR DESCRIPTION
Closes #242

Previous proposals: #941, #667

This PR introduces support for `types.Object` conversions with Go structs that utilize struct embedding:
- https://go.dev/ref/spec#Struct_types
- https://go.dev/doc/effective_go#embedding

This PR supports N levels of nested embedded struct types and applies the same `tfsdk` tag restrictions/validations regardless of where the tag appears in the struct.

### Example
```go
type thingResourceModel struct {
    Attr1 types.String `tfsdk:"attr_1"`
    Attr2 types.Bool   `tfsdk:"attr_2"`
    CommonModel
}

type CommonModel struct {
    Attr3 types.Int64 `tfsdk:"attr_3"`
    Attr4 types.List  `tfsdk:"attr_4"`
    EvenMoreCommonModel
}

type EvenMoreCommonModel struct {
    Attr5 types.String `tfsdk:"attr_5"`
    Attr6 types.Map    `tfsdk:"attr_6"`
}

func (r *thingResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
    resp.Schema = schema.Schema{
        Attributes: map[string]schema.Attribute{
            "attr_1": schema.StringAttribute{
                Required: true,
            },
            "attr_2": schema.BoolAttribute{
                Computed: true,
                PlanModifiers: []planmodifier.Bool{
                    boolplanmodifier.UseStateForUnknown(),
                },
            },
            "attr_3": schema.Int64Attribute{
                Required: true,
            },
            "attr_4": schema.ListAttribute{
                ElementType: types.StringType,
                Computed:    true,
                PlanModifiers: []planmodifier.List{
                    listplanmodifier.UseStateForUnknown(),
                },
            },
            "attr_5": schema.StringAttribute{
                Required: true,
            },
            "attr_6": schema.MapAttribute{
                ElementType: types.BoolType,
                Computed:    true,
                PlanModifiers: []planmodifier.Map{
                    mapplanmodifier.UseStateForUnknown(),
                },
            },
        },
    }
}
```

The same example schema could also be represented by these model combinations:
```go
type thingResourceModel struct {
    Attr1 types.String `tfsdk:"attr_1"`
    Attr2 types.Bool   `tfsdk:"attr_2"`
    CommonModel
    EvenMoreCommonModel
}

type CommonModel struct {
    Attr3 types.Int64 `tfsdk:"attr_3"`
    Attr4 types.List  `tfsdk:"attr_4"`
}

type EvenMoreCommonModel struct {
    Attr5 types.String `tfsdk:"attr_5"`
    Attr6 types.Map    `tfsdk:"attr_6"`
}
```
### Notes
- Additional test coverage: https://github.com/hashicorp/terraform-provider-corner/pull/263 
- To avoid having to refactor a good chunk of our reflection logic, we explicitly are not supporting struct embedding with pointers. That doesn't stop us from adding support in the future if it's deemed necessary (although supporting unexported struct embeds from pointers I don't think we can do)
  - The `encoding/json` library supports exported struct embedding via pointers, but it was also historically relying on a bug in Go that allowed setting unexported struct embedding with pointers to work. When that bug was fixed, they chose not to completely remove pointer struct embedding for compatibility reasons.
- This PR could be considered a change in behavior, as it adds support for unexported embedded structs which promote exported fields
  - These would be previously ignored, but now could potentially raise an error diagnostic if `tfsdk` ignore tags are not included
```go
type thingResourceModel struct {
    Attr1 types.String `tfsdk:"attr_1"`
    Attr2 types.Bool   `tfsdk:"attr_2"`
    existingModel
}

type existingModel struct {
    FieldNotRelated string // Needs a tfsdk tag now!
}
```
- You can ignore an entire embedded struct via the typical ignore tag
```go
type thingResourceModel struct {
    Attr1 types.String `tfsdk:"attr_1"`
    Attr2 types.Bool   `tfsdk:"attr_2"`
    existingModel      `tfsdk:"-"` // Ignored!
}

type existingModel struct {
    FieldNotRelated string
}
```