### PR TITLE
Remove references to a removed linter

### DIFF
--- a/internal/reflect/helpers_test.go
+++ b/internal/reflect/helpers_test.go
@@ -21,7 +21,7 @@ type ExampleStruct struct {
 	BoolField bool   `tfsdk:"bool_field"`
 	IgnoreMe  string `tfsdk:"-"`
 
-	unexported          string //nolint:structcheck,unused
+	unexported          string //nolint:unused
 	unexportedAndTagged string `tfsdk:"unexported_and_tagged"`
 }
 
@@ -136,7 +136,7 @@ func TestGetStructTags(t *testing.T) {
 				ExampleStruct
 				Field5 string `tfsdk:"field5"`
 
-				unexported          string //nolint:structcheck,unused
+				unexported          string //nolint:unused
 				unexportedAndTagged string `tfsdk:"unexported_and_tagged"`
 			}{},
 			expectedTags: map[string][]int{
@@ -193,7 +193,7 @@ func TestGetStructTags(t *testing.T) {
 				*ExampleStruct
 				Field5 string `tfsdk:"field5"`
 
-				unexported          string //nolint:structcheck,unused
+				unexported          string //nolint:unused
 				unexportedAndTagged string `tfsdk:"unexported_and_tagged"`
 			}{},
 			expectedTags: map[string][]int{

--- a/internal/reflect/struct_test.go
+++ b/internal/reflect/struct_test.go
@@ -809,7 +809,7 @@ func TestNewStruct_structtags_ignores(t *testing.T) {
 
 	var s struct {
 		ExportedAndTagged   string `tfsdk:"exported_and_tagged"`
-		unexported          string //nolint:structcheck,unused
+		unexported          string //nolint:unused
 		unexportedAndTagged string `tfsdk:"unexported_and_tagged"`
 		ExportedAndExcluded string `tfsdk:"-"`
 	}
@@ -850,13 +850,13 @@ func TestNewStruct_embedded_structtags_ignores(t *testing.T) {
 
 	type s1 struct {
 		ExportedAndTagged   string `tfsdk:"exported_and_tagged"`
-		unexported          string //nolint:structcheck,unused
+		unexported          string //nolint:unused
 		unexportedAndTagged string `tfsdk:"unexported_and_tagged"`
 		ExportedAndExcluded string `tfsdk:"-"`
 	}
 
 	type s2 struct {
-		unexportedField string //nolint:structcheck,unused
+		unexportedField string //nolint:unused
 	}
 
 	var s struct {
@@ -2149,7 +2149,7 @@ func TestFromStruct_structtags_ignores(t *testing.T) {
 
 	type s struct {
 		ExportedAndTagged   string `tfsdk:"exported_and_tagged"`
-		unexported          string //nolint:structcheck,unused
+		unexported          string //nolint:unused
 		unexportedAndTagged string `tfsdk:"unexported_and_tagged"`
 		ExportedAndExcluded string `tfsdk:"-"`
 	}
@@ -2188,13 +2188,13 @@ func TestFromStruct_embedded_structtags_ignores(t *testing.T) {
 
 	type s1 struct {
 		ExportedAndTagged   string `tfsdk:"exported_and_tagged"`
-		unexported          string //nolint:structcheck,unused
+		unexported          string //nolint:unused
 		unexportedAndTagged string `tfsdk:"unexported_and_tagged"`
 		ExportedAndExcluded string `tfsdk:"-"`
 	}
 
 	type s2 struct {
-		unexportedField string //nolint:structcheck,unused
+		unexportedField string //nolint:unused
 	}
 
 	type s struct {


### PR DESCRIPTION
## Description

`structcheck` was removed in golangci-lint v2.

https://golangci-lint.run/product/migration-guide/#deprecated-linters

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

None