### PR TITLE
internal/fwserver: Move write-only nullification to earlier in PlanResourceChange

### DIFF
--- a/.changes/unreleased/BUG FIXES-20250219-152752.yaml
+++ b/.changes/unreleased/BUG FIXES-20250219-152752.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'internal/fwserver: fixed bug where write-only attributes set in configuration would cause perpetual diffs for computed attributes.'
+time: 2025-02-19T15:27:52.52508-05:00
+custom:
+    Issue: "1097"


### PR DESCRIPTION
Fixes: https://github.com/hashicorp/terraform-plugin-framework/issues/1096

During PlanResourceChange, computed attributes that are `null` in the configuration are marked as `unknown`. This logic only runs when there is a non-null planned state and the planned state is not equal to the prior state. If a write-only attribute is set in config, then the prior state (which is always `null`) and planned state (which contains the config value) will always differ causing `null` computed values to always be marked as `unknown` instead of using the prior value. This causes perpetual diffs after resource creation if a write-only attribute is set in config and the resource has non-null computed attribute values in state. 

The fix moves the write-only value nullification for the planned state to happen before this check.