### PR TITLE
Add education and web presence ability to approve PRs to website files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,6 @@
 * @hashicorp/terraform-devex
+
+# web presence and education
+
+
+/website/       @hashicorp/team-docs-packer-and-terraform @hashicorp/web-presence @hashicorp/terraform-devex


### PR DESCRIPTION
I'm trying to standardize the education and web presence team's permissions across all the code repos that contain docs. Please let me know if you have any feedback! 