### PR TITLE
Implement validation logic for "identityschema.ListAttribute"

### DIFF
--- a/internal/fwschema/diagnostics.go
+++ b/internal/fwschema/diagnostics.go
@@ -64,3 +64,18 @@ func AttributeDefaultTypeMismatchDiag(attributePath path.Path, expectedType attr
 			"The default value must match the type of the schema.",
 	)
 }
+
+// AttributeInvalidElementTypeDiag returns an error diagnostic to provider
+// developers about using non-primitive types in their Attribute
+// implementation. This is not allowed.
+func AttributeInvalidElementTypeDiag(attributePath path.Path) diag.Diagnostic {
+	// The diagnostic path is intentionally omitted as it is invalid in this
+	// context. Diagnostic paths are intended to be mapped to actual data,
+	// while this path information must be synthesized.
+	return diag.NewErrorDiagnostic(
+		"Invalid Attribute Implementation",
+		"When validating the schema, an implementation issue was found. "+
+			"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+			fmt.Sprintf("%q contains an Attribute type that is not allowed for Resource Identity. ", attributePath),
+	)
+}

--- a/internal/fwschema/diagnostics.go
+++ b/internal/fwschema/diagnostics.go
@@ -68,7 +68,7 @@ func AttributeDefaultTypeMismatchDiag(attributePath path.Path, expectedType attr
 // AttributeInvalidElementTypeDiag returns an error diagnostic to provider
 // developers about using non-primitive types in their Attribute
 // implementation. This is not allowed.
-func AttributeInvalidElementTypeDiag(attributePath path.Path) diag.Diagnostic {
+func AttributeInvalidElementTypeDiag(attributePath path.Path, actualType attr.Type) diag.Diagnostic {
 	// The diagnostic path is intentionally omitted as it is invalid in this
 	// context. Diagnostic paths are intended to be mapped to actual data,
 	// while this path information must be synthesized.
@@ -76,6 +76,7 @@ func AttributeInvalidElementTypeDiag(attributePath path.Path) diag.Diagnostic {
 		"Invalid Attribute Implementation",
 		"When validating the schema, an implementation issue was found. "+
 			"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
-			fmt.Sprintf("%q contains an Attribute type that is not allowed for Resource Identity. ", attributePath),
+			fmt.Sprintf("%q contains an Attribute of type %q that is not allowed for Lists in Resource Identity. ", attributePath, actualType)+
+			"Lists in Resource Identity may only have primitive element types such as Bool, Int, Float, Number and String.",
 	)
 }

--- a/internal/fwschema/diagnostics.go
+++ b/internal/fwschema/diagnostics.go
@@ -76,7 +76,7 @@ func AttributeInvalidElementTypeDiag(attributePath path.Path, actualType attr.Ty
 		"Invalid Attribute Implementation",
 		"When validating the schema, an implementation issue was found. "+
 			"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
-			fmt.Sprintf("%q contains an Attribute of type %q that is not allowed for Lists in Resource Identity. ", attributePath, actualType)+
+			fmt.Sprintf("%q contains an element of type %q that is not allowed for Lists in Resource Identity. ", attributePath, actualType)+
 			"Lists in Resource Identity may only have primitive element types such as Bool, Int, Float, Number and String.",
 	)
 }

--- a/internal/fwtype/static_collection_validation.go
+++ b/internal/fwtype/static_collection_validation.go
@@ -143,13 +143,13 @@ func ReturnCollectionWithDynamicTypeDiag() diag.Diagnostic {
 // IsAllowedPrimitiveType checks if the given attr.Type is an allowed primitive type for resource identity.
 func IsAllowedPrimitiveType(typ attr.Type) bool {
 	switch typ.(type) {
-	case basetypes.BoolType,
-		basetypes.Float64Type,
-		basetypes.Float32Type,
-		basetypes.Int64Type,
-		basetypes.Int32Type,
-		basetypes.NumberType,
-		basetypes.StringType:
+	case basetypes.BoolTypable,
+		basetypes.Float64Typable,
+		basetypes.Float32Typable,
+		basetypes.Int64Typable,
+		basetypes.Int32Typable,
+		basetypes.NumberTypable,
+		basetypes.StringTypable:
 		return true
 	default:
 		return false

--- a/internal/fwtype/static_collection_validation.go
+++ b/internal/fwtype/static_collection_validation.go
@@ -5,7 +5,6 @@ package fwtype
 
 import (
 	"fmt"
-
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -139,4 +138,20 @@ func ReturnCollectionWithDynamicTypeDiag() diag.Diagnostic {
 			"Dynamic types inside of collections are not currently supported in terraform-plugin-framework. "+
 			"If underlying dynamic values are required, replace the return definition with DynamicReturn instead.",
 	)
+}
+
+// IsAllowedPrimitiveType checks if the given attr.Type is an allowed primitive type for resource identity.
+func IsAllowedPrimitiveType(typ attr.Type) bool {
+	switch typ.(type) {
+	case basetypes.BoolType,
+		basetypes.Float64Type,
+		basetypes.Float32Type,
+		basetypes.Int64Type,
+		basetypes.Int32Type,
+		basetypes.NumberType,
+		basetypes.StringType:
+		return true
+	default:
+		return false
+	}
 }

--- a/internal/fwtype/static_collection_validation_test.go
+++ b/internal/fwtype/static_collection_validation_test.go
@@ -944,3 +944,82 @@ func TestTypeContainsCollectionWithDynamic(t *testing.T) {
 		})
 	}
 }
+
+func TestIsAllowedPrimitiveType(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attrTyp  attr.Type
+		expected bool
+	}{
+		"nil": {
+			attrTyp:  nil,
+			expected: false,
+		},
+		"dynamic": {
+			attrTyp:  types.DynamicType,
+			expected: false,
+		},
+		"bool": {
+			attrTyp:  types.BoolType,
+			expected: true,
+		},
+		"int64": {
+			attrTyp:  types.Int64Type,
+			expected: true,
+		},
+		"int32": {
+			attrTyp:  types.Int32Type,
+			expected: true,
+		},
+		"float64": {
+			attrTyp:  types.Float64Type,
+			expected: true,
+		},
+		"float32": {
+			attrTyp:  types.Float32Type,
+			expected: true,
+		},
+		"number": {
+			attrTyp:  types.NumberType,
+			expected: true,
+		},
+		"string": {
+			attrTyp:  types.StringType,
+			expected: true,
+		},
+		"list-missing": {
+			attrTyp:  types.ListType{},
+			expected: false,
+		},
+		"list-static": {
+			attrTyp: types.ListType{
+				ElemType: types.StringType,
+			},
+			expected: false,
+		},
+		"map": {
+			attrTyp:  types.MapType{},
+			expected: false,
+		},
+		"object": {
+			attrTyp:  types.ObjectType{},
+			expected: false,
+		},
+		"tuple": {
+			attrTyp:  types.TupleType{},
+			expected: false,
+		},
+	}
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := fwtype.IsAllowedPrimitiveType(testCase.attrTyp)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}

