### PR TITLE
Migrate docs to web-unified-docs

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -1,5 +1,8 @@
 # Terraform Documentation
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 This directory contains the portions of [the Terraform website][terraform.io] that pertain to the Terraform Plugin Framework.
 
 The files in this directory are intended to be used in conjunction with

--- a/website/README.md
+++ b/website/README.md
@@ -1,7 +1,7 @@
 # Terraform Documentation
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 This directory contains the portions of [the Terraform website][terraform.io] that pertain to the Terraform Plugin Framework.
 

--- a/website/docs/plugin/framework/acctests.mdx
+++ b/website/docs/plugin/framework/acctests.mdx
@@ -6,6 +6,9 @@ description: >-
   Terraform operations.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Acceptance tests
 
 Implement provider resource and data source acceptance tests with the [terraform-plugin-testing module](/terraform/plugin/testing). These tests are designed to execute Terraform commands against real Terraform configurations, simulating practitioner experiences with creating, refreshing, updating, and deleting infrastructure.

--- a/website/docs/plugin/framework/acctests.mdx
+++ b/website/docs/plugin/framework/acctests.mdx
@@ -7,7 +7,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Acceptance tests
 

--- a/website/docs/plugin/framework/acctests.mdx
+++ b/website/docs/plugin/framework/acctests.mdx
@@ -7,7 +7,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Acceptance tests
 

--- a/website/docs/plugin/framework/data-sources/configure.mdx
+++ b/website/docs/plugin/framework/data-sources/configure.mdx
@@ -5,6 +5,9 @@ description: >-
   Terraform plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Configure data sources
 
 [Data sources](/terraform/plugin/framework/data-sources) may require provider-level data or remote system clients to operate correctly. The framework supports the ability to configure this data and/or clients once within the provider, then pass that information to data sources by adding the `Configure` method.

--- a/website/docs/plugin/framework/data-sources/configure.mdx
+++ b/website/docs/plugin/framework/data-sources/configure.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Configure data sources
 

--- a/website/docs/plugin/framework/data-sources/index.mdx
+++ b/website/docs/plugin/framework/data-sources/index.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Data sources
 

--- a/website/docs/plugin/framework/data-sources/index.mdx
+++ b/website/docs/plugin/framework/data-sources/index.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Data sources
 

--- a/website/docs/plugin/framework/data-sources/index.mdx
+++ b/website/docs/plugin/framework/data-sources/index.mdx
@@ -5,6 +5,9 @@ description: >-
   framework can help you implement data sources.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Data sources
 
 [Data sources](/terraform/language/data-sources) are an abstraction that allow Terraform to reference external data. Unlike [managed resources](/terraform/language/resources), Terraform does not manage the lifecycle of the resource or data. Data sources are intended to have no side-effects.

--- a/website/docs/plugin/framework/data-sources/timeouts.mdx
+++ b/website/docs/plugin/framework/data-sources/timeouts.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Timeouts
 

--- a/website/docs/plugin/framework/data-sources/timeouts.mdx
+++ b/website/docs/plugin/framework/data-sources/timeouts.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Timeouts
 

--- a/website/docs/plugin/framework/data-sources/timeouts.mdx
+++ b/website/docs/plugin/framework/data-sources/timeouts.mdx
@@ -4,6 +4,9 @@ description: >-
   Learn how to implement timeouts with the Terraform plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Timeouts
 
 The reality of cloud infrastructure is that it typically takes time to perform operations such as booting operating systems, discovering services, and replicating state across network edges. As the provider developer you should take known delays in data source APIs into account in the `Read` function of the data source. Terraform supports configurable timeouts to assist in these situations.

--- a/website/docs/plugin/framework/data-sources/validate-configuration.mdx
+++ b/website/docs/plugin/framework/data-sources/validate-configuration.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Validate data source configurations
 

--- a/website/docs/plugin/framework/data-sources/validate-configuration.mdx
+++ b/website/docs/plugin/framework/data-sources/validate-configuration.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Validate data source configurations
 

--- a/website/docs/plugin/framework/data-sources/validate-configuration.mdx
+++ b/website/docs/plugin/framework/data-sources/validate-configuration.mdx
@@ -5,6 +5,9 @@ description: >-
   framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Validate data source configurations
 
 [Data sources](/terraform/plugin/framework/data-sources) support validating an entire practitioner configuration in either declarative or imperative logic. Feedback, such as required syntax or acceptable combinations of values, is returned via [diagnostics](/terraform/plugin/framework/diagnostics).

--- a/website/docs/plugin/framework/debugging.mdx
+++ b/website/docs/plugin/framework/debugging.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Debugging framework Providers
 

--- a/website/docs/plugin/framework/debugging.mdx
+++ b/website/docs/plugin/framework/debugging.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Debugging framework Providers
 

--- a/website/docs/plugin/framework/debugging.mdx
+++ b/website/docs/plugin/framework/debugging.mdx
@@ -4,6 +4,9 @@ description: >-
   Learn how to implement debugger support in framework Terraform providers.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Debugging framework Providers
 
 This page contains implementation details for inspecting runtime information of a Terraform provider developed with Framework via a debugger tool by adjusting the [provider server](/terraform/plugin/framework/provider-servers) implementation. Review the top level [Debugging](/terraform/plugin/debugging) page for information pertaining to the overall Terraform provider debugging process and other inspection options, such as log-based debugging.

--- a/website/docs/plugin/framework/deprecations.mdx
+++ b/website/docs/plugin/framework/deprecations.mdx
@@ -5,6 +5,9 @@ description:
   renames in framework providers.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Deprecations, removals, and renames
 
 Terraform is trusted for managing many facets of infrastructure across many organizations. Part of that trust is due to consistent versioning guidelines and setting expectations for various levels of upgrades. Ensuring backwards compatibility for all patch and minor releases, potentially in concert with any upcoming major changes, is recommended and supported by the Terraform development framework. This allows operators to iteratively update their Terraform configurations rather than require massive refactoring.

--- a/website/docs/plugin/framework/deprecations.mdx
+++ b/website/docs/plugin/framework/deprecations.mdx
@@ -6,7 +6,7 @@ description:
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Deprecations, removals, and renames
 

--- a/website/docs/plugin/framework/deprecations.mdx
+++ b/website/docs/plugin/framework/deprecations.mdx
@@ -6,7 +6,7 @@ description:
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Deprecations, removals, and renames
 

--- a/website/docs/plugin/framework/diagnostics.mdx
+++ b/website/docs/plugin/framework/diagnostics.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Returning errors and warnings
 

--- a/website/docs/plugin/framework/diagnostics.mdx
+++ b/website/docs/plugin/framework/diagnostics.mdx
@@ -4,6 +4,9 @@ description: >-
   Learn how to return errors and warnings from the Terraform plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Returning errors and warnings
 
 Providers use `Diagnostics` to surface errors and warnings to practitioners,

--- a/website/docs/plugin/framework/diagnostics.mdx
+++ b/website/docs/plugin/framework/diagnostics.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Returning errors and warnings
 

