### PR TITLE
all: Adjust `UseStateForUnknown` plan modifiers to preserve known null state values

### DIFF
--- a/internal/fwserver/attribute_plan_modification_test.go
+++ b/internal/fwserver/attribute_plan_modification_test.go
@@ -2949,6 +2949,44 @@ func TestAttributeModifyPlan(t *testing.T) {
 						},
 					},
 				),
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Map{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Map{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+										},
+									},
+								},
+								map[string]tftypes.Value{
+									"key1": tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_computed": tftypes.NewValue(tftypes.String, "statevalue1"),
+										},
+									),
+								},
+							),
+						},
+					),
+				},
 				AttributeState: types.MapValueMust(
 					types.ObjectType{
 						AttrTypes: map[string]attr.Type{
@@ -3028,6 +3066,44 @@ func TestAttributeModifyPlan(t *testing.T) {
 							AttrTypes: map[string]attr.Type{
 								"nested_computed": types.StringType,
 							},
+						},
+					),
+				},
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Map{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Map{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+										},
+									},
+								},
+								map[string]tftypes.Value{
+									"key1": tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_computed": tftypes.NewValue(tftypes.String, "statevalue1"),
+										},
+									),
+								},
+							),
 						},
 					),
 				},

--- a/internal/fwserver/attribute_plan_modification_test.go
+++ b/internal/fwserver/attribute_plan_modification_test.go
@@ -641,6 +641,44 @@ func TestAttributeModifyPlan(t *testing.T) {
 						},
 					},
 				),
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_computed": tftypes.NewValue(tftypes.String, "statevalue1"),
+										},
+									),
+								},
+							),
+						},
+					),
+				},
 				AttributeState: types.ListValueMust(
 					types.ObjectType{
 						AttrTypes: map[string]attr.Type{
@@ -720,6 +758,44 @@ func TestAttributeModifyPlan(t *testing.T) {
 							AttrTypes: map[string]attr.Type{
 								"nested_computed": types.StringType,
 							},
+						},
+					),
+				},
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_computed": tftypes.NewValue(tftypes.String, "statevalue1"),
+										},
+									),
+								},
+							),
 						},
 					),
 				},

--- a/internal/fwserver/attribute_plan_modification_test.go
+++ b/internal/fwserver/attribute_plan_modification_test.go
@@ -1591,6 +1591,44 @@ func TestAttributeModifyPlan(t *testing.T) {
 						},
 					},
 				),
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_computed": tftypes.NewValue(tftypes.String, "statevalue1"),
+										},
+									),
+								},
+							),
+						},
+					),
+				},
 				AttributeState: types.SetValueMust(
 					types.ObjectType{
 						AttrTypes: map[string]attr.Type{
@@ -1670,6 +1708,44 @@ func TestAttributeModifyPlan(t *testing.T) {
 							AttrTypes: map[string]attr.Type{
 								"nested_computed": types.StringType,
 							},
+						},
+					),
+				},
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_computed": tftypes.NewValue(tftypes.String, "statevalue1"),
+										},
+									),
+								},
+							),
 						},
 					),
 				},

