### PR TITLE
internal/fwschemadata: Rewrite `SetValue` semantic equality logic to ignore order 

### DIFF
--- a/.changes/unreleased/BUG FIXES-20250117-110109.yaml
+++ b/.changes/unreleased/BUG FIXES-20250117-110109.yaml
@@ -1,0 +1,6 @@
+kind: BUG FIXES
+body: 'internal/fwschemadata: Set semantic equality logic has been adjusted and will
+  now ignore order of elements during comparison.'
+time: 2025-01-17T11:01:09.848503-05:00
+custom:
+  Issue: "1061"

--- a/internal/fwschemadata/value_semantic_equality_set.go
+++ b/internal/fwschemadata/value_semantic_equality_set.go
@@ -145,10 +145,10 @@ func ValueSemanticEqualitySetElements(ctx context.Context, req ValueSemanticEqua
 		}
 
 		// Loop through all prior value elements and see if there are any semantically equal elements
-		for pIdx, priorValue := range priorValueElements {
+		for pIdx, priorValueElement := range priorValueElements {
 			elementReq := ValueSemanticEqualityRequest{
 				Path:             req.Path.AtSetValue(proposedNewValueElement),
-				PriorValue:       priorValue,
+				PriorValue:       priorValueElement,
 				ProposedNewValue: proposedNewValueElement,
 			}
 			elementResp := &ValueSemanticEqualityResponse{

--- a/internal/fwschemadata/value_semantic_equality_set.go
+++ b/internal/fwschemadata/value_semantic_equality_set.go
@@ -128,10 +128,6 @@ func ValueSemanticEqualitySetElements(ctx context.Context, req ValueSemanticEqua
 	// Short circuit flag
 	updatedElements := false
 
-	// The underlying loop will mutate priorValueElements to avoid keeping
-	// duplicate semantically equal elements. Need the original length to avoid a panic
-	originalPriorElementsLength := len(priorValueElements)
-
 	// Loop through proposed elements by delegating to the recursive semantic
 	// equality logic. This ensures that recursion will catch a further
 	// underlying element type has its semantic equality logic checked, even if
@@ -139,10 +135,6 @@ func ValueSemanticEqualitySetElements(ctx context.Context, req ValueSemanticEqua
 	for idx, proposedNewValueElement := range proposedNewValueElements {
 		// Ensure new value always contains all of proposed new value
 		newValueElements[idx] = proposedNewValueElement
-
-		if idx >= originalPriorElementsLength {
-			continue
-		}
 
 		// Loop through all prior value elements and see if there are any semantically equal elements
 		for pIdx, priorValueElement := range priorValueElements {

--- a/internal/fwschemadata/value_semantic_equality_set.go
+++ b/internal/fwschemadata/value_semantic_equality_set.go
@@ -129,7 +129,7 @@ func ValueSemanticEqualitySetElements(ctx context.Context, req ValueSemanticEqua
 	updatedElements := false
 
 	// The underlying loop will mutate priorValueElements to avoid keeping
-	// duplicate semantically equal elements. Need the original length to avoid panicks
+	// duplicate semantically equal elements. Need the original length to avoid a panic
 	originalPriorElementsLength := len(priorValueElements)
 
 	// Loop through proposed elements by delegating to the recursive semantic

--- a/internal/fwschemadata/value_semantic_equality_set.go
+++ b/internal/fwschemadata/value_semantic_equality_set.go
@@ -128,10 +128,6 @@ func ValueSemanticEqualitySetElements(ctx context.Context, req ValueSemanticEqua
 	// Short circuit flag
 	updatedElements := false
 
-	// The underlying loop will mutate priorValueElements to avoid keeping
-	// duplicate semantically equal elements. Need the original length to avoid panicks
-	originalPriorElementsLength := len(priorValueElements)
-
 	// Loop through proposed elements by delegating to the recursive semantic
 	// equality logic. This ensures that recursion will catch a further
 	// underlying element type has its semantic equality logic checked, even if
@@ -140,44 +136,33 @@ func ValueSemanticEqualitySetElements(ctx context.Context, req ValueSemanticEqua
 		// Ensure new value always contains all of proposed new value
 		newValueElements[idx] = proposedNewValueElement
 
-		if idx >= originalPriorElementsLength {
+		if idx >= len(priorValueElements) {
 			continue
 		}
 
-		// Loop through all prior value elements and see if there are any semantically equal elements
-		for pIdx, priorValue := range priorValueElements {
-			elementReq := ValueSemanticEqualityRequest{
-				Path:             req.Path.AtSetValue(proposedNewValueElement),
-				PriorValue:       priorValue,
-				ProposedNewValue: proposedNewValueElement,
-			}
-			elementResp := &ValueSemanticEqualityResponse{
-				NewValue: elementReq.ProposedNewValue,
-			}
-
-			ValueSemanticEquality(ctx, elementReq, elementResp)
-
-			resp.Diagnostics.Append(elementResp.Diagnostics...)
-
-			if resp.Diagnostics.HasError() {
-				return
-			}
-
-			if elementResp.NewValue.Equal(elementReq.ProposedNewValue) {
-				// This prior value element didn't match, but there could be other elements that do
-				continue
-			}
-
-			// Prior state was kept, meaning that we found a semantically equal element
-			updatedElements = true
-
-			// Remove the semantically equal element from the slice of candidates
-			priorValueElements = append(priorValueElements[:pIdx], priorValueElements[pIdx+1:]...)
-
-			// Order doesn't matter, so we can just set the prior state element to this index
-			newValueElements[idx] = elementResp.NewValue
-			break
+		elementReq := ValueSemanticEqualityRequest{
+			Path:             req.Path.AtSetValue(proposedNewValueElement),
+			PriorValue:       priorValueElements[idx],
+			ProposedNewValue: proposedNewValueElement,
 		}
+		elementResp := &ValueSemanticEqualityResponse{
+			NewValue: elementReq.ProposedNewValue,
+		}
+
+		ValueSemanticEquality(ctx, elementReq, elementResp)
+
+		resp.Diagnostics.Append(elementResp.Diagnostics...)
+
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		if elementResp.NewValue.Equal(elementReq.ProposedNewValue) {
+			continue
+		}
+
+		updatedElements = true
+		newValueElements[idx] = elementResp.NewValue
 	}
 
 	// No changes required if the elements were not updated.

--- a/internal/fwschemadata/value_semantic_equality_set_test.go
+++ b/internal/fwschemadata/value_semantic_equality_set_test.go
@@ -50,6 +50,34 @@ func TestValueSemanticEqualitySet(t *testing.T) {
 				),
 			},
 		},
+		"SetValue-diff-order": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: types.SetValueMust(
+					types.StringType,
+					[]attr.Value{
+						types.StringValue("prior"),
+						types.StringValue("value"),
+					},
+				),
+				ProposedNewValue: types.SetValueMust(
+					types.StringType,
+					[]attr.Value{
+						types.StringValue("value"),
+						types.StringValue("new"),
+					},
+				),
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: types.SetValueMust(
+					types.StringType,
+					[]attr.Value{
+						types.StringValue("value"),
+						types.StringValue("new"),
+					},
+				),
+			},
+		},
 		// ElementType with semantic equality
 		"SetValue-StringValuableWithSemanticEquals-true": {
 			request: fwschemadata.ValueSemanticEqualityRequest{
@@ -91,6 +119,64 @@ func TestValueSemanticEqualitySet(t *testing.T) {
 				),
 			},
 		},
+		"SetValue-StringValuableWithSemanticEquals-true-diff-order": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: types.SetValueMust(
+					testtypes.StringTypeWithSemanticEquals{},
+					[]attr.Value{
+						testtypes.StringValueWithSemanticEquals{
+							StringValue: types.StringValue("keep-lowercase-123"),
+							SemanticallyEqualTo: testtypes.StringValueWithSemanticEquals{
+								StringValue: types.StringValue("KEEP-LOWERCASE-123"),
+							},
+						},
+						testtypes.StringValueWithSemanticEquals{
+							StringValue: types.StringValue("keep-lowercase-456"),
+							SemanticallyEqualTo: testtypes.StringValueWithSemanticEquals{
+								StringValue: types.StringValue("KEEP-LOWERCASE-456"),
+							},
+						},
+					},
+				),
+				ProposedNewValue: types.SetValueMust(
+					testtypes.StringTypeWithSemanticEquals{},
+					[]attr.Value{
+						testtypes.StringValueWithSemanticEquals{
+							StringValue: types.StringValue("KEEP-LOWERCASE-456"),
+							SemanticallyEqualTo: testtypes.StringValueWithSemanticEquals{
+								StringValue: types.StringValue("keep-lowercase-456"),
+							},
+						},
+						testtypes.StringValueWithSemanticEquals{
+							StringValue: types.StringValue("KEEP-LOWERCASE-123"),
+							SemanticallyEqualTo: testtypes.StringValueWithSemanticEquals{
+								StringValue: types.StringValue("keep-lowercase-123"),
+							},
+						},
+					},
+				),
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: types.SetValueMust(
+					testtypes.StringTypeWithSemanticEquals{},
+					[]attr.Value{
+						testtypes.StringValueWithSemanticEquals{
+							StringValue: types.StringValue("keep-lowercase-123"),
+							SemanticallyEqualTo: testtypes.StringValueWithSemanticEquals{
+								StringValue: types.StringValue("KEEP-LOWERCASE-123"),
+							},
+						},
+						testtypes.StringValueWithSemanticEquals{
+							StringValue: types.StringValue("keep-lowercase-456"),
+							SemanticallyEqualTo: testtypes.StringValueWithSemanticEquals{
+								StringValue: types.StringValue("KEEP-LOWERCASE-456"),
+							},
+						},
+					},
+				),
+			},
+		},
 		"SetValue-StringValuableWithSemanticEquals-false": {
 			request: fwschemadata.ValueSemanticEqualityRequest{
 				Path: path.Root("test"),
@@ -123,6 +209,58 @@ func TestValueSemanticEqualitySet(t *testing.T) {
 						SemanticEquals: false,
 					},
 					[]attr.Value{
+						testtypes.StringValueWithSemanticEquals{
+							StringValue:    types.StringValue("new"),
+							SemanticEquals: false,
+						},
+					},
+				),
+			},
+		},
+		"SetValue-StringValuableWithSemanticEquals-false-diff-order": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: types.SetValueMust(
+					testtypes.StringTypeWithSemanticEquals{
+						SemanticEquals: false,
+					},
+					[]attr.Value{
+						testtypes.StringValueWithSemanticEquals{
+							StringValue:    types.StringValue("prior"),
+							SemanticEquals: false,
+						},
+						testtypes.StringValueWithSemanticEquals{
+							StringValue:    types.StringValue("value"),
+							SemanticEquals: false,
+						},
+					},
+				),
+				ProposedNewValue: types.SetValueMust(
+					testtypes.StringTypeWithSemanticEquals{
+						SemanticEquals: false,
+					},
+					[]attr.Value{
+						testtypes.StringValueWithSemanticEquals{
+							StringValue:    types.StringValue("value"),
+							SemanticEquals: false,
+						},
+						testtypes.StringValueWithSemanticEquals{
+							StringValue:    types.StringValue("new"),
+							SemanticEquals: false,
+						},
+					},
+				),
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: types.SetValueMust(
+					testtypes.StringTypeWithSemanticEquals{
+						SemanticEquals: false,
+					},
+					[]attr.Value{
+						testtypes.StringValueWithSemanticEquals{
+							StringValue:    types.StringValue("value"),
+							SemanticEquals: false,
+						},
 						testtypes.StringValueWithSemanticEquals{
 							StringValue:    types.StringValue("new"),
 							SemanticEquals: false,
@@ -267,6 +405,136 @@ func TestValueSemanticEqualitySet(t *testing.T) {
 				),
 			},
 		},
+		"SetValue-SetValue-StringValuableWithSemanticEquals-true-diff-order": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: types.SetValueMust(
+					types.SetType{
+						ElemType: testtypes.StringTypeWithSemanticEquals{},
+					},
+					[]attr.Value{
+						types.SetValueMust(
+							testtypes.StringTypeWithSemanticEquals{},
+							[]attr.Value{
+								testtypes.StringValueWithSemanticEquals{
+									StringValue: types.StringValue("keep-lowercase-123"),
+									SemanticallyEqualTo: testtypes.StringValueWithSemanticEquals{
+										StringValue: types.StringValue("KEEP-LOWERCASE-123"),
+									},
+								},
+								testtypes.StringValueWithSemanticEquals{
+									StringValue: types.StringValue("keep-lowercase-456"),
+									SemanticallyEqualTo: testtypes.StringValueWithSemanticEquals{
+										StringValue: types.StringValue("KEEP-LOWERCASE-456"),
+									},
+								},
+							},
+						),
+						types.SetValueMust(
+							testtypes.StringTypeWithSemanticEquals{},
+							[]attr.Value{
+								testtypes.StringValueWithSemanticEquals{
+									StringValue: types.StringValue("keep-lowercase-789"),
+									SemanticallyEqualTo: testtypes.StringValueWithSemanticEquals{
+										StringValue: types.StringValue("KEEP-LOWERCASE-789"),
+									},
+								},
+								testtypes.StringValueWithSemanticEquals{
+									StringValue: types.StringValue("keep-lowercase-012"),
+									SemanticallyEqualTo: testtypes.StringValueWithSemanticEquals{
+										StringValue: types.StringValue("KEEP-LOWERCASE-012"),
+									},
+								},
+							},
+						),
+					},
+				),
+				ProposedNewValue: types.SetValueMust(
+					types.SetType{
+						ElemType: testtypes.StringTypeWithSemanticEquals{},
+					},
+					[]attr.Value{
+						types.SetValueMust(
+							testtypes.StringTypeWithSemanticEquals{},
+							[]attr.Value{
+								testtypes.StringValueWithSemanticEquals{
+									StringValue: types.StringValue("KEEP-LOWERCASE-012"),
+									SemanticallyEqualTo: testtypes.StringValueWithSemanticEquals{
+										StringValue: types.StringValue("keep-lowercase-012"),
+									},
+								},
+								testtypes.StringValueWithSemanticEquals{
+									StringValue: types.StringValue("KEEP-LOWERCASE-789"),
+									SemanticallyEqualTo: testtypes.StringValueWithSemanticEquals{
+										StringValue: types.StringValue("keep-lowercase-789"),
+									},
+								},
+							},
+						),
+						types.SetValueMust(
+							testtypes.StringTypeWithSemanticEquals{},
+							[]attr.Value{
+								testtypes.StringValueWithSemanticEquals{
+									StringValue: types.StringValue("KEEP-LOWERCASE-456"),
+									SemanticallyEqualTo: testtypes.StringValueWithSemanticEquals{
+										StringValue: types.StringValue("keep-lowercase-456"),
+									},
+								},
+								testtypes.StringValueWithSemanticEquals{
+									StringValue: types.StringValue("KEEP-LOWERCASE-123"),
+									SemanticallyEqualTo: testtypes.StringValueWithSemanticEquals{
+										StringValue: types.StringValue("keep-lowercase-123"),
+									},
+								},
+							},
+						),
+					},
+				),
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: types.SetValueMust(
+					types.SetType{
+						ElemType: testtypes.StringTypeWithSemanticEquals{},
+					},
+					[]attr.Value{
+						types.SetValueMust(
+							testtypes.StringTypeWithSemanticEquals{},
+							[]attr.Value{
+								testtypes.StringValueWithSemanticEquals{
+									StringValue: types.StringValue("keep-lowercase-123"),
+									SemanticallyEqualTo: testtypes.StringValueWithSemanticEquals{
+										StringValue: types.StringValue("KEEP-LOWERCASE-123"),
+									},
+								},
+								testtypes.StringValueWithSemanticEquals{
+									StringValue: types.StringValue("keep-lowercase-456"),
+									SemanticallyEqualTo: testtypes.StringValueWithSemanticEquals{
+										StringValue: types.StringValue("KEEP-LOWERCASE-456"),
+									},
+								},
+							},
+						),
+						types.SetValueMust(
+							testtypes.StringTypeWithSemanticEquals{},
+							[]attr.Value{
+								testtypes.StringValueWithSemanticEquals{
+									StringValue: types.StringValue("keep-lowercase-789"),
+									SemanticallyEqualTo: testtypes.StringValueWithSemanticEquals{
+										StringValue: types.StringValue("KEEP-LOWERCASE-789"),
+									},
+								},
+								testtypes.StringValueWithSemanticEquals{
+									StringValue: types.StringValue("keep-lowercase-012"),
+									SemanticallyEqualTo: testtypes.StringValueWithSemanticEquals{
+										StringValue: types.StringValue("KEEP-LOWERCASE-012"),
+									},
+								},
+							},
+						),
+					},
+				),
+			},
+		},
 		"SetValue-SetValue-StringValuableWithSemanticEquals-false": {
 			request: fwschemadata.ValueSemanticEqualityRequest{
 				Path: path.Root("test"),
@@ -319,6 +587,106 @@ func TestValueSemanticEqualitySet(t *testing.T) {
 						},
 					},
 					[]attr.Value{
+						types.SetValueMust(
+							testtypes.StringTypeWithSemanticEquals{
+								SemanticEquals: false,
+							},
+							[]attr.Value{
+								testtypes.StringValueWithSemanticEquals{
+									StringValue:    types.StringValue("new"),
+									SemanticEquals: false,
+								},
+							},
+						),
+					},
+				),
+			},
+		},
+		"SetValue-SetValue-StringValuableWithSemanticEquals-false-diff-order": {
+			request: fwschemadata.ValueSemanticEqualityRequest{
+				Path: path.Root("test"),
+				PriorValue: types.SetValueMust(
+					types.SetType{
+						ElemType: testtypes.StringTypeWithSemanticEquals{
+							SemanticEquals: false,
+						},
+					},
+					[]attr.Value{
+						types.SetValueMust(
+							testtypes.StringTypeWithSemanticEquals{
+								SemanticEquals: false,
+							},
+							[]attr.Value{
+								testtypes.StringValueWithSemanticEquals{
+									StringValue:    types.StringValue("prior"),
+									SemanticEquals: false,
+								},
+							},
+						),
+						types.SetValueMust(
+							testtypes.StringTypeWithSemanticEquals{
+								SemanticEquals: false,
+							},
+							[]attr.Value{
+								testtypes.StringValueWithSemanticEquals{
+									StringValue:    types.StringValue("value"),
+									SemanticEquals: false,
+								},
+							},
+						),
+					},
+				),
+				ProposedNewValue: types.SetValueMust(
+					types.SetType{
+						ElemType: testtypes.StringTypeWithSemanticEquals{
+							SemanticEquals: false,
+						},
+					},
+					[]attr.Value{
+						types.SetValueMust(
+							testtypes.StringTypeWithSemanticEquals{
+								SemanticEquals: false,
+							},
+							[]attr.Value{
+								testtypes.StringValueWithSemanticEquals{
+									StringValue:    types.StringValue("value"),
+									SemanticEquals: false,
+								},
+							},
+						),
+						types.SetValueMust(
+							testtypes.StringTypeWithSemanticEquals{
+								SemanticEquals: false,
+							},
+							[]attr.Value{
+								testtypes.StringValueWithSemanticEquals{
+									StringValue:    types.StringValue("new"),
+									SemanticEquals: false,
+								},
+							},
+						),
+					},
+				),
+			},
+			expected: &fwschemadata.ValueSemanticEqualityResponse{
+				NewValue: types.SetValueMust(
+					types.SetType{
+						ElemType: testtypes.StringTypeWithSemanticEquals{
+							SemanticEquals: false,
+						},
+					},
+					[]attr.Value{
+						types.SetValueMust(
+							testtypes.StringTypeWithSemanticEquals{
+								SemanticEquals: false,
+							},
+							[]attr.Value{
+								testtypes.StringValueWithSemanticEquals{
+									StringValue:    types.StringValue("value"),
+									SemanticEquals: false,
+								},
+							},
+						),
 						types.SetValueMust(
 							testtypes.StringTypeWithSemanticEquals{
 								SemanticEquals: false,

--- a/internal/testing/testtypes/stringwithsemanticequals.go
+++ b/internal/testing/testtypes/stringwithsemanticequals.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
@@ -25,11 +24,11 @@ var (
 type StringTypeWithSemanticEquals struct {
 	basetypes.StringType
 
-	// Will always return true for semantic equality
+	// Will always return this boolean for semantic equality
 	SemanticEquals bool
 
-	// Will only return semantic equality as true if the string matches this
-	SemanticallyEqualTo types.String
+	// Will only return semantic equality as true if the attr.Value matches this
+	SemanticallyEqualTo attr.Value
 
 	SemanticEqualsDiagnostics diag.Diagnostics
 }
@@ -98,10 +97,10 @@ func (t StringTypeWithSemanticEquals) ValueType(ctx context.Context) attr.Value 
 type StringValueWithSemanticEquals struct {
 	basetypes.StringValue
 
-	// Will always return true for semantic equality
+	// Will always return this boolean for semantic equality
 	SemanticEquals bool
 
-	// Will only return semantic equality as true if the string matches this
+	// Will only return semantic equality as true if the attr.Value matches this
 	SemanticallyEqualTo attr.Value
 
 	SemanticEqualsDiagnostics diag.Diagnostics

--- a/internal/testing/testtypes/stringwithsemanticequals.go
+++ b/internal/testing/testtypes/stringwithsemanticequals.go
@@ -118,7 +118,7 @@ func (v StringValueWithSemanticEquals) Equal(o attr.Value) bool {
 }
 
 func (v StringValueWithSemanticEquals) StringSemanticEquals(ctx context.Context, otherV basetypes.StringValuable) (bool, diag.Diagnostics) {
-	if v.SemanticallyEqualTo != nil {
+	if v.SemanticallyEqualTo != nil && !v.SemanticallyEqualTo.IsNull() {
 		return v.SemanticallyEqualTo.Equal(otherV), v.SemanticEqualsDiagnostics
 	}
 	return v.SemanticEquals, v.SemanticEqualsDiagnostics

--- a/internal/testing/testtypes/stringwithsemanticequals.go
+++ b/internal/testing/testtypes/stringwithsemanticequals.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
@@ -24,7 +25,12 @@ var (
 type StringTypeWithSemanticEquals struct {
 	basetypes.StringType
 
-	SemanticEquals            bool
+	// Will always return true for semantic equality
+	SemanticEquals bool
+
+	// Will only return semantic equality as true if the string matches this
+	SemanticallyEqualTo types.String
+
 	SemanticEqualsDiagnostics diag.Diagnostics
 }
 
@@ -52,6 +58,7 @@ func (t StringTypeWithSemanticEquals) ValueFromString(ctx context.Context, in ba
 	value := StringValueWithSemanticEquals{
 		StringValue:               in,
 		SemanticEquals:            t.SemanticEquals,
+		SemanticallyEqualTo:       t.SemanticallyEqualTo,
 		SemanticEqualsDiagnostics: t.SemanticEqualsDiagnostics,
 	}
 
@@ -83,6 +90,7 @@ func (t StringTypeWithSemanticEquals) ValueFromTerraform(ctx context.Context, in
 func (t StringTypeWithSemanticEquals) ValueType(ctx context.Context) attr.Value {
 	return StringValueWithSemanticEquals{
 		SemanticEquals:            t.SemanticEquals,
+		SemanticallyEqualTo:       t.SemanticallyEqualTo,
 		SemanticEqualsDiagnostics: t.SemanticEqualsDiagnostics,
 	}
 }
@@ -90,7 +98,12 @@ func (t StringTypeWithSemanticEquals) ValueType(ctx context.Context) attr.Value 
 type StringValueWithSemanticEquals struct {
 	basetypes.StringValue
 
-	SemanticEquals            bool
+	// Will always return true for semantic equality
+	SemanticEquals bool
+
+	// Will only return semantic equality as true if the string matches this
+	SemanticallyEqualTo attr.Value
+
 	SemanticEqualsDiagnostics diag.Diagnostics
 }
 
@@ -105,6 +118,9 @@ func (v StringValueWithSemanticEquals) Equal(o attr.Value) bool {
 }
 
 func (v StringValueWithSemanticEquals) StringSemanticEquals(ctx context.Context, otherV basetypes.StringValuable) (bool, diag.Diagnostics) {
+	if v.SemanticallyEqualTo != nil {
+		return v.SemanticallyEqualTo.Equal(otherV), v.SemanticEqualsDiagnostics
+	}
 	return v.SemanticEquals, v.SemanticEqualsDiagnostics
 }
 


### PR DESCRIPTION
Closes #1061

This PR fixes the set semantic equality logic, which prior to this change, was written equivalent to list semantic equality.

Sets are unordered, so to correctly compare the semantic equality of two sets, we must compare each element in the set against all other elements to determine if there is a semantically equivalent element in the set. Once we find a semantically equal element, we remove it from the slice of candidates and continue.

----------

As an example, consider a set of case insensitive strings.

With the previous logic, the following sets would be considered semantically equal:
```bash
["value-a", "value-b", "value-c"]
["VALUE-A", "VALUE-B", "VALUE-C"]
```

However the following set would be incorrectly considered semantically not equal, due to the difference in order:
```bash
["value-a", "value-b", "value-c"]
["VALUE-B", "VALUE-C", "VALUE-A"]
```

This change will result in both of these examples being considered semantically equal.

### Corner tests

I also wrote some acceptance tests to make it a little easier to understand the impact (using IPv6 address strings as an example)

https://github.com/hashicorp/terraform-provider-corner/pull/297

### Unit test failures before the fix
https://github.com/hashicorp/terraform-plugin-framework/actions/runs/12832297072/job/35784696031?pr=1064
```bash
--- FAIL: TestValueSemanticEqualitySet (0.00s)
    --- FAIL: TestValueSemanticEqualitySet/SetValue-SetValue-StringValuableWithSemanticEquals-true-diff-order (0.00s)
        value_semantic_equality_set_test.go:1021: unexpected difference:   &fwschemadata.ValueSemanticEqualityResponse{
            - 	NewValue:    s`[["KEEP-LOWERCASE-012","KEEP-LOWERCASE-789"],["KEEP-LOWERCASE-456","KEEP-LOWERCASE-123"]]`,
            + 	NewValue:    s`[["keep-lowercase-123","keep-lowercase-456"],["keep-lowercase-789","keep-lowercase-012"]]`,
              	Diagnostics: nil,
              }
    --- FAIL: TestValueSemanticEqualitySet/SetValue-StringValuableWithSemanticEquals-true-diff-order (0.00s)
        value_semantic_equality_set_test.go:10[21](https://github.com/hashicorp/terraform-plugin-framework/actions/runs/12832297072/job/35784696031?pr=1064#step:5:22): unexpected difference:   &fwschemadata.ValueSemanticEqualityResponse{
            - 	NewValue:    s`["KEEP-LOWERCASE-456","KEEP-LOWERCASE-123"]`,
            + 	NewValue:    s`["keep-lowercase-123","keep-lowercase-456"]`,
              	Diagnostics: nil,
              }
```
