### PR TITLE
docs: Add more clarification for unknown values during config validation

### DIFF
--- a/website/docs/plugin/framework/handling-data/terraform-concepts.mdx
+++ b/website/docs/plugin/framework/handling-data/terraform-concepts.mdx
@@ -119,5 +119,10 @@ value. However, by the time a resource is expected to be created, read, updated,
 deleted, only its computed attributes can be unknown. The rest are
 guaranteed to have known values (or be null).
 
-Provider configuration values can be unknown, and providers should handle that
-situation, even if that means just returning an error.
+For concepts such as resource and data source [configuration validation](/terraform/plugin/framework/validation),
+this means that Terraform guarantees to call validation for a non-computed attribute
+eventually with a known value, so the provider should typically avoid returning error diagnostics
+when encountering an unknown value during validation.
+
+Provider configuration values [can also be unknown](/terraform/plugin/framework/providers#unknown-values), and
+providers should handle that situation, even if that means just returning an error.


### PR DESCRIPTION
Follow-up from a recent discuss post: https://discuss.hashicorp.com/t/no-way-to-validate-an-unknown-attribute-value/68730

Our wording around unknown values was causing confusion, Terraform guarantees to call validation for non-computed attributes with a known value before applying.