--- a/internal/fwserver/attribute_plan_modification_test.go
+++ b/internal/fwserver/attribute_plan_modification_test.go
@@ -979,6 +979,60 @@ func TestAttributeModifyPlan(t *testing.T) {
 						),
 					},
 				),
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+											"nested_required": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+											"nested_required": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed": tftypes.String,
+												"nested_required": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_computed": tftypes.NewValue(tftypes.String, "statevalue1"),
+											"nested_required": tftypes.NewValue(tftypes.String, "testvalue1"),
+										},
+									),
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed": tftypes.String,
+												"nested_required": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_computed": tftypes.NewValue(tftypes.String, "statevalue2"),
+											"nested_required": tftypes.NewValue(tftypes.String, "testvalue2"),
+										},
+									),
+								},
+							),
+						},
+					),
+				},
 				AttributeState: types.ListValueMust(
 					types.ObjectType{
 						AttrTypes: map[string]attr.Type{
@@ -1742,6 +1796,60 @@ func TestAttributeModifyPlan(t *testing.T) {
 						),
 					},
 				),
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+											"nested_required": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+											"nested_required": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed": tftypes.String,
+												"nested_required": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_computed": tftypes.NewValue(tftypes.String, "statevalue1"),
+											"nested_required": tftypes.NewValue(tftypes.String, "testvalue1"),
+										},
+									),
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed": tftypes.String,
+												"nested_required": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_computed": tftypes.NewValue(tftypes.String, "statevalue2"),
+											"nested_required": tftypes.NewValue(tftypes.String, "testvalue2"),
+										},
+									),
+								},
+							),
+						},
+					),
+				},
 				AttributeState: types.SetValueMust(
 					types.ObjectType{
 						AttrTypes: map[string]attr.Type{
@@ -1887,6 +1995,60 @@ func TestAttributeModifyPlan(t *testing.T) {
 						),
 					},
 				),
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+											"nested_required": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+											"nested_required": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed": tftypes.String,
+												"nested_required": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_computed": tftypes.NewValue(tftypes.String, "statevalue1"),
+											"nested_required": tftypes.NewValue(tftypes.String, "testvalue1"),
+										},
+									),
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed": tftypes.String,
+												"nested_required": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_computed": tftypes.NewValue(tftypes.String, "statevalue2"),
+											"nested_required": tftypes.NewValue(tftypes.String, "testvalue2"),
+										},
+									),
+								},
+							),
+						},
+					),
+				},
 				AttributeState: types.SetValueMust(
 					types.ObjectType{
 						AttrTypes: map[string]attr.Type{
@@ -2016,6 +2178,60 @@ func TestAttributeModifyPlan(t *testing.T) {
 						),
 					},
 				),
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+											"nested_required": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+											"nested_required": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed": tftypes.String,
+												"nested_required": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_computed": tftypes.NewValue(tftypes.String, "statevalue1"),
+											"nested_required": tftypes.NewValue(tftypes.String, "testvalue1"),
+										},
+									),
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed": tftypes.String,
+												"nested_required": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_computed": tftypes.NewValue(tftypes.String, "statevalue2"),
+											"nested_required": tftypes.NewValue(tftypes.String, "testvalue2"),
+										},
+									),
+								},
+							),
+						},
+					),
+				},
 				AttributeState: types.SetValueMust(
 					types.ObjectType{
 						AttrTypes: map[string]attr.Type{

--- a/internal/fwserver/attribute_plan_modification_test.go
+++ b/internal/fwserver/attribute_plan_modification_test.go
@@ -3421,6 +3421,31 @@ func TestAttributeModifyPlan(t *testing.T) {
 						"nested_computed": types.StringType,
 					},
 				),
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"nested_computed": tftypes.String,
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"nested_computed": tftypes.String,
+									},
+								},
+								map[string]tftypes.Value{
+									"nested_computed": tftypes.NewValue(tftypes.String, "statevalue1"),
+								},
+							),
+						},
+					),
+				},
 				AttributeState: types.ObjectValueMust(
 					map[string]attr.Type{
 						"nested_computed": types.StringType,
@@ -3476,6 +3501,31 @@ func TestAttributeModifyPlan(t *testing.T) {
 					ObjectValue: types.ObjectUnknown(
 						map[string]attr.Type{
 							"nested_computed": types.StringType,
+						},
+					),
+				},
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"nested_computed": tftypes.String,
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"nested_computed": tftypes.String,
+									},
+								},
+								map[string]tftypes.Value{
+									"nested_computed": tftypes.NewValue(tftypes.String, "statevalue1"),
+								},
+							),
 						},
 					),
 				},

