### PR TITLE
resource: Add identity to DeleteRequest

### DIFF
--- a/internal/fwserver/server_applyresourcechange.go
+++ b/internal/fwserver/server_applyresourcechange.go
@@ -76,6 +76,10 @@ func (s *Server) ApplyResourceChange(ctx context.Context, req *ApplyResourceChan
 		deleteReq := &DeleteResourceRequest{
 			PlannedPrivate: req.PlannedPrivate,
 			PriorState:     req.PriorState,
+			// MAINTAINER NOTE: There isn't a separate data field for prior identity, like there is with prior_state and planned_state.
+			// Here the planned_identity field will contain what would be considered the prior identity (since the final identity value
+			// after deleting will be null).
+			PriorIdentity:  req.PlannedIdentity,
 			ProviderMeta:   req.ProviderMeta,
 			ResourceSchema: req.ResourceSchema,
 			IdentitySchema: req.IdentitySchema,

--- a/internal/fwserver/server_applyresourcechange_test.go
+++ b/internal/fwserver/server_applyresourcechange_test.go
@@ -69,6 +69,11 @@ func TestServerApplyResourceChange(t *testing.T) {
 		Schema: testSchema,
 	}
 
+	testEmptyIdentity := &tfsdk.ResourceIdentity{
+		Raw:    tftypes.NewValue(testIdentityType, nil),
+		Schema: testIdentitySchema,
+	}
+
 	type testSchemaData struct {
 		TestComputed types.String `tfsdk:"test_computed"`
 		TestRequired types.String `tfsdk:"test_required"`
@@ -689,6 +694,52 @@ func TestServerApplyResourceChange(t *testing.T) {
 				NewState: testEmptyState,
 			},
 		},
+		"delete-request-prioridentity": {
+			server: &fwserver.Server{
+				Provider: &testprovider.Provider{},
+			},
+			request: &fwserver.ApplyResourceChangeRequest{
+				PlannedState: testEmptyPlan,
+				PriorState: &tfsdk.State{
+					Raw: tftypes.NewValue(testSchemaType, map[string]tftypes.Value{
+						"test_computed": tftypes.NewValue(tftypes.String, nil),
+						"test_required": tftypes.NewValue(tftypes.String, "test-priorstate-value"),
+					}),
+					Schema: testSchema,
+				},
+				PlannedIdentity: &tfsdk.ResourceIdentity{
+					Raw: tftypes.NewValue(testIdentityType, map[string]tftypes.Value{
+						"test_id": tftypes.NewValue(tftypes.String, "id-123"),
+					}),
+					Schema: testIdentitySchema,
+				},
+				IdentitySchema: testIdentitySchema,
+				ResourceSchema: testSchema,
+				Resource: &testprovider.ResourceWithIdentity{
+					Resource: &testprovider.Resource{
+						CreateMethod: func(_ context.Context, _ resource.CreateRequest, resp *resource.CreateResponse) {
+							resp.Diagnostics.AddError("Unexpected Method Call", "Expected: Delete, Got: Create")
+						},
+						DeleteMethod: func(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+							var identityData testIdentitySchemaData
+
+							resp.Diagnostics.Append(req.Identity.Get(ctx, &identityData)...)
+
+							if identityData.TestID.ValueString() != "id-123" {
+								resp.Diagnostics.AddError("Unexpected req.Identity Value", "Got: "+identityData.TestID.ValueString())
+							}
+						},
+						UpdateMethod: func(_ context.Context, _ resource.UpdateRequest, resp *resource.UpdateResponse) {
+							resp.Diagnostics.AddError("Unexpected Method Call", "Expected: Delete, Got: Update")
+						},
+					},
+				},
+			},
+			expectedResponse: &fwserver.ApplyResourceChangeResponse{
+				NewIdentity: testEmptyIdentity,
+				NewState:    testEmptyState,
+			},
+		},
 		"delete-request-providermeta": {
 			server: &fwserver.Server{
 				Provider: &testprovider.Provider{},
@@ -982,6 +1033,12 @@ func TestServerApplyResourceChange(t *testing.T) {
 					}),
 					Schema: testSchema,
 				},
+				PlannedIdentity: &tfsdk.ResourceIdentity{
+					Raw: tftypes.NewValue(testIdentityType, map[string]tftypes.Value{
+						"test_id": tftypes.NewValue(tftypes.String, "id-123"),
+					}),
+					Schema: testIdentitySchema,
+				},
 				IdentitySchema: testIdentitySchema,
 				ResourceSchema: testSchema,
 				Resource: &testprovider.ResourceWithIdentity{
@@ -990,10 +1047,11 @@ func TestServerApplyResourceChange(t *testing.T) {
 							resp.Diagnostics.AddError("Unexpected Method Call", "Expected: Delete, Got: Create")
 						},
 						DeleteMethod: func(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-							if resp.Identity == nil || !resp.Identity.Raw.IsNull() {
+							// The identity is automatically set to null in the response after the Delete method is called
+							if resp.Identity == nil || resp.Identity.Raw.IsNull() {
 								resp.Diagnostics.AddError(
 									"Unexpected resp.Identity",
-									"expected resp.Identity to be a null object of the schema type.",
+									"expected resp.Identity to be a known non-null object of the schema type.",
 								)
 							}
 						},
@@ -1004,11 +1062,8 @@ func TestServerApplyResourceChange(t *testing.T) {
 				},
 			},
 			expectedResponse: &fwserver.ApplyResourceChangeResponse{
-				NewIdentity: &tfsdk.ResourceIdentity{
-					Raw:    tftypes.NewValue(testIdentityType, nil),
-					Schema: testIdentitySchema,
-				},
-				NewState: testEmptyState,
+				NewIdentity: testEmptyIdentity,
+				NewState:    testEmptyState,
 			},
 		},
 		"update-request-config": {

--- a/resource/delete.go
+++ b/resource/delete.go
@@ -17,6 +17,10 @@ type DeleteRequest struct {
 	// operation.
 	State tfsdk.State
 
+	// Identity is the current identity of the resource prior to the Delete
+	// operation. If the resource does not support identity, this value will not be set.
+	Identity *tfsdk.ResourceIdentity
+
 	// ProviderMeta is metadata from the provider_meta block of the module.
 	ProviderMeta tfsdk.Config
 


### PR DESCRIPTION
**Context:** https://hashicorp.atlassian.net/browse/TFECO-9284

This PR introduces the `Identity` field to `DeleteRequest`. This was missed during initial implementation, despite always existing in the protocol/core. I left a comment explaining the possible confusion of using "planned" objects as a "prior" object.