### PR TITLE
Add Callout for `PreferWriteOnlyAttribute()` validator in documentation

### DIFF
--- a/website/docs/plugin/framework/resources/write-only-arguments.mdx
+++ b/website/docs/plugin/framework/resources/write-only-arguments.mdx
@@ -56,7 +56,7 @@ retrieving values from configuration.
 <Note>
 
     These validators will produce persistent warnings for practitioners on every Terraform run as long as the specified non-write-only attribute
-    has a value in the configuration. The validators will also produce warnings for users of modules who cannot immediately take action on the warning.
+    has a value in the configuration. The validators will also produce warnings for users of shared modules who cannot immediately take action on the warning.
 
 </Note>
 

--- a/website/docs/plugin/framework/resources/write-only-arguments.mdx
+++ b/website/docs/plugin/framework/resources/write-only-arguments.mdx
@@ -53,6 +53,13 @@ retrieving values from configuration.
 
 ## PreferWriteOnlyAttribute Validators
 
+<Note>
+
+    These validators will produce persistent warnings for practitioners on every Terraform run as long as the specified non-write-only attribute
+    has a value in the configuration. The validators will also produce warnings for users of modules who cannot immediately take action on the warning.
+
+</Note>
+
 The `PreferWriteOnlyAttribute()` validators available in the [`terraform-plugin-framework-validators` Go module](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework-validators)
 can be used when you have a write-only version of an existing attribute, and you want to encourage practitioners to use the write-only version whenever possible.
 


### PR DESCRIPTION
Adds a callout for `PreferWriteOnlyAttribute()` validator usage about the persistent nature of the warnings for practitioners.