### PR TITLE
fwserver: add list resources to `GetMetadata`

### DIFF
--- a/internal/fwserver/server.go
+++ b/internal/fwserver/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/function"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/logging"
+	"github.com/hashicorp/terraform-plugin-framework/list"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 )
@@ -112,6 +113,17 @@ type Server struct {
 	// functionFuncsMutex is a mutex to protect concurrent functionFuncs
 	// access from race conditions.
 	functionFuncsMutex sync.Mutex
+
+	// listResourceFuncs is a map of known ListResource factory functions.
+	listResourceFuncs map[string]func() list.ListResource
+
+	// listResourceFuncsDiags are the cached Diagnostics obtained while
+	// populating listResourceFuncs.
+	listResourceFuncsDiags diag.Diagnostics
+
+	// listResourceFuncsMutex is a mutex to protect concurrent listResourceFuncs
+	// access from race conditions.
+	listResourceFuncsMutex sync.Mutex
 
 	// providerSchema is the cached Provider Schema for RPCs that need to
 	// convert configuration data from the protocol. If not found, it will be

--- a/internal/fwserver/server_getmetadata.go
+++ b/internal/fwserver/server_getmetadata.go
@@ -20,6 +20,7 @@ type GetMetadataResponse struct {
 	Diagnostics        diag.Diagnostics
 	EphemeralResources []EphemeralResourceMetadata
 	Functions          []FunctionMetadata
+	ListResources      []ListResourceMetadata
 	Resources          []ResourceMetadata
 	ServerCapabilities *ServerCapabilities
 }
@@ -52,28 +53,39 @@ type ResourceMetadata struct {
 	TypeName string
 }
 
+// ListResourceMetadata is the framework server equivalent of the
+// tfprotov5.ListResourceMetadata and tfprotov6.ListResourceMetadata types.
+type ListResourceMetadata struct {
+	// TypeName is the name of the list resource.
+	TypeName string
+}
+
 // GetMetadata implements the framework server GetMetadata RPC.
 func (s *Server) GetMetadata(ctx context.Context, req *GetMetadataRequest, resp *GetMetadataResponse) {
 	resp.DataSources = []DataSourceMetadata{}
 	resp.EphemeralResources = []EphemeralResourceMetadata{}
 	resp.Functions = []FunctionMetadata{}
+	resp.ListResources = []ListResourceMetadata{}
 	resp.Resources = []ResourceMetadata{}
+
 	resp.ServerCapabilities = s.ServerCapabilities()
 
 	datasourceMetadatas, diags := s.DataSourceMetadatas(ctx)
-
 	resp.Diagnostics.Append(diags...)
 
 	ephemeralResourceMetadatas, diags := s.EphemeralResourceMetadatas(ctx)
-
 	resp.Diagnostics.Append(diags...)
 
 	functionMetadatas, diags := s.FunctionMetadatas(ctx)
-
 	resp.Diagnostics.Append(diags...)
 
 	resourceMetadatas, diags := s.ResourceMetadatas(ctx)
+	resp.Diagnostics.Append(diags...)
 
+	// Metadata for list resources must be retrieved after metadata for managed
+	// resources. Server.ListResourceMetadatas checks that each list resource
+	// type nane matches a known managed Resource type name.
+	listResourceMetadatas, diags := s.ListResourceMetadatas(ctx)
 	resp.Diagnostics.Append(diags...)
 
 	if resp.Diagnostics.HasError() {
@@ -83,5 +95,6 @@ func (s *Server) GetMetadata(ctx context.Context, req *GetMetadataRequest, resp 
 	resp.DataSources = datasourceMetadatas
 	resp.EphemeralResources = ephemeralResourceMetadatas
 	resp.Functions = functionMetadatas
+	resp.ListResources = listResourceMetadatas
 	resp.Resources = resourceMetadatas
 }

--- a/internal/fwserver/server_getmetadata_test.go
+++ b/internal/fwserver/server_getmetadata_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -16,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/function"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
 	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testprovider"
+	"github.com/hashicorp/terraform-plugin-framework/list"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 )
@@ -485,6 +487,190 @@ func TestServerGetMetadata(t *testing.T) {
 				},
 			},
 		},
