### PR TITLE
docs: Remove experimental verbiage from ephemeral resources

### DIFF
--- a/.changes/unreleased/NOTES-20250212-105343.yaml
+++ b/.changes/unreleased/NOTES-20250212-105343.yaml
@@ -1,0 +1,6 @@
+kind: NOTES
+body: 'ephemeral: Ephemeral resources are now considered generally available and protected
+  by compatibility promises.'
+time: 2025-02-12T10:53:43.499303-05:00
+custom:
+  Issue: "1052"

--- a/ephemeral/doc.go
+++ b/ephemeral/doc.go
@@ -20,7 +20,4 @@
 // that has its own configuration and lifecycle logic. The [ephemeral.EphemeralResource]
 // implementations are referenced by the [provider.ProviderWithEphemeralResources] type
 // EphemeralResources method, which enables the ephemeral resource practitioner usage.
-//
-// NOTE: Ephemeral resource support is experimental and exposed without compatibility promises until
-// these notices are removed.
 package ephemeral

--- a/ephemeral/ephemeral_resource.go
+++ b/ephemeral/ephemeral_resource.go
@@ -24,9 +24,6 @@ import (
 //     HashiCorp Vault leases, which can be renewed without changing their data.
 //
 //   - Close: Allows providers to clean up the ephemeral resource via EphemeralResourceWithClose.
-//
-// NOTE: Ephemeral resource support is experimental and exposed without compatibility promises until
-// these notices are removed.
 type EphemeralResource interface {
 	// Metadata should return the full name of the ephemeral resource, such as
 	// examplecloud_thing.

--- a/ephemeral/schema/doc.go
+++ b/ephemeral/schema/doc.go
@@ -5,7 +5,4 @@
 // Ephemeral resource schemas define the structure and value types for configuration
 // and result data. Schemas are implemented via the ephemeral.EphemeralResource type
 // Schema method.
-//
-// NOTE: Ephemeral resource support is experimental and exposed without compatibility promises until
-// these notices are removed.
 package schema

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -90,9 +90,6 @@ type ProviderWithFunctions interface {
 // include ephemeral resources for usage in practitioner configurations.
 //
 // Ephemeral resources are supported in Terraform version 1.10 and later.
-//
-// NOTE: Ephemeral resource support is experimental and exposed without compatibility promises until
-// these notices are removed.
 type ProviderWithEphemeralResources interface {
 	Provider
 


### PR DESCRIPTION
Closes #1052 