--- a/resource/identityschema/list_attribute.go
+++ b/resource/identityschema/list_attribute.go
@@ -168,6 +168,6 @@ func (a ListAttribute) ValidateImplementation(_ context.Context, req fwschema.Va
 	}
 
 	if a.CustomType == nil && !fwtype.IsAllowedPrimitiveType(a.ElementType) {
-		resp.Diagnostics.Append(fwschema.AttributeInvalidElementTypeDiag(req.Path))
+		resp.Diagnostics.Append(fwschema.AttributeInvalidElementTypeDiag(req.Path, a.ElementType))
 	}
 }

--- a/resource/identityschema/list_attribute.go
+++ b/resource/identityschema/list_attribute.go
@@ -5,6 +5,7 @@ package identityschema
 
 import (
 	"context"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwtype"
 
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 
@@ -160,10 +161,12 @@ func (a ListAttribute) IsOptionalForImport() bool {
 // provider-defined implementation of the attribute to prevent unexpected
 // errors or panics. This logic runs during the GetResourceIdentitySchemas RPC and
 // should never include false positives.
-func (a ListAttribute) ValidateImplementation(ctx context.Context, req fwschema.ValidateImplementationRequest, resp *fwschema.ValidateImplementationResponse) {
+func (a ListAttribute) ValidateImplementation(_ context.Context, req fwschema.ValidateImplementationRequest, resp *fwschema.ValidateImplementationResponse) {
 	if a.CustomType == nil && a.ElementType == nil {
 		resp.Diagnostics.Append(fwschema.AttributeMissingElementTypeDiag(req.Path))
 	}
 
-	// TODO:ResourceIdentity: Write validation + tests that ensure the element type only contains primitive elements (bool, string, number)
+	if !fwtype.IsAllowedPrimitiveType(a.ElementType) {
+		resp.Diagnostics.Append(fwschema.AttributeInvalidElementTypeDiag(req.Path))
+	}
 }

--- a/resource/identityschema/list_attribute.go
+++ b/resource/identityschema/list_attribute.go
@@ -167,7 +167,7 @@ func (a ListAttribute) ValidateImplementation(_ context.Context, req fwschema.Va
 		return
 	}
 
-	if !fwtype.IsAllowedPrimitiveType(a.ElementType) {
+	if a.CustomType == nil && !fwtype.IsAllowedPrimitiveType(a.ElementType) {
 		resp.Diagnostics.Append(fwschema.AttributeInvalidElementTypeDiag(req.Path))
 	}
 }

--- a/resource/identityschema/list_attribute.go
+++ b/resource/identityschema/list_attribute.go
@@ -164,6 +164,7 @@ func (a ListAttribute) IsOptionalForImport() bool {
 func (a ListAttribute) ValidateImplementation(_ context.Context, req fwschema.ValidateImplementationRequest, resp *fwschema.ValidateImplementationResponse) {
 	if a.CustomType == nil && a.ElementType == nil {
 		resp.Diagnostics.Append(fwschema.AttributeMissingElementTypeDiag(req.Path))
+		return
 	}
 
 	if !fwtype.IsAllowedPrimitiveType(a.ElementType) {

--- a/resource/identityschema/list_attribute_test.go
+++ b/resource/identityschema/list_attribute_test.go
@@ -6,6 +6,7 @@ package identityschema_test
 import (
 	"context"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"strings"
 	"testing"
 
@@ -13,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
-	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testtypes"
@@ -476,6 +476,132 @@ func TestListAttributeValidateImplementation(t *testing.T) {
 							"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
 							"\"test\" is missing the CustomType or ElementType field on a collection Attribute. "+
 							"One of these fields is required to prevent other unexpected errors or panics.",
+					),
+				},
+			},
+		},
+		"elementtype-bool": {
+			attribute: identityschema.ListAttribute{
+				RequiredForImport: true,
+				ElementType:       types.BoolType,
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{},
+		},
+		"elementtype-int64": {
+			attribute: identityschema.ListAttribute{
+				RequiredForImport: true,
+				ElementType:       types.Int64Type,
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{},
+		},
+		"elementtype-int32": {
+			attribute: identityschema.ListAttribute{
+				RequiredForImport: true,
+				ElementType:       types.Int32Type,
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{},
+		},
+		"elementtype-float64": {
+			attribute: identityschema.ListAttribute{
+				RequiredForImport: true,
+				ElementType:       types.Float64Type,
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{},
+		},
+		"elementtype-float32": {
+			attribute: identityschema.ListAttribute{
+				RequiredForImport: true,
+				ElementType:       types.Float32Type,
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{},
+		},
+		"elementtype-number": {
+			attribute: identityschema.ListAttribute{
+				RequiredForImport: true,
+				ElementType:       types.NumberType,
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{},
+		},
+		"elementtype-notprimitive-dynamic": {
+			attribute: identityschema.ListAttribute{
+				RequiredForImport: true,
+				ElementType:       types.DynamicType,
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic(
+						"Invalid Attribute Implementation",
+						"When validating the schema, an implementation issue was found. "+
+							"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+							fmt.Sprintf("\"test\" contains an Attribute type that is not allowed for Resource Identity. "),
+					),
+				},
+			},
+		},
+		"elementtype-notprimitive-object": {
+			attribute: identityschema.ListAttribute{
+				RequiredForImport: true,
+				ElementType:       types.ObjectType{},
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic(
+						"Invalid Attribute Implementation",
+						"When validating the schema, an implementation issue was found. "+
+							"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+							fmt.Sprintf("\"test\" contains an Attribute type that is not allowed for Resource Identity. "),
+					),
+				},
+			},
+		},
+		"elementtype-notprimitive-map": {
+			attribute: identityschema.ListAttribute{
+				RequiredForImport: true,
+				ElementType:       types.MapType{},
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic(
+						"Invalid Attribute Implementation",
+						"When validating the schema, an implementation issue was found. "+
+							"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+							fmt.Sprintf("\"test\" contains an Attribute type that is not allowed for Resource Identity. "),
 					),
 				},
 			},

--- a/resource/identityschema/list_attribute_test.go
+++ b/resource/identityschema/list_attribute_test.go
@@ -561,7 +561,7 @@ func TestListAttributeValidateImplementation(t *testing.T) {
 						"Invalid Attribute Implementation",
 						"When validating the schema, an implementation issue was found. "+
 							"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
-							fmt.Sprintf("\"test\" contains an Attribute type that is not allowed for Resource Identity. "),
+							"\"test\" contains an Attribute type that is not allowed for Resource Identity. ",
 					),
 				},
 			},
@@ -581,7 +581,7 @@ func TestListAttributeValidateImplementation(t *testing.T) {
 						"Invalid Attribute Implementation",
 						"When validating the schema, an implementation issue was found. "+
 							"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
-							fmt.Sprintf("\"test\" contains an Attribute type that is not allowed for Resource Identity. "),
+							"\"test\" contains an Attribute type that is not allowed for Resource Identity. ",
 					),
 				},
 			},
@@ -601,7 +601,7 @@ func TestListAttributeValidateImplementation(t *testing.T) {
 						"Invalid Attribute Implementation",
 						"When validating the schema, an implementation issue was found. "+
 							"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
-							fmt.Sprintf("\"test\" contains an Attribute type that is not allowed for Resource Identity. "),
+							"\"test\" contains an Attribute type that is not allowed for Resource Identity. ",
 					),
 				},
 			},