--- a/internal/fwserver/block_plan_modification_test.go
+++ b/internal/fwserver/block_plan_modification_test.go
@@ -1874,6 +1874,92 @@ func TestBlockModifyPlan(t *testing.T) {
 						),
 					},
 				),
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"id": tftypes.String,
+											"list": tftypes.List{
+												ElementType: tftypes.Object{
+													AttributeTypes: map[string]tftypes.Type{
+														"nested_computed": tftypes.String,
+														"nested_required": tftypes.String,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"id": tftypes.String,
+											"list": tftypes.List{
+												ElementType: tftypes.Object{
+													AttributeTypes: map[string]tftypes.Type{
+														"nested_computed": tftypes.String,
+														"nested_required": tftypes.String,
+													},
+												},
+											},
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"id": tftypes.String,
+												"list": tftypes.List{
+													ElementType: tftypes.Object{
+														AttributeTypes: map[string]tftypes.Type{
+															"nested_computed": tftypes.String,
+															"nested_required": tftypes.String,
+														},
+													},
+												},
+											},
+										},
+										map[string]tftypes.Value{
+											"id": tftypes.NewValue(tftypes.String, "one"),
+											"list": tftypes.NewValue(
+												tftypes.List{
+													ElementType: tftypes.Object{
+														AttributeTypes: map[string]tftypes.Type{
+															"nested_computed": tftypes.String,
+															"nested_required": tftypes.String,
+														},
+													},
+												},
+												[]tftypes.Value{
+													tftypes.NewValue(
+														tftypes.Object{
+															AttributeTypes: map[string]tftypes.Type{
+																"nested_computed": tftypes.String,
+																"nested_required": tftypes.String,
+															},
+														},
+														map[string]tftypes.Value{
+															"nested_computed": tftypes.NewValue(tftypes.String, "statevalue"),
+															"nested_required": tftypes.NewValue(tftypes.String, "configvalue"),
+														},
+													),
+												},
+											),
+										},
+									),
+								},
+							),
+						},
+					),
+				},
 				AttributeState: types.ListValueMust(
 					types.ObjectType{
 						AttrTypes: map[string]attr.Type{
@@ -1989,7 +2075,7 @@ func TestBlockModifyPlan(t *testing.T) {
 				NestedObject: testschema.NestedBlockObject{
 					Attributes: map[string]fwschema.Attribute{
 						"nested_computed": testschema.AttributeWithStringPlanModifiers{
-							Required: true,
+							Computed: true,
 							PlanModifiers: []planmodifier.String{
 								stringplanmodifier.UseStateForUnknown(),
 							},
@@ -2065,6 +2151,60 @@ func TestBlockModifyPlan(t *testing.T) {
 						),
 					},
 				),
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+											"nested_required": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+											"nested_required": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed": tftypes.String,
+												"nested_required": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_computed": tftypes.NewValue(tftypes.String, "statevalue1"),
+											"nested_required": tftypes.NewValue(tftypes.String, "testvalue1"),
+										},
+									),
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed": tftypes.String,
+												"nested_required": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_computed": tftypes.NewValue(tftypes.String, "statevalue2"),
+											"nested_required": tftypes.NewValue(tftypes.String, "testvalue2"),
+										},
+									),
+								},
+							),
+						},
+					),
+				},
 				AttributeState: types.ListValueMust(
 					types.ObjectType{
 						AttrTypes: map[string]attr.Type{
@@ -2138,7 +2278,7 @@ func TestBlockModifyPlan(t *testing.T) {
 				NestedObject: testschema.NestedBlockObject{
 					Attributes: map[string]fwschema.Attribute{
 						"nested_computed": testschema.AttributeWithStringPlanModifiers{
-							Required: true,
+							Computed: true,
 							PlanModifiers: []planmodifier.String{
 								stringplanmodifier.UseStateForUnknown(),
 							},
@@ -2194,6 +2334,60 @@ func TestBlockModifyPlan(t *testing.T) {
 						),
 					},
 				),
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+											"nested_required": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+											"nested_required": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed": tftypes.String,
+												"nested_required": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_computed": tftypes.NewValue(tftypes.String, "statevalue1"),
+											"nested_required": tftypes.NewValue(tftypes.String, "testvalue1"),
+										},
+									),
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed": tftypes.String,
+												"nested_required": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_computed": tftypes.NewValue(tftypes.String, "statevalue2"),
+											"nested_required": tftypes.NewValue(tftypes.String, "testvalue2"),
+										},
+									),
+								},
+							),
+						},
+					),
+				},
 				AttributeState: types.ListValueMust(
 					types.ObjectType{
 						AttrTypes: map[string]attr.Type{
@@ -2255,7 +2449,7 @@ func TestBlockModifyPlan(t *testing.T) {
 				NestedObject: testschema.NestedBlockObject{
 					Attributes: map[string]fwschema.Attribute{
 						"nested_computed": testschema.AttributeWithStringPlanModifiers{
-							Required: true,
+							Computed: true,
 							PlanModifiers: []planmodifier.String{
 								stringplanmodifier.UseStateForUnknown(),
 							},
@@ -2331,6 +2525,60 @@ func TestBlockModifyPlan(t *testing.T) {
 						),
 					},
 				),
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+											"nested_required": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+											"nested_required": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed": tftypes.String,
+												"nested_required": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_computed": tftypes.NewValue(tftypes.String, "statevalue1"),
+											"nested_required": tftypes.NewValue(tftypes.String, "testvalue1"),
+										},
+									),
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed": tftypes.String,
+												"nested_required": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_computed": tftypes.NewValue(tftypes.String, "statevalue2"),
+											"nested_required": tftypes.NewValue(tftypes.String, "testvalue2"),
+										},
+									),
+								},
+							),
+						},
+					),
+				},
 				AttributeState: types.SetValueMust(
 					types.ObjectType{
 						AttrTypes: map[string]attr.Type{
@@ -2476,6 +2724,60 @@ func TestBlockModifyPlan(t *testing.T) {
 						),
 					},
 				),
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+											"nested_required": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+											"nested_required": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed": tftypes.String,
+												"nested_required": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_computed": tftypes.NewValue(tftypes.String, "statevalue1"),
+											"nested_required": tftypes.NewValue(tftypes.String, "testvalue1"),
+										},
+									),
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed": tftypes.String,
+												"nested_required": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_computed": tftypes.NewValue(tftypes.String, "statevalue2"),
+											"nested_required": tftypes.NewValue(tftypes.String, "testvalue2"),
+										},
+									),
+								},
+							),
+						},
+					),
+				},
 				AttributeState: types.SetValueMust(
 					types.ObjectType{
 						AttrTypes: map[string]attr.Type{
@@ -2605,6 +2907,60 @@ func TestBlockModifyPlan(t *testing.T) {
 						),
 					},
 				),
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+											"nested_required": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+											"nested_required": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed": tftypes.String,
+												"nested_required": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_computed": tftypes.NewValue(tftypes.String, "statevalue1"),
+											"nested_required": tftypes.NewValue(tftypes.String, "testvalue1"),
+										},
+									),
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed": tftypes.String,
+												"nested_required": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_computed": tftypes.NewValue(tftypes.String, "statevalue2"),
+											"nested_required": tftypes.NewValue(tftypes.String, "testvalue2"),
+										},
+									),
+								},
+							),
+						},
+					),
+				},
 				AttributeState: types.SetValueMust(
 					types.ObjectType{
 						AttrTypes: map[string]attr.Type{
@@ -3188,6 +3544,34 @@ func TestBlockModifyPlan(t *testing.T) {
 						"nested_required": types.StringValue("testvalue"),
 					},
 				),
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"nested_computed": tftypes.String,
+										"nested_required": tftypes.String,
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"nested_computed": tftypes.String,
+										"nested_required": tftypes.String,
+									},
+								},
+								map[string]tftypes.Value{
+									"nested_computed": tftypes.NewValue(tftypes.String, "statevalue"),
+									"nested_required": tftypes.NewValue(tftypes.String, "testvalue"),
+								},
+							),
+						},
+					),
+				},
 				AttributeState: types.ObjectValueMust(
 					map[string]attr.Type{
 						"nested_computed": types.StringType,

--- a/internal/fwserver/block_plan_modification_test.go
+++ b/internal/fwserver/block_plan_modification_test.go
@@ -3045,6 +3045,44 @@ func TestBlockModifyPlan(t *testing.T) {
 						},
 					},
 				),
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_computed": tftypes.NewValue(tftypes.String, "statevalue1"),
+										},
+									),
+								},
+							),
+						},
+					),
+				},
 				AttributeState: types.SetValueMust(
 					types.ObjectType{
 						AttrTypes: map[string]attr.Type{
@@ -3121,6 +3159,44 @@ func TestBlockModifyPlan(t *testing.T) {
 							AttrTypes: map[string]attr.Type{
 								"nested_computed": types.StringType,
 							},
+						},
+					),
+				},
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_computed": tftypes.NewValue(tftypes.String, "statevalue1"),
+										},
+									),
+								},
+							),
 						},
 					),
 				},

