### PR TITLE
chore: Prep for `v1.15.0-alpha.1` pre-release

### DIFF
--- a/.changes/unreleased/NOTES-20250318-161843.yaml
+++ b/.changes/unreleased/NOTES-20250318-161843.yaml
@@ -1,0 +1,8 @@
+kind: NOTES
+body: This alpha pre-release contains an initial implementation for managed resource identity, which can used with Terraform v1.12.0-alpha20250312,
+    to store and read identity data during plan and apply workflows. A managed resource identity can be used by implementing the
+    optional `resource.ResourceWithIdentity` interface and defining an identity schema. Once the identity schema is defined, you can
+    read and store identity data in the state file via the new `Identity` fields in the response objects on the resource CRUD methods.
+time: 2025-03-18T16:18:43.661104-04:00
+custom:
+    Issue: "1112"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,5 +5,6 @@ builds:
 milestones:
   - close: true
 release:
+  prerelease: auto
   ids:
     - 'none'

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.23.7
 
 require (
 	github.com/google/go-cmp v0.7.0
-	github.com/hashicorp/terraform-plugin-go v0.26.1-0.20250314120210-d406d3409aef
+	github.com/hashicorp/terraform-plugin-go v0.27.0-alpha.1
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,8 @@ github.com/hashicorp/go-plugin v1.6.3 h1:xgHB+ZUSYeuJi96WtxEjzi23uh7YQpznjGh0U0U
 github.com/hashicorp/go-plugin v1.6.3/go.mod h1:MRobyh+Wc/nYy1V4KAXUiYfzxoYhs7V1mlH1Z7iY2h0=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
-github.com/hashicorp/terraform-plugin-go v0.26.1-0.20250314120210-d406d3409aef h1:RtNtj/RAsw/ef2bpeMlCDo+HsREcQVyJ+20AzikH3kw=
-github.com/hashicorp/terraform-plugin-go v0.26.1-0.20250314120210-d406d3409aef/go.mod h1:MfDwS/KnIy2QzCwdRtuqIjZ23gpYa9Vm+Z8cFpx8qtU=
+github.com/hashicorp/terraform-plugin-go v0.27.0-alpha.1 h1:/IZFNUEafGnJGXRe2iNQQ+vtzEw/5qiD+gOxkFrNbi4=
+github.com/hashicorp/terraform-plugin-go v0.27.0-alpha.1/go.mod h1:Tf2HngbyKvovAlGXgBOVGm3EDvbNaN/StUaTXwrej4o=
 github.com/hashicorp/terraform-plugin-log v0.9.0 h1:i7hOA+vdAItN1/7UrfBqBwvYPQ9TFvymaRGZED3FCV0=
 github.com/hashicorp/terraform-plugin-log v0.9.0/go.mod h1:rKL8egZQ/eXSyDqzLUuwUYLVdlYeamldAHSxjUFADow=
 github.com/hashicorp/terraform-registry-address v0.2.4 h1:JXu/zHB2Ymg/TGVCRu10XqNa4Sh2bWcqCNyKWjnCPJA=


### PR DESCRIPTION
This PR bumps to use the `alpha.1` release from plugin-go for resource identity.

This PR also adds a changelog for the `v1.15.0-alpha.1` pre-release, as well as sets up the goreleaser file to not show the pre-release as latest 😄 

I tried to give some minimal detail on where to look for the changes since we don't have any official documentation with this pre-release.