--- a/website/docs/plugin/framework/ephemeral-resources/close.mdx
+++ b/website/docs/plugin/framework/ephemeral-resources/close.mdx
@@ -4,6 +4,9 @@ description: >-
   Learn how to close ephemeral resource in the Terraform plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Closing Ephemeral Resources
 
 Close is an optional part of the Terraform lifecycle for an ephemeral resource, which is different from the [managed resource lifecycle](https://github.com/hashicorp/terraform/blob/main/docs/resource-instance-change-lifecycle.md). During any Terraform operation (like [`terraform plan`](/terraform/cli/commands/plan) or [`terraform apply`](/terraform/cli/commands/apply)), when an ephemeral resource's data is needed, Terraform initially retrieves that data with the [`Open`](/terraform/plugin/framework/ephemeral-resources/open) lifecycle handler. Once the ephemeral resource data is no longer needed, Terraform calls the provider `CloseEphemeralResource` RPC, in which the framework calls the [`ephemeral.EphemeralResourceWithClose` interface `Close` method](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral#EphemeralResourceWithClose). The request contains any `Private` data set in the latest `Open` or `Renew` call.

--- a/website/docs/plugin/framework/ephemeral-resources/close.mdx
+++ b/website/docs/plugin/framework/ephemeral-resources/close.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Closing Ephemeral Resources
 

--- a/website/docs/plugin/framework/ephemeral-resources/close.mdx
+++ b/website/docs/plugin/framework/ephemeral-resources/close.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Closing Ephemeral Resources
 

--- a/website/docs/plugin/framework/ephemeral-resources/configure.mdx
+++ b/website/docs/plugin/framework/ephemeral-resources/configure.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Configuring ephemeral resources
 

--- a/website/docs/plugin/framework/ephemeral-resources/configure.mdx
+++ b/website/docs/plugin/framework/ephemeral-resources/configure.mdx
@@ -5,6 +5,9 @@ description: >-
   the Terraform plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Configuring ephemeral resources
 
 [Ephemeral Resources](/terraform/plugin/framework/ephemeral-resources) may require provider-level data or remote system clients to operate correctly. The framework supports the ability to configure this data and/or clients once within the provider, then pass that information to ephemeral resources by adding the `Configure` method.

--- a/website/docs/plugin/framework/ephemeral-resources/configure.mdx
+++ b/website/docs/plugin/framework/ephemeral-resources/configure.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Configuring ephemeral resources
 

--- a/website/docs/plugin/framework/ephemeral-resources/index.mdx
+++ b/website/docs/plugin/framework/ephemeral-resources/index.mdx
@@ -7,7 +7,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Ephemeral resources
 

--- a/website/docs/plugin/framework/ephemeral-resources/index.mdx
+++ b/website/docs/plugin/framework/ephemeral-resources/index.mdx
@@ -7,7 +7,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Ephemeral resources
 

--- a/website/docs/plugin/framework/ephemeral-resources/index.mdx
+++ b/website/docs/plugin/framework/ephemeral-resources/index.mdx
@@ -6,6 +6,9 @@ description: >-
   to implement ephemeral resources in the Terraform plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Ephemeral resources
 
 <Highlight>

--- a/website/docs/plugin/framework/ephemeral-resources/open.mdx
+++ b/website/docs/plugin/framework/ephemeral-resources/open.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Opening ephemeral resources
 

--- a/website/docs/plugin/framework/ephemeral-resources/open.mdx
+++ b/website/docs/plugin/framework/ephemeral-resources/open.mdx
@@ -4,6 +4,9 @@ description: >-
   Learn how to open ephemeral resource in the Terraform plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Opening ephemeral resources
 
 Open is part of the Terraform lifecycle for an ephemeral resource, which is different from the [managed resource lifecycle](https://github.com/hashicorp/terraform/blob/main/docs/resource-instance-change-lifecycle.md). During any Terraform operation (like [`terraform plan`](/terraform/cli/commands/plan) or [`terraform apply`](/terraform/cli/commands/apply)), when an ephemeral resource's data is needed, Terraform calls the provider `OpenEphemeralResource` RPC, in which the framework calls the [`ephemeral.EphemeralResource` interface `Open` method](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral#EphemeralResource.Open). The request contains the configuration supplied to Terraform for the ephemeral resource. The response contains the ephemeral result data. The data is defined by the [schema](/terraform/plugin/framework/handling-data/schemas) of the ephemeral resource.

--- a/website/docs/plugin/framework/ephemeral-resources/open.mdx
+++ b/website/docs/plugin/framework/ephemeral-resources/open.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Opening ephemeral resources
 

--- a/website/docs/plugin/framework/ephemeral-resources/renew.mdx
+++ b/website/docs/plugin/framework/ephemeral-resources/renew.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Renewing ephemeral resources
 

--- a/website/docs/plugin/framework/ephemeral-resources/renew.mdx
+++ b/website/docs/plugin/framework/ephemeral-resources/renew.mdx
@@ -4,6 +4,9 @@ description: >-
   Learn how to renew ephemeral resource in the Terraform plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Renewing ephemeral resources
 
 Renew is an optional part of the Terraform lifecycle for an ephemeral resource, which is different from the [managed resource lifecycle](https://github.com/hashicorp/terraform/blob/main/docs/resource-instance-change-lifecycle.md). During any Terraform operation (like [`terraform plan`](/terraform/cli/commands/plan) or [`terraform apply`](/terraform/cli/commands/apply)), when an ephemeral resource's data is needed, Terraform initially retrieves that data with the [`Open`](/terraform/plugin/framework/ephemeral-resources/open) lifecycle handler. During `Open`, ephemeral resources can opt to include a timestamp in the `RenewAt` response field to indicate to Terraform when a provider must renew an ephemeral resource. If an ephemeral resource's data is still in-use and the `RenewAt` timestamp has passed, Terraform calls the provider `RenewEphemeralResource` RPC, in which the framework calls the [`ephemeral.EphemeralResourceWithRenew` interface `Renew` method](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/ephemeral#EphemeralResourceWithRenew). The request contains any `Private` data set in the latest `Open` or `Renew` call. The response contains `Private` data and an optional `RenewAt` field for further renew executions.

--- a/website/docs/plugin/framework/ephemeral-resources/renew.mdx
+++ b/website/docs/plugin/framework/ephemeral-resources/renew.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Renewing ephemeral resources
 

--- a/website/docs/plugin/framework/ephemeral-resources/validate-configuration.mdx
+++ b/website/docs/plugin/framework/ephemeral-resources/validate-configuration.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Validate ephemeral resource configurations
 

--- a/website/docs/plugin/framework/ephemeral-resources/validate-configuration.mdx
+++ b/website/docs/plugin/framework/ephemeral-resources/validate-configuration.mdx
@@ -5,6 +5,9 @@ description: >-
   plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Validate ephemeral resource configurations
 
 [Ephemeral resources](/terraform/plugin/framework/ephemeral-resources) support validating an entire practitioner configuration in either declarative or imperative logic. Feedback, such as required syntax or acceptable combinations of values, is returned via [diagnostics](/terraform/plugin/framework/diagnostics).

--- a/website/docs/plugin/framework/ephemeral-resources/validate-configuration.mdx
+++ b/website/docs/plugin/framework/ephemeral-resources/validate-configuration.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Validate ephemeral resource configurations
 

--- a/website/docs/plugin/framework/functions/concepts.mdx
+++ b/website/docs/plugin/framework/functions/concepts.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Provider-defined functions
 

--- a/website/docs/plugin/framework/functions/concepts.mdx
+++ b/website/docs/plugin/framework/functions/concepts.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Provider-defined functions
 

--- a/website/docs/plugin/framework/functions/concepts.mdx
+++ b/website/docs/plugin/framework/functions/concepts.mdx
@@ -5,6 +5,9 @@ description: >-
   functions for practitions to use in their Terraform configurations.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Provider-defined functions
 
 This page describes Terraform concepts relating to provider-defined functions within framework-based provider code. Provider-defined functions are supported in Terraform 1.8 and later. The [What is Terraform](/terraform/intro), [Terraform language](/terraform/language), and [Plugin Development](/terraform/plugin) documentation covers more general concepts behind Terraform's workflow, its configuration, and how it interacts with providers.

--- a/website/docs/plugin/framework/functions/documentation.mdx
+++ b/website/docs/plugin/framework/functions/documentation.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Documenting functions
 

--- a/website/docs/plugin/framework/functions/documentation.mdx
+++ b/website/docs/plugin/framework/functions/documentation.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Documenting functions
 

--- a/website/docs/plugin/framework/functions/documentation.mdx
+++ b/website/docs/plugin/framework/functions/documentation.mdx
@@ -5,6 +5,9 @@ description: >-
   framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Documenting functions
 
 When a function is [implemented](/terraform/plugin/framework/functions/implementation), ensure the function is discoverable by practitioners with usage information.

--- a/website/docs/plugin/framework/functions/errors.mdx
+++ b/website/docs/plugin/framework/functions/errors.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Returning errors from function
 

--- a/website/docs/plugin/framework/functions/errors.mdx
+++ b/website/docs/plugin/framework/functions/errors.mdx
@@ -5,6 +5,9 @@ description: >-
   plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Returning errors from function
 
 Providers use [`FuncError`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/function#FuncError) to

--- a/website/docs/plugin/framework/functions/errors.mdx
+++ b/website/docs/plugin/framework/functions/errors.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Returning errors from function
 

--- a/website/docs/plugin/framework/functions/implementation.mdx
+++ b/website/docs/plugin/framework/functions/implementation.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Implement provider-defined functions
 

--- a/website/docs/plugin/framework/functions/implementation.mdx
+++ b/website/docs/plugin/framework/functions/implementation.mdx
@@ -5,6 +5,9 @@ description: >-
   plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Implement provider-defined functions
 
 The framework supports implementing functions based on Terraform's [concepts for provider-defined functions](/terraform/plugin/framework/functions/concepts). It is recommended to understand those concepts before implementing a function since the terminology is used throughout this page and there are details that simplify function handling as compared to other provider concepts. Provider-defined functions are supported in Terraform 1.8 and later.

--- a/website/docs/plugin/framework/functions/implementation.mdx
+++ b/website/docs/plugin/framework/functions/implementation.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Implement provider-defined functions
 

--- a/website/docs/plugin/framework/functions/index.mdx
+++ b/website/docs/plugin/framework/functions/index.mdx
@@ -7,7 +7,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 
 # Provider-defined functions

--- a/website/docs/plugin/framework/functions/index.mdx
+++ b/website/docs/plugin/framework/functions/index.mdx
@@ -7,7 +7,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 
 # Provider-defined functions

--- a/website/docs/plugin/framework/functions/index.mdx
+++ b/website/docs/plugin/framework/functions/index.mdx
@@ -6,6 +6,9 @@ description: >-
   plugin framework can help you implement provider-defined functions.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 
 # Provider-defined functions
 

--- a/website/docs/plugin/framework/functions/parameters/bool.mdx
+++ b/website/docs/plugin/framework/functions/parameters/bool.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Boolean function parameters
 

--- a/website/docs/plugin/framework/functions/parameters/bool.mdx
+++ b/website/docs/plugin/framework/functions/parameters/bool.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Boolean function parameters
 

--- a/website/docs/plugin/framework/functions/parameters/bool.mdx
+++ b/website/docs/plugin/framework/functions/parameters/bool.mdx
@@ -5,6 +5,9 @@ description: >-
   plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Boolean function parameters
 
 Bool function parameters expect a boolean true or false value from a practitioner configuration. Values are accessible in function logic by the Go built-in `bool` type, Go built-in `*bool` type, or the [framework bool type](/terraform/plugin/framework/handling-data/types/bool).

--- a/website/docs/plugin/framework/functions/parameters/dynamic.mdx
+++ b/website/docs/plugin/framework/functions/parameters/dynamic.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Dynamic function parameters
 

--- a/website/docs/plugin/framework/functions/parameters/dynamic.mdx
+++ b/website/docs/plugin/framework/functions/parameters/dynamic.mdx
@@ -5,6 +5,9 @@ description: >-
   framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Dynamic function parameters
 
 <Tip>

--- a/website/docs/plugin/framework/functions/parameters/dynamic.mdx
+++ b/website/docs/plugin/framework/functions/parameters/dynamic.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Dynamic function parameters
 

--- a/website/docs/plugin/framework/functions/parameters/float32.mdx
+++ b/website/docs/plugin/framework/functions/parameters/float32.mdx
@@ -5,6 +5,9 @@ description: >-
   Terraform plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Float32 Function Parameter
 
 <Tip>

--- a/website/docs/plugin/framework/functions/parameters/float32.mdx
+++ b/website/docs/plugin/framework/functions/parameters/float32.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Float32 Function Parameter
 

--- a/website/docs/plugin/framework/functions/parameters/float32.mdx
+++ b/website/docs/plugin/framework/functions/parameters/float32.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Float32 Function Parameter
 

--- a/website/docs/plugin/framework/functions/parameters/float64.mdx
+++ b/website/docs/plugin/framework/functions/parameters/float64.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Float64 function parameters
 

--- a/website/docs/plugin/framework/functions/parameters/float64.mdx
+++ b/website/docs/plugin/framework/functions/parameters/float64.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Float64 function parameters
 

--- a/website/docs/plugin/framework/functions/parameters/float64.mdx
+++ b/website/docs/plugin/framework/functions/parameters/float64.mdx
@@ -5,6 +5,9 @@ description: >-
   Terraform plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Float64 function parameters
 
 <Tip>

--- a/website/docs/plugin/framework/functions/parameters/index.mdx
+++ b/website/docs/plugin/framework/functions/parameters/index.mdx
@@ -6,6 +6,9 @@ description: >-
   arguments in a function definition.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Function parameters
 
 Parameters in [function definitions](/terraform/plugin/framework/functions/implementation#definition-method) describes how data values are passed to the function logic. Every parameter type has an associated [value type](/terraform/plugin/framework/handling-data/types), although this data handling is simplified for function implementations over other provider concepts, such as resource implementations.

--- a/website/docs/plugin/framework/functions/parameters/index.mdx
+++ b/website/docs/plugin/framework/functions/parameters/index.mdx
@@ -7,7 +7,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Function parameters
 

--- a/website/docs/plugin/framework/functions/parameters/index.mdx
+++ b/website/docs/plugin/framework/functions/parameters/index.mdx
@@ -7,7 +7,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Function parameters
 

--- a/website/docs/plugin/framework/functions/parameters/int32.mdx
+++ b/website/docs/plugin/framework/functions/parameters/int32.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Int32 function parameters
 

--- a/website/docs/plugin/framework/functions/parameters/int32.mdx
+++ b/website/docs/plugin/framework/functions/parameters/int32.mdx
@@ -5,6 +5,9 @@ description: >-
   Terraform plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Int32 function parameters
 
 <Tip>

--- a/website/docs/plugin/framework/functions/parameters/int32.mdx
+++ b/website/docs/plugin/framework/functions/parameters/int32.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Int32 function parameters
 

--- a/website/docs/plugin/framework/functions/parameters/int64.mdx
+++ b/website/docs/plugin/framework/functions/parameters/int64.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Int64 function parameters
 

--- a/website/docs/plugin/framework/functions/parameters/int64.mdx
+++ b/website/docs/plugin/framework/functions/parameters/int64.mdx
@@ -5,6 +5,9 @@ description: >-
   Terraform plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Int64 function parameters
 
 <Tip>

--- a/website/docs/plugin/framework/functions/parameters/int64.mdx
+++ b/website/docs/plugin/framework/functions/parameters/int64.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Int64 function parameters
 

--- a/website/docs/plugin/framework/functions/parameters/list.mdx
+++ b/website/docs/plugin/framework/functions/parameters/list.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # List function parameters
 

--- a/website/docs/plugin/framework/functions/parameters/list.mdx
+++ b/website/docs/plugin/framework/functions/parameters/list.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # List function parameters
 

--- a/website/docs/plugin/framework/functions/parameters/list.mdx
+++ b/website/docs/plugin/framework/functions/parameters/list.mdx
@@ -5,6 +5,9 @@ description: >-
   Terraform plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # List function parameters
 
 List function parameters expect an ordered collection of single element type value from a practitioner configuration. Values are accessible in function logic by a Go slice of an appropriate pointer type to match the element type `[]*T` or the [framework list type](/terraform/plugin/framework/handling-data/types/list).

--- a/website/docs/plugin/framework/functions/parameters/map.mdx
+++ b/website/docs/plugin/framework/functions/parameters/map.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # List function parameters
 

--- a/website/docs/plugin/framework/functions/parameters/map.mdx
+++ b/website/docs/plugin/framework/functions/parameters/map.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # List function parameters
 

--- a/website/docs/plugin/framework/functions/parameters/map.mdx
+++ b/website/docs/plugin/framework/functions/parameters/map.mdx
@@ -5,6 +5,9 @@ description: >-
   Terraform plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # List function parameters
 
 Map function parameters expect a mapping of arbitrary string keys to values of single element type from a practitioner configuration. Values are accessible in function logic by a Go map of string keys to values of an appropriate pointer type to match the element type `map[string]*T` or the [framework map type](/terraform/plugin/framework/handling-data/types/map).

--- a/website/docs/plugin/framework/functions/parameters/number.mdx
+++ b/website/docs/plugin/framework/functions/parameters/number.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Number function parameters
 

--- a/website/docs/plugin/framework/functions/parameters/number.mdx
+++ b/website/docs/plugin/framework/functions/parameters/number.mdx
@@ -5,6 +5,9 @@ description: >-
   the Terraform plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Number function parameters
 
 <Tip>

--- a/website/docs/plugin/framework/functions/parameters/number.mdx
+++ b/website/docs/plugin/framework/functions/parameters/number.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Number function parameters
 

--- a/website/docs/plugin/framework/functions/parameters/object.mdx
+++ b/website/docs/plugin/framework/functions/parameters/object.mdx
@@ -5,6 +5,9 @@ description: >-
   the Terraform plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Object function parameters
 
 Object function parameters expect a single structure mapping explicit attribute names to type definitions from a practitioner configuration. Values are accessible in function logic by a Go structure type annotated with `tfsdk` field tags or the [framework object type](/terraform/plugin/framework/handling-data/types/object).

--- a/website/docs/plugin/framework/functions/parameters/object.mdx
+++ b/website/docs/plugin/framework/functions/parameters/object.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Object function parameters
 

--- a/website/docs/plugin/framework/functions/parameters/object.mdx
+++ b/website/docs/plugin/framework/functions/parameters/object.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Object function parameters
 

--- a/website/docs/plugin/framework/functions/parameters/set.mdx
+++ b/website/docs/plugin/framework/functions/parameters/set.mdx
@@ -5,6 +5,9 @@ description: >-
   the Terraform plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Set function parameters
 
 Set function parameters expect an unordered, unique collection of single element type value from a practitioner configuration. Values are accessible in function logic by a Go slice of an appropriate pointer type to match the element type `[]*T` or the [framework set type](/terraform/plugin/framework/handling-data/types/set).

--- a/website/docs/plugin/framework/functions/parameters/set.mdx
+++ b/website/docs/plugin/framework/functions/parameters/set.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Set function parameters
 

--- a/website/docs/plugin/framework/functions/parameters/set.mdx
+++ b/website/docs/plugin/framework/functions/parameters/set.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Set function parameters
 

--- a/website/docs/plugin/framework/functions/parameters/string.mdx
+++ b/website/docs/plugin/framework/functions/parameters/string.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # String function parameters
 

--- a/website/docs/plugin/framework/functions/parameters/string.mdx
+++ b/website/docs/plugin/framework/functions/parameters/string.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # String function parameters
 

--- a/website/docs/plugin/framework/functions/parameters/string.mdx
+++ b/website/docs/plugin/framework/functions/parameters/string.mdx
@@ -5,6 +5,9 @@ description: >-
   the Terraform plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # String function parameters
 
 String function parameters expect a collection of UTF-8 encoded bytes from a practitioner configuration. Values are accessible in function logic by the Go built-in `string` type, Go built-in `*string` type, or the [framework string type](/terraform/plugin/framework/handling-data/types/string).

--- a/website/docs/plugin/framework/functions/returns/bool.mdx
+++ b/website/docs/plugin/framework/functions/returns/bool.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Boolean return values
 

--- a/website/docs/plugin/framework/functions/returns/bool.mdx
+++ b/website/docs/plugin/framework/functions/returns/bool.mdx
@@ -5,6 +5,9 @@ description: >-
   plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Boolean return values
 
 Bool function return values expect a boolean true or false value from function logic. Set values in function logic with the Go built-in `bool` type, Go built-in `*bool` type, or the [framework bool type](/terraform/plugin/framework/handling-data/types/bool).

--- a/website/docs/plugin/framework/functions/returns/bool.mdx
+++ b/website/docs/plugin/framework/functions/returns/bool.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Boolean return values
 

--- a/website/docs/plugin/framework/functions/returns/dynamic.mdx
+++ b/website/docs/plugin/framework/functions/returns/dynamic.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Dynamic function return values
 

--- a/website/docs/plugin/framework/functions/returns/dynamic.mdx
+++ b/website/docs/plugin/framework/functions/returns/dynamic.mdx
@@ -5,6 +5,9 @@ description: >-
   plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Dynamic function return values
 
 <Tip>

--- a/website/docs/plugin/framework/functions/returns/dynamic.mdx
+++ b/website/docs/plugin/framework/functions/returns/dynamic.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Dynamic function return values
 

--- a/website/docs/plugin/framework/functions/returns/float32.mdx
+++ b/website/docs/plugin/framework/functions/returns/float32.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Float32 return values
 

--- a/website/docs/plugin/framework/functions/returns/float32.mdx
+++ b/website/docs/plugin/framework/functions/returns/float32.mdx
@@ -5,6 +5,9 @@ description: >-
   Terraform plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Float32 return values
 
 <Tip>

--- a/website/docs/plugin/framework/functions/returns/float32.mdx
+++ b/website/docs/plugin/framework/functions/returns/float32.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Float32 return values
 

--- a/website/docs/plugin/framework/functions/returns/float64.mdx
+++ b/website/docs/plugin/framework/functions/returns/float64.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Float64 return values
 

--- a/website/docs/plugin/framework/functions/returns/float64.mdx
+++ b/website/docs/plugin/framework/functions/returns/float64.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Float64 return values
 

--- a/website/docs/plugin/framework/functions/returns/float64.mdx
+++ b/website/docs/plugin/framework/functions/returns/float64.mdx
@@ -5,6 +5,9 @@ description: >-
   Terraform plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Float64 return values
 
 <Tip>

--- a/website/docs/plugin/framework/functions/returns/index.mdx
+++ b/website/docs/plugin/framework/functions/returns/index.mdx
@@ -7,7 +7,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Return values
 

--- a/website/docs/plugin/framework/functions/returns/index.mdx
+++ b/website/docs/plugin/framework/functions/returns/index.mdx
@@ -7,7 +7,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Return values
 

--- a/website/docs/plugin/framework/functions/returns/index.mdx
+++ b/website/docs/plugin/framework/functions/returns/index.mdx
@@ -6,6 +6,9 @@ description: >-
   data in a function definition.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Return values
 
 A return in a [function definition](/terraform/plugin/framework/functions/implementation#definition-method) describes the result data value from function logic. Every return type has an associated [value type](/terraform/plugin/framework/handling-data/types), although this data handling is simplified for function implementations over other provider concepts, such as resource implementations.

--- a/website/docs/plugin/framework/functions/returns/int32.mdx
+++ b/website/docs/plugin/framework/functions/returns/int32.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Int32 return values
 

--- a/website/docs/plugin/framework/functions/returns/int32.mdx
+++ b/website/docs/plugin/framework/functions/returns/int32.mdx
@@ -5,6 +5,9 @@ description: >-
   Terraform plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Int32 return values
 
 <Tip>

--- a/website/docs/plugin/framework/functions/returns/int32.mdx
+++ b/website/docs/plugin/framework/functions/returns/int32.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Int32 return values
 

--- a/website/docs/plugin/framework/functions/returns/int64.mdx
+++ b/website/docs/plugin/framework/functions/returns/int64.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Int64 return values
 

--- a/website/docs/plugin/framework/functions/returns/int64.mdx
+++ b/website/docs/plugin/framework/functions/returns/int64.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Int64 return values
 

--- a/website/docs/plugin/framework/functions/returns/int64.mdx
+++ b/website/docs/plugin/framework/functions/returns/int64.mdx
@@ -5,6 +5,9 @@ description: >-
   Terraform plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Int64 return values
 
 <Tip>

--- a/website/docs/plugin/framework/functions/returns/list.mdx
+++ b/website/docs/plugin/framework/functions/returns/list.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # List return values
 

--- a/website/docs/plugin/framework/functions/returns/list.mdx
+++ b/website/docs/plugin/framework/functions/returns/list.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # List return values
 

--- a/website/docs/plugin/framework/functions/returns/list.mdx
+++ b/website/docs/plugin/framework/functions/returns/list.mdx
@@ -5,6 +5,9 @@ description: >-
   Terraform plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # List return values
 
 List function return expects an ordered collection of single element type value from function logic. Set values in function logic with a Go slice of an appropriate type to match the element type `[]T` or the [framework list type](/terraform/plugin/framework/handling-data/types/list).

--- a/website/docs/plugin/framework/functions/returns/map.mdx
+++ b/website/docs/plugin/framework/functions/returns/map.mdx
@@ -5,6 +5,9 @@ description: >-
   Terraform plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Map return values
 
 Map function return expects a mapping of arbitrary string keys to values of single element type from function logic. Set values in function logic with a Go map of string keys to values of an appropriate type to match the element type `map[string]T` or the [framework map type](/terraform/plugin/framework/handling-data/types/map).

--- a/website/docs/plugin/framework/functions/returns/map.mdx
+++ b/website/docs/plugin/framework/functions/returns/map.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Map return values
 

--- a/website/docs/plugin/framework/functions/returns/map.mdx
+++ b/website/docs/plugin/framework/functions/returns/map.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Map return values
 

--- a/website/docs/plugin/framework/functions/returns/number.mdx
+++ b/website/docs/plugin/framework/functions/returns/number.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Number return values
 

--- a/website/docs/plugin/framework/functions/returns/number.mdx
+++ b/website/docs/plugin/framework/functions/returns/number.mdx
@@ -5,6 +5,9 @@ description: >-
   with the Terraform plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Number return values
 
 <Tip>

--- a/website/docs/plugin/framework/functions/returns/number.mdx
+++ b/website/docs/plugin/framework/functions/returns/number.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Number return values
 

--- a/website/docs/plugin/framework/functions/returns/object.mdx
+++ b/website/docs/plugin/framework/functions/returns/object.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Object return values
 

--- a/website/docs/plugin/framework/functions/returns/object.mdx
+++ b/website/docs/plugin/framework/functions/returns/object.mdx
@@ -5,6 +5,9 @@ description: >-
   plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Object return values
 
 Object function return expects a single structure mapping explicit attribute names to type definitions from function logic. Set values in function logic with a Go structure type annotated with `tfsdk` field tags or the [framework map type](/terraform/plugin/framework/handling-data/types/map).

--- a/website/docs/plugin/framework/functions/returns/object.mdx
+++ b/website/docs/plugin/framework/functions/returns/object.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Object return values
 

--- a/website/docs/plugin/framework/functions/returns/set.mdx
+++ b/website/docs/plugin/framework/functions/returns/set.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Set return values
 

--- a/website/docs/plugin/framework/functions/returns/set.mdx
+++ b/website/docs/plugin/framework/functions/returns/set.mdx
@@ -5,6 +5,9 @@ description: >-
   plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Set return values
 
 Set function return expects an unordered, unique collection of single element type value from function logic. Set values in function logic with a Go slice of an appropriate type to match the element type `[]T` or the [framework set type](/terraform/plugin/framework/handling-data/types/set).

--- a/website/docs/plugin/framework/functions/returns/set.mdx
+++ b/website/docs/plugin/framework/functions/returns/set.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Set return values
 

--- a/website/docs/plugin/framework/functions/returns/string.mdx
+++ b/website/docs/plugin/framework/functions/returns/string.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # String return values
 

--- a/website/docs/plugin/framework/functions/returns/string.mdx
+++ b/website/docs/plugin/framework/functions/returns/string.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # String return values
 

--- a/website/docs/plugin/framework/functions/returns/string.mdx
+++ b/website/docs/plugin/framework/functions/returns/string.mdx
@@ -5,6 +5,9 @@ description: >-
   plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # String return values
 
 String function return expects a collection of UTF-8 encoded bytes from function logic. Set values in function logic with the Go built-in `string` type, Go built-in `*string` type, or the [framework string type](/terraform/plugin/framework/handling-data/types/string).

--- a/website/docs/plugin/framework/functions/testing.mdx
+++ b/website/docs/plugin/framework/functions/testing.mdx
@@ -5,6 +5,9 @@ description: >-
   plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Testing functions
 
 When a function is [implemented](/terraform/plugin/framework/functions/implementation), ensure the function behaves as expected. Follow [recommendations](#recommendations) to cover how practitioner configurations may call the function.

--- a/website/docs/plugin/framework/functions/testing.mdx
+++ b/website/docs/plugin/framework/functions/testing.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Testing functions
 

--- a/website/docs/plugin/framework/functions/testing.mdx
+++ b/website/docs/plugin/framework/functions/testing.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Testing functions
 

--- a/website/docs/plugin/framework/getting-started/code-walkthrough.mdx
+++ b/website/docs/plugin/framework/getting-started/code-walkthrough.mdx
@@ -7,7 +7,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Provider code walkthrough
 

--- a/website/docs/plugin/framework/getting-started/code-walkthrough.mdx
+++ b/website/docs/plugin/framework/getting-started/code-walkthrough.mdx
@@ -7,7 +7,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Provider code walkthrough
 

--- a/website/docs/plugin/framework/getting-started/code-walkthrough.mdx
+++ b/website/docs/plugin/framework/getting-started/code-walkthrough.mdx
@@ -6,6 +6,9 @@ description: >-
   by exploring its main components and libraries.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Provider code walkthrough
 
 [Terraform providers](/terraform/language/providers) let Terraform communicate with third parties, such as cloud providers, SaaS providers, and other APIs. Terraform and Terraform providers use gRPC to communicate. Terraform operates as a gRPC client and providers operate as gRPC servers.

--- a/website/docs/plugin/framework/handling-data/accessing-values.mdx
+++ b/website/docs/plugin/framework/handling-data/accessing-values.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Access state, configuration, and plan data
 

--- a/website/docs/plugin/framework/handling-data/accessing-values.mdx
+++ b/website/docs/plugin/framework/handling-data/accessing-values.mdx
@@ -5,6 +5,9 @@ description: >-
   the Terraform plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Access state, configuration, and plan data
 
 There are various points at which the provider needs access to the data from

--- a/website/docs/plugin/framework/handling-data/accessing-values.mdx
+++ b/website/docs/plugin/framework/handling-data/accessing-values.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Access state, configuration, and plan data
 

--- a/website/docs/plugin/framework/handling-data/attributes/bool.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/bool.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 
 # Boolean attributes

--- a/website/docs/plugin/framework/handling-data/attributes/bool.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/bool.mdx
@@ -4,6 +4,9 @@ description: >-
   Learn how to use boolean attributes with the Terraform plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 
 # Boolean attributes
 

--- a/website/docs/plugin/framework/handling-data/attributes/bool.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/bool.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 
 # Boolean attributes

--- a/website/docs/plugin/framework/handling-data/attributes/dynamic.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/dynamic.mdx
@@ -4,6 +4,9 @@ description: >-
   Learn how to use dynamic attributes with the Terraform plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Dynamic attribute
 
 <Tip>

--- a/website/docs/plugin/framework/handling-data/attributes/dynamic.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/dynamic.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Dynamic attribute
 

--- a/website/docs/plugin/framework/handling-data/attributes/dynamic.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/dynamic.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Dynamic attribute
 

--- a/website/docs/plugin/framework/handling-data/attributes/float32.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/float32.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Float32 attributes
 

--- a/website/docs/plugin/framework/handling-data/attributes/float32.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/float32.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Float32 attributes
 

--- a/website/docs/plugin/framework/handling-data/attributes/float32.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/float32.mdx
@@ -5,6 +5,9 @@ description: >-
   framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Float32 attributes
 
 <Tip>

--- a/website/docs/plugin/framework/handling-data/attributes/float64.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/float64.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Float64 attributes
 

--- a/website/docs/plugin/framework/handling-data/attributes/float64.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/float64.mdx
@@ -5,6 +5,9 @@ description: >-
   framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Float64 attributes
 
 <Tip>

--- a/website/docs/plugin/framework/handling-data/attributes/float64.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/float64.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Float64 attributes
 

--- a/website/docs/plugin/framework/handling-data/attributes/index.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/index.mdx
@@ -8,7 +8,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Attributes
 

--- a/website/docs/plugin/framework/handling-data/attributes/index.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/index.mdx
@@ -8,7 +8,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Attributes
 

--- a/website/docs/plugin/framework/handling-data/attributes/index.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/index.mdx
@@ -7,6 +7,9 @@ description: >-
   custom type.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Attributes
 
 Attributes are value storing fields in resource, data source, or provider [schemas](/terraform/plugin/framework/handling-data/schemas). Every attribute has an associated [value type](/terraform/plugin/framework/handling-data/types), which describes the kind of data the attribute can hold. Attributes also can describe value plan modifiers (resources only) and value validators in addition to those defined by the value type.

--- a/website/docs/plugin/framework/handling-data/attributes/int32.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/int32.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Int32 attributes
 

--- a/website/docs/plugin/framework/handling-data/attributes/int32.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/int32.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Int32 attributes
 

--- a/website/docs/plugin/framework/handling-data/attributes/int32.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/int32.mdx
@@ -5,6 +5,9 @@ description: >-
   framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Int32 attributes
 
 <Tip>

--- a/website/docs/plugin/framework/handling-data/attributes/int64.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/int64.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Int64 attributes
 

--- a/website/docs/plugin/framework/handling-data/attributes/int64.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/int64.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Int64 attributes
 

--- a/website/docs/plugin/framework/handling-data/attributes/int64.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/int64.mdx
@@ -5,6 +5,9 @@ description: >-
   framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Int64 attributes
 
 <Tip>

--- a/website/docs/plugin/framework/handling-data/attributes/list-nested.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/list-nested.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # List nested attributes
 

--- a/website/docs/plugin/framework/handling-data/attributes/list-nested.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/list-nested.mdx
@@ -4,6 +4,9 @@ description: >-
   Learn how to use list nested attributes with the Terraform plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # List nested attributes
 
 List nested attributes store an ordered collection of nested objects. Values are represented by a [list type](/terraform/plugin/framework/handling-data/types/list) in the framework, containing elements of [object type](/terraform/plugin/framework/handling-data/types/object).

--- a/website/docs/plugin/framework/handling-data/attributes/list-nested.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/list-nested.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # List nested attributes
 

--- a/website/docs/plugin/framework/handling-data/attributes/list.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/list.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # List attributes
 

--- a/website/docs/plugin/framework/handling-data/attributes/list.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/list.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # List attributes
 

--- a/website/docs/plugin/framework/handling-data/attributes/list.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/list.mdx
@@ -4,6 +4,9 @@ description: >-
   Learn how to use list attributes with the Terraform plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # List attributes
 
 List attributes store an ordered collection of single element type. Values are represented by a [list type](/terraform/plugin/framework/handling-data/types/list) in the framework, containing elements of the element type.

--- a/website/docs/plugin/framework/handling-data/attributes/map-nested.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/map-nested.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Map Nested Attribute
 

--- a/website/docs/plugin/framework/handling-data/attributes/map-nested.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/map-nested.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Map Nested Attribute
 

--- a/website/docs/plugin/framework/handling-data/attributes/map-nested.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/map-nested.mdx
@@ -4,6 +4,9 @@ description: >-
   Learn how to use map nested attributes with the Terraform plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Map Nested Attribute
 
 Map nested attributes store mapping of arbitrary string keys to nested objects. Values are represented by a [map type](/terraform/plugin/framework/handling-data/types/map) in the framework, containing elements of [object type](/terraform/plugin/framework/handling-data/types/object).

--- a/website/docs/plugin/framework/handling-data/attributes/map.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/map.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Map attributes
 

--- a/website/docs/plugin/framework/handling-data/attributes/map.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/map.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Map attributes
 

--- a/website/docs/plugin/framework/handling-data/attributes/map.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/map.mdx
@@ -4,6 +4,9 @@ description: >-
   Learn how to use map attributes with the Terraform plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Map attributes
 
 Map attributes store a mapping of arbitrary string keys to values of single element type. Values are represented by a [map type](/terraform/plugin/framework/handling-data/types/map) in the framework, containing elements of the element type.

--- a/website/docs/plugin/framework/handling-data/attributes/number.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/number.mdx
@@ -5,6 +5,9 @@ description: >-
   plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Number attributes
 
 <Tip>

--- a/website/docs/plugin/framework/handling-data/attributes/number.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/number.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Number attributes
 

--- a/website/docs/plugin/framework/handling-data/attributes/number.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/number.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Number attributes
 

--- a/website/docs/plugin/framework/handling-data/attributes/object.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/object.mdx
@@ -4,6 +4,9 @@ description: >-
   Learn how to use object attributes with the Terraform plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Object attributes
 
 <Tip>

--- a/website/docs/plugin/framework/handling-data/attributes/object.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/object.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Object attributes
 

--- a/website/docs/plugin/framework/handling-data/attributes/object.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/object.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Object attributes
 

--- a/website/docs/plugin/framework/handling-data/attributes/set-nested.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/set-nested.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Set nested attributes
 

--- a/website/docs/plugin/framework/handling-data/attributes/set-nested.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/set-nested.mdx
@@ -4,6 +4,9 @@ description: >-
   Learn how to use set nested attributes with the Terraform plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Set nested attributes
 
 Set nested attributes store a unique, unordered collection of nested objects. Values are represented by a [set type](/terraform/plugin/framework/handling-data/types/set) in the framework, containing elements of [object type](/terraform/plugin/framework/handling-data/types/object).

--- a/website/docs/plugin/framework/handling-data/attributes/set-nested.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/set-nested.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Set nested attributes
 

--- a/website/docs/plugin/framework/handling-data/attributes/set.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/set.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Set attributes
 

--- a/website/docs/plugin/framework/handling-data/attributes/set.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/set.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Set attributes
 

--- a/website/docs/plugin/framework/handling-data/attributes/set.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/set.mdx
@@ -4,6 +4,9 @@ description: >-
   Learn how to use set attributes with the Terraform plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Set attributes
 
 Set attributes store an unique, unordered collection of single element type. Values are represented by a [set type](/terraform/plugin/framework/handling-data/types/set) in the framework, containing elements of the element type.

--- a/website/docs/plugin/framework/handling-data/attributes/single-nested.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/single-nested.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Single nested attributes
 

--- a/website/docs/plugin/framework/handling-data/attributes/single-nested.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/single-nested.mdx
@@ -4,6 +4,9 @@ description: >-
   Learn how to use single nested attributes with the Terraform plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Single nested attributes
 
 Single nested attributes are a single structure mapping explicit attribute names to nested attribute definitions. Values are represented by a [object type](/terraform/plugin/framework/handling-data/types/object) in the framework, containing nested attribute values of the mapped attributes.

--- a/website/docs/plugin/framework/handling-data/attributes/single-nested.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/single-nested.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Single nested attributes
 

--- a/website/docs/plugin/framework/handling-data/attributes/string.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/string.mdx
@@ -4,6 +4,9 @@ description: >-
   Learn how to use string attributes with the Terraform plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # String attributes
 
 String attributes store a collection of UTF-8 encoded bytes. Values are represented by a [string type](/terraform/plugin/framework/handling-data/types/string) in the framework.

--- a/website/docs/plugin/framework/handling-data/attributes/string.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/string.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # String attributes
 

--- a/website/docs/plugin/framework/handling-data/attributes/string.mdx
+++ b/website/docs/plugin/framework/handling-data/attributes/string.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # String attributes
 

--- a/website/docs/plugin/framework/handling-data/blocks/index.mdx
+++ b/website/docs/plugin/framework/handling-data/blocks/index.mdx
@@ -7,7 +7,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Blocks
 

--- a/website/docs/plugin/framework/handling-data/blocks/index.mdx
+++ b/website/docs/plugin/framework/handling-data/blocks/index.mdx
@@ -6,6 +6,9 @@ description: >-
   provider schema.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Blocks
 
 <Tip>

--- a/website/docs/plugin/framework/handling-data/blocks/index.mdx
+++ b/website/docs/plugin/framework/handling-data/blocks/index.mdx
@@ -7,7 +7,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Blocks
 

--- a/website/docs/plugin/framework/handling-data/blocks/list-nested.mdx
+++ b/website/docs/plugin/framework/handling-data/blocks/list-nested.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # List nested blocks
 

--- a/website/docs/plugin/framework/handling-data/blocks/list-nested.mdx
+++ b/website/docs/plugin/framework/handling-data/blocks/list-nested.mdx
@@ -5,6 +5,9 @@ description: >-
   framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # List nested blocks
 
 <Tip>

--- a/website/docs/plugin/framework/handling-data/blocks/list-nested.mdx
+++ b/website/docs/plugin/framework/handling-data/blocks/list-nested.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # List nested blocks
 

--- a/website/docs/plugin/framework/handling-data/blocks/set-nested.mdx
+++ b/website/docs/plugin/framework/handling-data/blocks/set-nested.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Set nested blocks
 

--- a/website/docs/plugin/framework/handling-data/blocks/set-nested.mdx
+++ b/website/docs/plugin/framework/handling-data/blocks/set-nested.mdx
@@ -4,6 +4,9 @@ description: >-
   Learn to implement the set nested block type with the Terraform plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Set nested blocks
 
 <Tip>

--- a/website/docs/plugin/framework/handling-data/blocks/set-nested.mdx
+++ b/website/docs/plugin/framework/handling-data/blocks/set-nested.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Set nested blocks
 

--- a/website/docs/plugin/framework/handling-data/blocks/single-nested.mdx
+++ b/website/docs/plugin/framework/handling-data/blocks/single-nested.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Single nested blocks
 

--- a/website/docs/plugin/framework/handling-data/blocks/single-nested.mdx
+++ b/website/docs/plugin/framework/handling-data/blocks/single-nested.mdx
@@ -5,6 +5,9 @@ description: >-
   framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Single nested blocks
 
 <Tip>

--- a/website/docs/plugin/framework/handling-data/blocks/single-nested.mdx
+++ b/website/docs/plugin/framework/handling-data/blocks/single-nested.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Single nested blocks
 

--- a/website/docs/plugin/framework/handling-data/dynamic-data.mdx
+++ b/website/docs/plugin/framework/handling-data/dynamic-data.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Handling dynamic data
 

--- a/website/docs/plugin/framework/handling-data/dynamic-data.mdx
+++ b/website/docs/plugin/framework/handling-data/dynamic-data.mdx
@@ -5,6 +5,9 @@ description: >-
   framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Handling dynamic data
 
 <Note>

--- a/website/docs/plugin/framework/handling-data/dynamic-data.mdx
+++ b/website/docs/plugin/framework/handling-data/dynamic-data.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Handling dynamic data
 

--- a/website/docs/plugin/framework/handling-data/path-expressions.mdx
+++ b/website/docs/plugin/framework/handling-data/path-expressions.mdx
@@ -6,6 +6,9 @@ description: >-
   more actual paths within schema data.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 
 # Path expressions
 

--- a/website/docs/plugin/framework/handling-data/path-expressions.mdx
+++ b/website/docs/plugin/framework/handling-data/path-expressions.mdx
@@ -7,7 +7,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 
 # Path expressions

--- a/website/docs/plugin/framework/handling-data/path-expressions.mdx
+++ b/website/docs/plugin/framework/handling-data/path-expressions.mdx
@@ -7,7 +7,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 
 # Path expressions

--- a/website/docs/plugin/framework/handling-data/paths.mdx
+++ b/website/docs/plugin/framework/handling-data/paths.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Paths
 

--- a/website/docs/plugin/framework/handling-data/paths.mdx
+++ b/website/docs/plugin/framework/handling-data/paths.mdx
@@ -5,6 +5,9 @@ description: >-
   represent a location within a schema or schema-based data.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Paths
 
 An exact location within a [schema](/terraform/plugin/framework/handling-data/schemas) or schema-based data such as [`tfsdk.Config`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/tfsdk#Config), [`tfsdk.Plan`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/tfsdk#Plan), or [`tfsdk.State`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/tfsdk#State), is referred to as a path.

--- a/website/docs/plugin/framework/handling-data/paths.mdx
+++ b/website/docs/plugin/framework/handling-data/paths.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Paths
 

--- a/website/docs/plugin/framework/handling-data/schemas.mdx
+++ b/website/docs/plugin/framework/handling-data/schemas.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Schemas
 

--- a/website/docs/plugin/framework/handling-data/schemas.mdx
+++ b/website/docs/plugin/framework/handling-data/schemas.mdx
@@ -5,6 +5,9 @@ description: >-
   specify the constraints of Terraform configuration blocks.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Schemas
 
 Schemas specify the constraints of Terraform configuration blocks. They define what fields a provider,

--- a/website/docs/plugin/framework/handling-data/schemas.mdx
+++ b/website/docs/plugin/framework/handling-data/schemas.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Schemas
 

--- a/website/docs/plugin/framework/handling-data/terraform-concepts.mdx
+++ b/website/docs/plugin/framework/handling-data/terraform-concepts.mdx
@@ -5,6 +5,9 @@ description: >-
   configuration to schemas, attributes, and blocks.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Terraform data concepts
 
 This page describes Terraform concepts as they relate to handling data within framework-based provider code. The [What is Terraform](/terraform/intro), [Terraform language](/terraform/language), and [Plugin Development](/terraform/plugin) documentation covers more general concepts behind Terraform's workflow, its configuration, and how it interacts with providers.

--- a/website/docs/plugin/framework/handling-data/terraform-concepts.mdx
+++ b/website/docs/plugin/framework/handling-data/terraform-concepts.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Terraform data concepts
 

--- a/website/docs/plugin/framework/handling-data/terraform-concepts.mdx
+++ b/website/docs/plugin/framework/handling-data/terraform-concepts.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Terraform data concepts
 

--- a/website/docs/plugin/framework/handling-data/types/bool.mdx
+++ b/website/docs/plugin/framework/handling-data/types/bool.mdx
@@ -4,6 +4,9 @@ description: >-
   Learn how to implement boolean value types with the Terraform plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Bool types
 
 Bool types store a boolean true or false value.

--- a/website/docs/plugin/framework/handling-data/types/bool.mdx
+++ b/website/docs/plugin/framework/handling-data/types/bool.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Bool types
 

--- a/website/docs/plugin/framework/handling-data/types/bool.mdx
+++ b/website/docs/plugin/framework/handling-data/types/bool.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Bool types
 

--- a/website/docs/plugin/framework/handling-data/types/custom.mdx
+++ b/website/docs/plugin/framework/handling-data/types/custom.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Custom types
 

--- a/website/docs/plugin/framework/handling-data/types/custom.mdx
+++ b/website/docs/plugin/framework/handling-data/types/custom.mdx
@@ -4,6 +4,9 @@ description: >-
   Learn how to implement custom types with the Terraform plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Custom types
 
 Use existing custom types or develop custom types to consistently define behaviors for a kind of value across schemas. Custom types are supported on top of any framework-defined type.

--- a/website/docs/plugin/framework/handling-data/types/custom.mdx
+++ b/website/docs/plugin/framework/handling-data/types/custom.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Custom types
 

--- a/website/docs/plugin/framework/handling-data/types/dynamic.mdx
+++ b/website/docs/plugin/framework/handling-data/types/dynamic.mdx
@@ -4,6 +4,9 @@ description: >-
   Learn how to implement dynamic types with the Terraform plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Dynamic types
 
 <Tip>

--- a/website/docs/plugin/framework/handling-data/types/dynamic.mdx
+++ b/website/docs/plugin/framework/handling-data/types/dynamic.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Dynamic types
 

--- a/website/docs/plugin/framework/handling-data/types/dynamic.mdx
+++ b/website/docs/plugin/framework/handling-data/types/dynamic.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Dynamic types
 

--- a/website/docs/plugin/framework/handling-data/types/float32.mdx
+++ b/website/docs/plugin/framework/handling-data/types/float32.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Float32 types
 

--- a/website/docs/plugin/framework/handling-data/types/float32.mdx
+++ b/website/docs/plugin/framework/handling-data/types/float32.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Float32 types
 

--- a/website/docs/plugin/framework/handling-data/types/float32.mdx
+++ b/website/docs/plugin/framework/handling-data/types/float32.mdx
@@ -5,6 +5,9 @@ description: >-
   plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Float32 types
 
 <Tip>

--- a/website/docs/plugin/framework/handling-data/types/float64.mdx
+++ b/website/docs/plugin/framework/handling-data/types/float64.mdx
@@ -5,6 +5,9 @@ description: >-
   framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Float64 types
 
 <Tip>

--- a/website/docs/plugin/framework/handling-data/types/float64.mdx
+++ b/website/docs/plugin/framework/handling-data/types/float64.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Float64 types
 

--- a/website/docs/plugin/framework/handling-data/types/float64.mdx
+++ b/website/docs/plugin/framework/handling-data/types/float64.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Float64 types
 

--- a/website/docs/plugin/framework/handling-data/types/index.mdx
+++ b/website/docs/plugin/framework/handling-data/types/index.mdx
@@ -7,7 +7,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Data types
 

--- a/website/docs/plugin/framework/handling-data/types/index.mdx
+++ b/website/docs/plugin/framework/handling-data/types/index.mdx
@@ -7,7 +7,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Data types
 

--- a/website/docs/plugin/framework/handling-data/types/index.mdx
+++ b/website/docs/plugin/framework/handling-data/types/index.mdx
@@ -6,6 +6,9 @@ description: >-
   types based off of the built-in attribute types.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Data types
 
 Types are value storage and access mechanism for resource, data source, or provider [schema](/terraform/plugin/framework/handling-data/schemas) data. Every attribute and block has an associated type, which describes the kind of data. These types fully support Terraform's [type system concepts](/terraform/plugin/framework/handling-data/terraform-concepts) that cannot be represented in Go built-in types, such as `*string`. Framework types can be extended by implementing [custom types](/terraform/plugin/framework/handling-data/types/custom) in provider code or shared libraries to provide specific use case functionality.

--- a/website/docs/plugin/framework/handling-data/types/int32.mdx
+++ b/website/docs/plugin/framework/handling-data/types/int32.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Int32 types
 

--- a/website/docs/plugin/framework/handling-data/types/int32.mdx
+++ b/website/docs/plugin/framework/handling-data/types/int32.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Int32 types
 

--- a/website/docs/plugin/framework/handling-data/types/int32.mdx
+++ b/website/docs/plugin/framework/handling-data/types/int32.mdx
@@ -5,6 +5,9 @@ description: >-
   framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Int32 types
 
 <Tip>

--- a/website/docs/plugin/framework/handling-data/types/int64.mdx
+++ b/website/docs/plugin/framework/handling-data/types/int64.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Int64 types
 

--- a/website/docs/plugin/framework/handling-data/types/int64.mdx
+++ b/website/docs/plugin/framework/handling-data/types/int64.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Int64 types
 

--- a/website/docs/plugin/framework/handling-data/types/int64.mdx
+++ b/website/docs/plugin/framework/handling-data/types/int64.mdx
@@ -5,6 +5,9 @@ description: >-
   framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Int64 types
 
 <Tip>

--- a/website/docs/plugin/framework/handling-data/types/list.mdx
+++ b/website/docs/plugin/framework/handling-data/types/list.mdx
@@ -5,6 +5,9 @@ description: >-
   framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # List types
 
 List types store an ordered collection of single element type.

--- a/website/docs/plugin/framework/handling-data/types/list.mdx
+++ b/website/docs/plugin/framework/handling-data/types/list.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # List types
 

--- a/website/docs/plugin/framework/handling-data/types/list.mdx
+++ b/website/docs/plugin/framework/handling-data/types/list.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # List types
 

--- a/website/docs/plugin/framework/handling-data/types/map.mdx
+++ b/website/docs/plugin/framework/handling-data/types/map.mdx
@@ -5,6 +5,9 @@ description: >-
   framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Map type
 
 Map types store an ordered collection of single element type.

--- a/website/docs/plugin/framework/handling-data/types/map.mdx
+++ b/website/docs/plugin/framework/handling-data/types/map.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Map type
 

--- a/website/docs/plugin/framework/handling-data/types/map.mdx
+++ b/website/docs/plugin/framework/handling-data/types/map.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Map type
 

--- a/website/docs/plugin/framework/handling-data/types/number.mdx
+++ b/website/docs/plugin/framework/handling-data/types/number.mdx
@@ -5,6 +5,9 @@ description: >-
   framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Number types
 
 <Tip>

--- a/website/docs/plugin/framework/handling-data/types/number.mdx
+++ b/website/docs/plugin/framework/handling-data/types/number.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Number types
 

--- a/website/docs/plugin/framework/handling-data/types/number.mdx
+++ b/website/docs/plugin/framework/handling-data/types/number.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Number types
 

--- a/website/docs/plugin/framework/handling-data/types/object.mdx
+++ b/website/docs/plugin/framework/handling-data/types/object.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Object types
 

--- a/website/docs/plugin/framework/handling-data/types/object.mdx
+++ b/website/docs/plugin/framework/handling-data/types/object.mdx
@@ -4,6 +4,9 @@ description: >-
   Learn how to implement object value types with the Terraform plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Object types
 
 Object types store a mapping of explicit attribute names to value types. Objects must declare all attribute values, even when null or unknown, unless the entire object is null or unknown.

--- a/website/docs/plugin/framework/handling-data/types/object.mdx
+++ b/website/docs/plugin/framework/handling-data/types/object.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Object types
 

--- a/website/docs/plugin/framework/handling-data/types/set.mdx
+++ b/website/docs/plugin/framework/handling-data/types/set.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Set types
 

--- a/website/docs/plugin/framework/handling-data/types/set.mdx
+++ b/website/docs/plugin/framework/handling-data/types/set.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Set types
 

--- a/website/docs/plugin/framework/handling-data/types/set.mdx
+++ b/website/docs/plugin/framework/handling-data/types/set.mdx
@@ -4,6 +4,9 @@ description: >-
   Learn how to implement set value types with the Terraform plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Set types
 
 Set types store an ordered collection of single element type.

--- a/website/docs/plugin/framework/handling-data/types/string.mdx
+++ b/website/docs/plugin/framework/handling-data/types/string.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # String types
 

--- a/website/docs/plugin/framework/handling-data/types/string.mdx
+++ b/website/docs/plugin/framework/handling-data/types/string.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # String types
 

--- a/website/docs/plugin/framework/handling-data/types/string.mdx
+++ b/website/docs/plugin/framework/handling-data/types/string.mdx
@@ -4,6 +4,9 @@ description: >-
   Learn how to implement string value types with the Terraform plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # String types
 
 String types store a collection of UTF-8 encoded bytes.

--- a/website/docs/plugin/framework/handling-data/types/tuple.mdx
+++ b/website/docs/plugin/framework/handling-data/types/tuple.mdx
@@ -4,6 +4,9 @@ description: >-
   Learn how to implement tuple value types with the Terraform plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Tuple types
 
 <Note>

--- a/website/docs/plugin/framework/handling-data/types/tuple.mdx
+++ b/website/docs/plugin/framework/handling-data/types/tuple.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Tuple types
 

--- a/website/docs/plugin/framework/handling-data/types/tuple.mdx
+++ b/website/docs/plugin/framework/handling-data/types/tuple.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Tuple types
 

--- a/website/docs/plugin/framework/handling-data/writing-state.mdx
+++ b/website/docs/plugin/framework/handling-data/writing-state.mdx
@@ -5,6 +5,9 @@ description: >-
   plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Writing state
 
 One of the primary jobs of a Terraform provider is to manage the provider's

--- a/website/docs/plugin/framework/handling-data/writing-state.mdx
+++ b/website/docs/plugin/framework/handling-data/writing-state.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Writing state
 

--- a/website/docs/plugin/framework/handling-data/writing-state.mdx
+++ b/website/docs/plugin/framework/handling-data/writing-state.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Writing state
 

--- a/website/docs/plugin/framework/index.mdx
+++ b/website/docs/plugin/framework/index.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Terraform plugin framework
 

--- a/website/docs/plugin/framework/index.mdx
+++ b/website/docs/plugin/framework/index.mdx
@@ -5,6 +5,9 @@ description: >-
   providers. Learn how the plugin framework works with Terraform core.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Terraform plugin framework
 
 The plugin framework is HashiCorp’s recommended way develop Terraform Plugins on [protocol version 6](/terraform/plugin/terraform-plugin-protocol#protocol-version-6) or [protocol version 5](/terraform/plugin/terraform-plugin-protocol#protocol-version-5). 

--- a/website/docs/plugin/framework/index.mdx
+++ b/website/docs/plugin/framework/index.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Terraform plugin framework
 

--- a/website/docs/plugin/framework/internals/index.mdx
+++ b/website/docs/plugin/framework/internals/index.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Framework internals
 

--- a/website/docs/plugin/framework/internals/index.mdx
+++ b/website/docs/plugin/framework/internals/index.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Framework internals
 

--- a/website/docs/plugin/framework/internals/index.mdx
+++ b/website/docs/plugin/framework/internals/index.mdx
@@ -5,6 +5,9 @@ description: >-
   Learn about the internal implementation details of the framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Framework internals
 
 The following information describes some internals of the Terraform Plugin Framework in order to provide a more in-depth view of specific aspects of Framework behaviour.

--- a/website/docs/plugin/framework/internals/rpcs.mdx
+++ b/website/docs/plugin/framework/internals/rpcs.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # RPCs and framework functionality
 

--- a/website/docs/plugin/framework/internals/rpcs.mdx
+++ b/website/docs/plugin/framework/internals/rpcs.mdx
@@ -4,6 +4,9 @@ description: >-
   Learn how Terraform uses RPCs to support provider functionality.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # RPCs and framework functionality
 
 The correlation between the Terraform command, the RPCs that are issued and the Terraform plugin framework methods that are called is as follows:

--- a/website/docs/plugin/framework/internals/rpcs.mdx
+++ b/website/docs/plugin/framework/internals/rpcs.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # RPCs and framework functionality
 

--- a/website/docs/plugin/framework/migrating/attributes-blocks/attribute-schema.mdx
+++ b/website/docs/plugin/framework/migrating/attributes-blocks/attribute-schema.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Migrating attribute schema
 

--- a/website/docs/plugin/framework/migrating/attributes-blocks/attribute-schema.mdx
+++ b/website/docs/plugin/framework/migrating/attributes-blocks/attribute-schema.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Migrating attribute schema
 

--- a/website/docs/plugin/framework/migrating/attributes-blocks/attribute-schema.mdx
+++ b/website/docs/plugin/framework/migrating/attributes-blocks/attribute-schema.mdx
@@ -5,6 +5,9 @@ description: >-
   the terraform-plugin-mux Go library.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Migrating attribute schema
 
 Attributes define how users can configure values for your Terraform provider, resources, and data sources. Refer to

--- a/website/docs/plugin/framework/migrating/attributes-blocks/blocks-computed.mdx
+++ b/website/docs/plugin/framework/migrating/attributes-blocks/blocks-computed.mdx
@@ -5,6 +5,9 @@ description: >-
   validators in the plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Migrating blocks with computed fields
 
 Some providers, resources, and data sources include repeatable nested blocks in their attributes. Some blocks contain

--- a/website/docs/plugin/framework/migrating/attributes-blocks/blocks-computed.mdx
+++ b/website/docs/plugin/framework/migrating/attributes-blocks/blocks-computed.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Migrating blocks with computed fields
 

--- a/website/docs/plugin/framework/migrating/attributes-blocks/blocks-computed.mdx
+++ b/website/docs/plugin/framework/migrating/attributes-blocks/blocks-computed.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Migrating blocks with computed fields
 

--- a/website/docs/plugin/framework/migrating/attributes-blocks/blocks.mdx
+++ b/website/docs/plugin/framework/migrating/attributes-blocks/blocks.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Migrating blocks
 

--- a/website/docs/plugin/framework/migrating/attributes-blocks/blocks.mdx
+++ b/website/docs/plugin/framework/migrating/attributes-blocks/blocks.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Migrating blocks
 

--- a/website/docs/plugin/framework/migrating/attributes-blocks/blocks.mdx
+++ b/website/docs/plugin/framework/migrating/attributes-blocks/blocks.mdx
@@ -5,6 +5,9 @@ description: >-
   framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Migrating blocks
 
 Some providers, resources, and data sources include repeatable nested blocks in their attributes. These nested blocks

--- a/website/docs/plugin/framework/migrating/attributes-blocks/default-values.mdx
+++ b/website/docs/plugin/framework/migrating/attributes-blocks/default-values.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Migrating attribute default values
 

--- a/website/docs/plugin/framework/migrating/attributes-blocks/default-values.mdx
+++ b/website/docs/plugin/framework/migrating/attributes-blocks/default-values.mdx
@@ -5,6 +5,9 @@ description: >-
   attribute plan modifier in the plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Migrating attribute default values
 
 Default values support is only available in the Framework for resources. Handle default values for data source attributes within the [data source `Read` method](/terraform/plugin/framework/data-sources#read-method) and default values for provider attributes within the [provider `Configure` method](/terraform/plugin/framework/providers#configure-method).

--- a/website/docs/plugin/framework/migrating/attributes-blocks/default-values.mdx
+++ b/website/docs/plugin/framework/migrating/attributes-blocks/default-values.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Migrating attribute default values
 

--- a/website/docs/plugin/framework/migrating/attributes-blocks/fields.mdx
+++ b/website/docs/plugin/framework/migrating/attributes-blocks/fields.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Migrating attribute fields
 

--- a/website/docs/plugin/framework/migrating/attributes-blocks/fields.mdx
+++ b/website/docs/plugin/framework/migrating/attributes-blocks/fields.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Migrating attribute fields
 

--- a/website/docs/plugin/framework/migrating/attributes-blocks/fields.mdx
+++ b/website/docs/plugin/framework/migrating/attributes-blocks/fields.mdx
@@ -5,6 +5,9 @@ description: >-
   fields from SDKv2 to the plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Migrating attribute fields
 
 A subset of attribute fields, such as required, optional, computed, or sensitive, define attribute behavior as boolean flags. Refer to

--- a/website/docs/plugin/framework/migrating/attributes-blocks/force-new.mdx
+++ b/website/docs/plugin/framework/migrating/attributes-blocks/force-new.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Migrating attribute ForceNew triggers
 

--- a/website/docs/plugin/framework/migrating/attributes-blocks/force-new.mdx
+++ b/website/docs/plugin/framework/migrating/attributes-blocks/force-new.mdx
@@ -5,6 +5,9 @@ description: >-
   modifiers in the framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Migrating attribute ForceNew triggers
 
 In Terraform, sometimes a resource must be replaced when the value of an attribute changes. In SDKv2, this is

--- a/website/docs/plugin/framework/migrating/attributes-blocks/force-new.mdx
+++ b/website/docs/plugin/framework/migrating/attributes-blocks/force-new.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Migrating attribute ForceNew triggers
 

--- a/website/docs/plugin/framework/migrating/attributes-blocks/types.mdx
+++ b/website/docs/plugin/framework/migrating/attributes-blocks/types.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Migrating attribute types
 

--- a/website/docs/plugin/framework/migrating/attributes-blocks/types.mdx
+++ b/website/docs/plugin/framework/migrating/attributes-blocks/types.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Migrating attribute types
 

--- a/website/docs/plugin/framework/migrating/attributes-blocks/types.mdx
+++ b/website/docs/plugin/framework/migrating/attributes-blocks/types.mdx
@@ -4,6 +4,9 @@ description: >-
   Learn how to migrate attribute type from SDKv2 to the plugin Framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Migrating attribute types
 
 An attribute either contains a primitive type, such as an integer or a string, or contains other attributes. Attributes

--- a/website/docs/plugin/framework/migrating/attributes-blocks/validators-custom.mdx
+++ b/website/docs/plugin/framework/migrating/attributes-blocks/validators-custom.mdx
@@ -6,6 +6,9 @@ description: >-
   check attribute values for required syntax, types, and acceptable values.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Migrating attribute custom validators
 
 You can write custom validations that give users feedback about required syntax, types, and acceptable values in your

--- a/website/docs/plugin/framework/migrating/attributes-blocks/validators-custom.mdx
+++ b/website/docs/plugin/framework/migrating/attributes-blocks/validators-custom.mdx
@@ -7,7 +7,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Migrating attribute custom validators
 

--- a/website/docs/plugin/framework/migrating/attributes-blocks/validators-custom.mdx
+++ b/website/docs/plugin/framework/migrating/attributes-blocks/validators-custom.mdx
@@ -7,7 +7,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Migrating attribute custom validators
 

--- a/website/docs/plugin/framework/migrating/attributes-blocks/validators-predefined.mdx
+++ b/website/docs/plugin/framework/migrating/attributes-blocks/validators-predefined.mdx
@@ -8,7 +8,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Migrating predefined attribute validators
 

--- a/website/docs/plugin/framework/migrating/attributes-blocks/validators-predefined.mdx
+++ b/website/docs/plugin/framework/migrating/attributes-blocks/validators-predefined.mdx
@@ -7,6 +7,9 @@ description: >-
   and acceptable values.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Migrating predefined attribute validators
 
 Attribute validators ensure that attributes do or do not contain specific values. You can use predefined validators for

--- a/website/docs/plugin/framework/migrating/attributes-blocks/validators-predefined.mdx
+++ b/website/docs/plugin/framework/migrating/attributes-blocks/validators-predefined.mdx
@@ -8,7 +8,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Migrating predefined attribute validators
 

--- a/website/docs/plugin/framework/migrating/benefits.mdx
+++ b/website/docs/plugin/framework/migrating/benefits.mdx
@@ -7,7 +7,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Benefits of migrating to the plugin framework
 

--- a/website/docs/plugin/framework/migrating/benefits.mdx
+++ b/website/docs/plugin/framework/migrating/benefits.mdx
@@ -7,7 +7,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Benefits of migrating to the plugin framework
 

--- a/website/docs/plugin/framework/migrating/benefits.mdx
+++ b/website/docs/plugin/framework/migrating/benefits.mdx
@@ -6,6 +6,9 @@ description: >-
   over the previous SDKv2.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Benefits of migrating to the plugin framework
 
 We recommend using the plugin framework to develop your provider because it offers significant benefits in comparison to SDKv2. We designed the framework with feedback from thousands of existing providers, so the framework significantly improves upon the functionality available in SDKv2.

--- a/website/docs/plugin/framework/migrating/data-sources/index.mdx
+++ b/website/docs/plugin/framework/migrating/data-sources/index.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Migrating data sources
 

--- a/website/docs/plugin/framework/migrating/data-sources/index.mdx
+++ b/website/docs/plugin/framework/migrating/data-sources/index.mdx
@@ -4,6 +4,9 @@ description: >-
   Learn how to migrate a data source from SDKv2 to the plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Migrating data sources
 
 Data sources let Terraform reference external data. Unlike resources, Terraform does not create, update, or delete

--- a/website/docs/plugin/framework/migrating/data-sources/index.mdx
+++ b/website/docs/plugin/framework/migrating/data-sources/index.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Migrating data sources
 

--- a/website/docs/plugin/framework/migrating/data-sources/timeouts.mdx
+++ b/website/docs/plugin/framework/migrating/data-sources/timeouts.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Migrating timeouts
 

--- a/website/docs/plugin/framework/migrating/data-sources/timeouts.mdx
+++ b/website/docs/plugin/framework/migrating/data-sources/timeouts.mdx
@@ -4,6 +4,9 @@ description: >-
   Learn how to migrate timeouts from SDKv2 to the framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Migrating timeouts
 
 The Framework can be used in conjunction with the [terraform-plugin-framework-timeouts](https://github.com/hashicorp/terraform-plugin-framework-timeouts) module in order to allow defining timeouts in configuration and have them be available in `Read` functions.

--- a/website/docs/plugin/framework/migrating/data-sources/timeouts.mdx
+++ b/website/docs/plugin/framework/migrating/data-sources/timeouts.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Migrating timeouts
 

--- a/website/docs/plugin/framework/migrating/index.mdx
+++ b/website/docs/plugin/framework/migrating/index.mdx
@@ -4,6 +4,9 @@ description: >-
   Learn how to migrate your provider from SDKv2 to the plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Overview
 
 This guide helps you migrate a Terraform provider from SDKv2 to the plugin Framework. We recommend migrating because the Framework has abstractions that make it easier to use, and it represents the future of Terraform plugin development. Refer to [Plugin Framework Benefits](/terraform/plugin/framework-benefits) for higher level details about how the framework makes provider development easier and [Feature Comparison](/terraform/plugin/framework/migrating/benefits) for a detailed functionality comparison between the SDKv2 and the framework.

--- a/website/docs/plugin/framework/migrating/index.mdx
+++ b/website/docs/plugin/framework/migrating/index.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Overview
 

--- a/website/docs/plugin/framework/migrating/index.mdx
+++ b/website/docs/plugin/framework/migrating/index.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Overview
 

--- a/website/docs/plugin/framework/migrating/mux.mdx
+++ b/website/docs/plugin/framework/migrating/mux.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Muxing
 

--- a/website/docs/plugin/framework/migrating/mux.mdx
+++ b/website/docs/plugin/framework/migrating/mux.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Muxing
 

--- a/website/docs/plugin/framework/migrating/mux.mdx
+++ b/website/docs/plugin/framework/migrating/mux.mdx
@@ -5,6 +5,9 @@ description: >-
   the terraform-plugin-mux Go library.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Muxing
 
 Muxing enables multiple underlying provider implementations to exist within the same logical provider server via the [terraform-plugin-mux Go module](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-mux). Each underlying provider implementation serves different managed resources and data sources. Refer to the [Combining and Translating documentation](/terraform/plugin/mux) for full details about muxing configuration.

--- a/website/docs/plugin/framework/migrating/providers/index.mdx
+++ b/website/docs/plugin/framework/migrating/providers/index.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Migrating providers
 

--- a/website/docs/plugin/framework/migrating/providers/index.mdx
+++ b/website/docs/plugin/framework/migrating/providers/index.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Migrating providers
 

--- a/website/docs/plugin/framework/migrating/providers/index.mdx
+++ b/website/docs/plugin/framework/migrating/providers/index.mdx
@@ -5,6 +5,9 @@ description: >-
   framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Migrating providers
 
 Providers are Terraform plugins that define resources and data sources for practitioners to use. You serve your

--- a/website/docs/plugin/framework/migrating/resources/crud.mdx
+++ b/website/docs/plugin/framework/migrating/resources/crud.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # CRUD functions
 

--- a/website/docs/plugin/framework/migrating/resources/crud.mdx
+++ b/website/docs/plugin/framework/migrating/resources/crud.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # CRUD functions
 

--- a/website/docs/plugin/framework/migrating/resources/crud.mdx
+++ b/website/docs/plugin/framework/migrating/resources/crud.mdx
@@ -5,6 +5,9 @@ description: >-
   functions from SDKv2 to the plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # CRUD functions
 
 In Terraform, a resource represents a single instance of a given resource type. They modify a specific resource in the

--- a/website/docs/plugin/framework/migrating/resources/import.mdx
+++ b/website/docs/plugin/framework/migrating/resources/import.mdx
@@ -6,6 +6,9 @@ description: >-
   their Terraform projects.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Resource import
 
 Practitioners can use the [`terraform import` command](/terraform/cli/commands/import) to let Terraform

--- a/website/docs/plugin/framework/migrating/resources/import.mdx
+++ b/website/docs/plugin/framework/migrating/resources/import.mdx
@@ -7,7 +7,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Resource import
 

--- a/website/docs/plugin/framework/migrating/resources/import.mdx
+++ b/website/docs/plugin/framework/migrating/resources/import.mdx
@@ -7,7 +7,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Resource import
 

--- a/website/docs/plugin/framework/migrating/resources/index.mdx
+++ b/website/docs/plugin/framework/migrating/resources/index.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Migrating resources
 

--- a/website/docs/plugin/framework/migrating/resources/index.mdx
+++ b/website/docs/plugin/framework/migrating/resources/index.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Migrating resources
 

--- a/website/docs/plugin/framework/migrating/resources/index.mdx
+++ b/website/docs/plugin/framework/migrating/resources/index.mdx
@@ -4,6 +4,9 @@ description: >-
   Learn how to migrate resources from SDKv2 to the plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Migrating resources
 
 Resources are an abstraction that allow Terraform to manage infrastructure objects by defining create, read, update,

--- a/website/docs/plugin/framework/migrating/resources/plan-modification.mdx
+++ b/website/docs/plugin/framework/migrating/resources/plan-modification.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Plan modification
 

--- a/website/docs/plugin/framework/migrating/resources/plan-modification.mdx
+++ b/website/docs/plugin/framework/migrating/resources/plan-modification.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Plan modification
 

--- a/website/docs/plugin/framework/migrating/resources/plan-modification.mdx
+++ b/website/docs/plugin/framework/migrating/resources/plan-modification.mdx
@@ -5,6 +5,9 @@ description: >-
   plan modifiers in the Terraform plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Plan modification
 
 Your provider can modify the Terraform plan to match the expected end state. This can include replacing unknown values

--- a/website/docs/plugin/framework/migrating/resources/state-upgrade.mdx
+++ b/website/docs/plugin/framework/migrating/resources/state-upgrade.mdx
@@ -7,7 +7,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # State upgraders
 

--- a/website/docs/plugin/framework/migrating/resources/state-upgrade.mdx
+++ b/website/docs/plugin/framework/migrating/resources/state-upgrade.mdx
@@ -6,6 +6,9 @@ description: >-
   old schema configurations.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # State upgraders
 
 When you update a resource's implementation in your provider, some changes may not be compatible with old versions. You

--- a/website/docs/plugin/framework/migrating/resources/state-upgrade.mdx
+++ b/website/docs/plugin/framework/migrating/resources/state-upgrade.mdx
@@ -7,7 +7,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # State upgraders
 

--- a/website/docs/plugin/framework/migrating/resources/timeouts.mdx
+++ b/website/docs/plugin/framework/migrating/resources/timeouts.mdx
@@ -4,6 +4,9 @@ description: >-
   Learn how to migrate timeouts from SDKv2 to the framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Timeouts
 
 The Framework can be used in conjunction with the [terraform-plugin-framework-timeouts](https://github.com/hashicorp/terraform-plugin-framework-timeouts) module in order to allow defining timeouts in configuration and have them be available in CRUD functions.

--- a/website/docs/plugin/framework/migrating/resources/timeouts.mdx
+++ b/website/docs/plugin/framework/migrating/resources/timeouts.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Timeouts
 

--- a/website/docs/plugin/framework/migrating/resources/timeouts.mdx
+++ b/website/docs/plugin/framework/migrating/resources/timeouts.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Timeouts
 

--- a/website/docs/plugin/framework/migrating/schema/index.mdx
+++ b/website/docs/plugin/framework/migrating/schema/index.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Migrating schema
 

--- a/website/docs/plugin/framework/migrating/schema/index.mdx
+++ b/website/docs/plugin/framework/migrating/schema/index.mdx
@@ -4,6 +4,9 @@ description: >-
    Learn how to migrate schema from SDKv2 to the plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Migrating schema
 
 Providers, resources, and data sources all use schema to define their attributes and behavior. Schemas specify the

--- a/website/docs/plugin/framework/migrating/schema/index.mdx
+++ b/website/docs/plugin/framework/migrating/schema/index.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Migrating schema
 

--- a/website/docs/plugin/framework/migrating/testing.mdx
+++ b/website/docs/plugin/framework/migrating/testing.mdx
@@ -5,6 +5,9 @@ description: >-
   Framework does not affect provider behavior.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Testing
 
 During migration, you should [write tests](#testing-migration) to verify that the behaviour of your provider has not

--- a/website/docs/plugin/framework/migrating/testing.mdx
+++ b/website/docs/plugin/framework/migrating/testing.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Testing
 

--- a/website/docs/plugin/framework/migrating/testing.mdx
+++ b/website/docs/plugin/framework/migrating/testing.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Testing
 

--- a/website/docs/plugin/framework/provider-servers.mdx
+++ b/website/docs/plugin/framework/provider-servers.mdx
@@ -7,7 +7,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Provider servers
 

--- a/website/docs/plugin/framework/provider-servers.mdx
+++ b/website/docs/plugin/framework/provider-servers.mdx
@@ -7,7 +7,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Provider servers
 

--- a/website/docs/plugin/framework/provider-servers.mdx
+++ b/website/docs/plugin/framework/provider-servers.mdx
@@ -6,6 +6,9 @@ description: >-
   APIs.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Provider servers
 
 Before a [provider](/terraform/plugin/framework/providers) can be used with Terraform, it must implement a [gRPC server](https://grpc.io) that supports Terraform-specific connection and handshake handling on startup. The server must then implement the [Terraform Plugin Protocol](/terraform/plugin/how-terraform-works#terraform-plugin-protocol).

--- a/website/docs/plugin/framework/providers/index.mdx
+++ b/website/docs/plugin/framework/providers/index.mdx
@@ -6,6 +6,9 @@ description: >-
   interact with APIs.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Providers
 
 Providers are Terraform plugins that define [resources](/terraform/plugin/framework/resources) and [data sources](/terraform/plugin/framework/data-sources) for practitioners to use. Providers are wrapped by a [provider server](/terraform/plugin/framework/provider-servers) for interacting with Terraform.

--- a/website/docs/plugin/framework/providers/index.mdx
+++ b/website/docs/plugin/framework/providers/index.mdx
@@ -7,7 +7,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Providers
 

--- a/website/docs/plugin/framework/providers/index.mdx
+++ b/website/docs/plugin/framework/providers/index.mdx
@@ -7,7 +7,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Providers
 

--- a/website/docs/plugin/framework/providers/validate-configuration.mdx
+++ b/website/docs/plugin/framework/providers/validate-configuration.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Validate provider configuration
 

--- a/website/docs/plugin/framework/providers/validate-configuration.mdx
+++ b/website/docs/plugin/framework/providers/validate-configuration.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Validate provider configuration
 

--- a/website/docs/plugin/framework/providers/validate-configuration.mdx
+++ b/website/docs/plugin/framework/providers/validate-configuration.mdx
@@ -5,6 +5,9 @@ description: >-
   framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Validate provider configuration
 
 [Providers](/terraform/plugin/framework/providers) support validating an entire practitioner configuration in either declarative or imperative logic. Feedback, such as required syntax or acceptable combinations of values, is returned via [diagnostics](/terraform/plugin/framework/diagnostics).

--- a/website/docs/plugin/framework/resources/configure.mdx
+++ b/website/docs/plugin/framework/resources/configure.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Configure resources
 

--- a/website/docs/plugin/framework/resources/configure.mdx
+++ b/website/docs/plugin/framework/resources/configure.mdx
@@ -5,6 +5,9 @@ description: >-
   the Terraform plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Configure resources
 
 [Resources](/terraform/plugin/framework/resources) may require provider-level data or remote system clients to operate correctly. The framework supports the ability to configure this data and/or clients once within the provider, then pass that information to resources by adding the `Configure` method.

--- a/website/docs/plugin/framework/resources/configure.mdx
+++ b/website/docs/plugin/framework/resources/configure.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Configure resources
 

--- a/website/docs/plugin/framework/resources/create.mdx
+++ b/website/docs/plugin/framework/resources/create.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Create resources
 

--- a/website/docs/plugin/framework/resources/create.mdx
+++ b/website/docs/plugin/framework/resources/create.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Create resources
 

--- a/website/docs/plugin/framework/resources/create.mdx
+++ b/website/docs/plugin/framework/resources/create.mdx
@@ -4,6 +4,9 @@ description: >-
   Learn how to implement resource creation in the Terraform plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Create resources
 
 Creation is part of the basic Terraform lifecycle for managing resources. During the [`terraform apply` command](/terraform/cli/commands/apply), Terraform calls the provider [`ApplyResourceChange`](/terraform/plugin/framework/internals/rpcs#applyresourcechange-rpc) RPC, in which the framework calls the [`resource.Resource` interface `Create` method](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#Resource.Create). The request contains Terraform configuration and plan data. The response expects the applied Terraform state data, including any computed values. The data is defined by the [schema](/terraform/plugin/framework/data-handling/schemas) of the resource.

--- a/website/docs/plugin/framework/resources/default.mdx
+++ b/website/docs/plugin/framework/resources/default.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Default values
 

--- a/website/docs/plugin/framework/resources/default.mdx
+++ b/website/docs/plugin/framework/resources/default.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Default values
 

--- a/website/docs/plugin/framework/resources/default.mdx
+++ b/website/docs/plugin/framework/resources/default.mdx
@@ -5,6 +5,9 @@ description: >-
   plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Default values
 
 After [validation](/terraform/plugin/framework/validation) and before applying configuration changes, Terraform generates a plan that describes the expected values and behaviors of those changes. Resources can then tailor the plan to set default values on computed resource attributes that are null in the configuration.

--- a/website/docs/plugin/framework/resources/delete.mdx
+++ b/website/docs/plugin/framework/resources/delete.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Delete resources
 

--- a/website/docs/plugin/framework/resources/delete.mdx
+++ b/website/docs/plugin/framework/resources/delete.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Delete resources
 

--- a/website/docs/plugin/framework/resources/delete.mdx
+++ b/website/docs/plugin/framework/resources/delete.mdx
@@ -4,6 +4,9 @@ description: >-
   Learn how to implement resource deletion in the Terraform plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Delete resources
 
 Deletion is part of the basic Terraform lifecycle for managing resources. During the [`terraform apply` command](/terraform/cli/commands/apply), Terraform calls the provider [`ApplyResourceChange`](/terraform/plugin/framework/internals/rpcs#applyresourcechange-rpc) RPC, in which the framework calls the [`resource.Resource` interface `Delete` method](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#Resource.Delete). The request contains Terraform prior state data. The response is only for returning diagnostics. The data is defined by the [schema](/terraform/plugin/framework/schemas) of the resource.

--- a/website/docs/plugin/framework/resources/import.mdx
+++ b/website/docs/plugin/framework/resources/import.mdx
@@ -4,6 +4,9 @@ description: >-
   Learn how to support resource import using the Terraform plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Resource import
 
 Practitioners can use the  [`terraform import` command](/terraform/cli/commands/import) to let Terraform begin managing existing infrastructure resources. Resources can implement the `ImportState` method, which must either specify enough Terraform state for the `Read` method to refresh [`resource.Resource`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#Resource) or return an error.

--- a/website/docs/plugin/framework/resources/import.mdx
+++ b/website/docs/plugin/framework/resources/import.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Resource import
 

--- a/website/docs/plugin/framework/resources/import.mdx
+++ b/website/docs/plugin/framework/resources/import.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Resource import
 

--- a/website/docs/plugin/framework/resources/index.mdx
+++ b/website/docs/plugin/framework/resources/index.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Resources
 

--- a/website/docs/plugin/framework/resources/index.mdx
+++ b/website/docs/plugin/framework/resources/index.mdx
@@ -5,6 +5,9 @@ description: >-
   allow Terraform to manage infrastructure objects.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Resources
 
 [Resources](/terraform/language/resources) are an abstraction that allow Terraform to manage infrastructure objects, such as a compute instance, an access policy, or disk. Terraform assumes that every resource:

--- a/website/docs/plugin/framework/resources/index.mdx
+++ b/website/docs/plugin/framework/resources/index.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Resources
 

--- a/website/docs/plugin/framework/resources/plan-modification.mdx
+++ b/website/docs/plugin/framework/resources/plan-modification.mdx
@@ -5,6 +5,9 @@ description: >-
   framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Plan modification
 
 After [validation](/terraform/plugin/framework/validation) and before applying configuration changes, Terraform generates a plan that describes the expected values and behaviors of those changes. Resources can then tailor the plan to match the expected end state, prevent errant in-place updates, or return any [diagnostics](/terraform/plugin/framework/diagnostics).

--- a/website/docs/plugin/framework/resources/plan-modification.mdx
+++ b/website/docs/plugin/framework/resources/plan-modification.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Plan modification
 

--- a/website/docs/plugin/framework/resources/plan-modification.mdx
+++ b/website/docs/plugin/framework/resources/plan-modification.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Plan modification
 

--- a/website/docs/plugin/framework/resources/private-state.mdx
+++ b/website/docs/plugin/framework/resources/private-state.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Private state management
 

--- a/website/docs/plugin/framework/resources/private-state.mdx
+++ b/website/docs/plugin/framework/resources/private-state.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Private state management
 

--- a/website/docs/plugin/framework/resources/private-state.mdx
+++ b/website/docs/plugin/framework/resources/private-state.mdx
@@ -5,6 +5,9 @@ description: >-
   Private state is provider-only data storage for resources.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Private state management
 
 Resource private state is provider maintained data that is stored in Terraform state alongside the schema-defined data. Private state is never accessed or exposed by Terraform plans, however providers can use this data storage for advanced use cases.

--- a/website/docs/plugin/framework/resources/read.mdx
+++ b/website/docs/plugin/framework/resources/read.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Read resources
 

--- a/website/docs/plugin/framework/resources/read.mdx
+++ b/website/docs/plugin/framework/resources/read.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Read resources
 

--- a/website/docs/plugin/framework/resources/read.mdx
+++ b/website/docs/plugin/framework/resources/read.mdx
@@ -4,6 +4,9 @@ description: >-
   Learn how to implement resource read in the Terraform plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Read resources
 
 Read (refresh) is part of the basic Terraform lifecycle for managing resources. During the [`terraform apply`](/terraform/cli/commands/apply), [`terraform plan`](/terraform/cli/commands/plan), and [`terraform refresh`](/terraform/cli/commands/refresh) commands, Terraform calls the provider [`ReadResource`](/terraform/plugin/framework/internals/rpcs#readresource-rpc) RPC, in which the framework calls the [`resource.Resource` interface `Read` method](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#Resource.Read). The `Read` method is also executed after [resource import](/terraform/plugin/framework/resources/import). The request contains Terraform prior state data. The response contains the refreshed state data. The data is defined by the [schema](/terraform/plugin/framework/schemas) of the resource.

--- a/website/docs/plugin/framework/resources/state-move.mdx
+++ b/website/docs/plugin/framework/resources/state-move.mdx
@@ -5,6 +5,9 @@ description: >-
   the Terraform plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # State move
 
 <Tip>

--- a/website/docs/plugin/framework/resources/state-move.mdx
+++ b/website/docs/plugin/framework/resources/state-move.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # State move
 

--- a/website/docs/plugin/framework/resources/state-move.mdx
+++ b/website/docs/plugin/framework/resources/state-move.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # State move
 

--- a/website/docs/plugin/framework/resources/state-upgrade.mdx
+++ b/website/docs/plugin/framework/resources/state-upgrade.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # State upgrade
 

--- a/website/docs/plugin/framework/resources/state-upgrade.mdx
+++ b/website/docs/plugin/framework/resources/state-upgrade.mdx
@@ -5,6 +5,9 @@ description: >-
   one version of your Terraform framework provider to another.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # State upgrade
 
 A resource schema captures the structure and types of the resource [state](/terraform/language/state). Any state data that does not conform to the resource schema will generate errors or may not be persisted properly. Over time, it may be necessary for resources to make breaking changes to their schemas, such as changing an attribute type. Terraform supports versioning of these resource schemas and the current version is saved into the Terraform state. When the provider advertises a newer schema version, Terraform will call back to the provider to attempt to upgrade from the saved schema version to the one advertised. This operation is performed prior to planning, but with a configured provider.

--- a/website/docs/plugin/framework/resources/state-upgrade.mdx
+++ b/website/docs/plugin/framework/resources/state-upgrade.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # State upgrade
 

--- a/website/docs/plugin/framework/resources/timeouts.mdx
+++ b/website/docs/plugin/framework/resources/timeouts.mdx
@@ -4,6 +4,9 @@ description: >-
   Learn how to implement timeouts with the Terraform plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Timeouts
 
 The reality of cloud infrastructure is that it typically takes time to perform operations such as booting operating systems, discovering services, and replicating state across network edges. As the provider developer you should take known delays in resource APIs into account in the CRUD functions of the resource. Terraform supports configurable timeouts to assist in these situations.

--- a/website/docs/plugin/framework/resources/timeouts.mdx
+++ b/website/docs/plugin/framework/resources/timeouts.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Timeouts
 

--- a/website/docs/plugin/framework/resources/timeouts.mdx
+++ b/website/docs/plugin/framework/resources/timeouts.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Timeouts
 

--- a/website/docs/plugin/framework/resources/update.mdx
+++ b/website/docs/plugin/framework/resources/update.mdx
@@ -5,6 +5,9 @@ description: >-
   plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Update resources
 
 In-place update is part of the basic Terraform lifecycle for managing resources. During the [`terraform apply` command](/terraform/cli/commands/apply), Terraform calls the provider [`ApplyResourceChange`](/terraform/plugin/framework/internals/rpcs#applyresourcechange-rpc) RPC, in which the framework calls the [`resource.Resource` interface `Update` method](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/resource#Resource.Update). The request contains Terraform prior state, configuration, and plan data. The response contains updated state data. The data is defined by the [schema](/terraform/plugin/framework/schemas) of the resource.

--- a/website/docs/plugin/framework/resources/update.mdx
+++ b/website/docs/plugin/framework/resources/update.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Update resources
 

--- a/website/docs/plugin/framework/resources/update.mdx
+++ b/website/docs/plugin/framework/resources/update.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Update resources
 

--- a/website/docs/plugin/framework/resources/validate-configuration.mdx
+++ b/website/docs/plugin/framework/resources/validate-configuration.mdx
@@ -5,6 +5,9 @@ description: >-
   framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Validate configuration
 
 [Resources](/terraform/plugin/framework/resources) support validating an entire practitioner configuration in either declarative or imperative logic. Feedback, such as required syntax or acceptable combinations of values, is returned via [diagnostics](/terraform/plugin/framework/diagnostics).

--- a/website/docs/plugin/framework/resources/validate-configuration.mdx
+++ b/website/docs/plugin/framework/resources/validate-configuration.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Validate configuration
 

--- a/website/docs/plugin/framework/resources/validate-configuration.mdx
+++ b/website/docs/plugin/framework/resources/validate-configuration.mdx
@@ -6,7 +6,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Validate configuration
 

--- a/website/docs/plugin/framework/resources/write-only-arguments.mdx
+++ b/website/docs/plugin/framework/resources/write-only-arguments.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Write-only Arguments
 

--- a/website/docs/plugin/framework/resources/write-only-arguments.mdx
+++ b/website/docs/plugin/framework/resources/write-only-arguments.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Write-only Arguments
 

--- a/website/docs/plugin/framework/resources/write-only-arguments.mdx
+++ b/website/docs/plugin/framework/resources/write-only-arguments.mdx
@@ -4,6 +4,9 @@ description: >-
   How to implement write-only arguments with the provider development framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Write-only Arguments
 
 Write-only arguments are managed resource attributes that are configured by practitioners but are not persisted to the Terraform plan or state artifacts. Write-only arguments are supported in Terraform 1.11 and later.

--- a/website/docs/plugin/framework/validation.mdx
+++ b/website/docs/plugin/framework/validation.mdx
@@ -4,6 +4,9 @@ description: >-
   Learn how to validate configuration values using the Terraform plugin framework.
 ---
 
+> [!IMPORTANT]  
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+
 # Validation
 
 The framework can return [diagnostics](/terraform/plugin/framework/diagnostics) feedback for values in provider, resource, and data source configurations or [errors](/terraform/plugin/framework/functions/errors) feedback for values in function parameters. This allows you to write validations that give users feedback about required syntax, types, and acceptable values.

--- a/website/docs/plugin/framework/validation.mdx
+++ b/website/docs/plugin/framework/validation.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the [`hashicorp/web-unified-docs`](https://github.com/hashicorp/web-unified-docs) repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Validation
 

--- a/website/docs/plugin/framework/validation.mdx
+++ b/website/docs/plugin/framework/validation.mdx
@@ -5,7 +5,7 @@ description: >-
 ---
 
 > [!IMPORTANT]  
-> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on [developer.hashicorp.com](https://developer.hashicorp.com)
+> **Documentation Update:** Product documentation previously located in `/website` has moved to the `hashicorp/web-unified-docs` repository, where all product documentation is now centralized. Please make contributions directly to `web-unified-docs`, since changes to `/website` in this repository will not appear on developer.hashicorp.com.
 
 # Validation
 


### PR DESCRIPTION
We are migrating the `terraform-plugin-*` documentation to a unified HashiCorp product documentation repository. As a result of this migration, the unified repo (`web-unified-docs`) will be the source of truth.

This PR adds a noticed to all existing MDX files in the original location so folks know where to contribute. We plan on deprecating and removing the files in `/website`.