--- a/internal/fwserver/block_plan_modification_test.go
+++ b/internal/fwserver/block_plan_modification_test.go
@@ -996,6 +996,44 @@ func TestBlockModifyPlan(t *testing.T) {
 						},
 					},
 				),
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_computed": tftypes.NewValue(tftypes.String, "statevalue1"),
+										},
+									),
+								},
+							),
+						},
+					),
+				},
 				AttributeState: types.ListValueMust(
 					types.ObjectType{
 						AttrTypes: map[string]attr.Type{
@@ -1072,6 +1110,44 @@ func TestBlockModifyPlan(t *testing.T) {
 							AttrTypes: map[string]attr.Type{
 								"nested_computed": types.StringType,
 							},
+						},
+					),
+				},
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_computed": tftypes.NewValue(tftypes.String, "statevalue1"),
+										},
+									),
+								},
+							),
 						},
 					),
 				},

--- a/internal/fwserver/block_plan_modification_test.go
+++ b/internal/fwserver/block_plan_modification_test.go
@@ -3772,6 +3772,31 @@ func TestBlockModifyPlan(t *testing.T) {
 						"nested_computed": types.StringType,
 					},
 				),
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"nested_computed": tftypes.String,
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"nested_computed": tftypes.String,
+									},
+								},
+								map[string]tftypes.Value{
+									"nested_computed": tftypes.NewValue(tftypes.String, "statevalue1"),
+								},
+							),
+						},
+					),
+				},
 				AttributeState: types.ObjectValueMust(
 					map[string]attr.Type{
 						"nested_computed": types.StringType,
@@ -3824,6 +3849,31 @@ func TestBlockModifyPlan(t *testing.T) {
 					ObjectValue: types.ObjectUnknown(
 						map[string]attr.Type{
 							"nested_computed": types.StringType,
+						},
+					),
+				},
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"nested_computed": tftypes.String,
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"nested_computed": tftypes.String,
+									},
+								},
+								map[string]tftypes.Value{
+									"nested_computed": tftypes.NewValue(tftypes.String, "statevalue1"),
+								},
+							),
 						},
 					),
 				},