+		"listresources": {
+			server: &fwserver.Server{
+				Provider: &testprovider.Provider{
+					ListResourcesMethod: func(_ context.Context) []func() list.ListResource {
+						return []func() list.ListResource{
+							func() list.ListResource {
+								return &testprovider.ListResource{
+									MetadataMethod: func(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
+										resp.TypeName = "test_resource_1"
+									},
+								}
+							},
+						}
+					},
+					ResourcesMethod: func(_ context.Context) []func() resource.Resource {
+						return []func() resource.Resource{
+							func() resource.Resource {
+								return &testprovider.Resource{
+									MetadataMethod: func(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
+										resp.TypeName = "test_resource_1"
+									},
+								}
+							},
+						}
+					},
+				},
+			},
+			request: &fwserver.GetMetadataRequest{},
+			expectedResponse: &fwserver.GetMetadataResponse{
+				DataSources:        []fwserver.DataSourceMetadata{},
+				EphemeralResources: []fwserver.EphemeralResourceMetadata{},
+				Diagnostics:        diag.Diagnostics{},
+				Functions:          []fwserver.FunctionMetadata{},
+				ListResources: []fwserver.ListResourceMetadata{
+					{TypeName: "test_resource_1"},
+				},
+				Resources: []fwserver.ResourceMetadata{
+					{TypeName: "test_resource_1"},
+				},
+				ServerCapabilities: &fwserver.ServerCapabilities{
+					GetProviderSchemaOptional: true,
+					MoveResourceState:         true,
+					PlanDestroy:               true,
+				},
+			},
+		},
+		"list-resources-empty-type-name": {
+			server: &fwserver.Server{
+				Provider: &testprovider.Provider{
+					ListResourcesMethod: func(_ context.Context) []func() list.ListResource {
+						return []func() list.ListResource{
+							func() list.ListResource {
+								return &testprovider.ListResource{
+									MetadataMethod: func(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
+										resp.TypeName = ""
+									},
+								}
+							},
+						}
+					},
+				},
+			},
+			request: &fwserver.GetMetadataRequest{},
+			expectedResponse: &fwserver.GetMetadataResponse{
+				DataSources:        []fwserver.DataSourceMetadata{},
+				EphemeralResources: []fwserver.EphemeralResourceMetadata{},
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic(
+						"ListResource Type Name Missing",
+						"The *testprovider.ListResource ListResource returned an empty string from the Metadata method. "+
+							"This is always an issue with the provider and should be reported to the provider developers.",
+					),
+				},
+				Functions: []fwserver.FunctionMetadata{},
+				Resources: []fwserver.ResourceMetadata{},
+				ServerCapabilities: &fwserver.ServerCapabilities{
+					GetProviderSchemaOptional: true,
+					MoveResourceState:         true,
+					PlanDestroy:               true,
+				},
+			},
+		},
+		"list-resources-duplicate-type-name": {
+			server: &fwserver.Server{
+				Provider: &testprovider.Provider{
+					ListResourcesMethod: func(_ context.Context) []func() list.ListResource {
+						return []func() list.ListResource{
+							func() list.ListResource {
+								return &testprovider.ListResource{
+									MetadataMethod: func(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
+										resp.TypeName = "test_resource"
+									},
+								}
+							},
+							func() list.ListResource {
+								return &testprovider.ListResource{
+									MetadataMethod: func(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
+										resp.TypeName = "test_resource"
+									},
+								}
+							},
+						}
+					},
+					ResourcesMethod: func(_ context.Context) []func() resource.Resource {
+						return []func() resource.Resource{
+							func() resource.Resource {
+								return &testprovider.Resource{
+									MetadataMethod: func(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
+										resp.TypeName = "test_resource"
+									},
+								}
+							},
+						}
+					},
+				},
+			},
+			request: &fwserver.GetMetadataRequest{},
+			expectedResponse: &fwserver.GetMetadataResponse{
+				DataSources:        []fwserver.DataSourceMetadata{},
+				EphemeralResources: []fwserver.EphemeralResourceMetadata{},
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic(
+						"Duplicate ListResource Type Defined",
+						"The test_resource ListResource type name was returned for multiple list resources. "+
+							"ListResource type names must be unique. "+
+							"This is always an issue with the provider and should be reported to the provider developers.",
+					),
+				},
+				Functions: []fwserver.FunctionMetadata{},
+				Resources: []fwserver.ResourceMetadata{},
+				ServerCapabilities: &fwserver.ServerCapabilities{
+					GetProviderSchemaOptional: true,
+					MoveResourceState:         true,
+					PlanDestroy:               true,
+				},
+			},
+		},
+		"list-resources-no-matching-managed-resource-type": {
+			server: &fwserver.Server{
+				Provider: &testprovider.Provider{
+					ListResourcesMethod: func(_ context.Context) []func() list.ListResource {
+						return []func() list.ListResource{
+							func() list.ListResource {
+								return &testprovider.ListResource{
+									MetadataMethod: func(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
+										resp.TypeName = "test_resource_1"
+									},
+								}
+							},
+						}
+					},
+					ResourcesMethod: func(_ context.Context) []func() resource.Resource {
+						return []func() resource.Resource{
+							func() resource.Resource {
+								return &testprovider.Resource{
+									MetadataMethod: func(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
+										resp.TypeName = "test_resource_2"
+									},
+								}
+							},
+						}
+					},
+				},
+			},
+			request: &fwserver.GetMetadataRequest{},
+			expectedResponse: &fwserver.GetMetadataResponse{
+				DataSources:        []fwserver.DataSourceMetadata{},
+				EphemeralResources: []fwserver.EphemeralResourceMetadata{},
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic(
+						"ListResource Type Defined without a Matching Managed Resource Type",
+						"The test_resource_1 ListResource type name was returned, but no matching managed Resource type was defined. "+
+							"This is always an issue with the provider and should be reported to the provider developers.",
+					),
+				},
+				Functions: []fwserver.FunctionMetadata{},
+				Resources: []fwserver.ResourceMetadata{},
+				ServerCapabilities: &fwserver.ServerCapabilities{
+					GetProviderSchemaOptional: true,
+					MoveResourceState:         true,
+					PlanDestroy:               true,
+				},
+			},
+		},
 		"resources": {
 			server: &fwserver.Server{
 				Provider: &testprovider.Provider{
@@ -666,11 +852,19 @@ func TestServerGetMetadata(t *testing.T) {
 				return response.Functions[i].Name < response.Functions[j].Name
 			})
 
+			sort.Slice(response.ListResources, func(i int, j int) bool {
+				return response.ListResources[i].TypeName < response.ListResources[j].TypeName
+			})
+
 			sort.Slice(response.Resources, func(i int, j int) bool {
 				return response.Resources[i].TypeName < response.Resources[j].TypeName
 			})
 
-			if diff := cmp.Diff(response, testCase.expectedResponse); diff != "" {
+			opts := cmp.Options{
+				cmpopts.EquateEmpty(),
+			}
+
+			if diff := cmp.Diff(response, testCase.expectedResponse, opts...); diff != "" {
 				t.Errorf("unexpected difference: %s", diff)
 			}
 		})

--- a/internal/fwserver/server_listresources.go
+++ b/internal/fwserver/server_listresources.go
@@ -1,0 +1,100 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package fwserver
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/internal/logging"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+)
+
+// ListResourceFuncs returns a map of ListResource functions. The results are
+// cached on first use.
+func (s *Server) ListResourceFuncs(ctx context.Context) (map[string]func() list.ListResource, diag.Diagnostics) {
+	provider, ok := s.Provider.(provider.ProviderWithListResources)
+	if !ok {
+		return nil, nil
+	}
+
+	logging.FrameworkTrace(ctx, "Checking ListResourceTypes lock")
+	s.listResourceFuncsMutex.Lock()
+	defer s.listResourceFuncsMutex.Unlock()
+
+	if s.listResourceFuncs != nil {
+		return s.listResourceFuncs, s.resourceTypesDiags
+	}
+
+	providerTypeName := s.ProviderTypeName(ctx)
+	s.listResourceFuncs = make(map[string]func() list.ListResource)
+
+	logging.FrameworkTrace(ctx, "Calling provider defined ListResources")
+	listResourceFuncSlice := provider.ListResources(ctx)
+	logging.FrameworkTrace(ctx, "Called provider defined ListResources")
+
+	for _, listResourceFunc := range listResourceFuncSlice {
+		listResource := listResourceFunc()
+
+		metadataReq := resource.MetadataRequest{
+			ProviderTypeName: providerTypeName,
+		}
+		metadataResp := resource.MetadataResponse{}
+		listResource.Metadata(ctx, metadataReq, &metadataResp)
+
+		typeName := metadataResp.TypeName
+		if typeName == "" {
+			s.listResourceFuncsDiags.AddError(
+				"ListResource Type Name Missing",
+				fmt.Sprintf("The %T ListResource returned an empty string from the Metadata method. ", listResource)+
+					"This is always an issue with the provider and should be reported to the provider developers.",
+			)
+			continue
+		}
+
+		logging.FrameworkTrace(ctx, "Found resource type", map[string]interface{}{logging.KeyListResourceType: typeName}) // TODO: y?
+
+		if _, ok := s.listResourceFuncs[typeName]; ok {
+			s.listResourceFuncsDiags.AddError(
+				"Duplicate ListResource Type Defined",
+				fmt.Sprintf("The %s ListResource type name was returned for multiple list resources. ", typeName)+
+					"ListResource type names must be unique. "+
+					"This is always an issue with the provider and should be reported to the provider developers.",
+			)
+			continue
+		}
+
+		if _, ok := s.resourceFuncs[typeName]; !ok {
+			s.listResourceFuncsDiags.AddError(
+				"ListResource Type Defined without a Matching Managed Resource Type",
+				fmt.Sprintf("The %s ListResource type name was returned, but no matching managed Resource type was defined. ", typeName)+
+					"This is always an issue with the provider and should be reported to the provider developers.",
+			)
+			continue
+		}
+
+		s.listResourceFuncs[typeName] = listResourceFunc
+	}
+
+	return s.listResourceFuncs, s.listResourceFuncsDiags
+}
+
+// ListResourceMetadatas returns a slice of ListResourceMetadata for the GetMetadata
+// RPC.
+func (s *Server) ListResourceMetadatas(ctx context.Context) ([]ListResourceMetadata, diag.Diagnostics) {
+	resourceFuncs, diags := s.ListResourceFuncs(ctx)
+
+	resourceMetadatas := make([]ListResourceMetadata, 0, len(resourceFuncs))
+
+	for typeName := range resourceFuncs {
+		resourceMetadatas = append(resourceMetadatas, ListResourceMetadata{
+			TypeName: typeName,
+		})
+	}
+
+	return resourceMetadatas, diags
+}

--- a/internal/logging/keys.go
+++ b/internal/logging/keys.go
@@ -37,6 +37,9 @@ const (
 	// The type of resource being operated on, such as "random_pet"
 	KeyResourceType = "tf_resource_type"
 
+	// The type of list resource being operated on, such as "random_pet"
+	KeyListResourceType = "tf_list_resource_type"
+
 	// The type of value being operated on, such as "JSONStringValue".
 	KeyValueType = "tf_value_type"
 )

--- a/internal/testing/testprovider/list_resource.go
+++ b/internal/testing/testprovider/list_resource.go
@@ -1,0 +1,47 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package testprovider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+)
+
+var _ list.ListResource = &ListResource{}
+
+// Declarative list.ListResource for unit testing.
+type ListResource struct {
+	// ListResource interface methods
+	MetadataMethod                 func(context.Context, resource.MetadataRequest, *resource.MetadataResponse)
+	ListResourceConfigSchemaMethod func(context.Context, list.ListResourceSchemaRequest, *list.ListResourceSchemaResponse)
+	ListMethod                     func(context.Context, list.ListRequest, *list.ListResultsStream)
+}
+
+// Metadata satisfies the list.ListResource interface.
+func (r *ListResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	if r.MetadataMethod == nil {
+		return
+	}
+
+	r.MetadataMethod(ctx, req, resp)
+}
+
+// ListResourceConfigSchema satisfies the list.ListResource interface.
+func (r *ListResource) ListResourceConfigSchema(ctx context.Context, req list.ListResourceSchemaRequest, resp *list.ListResourceSchemaResponse) {
+	if r.ListResourceConfigSchemaMethod == nil {
+		return
+	}
+
+	r.ListResourceConfigSchemaMethod(ctx, req, resp)
+}
+
+// ListResource satisfies the list.ListResource interface.
+func (r *ListResource) List(ctx context.Context, req list.ListRequest, resp *list.ListResultsStream) {
+	if r.ListMethod == nil {
+		return
+	}
+	r.ListMethod(ctx, req, resp)
+}