--- a/resource/identityschema/list_attribute_test.go
+++ b/resource/identityschema/list_attribute_test.go
@@ -582,7 +582,7 @@ func TestListAttributeValidateImplementation(t *testing.T) {
 						"Invalid Attribute Implementation",
 						"When validating the schema, an implementation issue was found. "+
 							"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
-							"\"test\" contains an Attribute of type \"types.ObjectType[]\" that is not allowed for Lists in Resource Identity. "+
+							"\"test\" contains an element of type \"types.ObjectType[]\" that is not allowed for Lists in Resource Identity. "+
 							"Lists in Resource Identity may only have primitive element types such as Bool, Int, Float, Number and String.",
 					),
 				},

--- a/resource/identityschema/list_attribute_test.go
+++ b/resource/identityschema/list_attribute_test.go
@@ -561,7 +561,7 @@ func TestListAttributeValidateImplementation(t *testing.T) {
 						"Invalid Attribute Implementation",
 						"When validating the schema, an implementation issue was found. "+
 							"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
-							"\"test\" contains an Attribute of type \"basetypes.DynamicType\" that is not allowed for Lists in Resource Identity. "+
+							"\"test\" contains an element of type \"basetypes.DynamicType\" that is not allowed for Lists in Resource Identity. "+
 							"Lists in Resource Identity may only have primitive element types such as Bool, Int, Float, Number and String.",
 					),
 				},