--- a/resource/schema/boolplanmodifier/use_state_for_unknown.go
+++ b/resource/schema/boolplanmodifier/use_state_for_unknown.go
@@ -36,8 +36,8 @@ func (m useStateForUnknownModifier) MarkdownDescription(_ context.Context) strin
 
 // PlanModifyBool implements the plan modification logic.
 func (m useStateForUnknownModifier) PlanModifyBool(_ context.Context, req planmodifier.BoolRequest, resp *planmodifier.BoolResponse) {
-	// Do nothing if there is no state value.
-	if req.StateValue.IsNull() {
+	// Do nothing if there is no state (resource is being created).
+	if req.State.Raw.IsNull() {
 		return
 	}
 

--- a/resource/schema/dynamicplanmodifier/use_state_for_unknown.go
+++ b/resource/schema/dynamicplanmodifier/use_state_for_unknown.go
@@ -36,9 +36,8 @@ func (m useStateForUnknownModifier) MarkdownDescription(_ context.Context) strin
 
 // PlanModifyDynamic implements the plan modification logic.
 func (m useStateForUnknownModifier) PlanModifyDynamic(ctx context.Context, req planmodifier.DynamicRequest, resp *planmodifier.DynamicResponse) {
-	// Do nothing if there is no state value.
-	// This also requires checking if the underlying value is null.
-	if req.StateValue.IsNull() || req.StateValue.IsUnderlyingValueNull() {
+	// Do nothing if there is no state (resource is being created).
+	if req.State.Raw.IsNull() {
 		return
 	}
 

--- a/resource/schema/float32planmodifier/use_state_for_unknown.go
+++ b/resource/schema/float32planmodifier/use_state_for_unknown.go
@@ -36,8 +36,8 @@ func (m useStateForUnknownModifier) MarkdownDescription(_ context.Context) strin
 
 // PlanModifyFloat32 implements the plan modification logic.
 func (m useStateForUnknownModifier) PlanModifyFloat32(_ context.Context, req planmodifier.Float32Request, resp *planmodifier.Float32Response) {
-	// Do nothing if there is no state value.
-	if req.StateValue.IsNull() {
+	// Do nothing if there is no state (resource is being created).
+	if req.State.Raw.IsNull() {
 		return
 	}
 

--- a/resource/schema/float32planmodifier/use_state_for_unknown_test.go
+++ b/resource/schema/float32planmodifier/use_state_for_unknown_test.go
@@ -8,11 +8,11 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-framework/attr"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/float32planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
 func TestUseStateForUnknownModifierPlanModifyFloat32(t *testing.T) {
@@ -26,6 +26,16 @@ func TestUseStateForUnknownModifierPlanModifyFloat32(t *testing.T) {
 			// when we first create the resource, use the unknown
 			// value
 			request: planmodifier.Float32Request{
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"attr": tftypes.Number,
+							},
+						},
+						nil,
+					),
+				},
 				StateValue:  types.Float32Null(),
 				PlanValue:   types.Float32Unknown(),
 				ConfigValue: types.Float32Null(),
@@ -42,6 +52,18 @@ func TestUseStateForUnknownModifierPlanModifyFloat32(t *testing.T) {
 			// but we still want to preserve that value, in this
 			// case
 			request: planmodifier.Float32Request{
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"attr": tftypes.Number,
+							},
+						},
+						map[string]tftypes.Value{
+							"attr": tftypes.NewValue(tftypes.Number, 2.4),
+						},
+					),
+				},
 				StateValue:  types.Float32Value(2.4),
 				PlanValue:   types.Float32Value(1.2),
 				ConfigValue: types.Float32Null(),
@@ -50,16 +72,51 @@ func TestUseStateForUnknownModifierPlanModifyFloat32(t *testing.T) {
 				PlanValue: types.Float32Value(1.2),
 			},
 		},
-		"non-null-state-unknown-plan": {
+		"non-null-state-value-unknown-plan": {
 			// this is the situation we want to preserve the state
 			// in
 			request: planmodifier.Float32Request{
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"attr": tftypes.Number,
+							},
+						},
+						map[string]tftypes.Value{
+							"attr": tftypes.NewValue(tftypes.Number, 1.2),
+						},
+					),
+				},
 				StateValue:  types.Float32Value(1.2),
 				PlanValue:   types.Float32Unknown(),
 				ConfigValue: types.Float32Null(),
 			},
 			expected: &planmodifier.Float32Response{
 				PlanValue: types.Float32Value(1.2),
+			},
+		},
+		"null-state-value-unknown-plan": {
+			// Null state values are still known, so we should preserve this as well.
+			request: planmodifier.Float32Request{
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"attr": tftypes.Number,
+							},
+						},
+						map[string]tftypes.Value{
+							"attr": tftypes.NewValue(tftypes.Number, nil),
+						},
+					),
+				},
+				StateValue:  types.Float32Null(),
+				PlanValue:   types.Float32Unknown(),
+				ConfigValue: types.Float32Null(),
+			},
+			expected: &planmodifier.Float32Response{
+				PlanValue: types.Float32Null(),
 			},
 		},
 		"unknown-config": {
@@ -73,46 +130,6 @@ func TestUseStateForUnknownModifierPlanModifyFloat32(t *testing.T) {
 				StateValue:  types.Float32Value(1.2),
 				PlanValue:   types.Float32Unknown(),
 				ConfigValue: types.Float32Unknown(),
-			},
-			expected: &planmodifier.Float32Response{
-				PlanValue: types.Float32Unknown(),
-			},
-		},
-		"under-list": {
-			request: planmodifier.Float32Request{
-				ConfigValue: types.Float32Null(),
-				Path:        path.Root("test").AtListIndex(0).AtName("nested_test"),
-				PlanValue:   types.Float32Unknown(),
-				StateValue:  types.Float32Null(),
-			},
-			expected: &planmodifier.Float32Response{
-				PlanValue: types.Float32Unknown(),
-			},
-		},
-		"under-set": {
-			request: planmodifier.Float32Request{
-				ConfigValue: types.Float32Null(),
-				Path: path.Root("test").AtSetValue(
-					types.SetValueMust(
-						types.ObjectType{
-							AttrTypes: map[string]attr.Type{
-								"nested_test": types.Float32Type,
-							},
-						},
-						[]attr.Value{
-							types.ObjectValueMust(
-								map[string]attr.Type{
-									"nested_test": types.Float32Type,
-								},
-								map[string]attr.Value{
-									"nested_test": types.Float32Unknown(),
-								},
-							),
-						},
-					),
-				).AtName("nested_test"),
-				PlanValue:  types.Float32Unknown(),
-				StateValue: types.Float32Null(),
 			},
 			expected: &planmodifier.Float32Response{
 				PlanValue: types.Float32Unknown(),

--- a/resource/schema/float64planmodifier/use_state_for_unknown.go
+++ b/resource/schema/float64planmodifier/use_state_for_unknown.go
@@ -36,8 +36,8 @@ func (m useStateForUnknownModifier) MarkdownDescription(_ context.Context) strin
 
 // PlanModifyFloat64 implements the plan modification logic.
 func (m useStateForUnknownModifier) PlanModifyFloat64(_ context.Context, req planmodifier.Float64Request, resp *planmodifier.Float64Response) {
-	// Do nothing if there is no state value.
-	if req.StateValue.IsNull() {
+	// Do nothing if there is no state (resource is being created).
+	if req.State.Raw.IsNull() {
 		return
 	}
 

--- a/resource/schema/int32planmodifier/use_state_for_unknown.go
+++ b/resource/schema/int32planmodifier/use_state_for_unknown.go
@@ -36,8 +36,8 @@ func (m useStateForUnknownModifier) MarkdownDescription(_ context.Context) strin
 
 // PlanModifyInt32 implements the plan modification logic.
 func (m useStateForUnknownModifier) PlanModifyInt32(_ context.Context, req planmodifier.Int32Request, resp *planmodifier.Int32Response) {
-	// Do nothing if there is no state value.
-	if req.StateValue.IsNull() {
+	// Do nothing if there is no state (resource is being created).
+	if req.State.Raw.IsNull() {
 		return
 	}
 

--- a/resource/schema/int64planmodifier/use_state_for_unknown.go
+++ b/resource/schema/int64planmodifier/use_state_for_unknown.go
@@ -36,8 +36,8 @@ func (m useStateForUnknownModifier) MarkdownDescription(_ context.Context) strin
 
 // PlanModifyInt64 implements the plan modification logic.
 func (m useStateForUnknownModifier) PlanModifyInt64(_ context.Context, req planmodifier.Int64Request, resp *planmodifier.Int64Response) {
-	// Do nothing if there is no state value.
-	if req.StateValue.IsNull() {
+	// Do nothing if there is no state (resource is being created).
+	if req.State.Raw.IsNull() {
 		return
 	}
 

--- a/resource/schema/listplanmodifier/use_state_for_unknown.go
+++ b/resource/schema/listplanmodifier/use_state_for_unknown.go
@@ -36,8 +36,8 @@ func (m useStateForUnknownModifier) MarkdownDescription(_ context.Context) strin
 
 // PlanModifyList implements the plan modification logic.
 func (m useStateForUnknownModifier) PlanModifyList(_ context.Context, req planmodifier.ListRequest, resp *planmodifier.ListResponse) {
-	// Do nothing if there is no state value.
-	if req.StateValue.IsNull() {
+	// Do nothing if there is no state (resource is being created).
+	if req.State.Raw.IsNull() {
 		return
 	}
 

--- a/resource/schema/listplanmodifier/use_state_for_unknown_test.go
+++ b/resource/schema/listplanmodifier/use_state_for_unknown_test.go
@@ -9,10 +9,11 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
 func TestUseStateForUnknownModifierPlanModifyList(t *testing.T) {
@@ -26,6 +27,16 @@ func TestUseStateForUnknownModifierPlanModifyList(t *testing.T) {
 			// when we first create the resource, use the unknown
 			// value
 			request: planmodifier.ListRequest{
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"attr": tftypes.List{ElementType: tftypes.String},
+							},
+						},
+						nil,
+					),
+				},
 				StateValue:  types.ListNull(types.StringType),
 				PlanValue:   types.ListUnknown(types.StringType),
 				ConfigValue: types.ListNull(types.StringType),
@@ -42,6 +53,23 @@ func TestUseStateForUnknownModifierPlanModifyList(t *testing.T) {
 			// but we still want to preserve that value, in this
 			// case
 			request: planmodifier.ListRequest{
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"attr": tftypes.List{ElementType: tftypes.String},
+							},
+						},
+						map[string]tftypes.Value{
+							"attr": tftypes.NewValue(
+								tftypes.List{ElementType: tftypes.String},
+								[]tftypes.Value{
+									tftypes.NewValue(tftypes.String, "other"),
+								},
+							),
+						},
+					),
+				},
 				StateValue:  types.ListValueMust(types.StringType, []attr.Value{types.StringValue("other")}),
 				PlanValue:   types.ListValueMust(types.StringType, []attr.Value{types.StringValue("test")}),
 				ConfigValue: types.ListNull(types.StringType),
@@ -50,16 +78,59 @@ func TestUseStateForUnknownModifierPlanModifyList(t *testing.T) {
 				PlanValue: types.ListValueMust(types.StringType, []attr.Value{types.StringValue("test")}),
 			},
 		},
-		"non-null-state-unknown-plan": {
+		"non-null-state-value-unknown-plan": {
 			// this is the situation we want to preserve the state
 			// in
 			request: planmodifier.ListRequest{
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"attr": tftypes.List{ElementType: tftypes.String},
+							},
+						},
+						map[string]tftypes.Value{
+							"attr": tftypes.NewValue(
+								tftypes.List{ElementType: tftypes.String},
+								[]tftypes.Value{
+									tftypes.NewValue(tftypes.String, "test"),
+								},
+							),
+						},
+					),
+				},
 				StateValue:  types.ListValueMust(types.StringType, []attr.Value{types.StringValue("test")}),
 				PlanValue:   types.ListUnknown(types.StringType),
 				ConfigValue: types.ListNull(types.StringType),
 			},
 			expected: &planmodifier.ListResponse{
 				PlanValue: types.ListValueMust(types.StringType, []attr.Value{types.StringValue("test")}),
+			},
+		},
+		"null-state-value-unknown-plan": {
+			// Null state values are still known, so we should preserve this as well.
+			request: planmodifier.ListRequest{
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"attr": tftypes.List{ElementType: tftypes.String},
+							},
+						},
+						map[string]tftypes.Value{
+							"attr": tftypes.NewValue(
+								tftypes.List{ElementType: tftypes.String},
+								nil,
+							),
+						},
+					),
+				},
+				StateValue:  types.ListNull(types.StringType),
+				PlanValue:   types.ListUnknown(types.StringType),
+				ConfigValue: types.ListNull(types.StringType),
+			},
+			expected: &planmodifier.ListResponse{
+				PlanValue: types.ListNull(types.StringType),
 			},
 		},
 		"unknown-config": {
@@ -73,46 +144,6 @@ func TestUseStateForUnknownModifierPlanModifyList(t *testing.T) {
 				StateValue:  types.ListValueMust(types.StringType, []attr.Value{types.StringValue("test")}),
 				PlanValue:   types.ListUnknown(types.StringType),
 				ConfigValue: types.ListUnknown(types.StringType),
-			},
-			expected: &planmodifier.ListResponse{
-				PlanValue: types.ListUnknown(types.StringType),
-			},
-		},
-		"under-list": {
-			request: planmodifier.ListRequest{
-				ConfigValue: types.ListNull(types.StringType),
-				Path:        path.Root("test").AtListIndex(0).AtName("nested_test"),
-				PlanValue:   types.ListUnknown(types.StringType),
-				StateValue:  types.ListNull(types.StringType),
-			},
-			expected: &planmodifier.ListResponse{
-				PlanValue: types.ListUnknown(types.StringType),
-			},
-		},
-		"under-set": {
-			request: planmodifier.ListRequest{
-				ConfigValue: types.ListNull(types.StringType),
-				Path: path.Root("test").AtSetValue(
-					types.SetValueMust(
-						types.ObjectType{
-							AttrTypes: map[string]attr.Type{
-								"nested_test": types.ListType{ElemType: types.StringType},
-							},
-						},
-						[]attr.Value{
-							types.ObjectValueMust(
-								map[string]attr.Type{
-									"nested_test": types.ListType{ElemType: types.StringType},
-								},
-								map[string]attr.Value{
-									"nested_test": types.ListUnknown(types.StringType),
-								},
-							),
-						},
-					),
-				).AtName("nested_test"),
-				PlanValue:  types.ListUnknown(types.StringType),
-				StateValue: types.ListNull(types.StringType),
 			},
 			expected: &planmodifier.ListResponse{
 				PlanValue: types.ListUnknown(types.StringType),

--- a/resource/schema/mapplanmodifier/use_state_for_unknown.go
+++ b/resource/schema/mapplanmodifier/use_state_for_unknown.go
@@ -36,8 +36,8 @@ func (m useStateForUnknownModifier) MarkdownDescription(_ context.Context) strin
 
 // PlanModifyMap implements the plan modification logic.
 func (m useStateForUnknownModifier) PlanModifyMap(_ context.Context, req planmodifier.MapRequest, resp *planmodifier.MapResponse) {
-	// Do nothing if there is no state value.
-	if req.StateValue.IsNull() {
+	// Do nothing if there is no state (resource is being created).
+	if req.State.Raw.IsNull() {
 		return
 	}
 

--- a/resource/schema/numberplanmodifier/use_state_for_unknown.go
+++ b/resource/schema/numberplanmodifier/use_state_for_unknown.go
@@ -36,8 +36,8 @@ func (m useStateForUnknownModifier) MarkdownDescription(_ context.Context) strin
 
 // PlanModifyNumber implements the plan modification logic.
 func (m useStateForUnknownModifier) PlanModifyNumber(_ context.Context, req planmodifier.NumberRequest, resp *planmodifier.NumberResponse) {
-	// Do nothing if there is no state value.
-	if req.StateValue.IsNull() {
+	// Do nothing if there is no state (resource is being created).
+	if req.State.Raw.IsNull() {
 		return
 	}
 

--- a/resource/schema/objectplanmodifier/use_state_for_unknown.go
+++ b/resource/schema/objectplanmodifier/use_state_for_unknown.go
@@ -36,8 +36,8 @@ func (m useStateForUnknownModifier) MarkdownDescription(_ context.Context) strin
 
 // PlanModifyObject implements the plan modification logic.
 func (m useStateForUnknownModifier) PlanModifyObject(_ context.Context, req planmodifier.ObjectRequest, resp *planmodifier.ObjectResponse) {
-	// Do nothing if there is no state value.
-	if req.StateValue.IsNull() {
+	// Do nothing if there is no state (resource is being created).
+	if req.State.Raw.IsNull() {
 		return
 	}
 

--- a/resource/schema/setplanmodifier/use_state_for_unknown.go
+++ b/resource/schema/setplanmodifier/use_state_for_unknown.go
@@ -36,8 +36,8 @@ func (m useStateForUnknownModifier) MarkdownDescription(_ context.Context) strin
 
 // PlanModifySet implements the plan modification logic.
 func (m useStateForUnknownModifier) PlanModifySet(_ context.Context, req planmodifier.SetRequest, resp *planmodifier.SetResponse) {
-	// Do nothing if there is no state value.
-	if req.StateValue.IsNull() {
+	// Do nothing if there is no state (resource is being created).
+	if req.State.Raw.IsNull() {
 		return
 	}
 

--- a/resource/schema/stringplanmodifier/use_state_for_unknown.go
+++ b/resource/schema/stringplanmodifier/use_state_for_unknown.go
@@ -36,8 +36,8 @@ func (m useStateForUnknownModifier) MarkdownDescription(_ context.Context) strin
 
 // PlanModifyString implements the plan modification logic.
 func (m useStateForUnknownModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
-	// Do nothing if there is no state value.
-	if req.StateValue.IsNull() {
+	// Do nothing if there is no state (resource is being created).
+	if req.State.Raw.IsNull() {
 		return
 	}
 


### PR DESCRIPTION
## Related Issue

Closes #1117 

## Description

This PR adjusts all of the `UseStateForUnknown` plan modifiers to also preserve null state values (which are technically known). The original logic was excluding all null state values although we believe the intended behavior was to skip when creating resources (which should be checking the resource instance state for null, not the specific state value).

### Note
One of the impacts of fixing this bug would be any attributes in existing resource implementations that are relying on null values being set to unknown during update plans, which would now start to preserve the prior state (keeping null), so if the provider is not preserving those prior state values during apply, it could cause data consistency issues if that unknown marking was being relied on.

Off the top of my head, I'm not sure why you'd use `UseStateForUnknown` in this way, since the goal of this plan modifier has always been to denote an attribute that doesn't change during apply on updates. Fixing this bug doesn't change that goal, it just makes it more precise.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No
