### PR TITLE
docs: Fix package doc repeated copyright header

### DIFF
--- a/ephemeral/close.go
+++ b/ephemeral/close.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
+
 package ephemeral
 
 import (

--- a/ephemeral/config_validator.go
+++ b/ephemeral/config_validator.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
+
 package ephemeral
 
 import "context"

--- a/ephemeral/configure.go
+++ b/ephemeral/configure.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
+
 package ephemeral
 
 import (

--- a/ephemeral/ephemeral_resource.go
+++ b/ephemeral/ephemeral_resource.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
+
 package ephemeral
 
 import (

--- a/ephemeral/metadata.go
+++ b/ephemeral/metadata.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
+
 package ephemeral
 
 // MetadataRequest represents a request for the EphemeralResource to return metadata,

--- a/ephemeral/open.go
+++ b/ephemeral/open.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
+
 package ephemeral
 
 import (

--- a/ephemeral/renew.go
+++ b/ephemeral/renew.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
+
 package ephemeral
 
 import (

--- a/ephemeral/schema.go
+++ b/ephemeral/schema.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
+
 package ephemeral
 
 import (

--- a/ephemeral/validate_config.go
+++ b/ephemeral/validate_config.go
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
+
 package ephemeral
 
 import (


### PR DESCRIPTION
Nice little bug found in our copyright headers for the new `ephemeral` package docs.

The repeated lines are showing up because there is a missing newline in a number of the packages, causing the header to be repeated multiple time when running `go docs ephemeral`

Prior to the change:
https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework@v1.13.0/ephemeral

After the change:
```bash
 $ go doc ephemeral      
package ephemeral // import "github.com/hashicorp/terraform-plugin-framework/ephemeral"

Package ephemeral contains all interfaces, request types, and response types for
an ephemeral resource implementation.

In Terraform, an ephemeral resource is a concept which enables provider
developers to offer practitioners ephemeral values, which will not be stored
in any artifact produced by Terraform (plan/state). Ephemeral resources can
optionally implement renewal logic via the (EphemeralResource).Renew method and
cleanup logic via the (EphemeralResource).Close method.

Ephemeral resources are not saved into the Terraform plan or state and can
only be referenced in other ephemeral values, such as provider configuration
attributes. Ephemeral resources are defined by a type/name, such as
"examplecloud_thing", a schema representing the structure and data types of
configuration, and lifecycle logic.

The main starting point for implementations in this package is the
EphemeralResource type which represents an instance of an ephemeral
resource that has its own configuration and lifecycle logic.
The ephemeral.EphemeralResource implementations are referenced by the
[provider.ProviderWithEphemeralResources] type EphemeralResources method,
which enables the ephemeral resource practitioner usage.

NOTE: Ephemeral resource support is experimental and exposed without
compatibility promises until these notices are removed.

type CloseRequest struct{ ... }
type CloseResponse struct{ ... }
type ConfigValidator interface{ ... }
type ConfigureRequest struct{ ... }
type ConfigureResponse struct{ ... }
type Deferred struct{ ... }
type DeferredReason int32
    const DeferredReasonUnknown DeferredReason = 0 ...
type EphemeralResource interface{ ... }
type EphemeralResourceWithClose interface{ ... }
type EphemeralResourceWithConfigValidators interface{ ... }
type EphemeralResourceWithConfigure interface{ ... }
type EphemeralResourceWithRenew interface{ ... }
type EphemeralResourceWithValidateConfig interface{ ... }
type MetadataRequest struct{ ... }
type MetadataResponse struct{ ... }
type OpenClientCapabilities struct{ ... }
type OpenRequest struct{ ... }
type OpenResponse struct{ ... }
type RenewRequest struct{ ... }
type RenewResponse struct{ ... }
type SchemaRequest struct{}
type SchemaResponse struct{ ... }
type ValidateConfigRequest struct{ ... }
type ValidateConfigResponse struct{ ... }
```