--- a/resource/identityschema/list_attribute_test.go
+++ b/resource/identityschema/list_attribute_test.go
@@ -561,7 +561,8 @@ func TestListAttributeValidateImplementation(t *testing.T) {
 						"Invalid Attribute Implementation",
 						"When validating the schema, an implementation issue was found. "+
 							"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
-							"\"test\" contains an Attribute type that is not allowed for Resource Identity. ",
+							"\"test\" contains an Attribute of type \"basetypes.DynamicType\" that is not allowed for Lists in Resource Identity. "+
+							"Lists in Resource Identity may only have primitive element types such as Bool, Int, Float, Number and String.",
 					),
 				},
 			},
@@ -581,7 +582,8 @@ func TestListAttributeValidateImplementation(t *testing.T) {
 						"Invalid Attribute Implementation",
 						"When validating the schema, an implementation issue was found. "+
 							"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
-							"\"test\" contains an Attribute type that is not allowed for Resource Identity. ",
+							"\"test\" contains an Attribute of type \"types.ObjectType[]\" that is not allowed for Lists in Resource Identity. "+
+							"Lists in Resource Identity may only have primitive element types such as Bool, Int, Float, Number and String.",
 					),
 				},
 			},
@@ -601,7 +603,8 @@ func TestListAttributeValidateImplementation(t *testing.T) {
 						"Invalid Attribute Implementation",
 						"When validating the schema, an implementation issue was found. "+
 							"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
-							"\"test\" contains an Attribute type that is not allowed for Resource Identity. ",
+							"\"test\" contains an Attribute of type \"types.MapType[!!! MISSING TYPE !!!]\" that is not allowed for Lists in Resource Identity. "+
+							"Lists in Resource Identity may only have primitive element types such as Bool, Int, Float, Number and String.",
 					),
 				},
 			},

--- a/resource/identityschema/list_attribute_test.go
+++ b/resource/identityschema/list_attribute_test.go
@@ -603,7 +603,7 @@ func TestListAttributeValidateImplementation(t *testing.T) {
 						"Invalid Attribute Implementation",
 						"When validating the schema, an implementation issue was found. "+
 							"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
-							"\"test\" contains an Attribute of type \"types.MapType[!!! MISSING TYPE !!!]\" that is not allowed for Lists in Resource Identity. "+
+							"\"test\" contains an element of type \"types.MapType[!!! MISSING TYPE !!!]\" that is not allowed for Lists in Resource Identity. "+
 							"Lists in Resource Identity may only have primitive element types such as Bool, Int, Float, Number and String.",
 					),
 				},


### PR DESCRIPTION
Most of the “invalid” identity attribute types are simply not possible to create with Framework (without abusing custom types, which we can safely ignore imo) because we have a dedicated “identityschema” package: https://github.com/hashicorp/terraform-plugin-framework/tree/main/resource/identityschema

The lone validation we need to apply at runtime is checking the element type of the “identityschema.ListAttribute” since there is no restriction on what kind of “attr.Type” is provided. The only allowed element types are:

types.Bool

types.Int64, types.Int32, types.Float64, types.Float32, types.Number

types.String

The validation was done in the ValidateImplementation function which runs during GetResourceIdentitySchemas.

Added AttributeInvalidElementTypeDiag to give the error message and IsAllowedPrimitiveType to check to see if the element is an allowed type.