--- a/internal/testing/testprovider/provider.go
+++ b/internal/testing/testprovider/provider.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
+	"github.com/hashicorp/terraform-plugin-framework/list"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 )
@@ -21,8 +22,9 @@ type Provider struct {
 	ConfigureMethod          func(context.Context, provider.ConfigureRequest, *provider.ConfigureResponse)
 	SchemaMethod             func(context.Context, provider.SchemaRequest, *provider.SchemaResponse)
 	DataSourcesMethod        func(context.Context) []func() datasource.DataSource
-	ResourcesMethod          func(context.Context) []func() resource.Resource
 	EphemeralResourcesMethod func(context.Context) []func() ephemeral.EphemeralResource
+	ListResourcesMethod      func(context.Context) []func() list.ListResource
+	ResourcesMethod          func(context.Context) []func() resource.Resource
 }
 
 // Configure satisfies the provider.Provider interface.
@@ -59,6 +61,15 @@ func (p *Provider) Schema(ctx context.Context, req provider.SchemaRequest, resp 
 	}
 
 	p.SchemaMethod(ctx, req, resp)
+}
+
+// ListResources satisfies the provider.Provider interface.
+func (p *Provider) ListResources(ctx context.Context) []func() list.ListResource {
+	if p == nil || p.ListResourcesMethod == nil {
+		return nil
+	}
+
+	return p.ListResourcesMethod(ctx)
 }
 
 // Resources satisfies the provider.Provider interface.

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
 	"github.com/hashicorp/terraform-plugin-framework/function"
+	"github.com/hashicorp/terraform-plugin-framework/list"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 )
 
@@ -120,6 +121,17 @@ type ProviderWithMetaSchema interface {
 	// break without warning. It is not protected by version compatibility
 	// guarantees.
 	MetaSchema(context.Context, MetaSchemaRequest, *MetaSchemaResponse)
+}
+
+type ProviderWithListResources interface {
+	Provider
+
+	// ListResources returns a slice of functions to instantiate each Resource
+	// List implementation.
+	//
+	// The resource type name is determined by the ListResource implementing
+	// the Metadata method. All ListResources must have unique names.
+	ListResources(context.Context) []func() list.ListResource
 }
 
 // ProviderWithValidateConfig is an interface type that extends Provider to include imperative validation.


### PR DESCRIPTION
## Description

This pull request adds list resource metadata to the protocol-independent framework server implementation of `GetMetadata`.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No