### PR TITLE
list: populate and return `ListResourceSchemas` in `GetProviderSchema` for protov5 and protov6

### DIFF
--- a/internal/proto5server/server_getproviderschema_test.go
+++ b/internal/proto5server/server_getproviderschema_test.go
@@ -6,8 +6,6 @@ package proto5server
 import (
 	"bytes"
 	"context"
-	"github.com/hashicorp/terraform-plugin-framework/list"
-	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -19,6 +17,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
 	"github.com/hashicorp/terraform-plugin-framework/internal/logging"
 	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testprovider"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/provider/metaschema"
 	providerschema "github.com/hashicorp/terraform-plugin-framework/provider/schema"

--- a/internal/proto5server/server_getproviderschema_test.go
+++ b/internal/proto5server/server_getproviderschema_test.go
@@ -107,6 +107,7 @@ func TestServerGetProviderSchema(t *testing.T) {
 				},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				Provider: &tfprotov5.Schema{
 					Block: &tfprotov5.SchemaBlock{},
 				},
@@ -163,8 +164,7 @@ func TestServerGetProviderSchema(t *testing.T) {
 			},
 			request: &tfprotov5.GetProviderSchemaRequest{},
 			expectedResponse: &tfprotov5.GetProviderSchemaResponse{
-				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
-				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
+				DataSourceSchemas: map[string]*tfprotov5.Schema{},
 				Diagnostics: []*tfprotov5.Diagnostic{
 					{
 						Severity: tfprotov5.DiagnosticSeverityError,
@@ -174,7 +174,9 @@ func TestServerGetProviderSchema(t *testing.T) {
 							"This is always an issue with the provider and should be reported to the provider developers.",
 					},
 				},
-				Functions: map[string]*tfprotov5.Function{},
+				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
+				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				Provider: &tfprotov5.Schema{
 					Block: &tfprotov5.SchemaBlock{},
 				},
@@ -206,8 +208,7 @@ func TestServerGetProviderSchema(t *testing.T) {
 			},
 			request: &tfprotov5.GetProviderSchemaRequest{},
 			expectedResponse: &tfprotov5.GetProviderSchemaResponse{
-				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
-				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
+				DataSourceSchemas: map[string]*tfprotov5.Schema{},
 				Diagnostics: []*tfprotov5.Diagnostic{
 					{
 						Severity: tfprotov5.DiagnosticSeverityError,
@@ -216,7 +217,9 @@ func TestServerGetProviderSchema(t *testing.T) {
 							"This is always an issue with the provider and should be reported to the provider developers.",
 					},
 				},
-				Functions: map[string]*tfprotov5.Function{},
+				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
+				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				Provider: &tfprotov5.Schema{
 					Block: &tfprotov5.SchemaBlock{},
 				},
@@ -298,7 +301,8 @@ func TestServerGetProviderSchema(t *testing.T) {
 						},
 					},
 				},
-				Functions: map[string]*tfprotov5.Function{},
+				Functions:           map[string]*tfprotov5.Function{},
+				ListResourceSchemas: map[string]*tfprotov5.Schema{},
 				Provider: &tfprotov5.Schema{
 					Block: &tfprotov5.SchemaBlock{},
 				},
@@ -355,8 +359,7 @@ func TestServerGetProviderSchema(t *testing.T) {
 			},
 			request: &tfprotov5.GetProviderSchemaRequest{},
 			expectedResponse: &tfprotov5.GetProviderSchemaResponse{
-				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
-				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
+				DataSourceSchemas: map[string]*tfprotov5.Schema{},
 				Diagnostics: []*tfprotov5.Diagnostic{
 					{
 						Severity: tfprotov5.DiagnosticSeverityError,
@@ -366,7 +369,9 @@ func TestServerGetProviderSchema(t *testing.T) {
 							"This is always an issue with the provider and should be reported to the provider developers.",
 					},
 				},
-				Functions: map[string]*tfprotov5.Function{},
+				Functions:                map[string]*tfprotov5.Function{},
+				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				Provider: &tfprotov5.Schema{
 					Block: &tfprotov5.SchemaBlock{},
 				},
@@ -398,8 +403,7 @@ func TestServerGetProviderSchema(t *testing.T) {
 			},
 			request: &tfprotov5.GetProviderSchemaRequest{},
 			expectedResponse: &tfprotov5.GetProviderSchemaResponse{
-				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
-				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
+				DataSourceSchemas: map[string]*tfprotov5.Schema{},
 				Diagnostics: []*tfprotov5.Diagnostic{
 					{
 						Severity: tfprotov5.DiagnosticSeverityError,
@@ -408,7 +412,9 @@ func TestServerGetProviderSchema(t *testing.T) {
 							"This is always an issue with the provider and should be reported to the provider developers.",
 					},
 				},
-				Functions: map[string]*tfprotov5.Function{},
+				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
+				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				Provider: &tfprotov5.Schema{
 					Block: &tfprotov5.SchemaBlock{},
 				},
@@ -473,6 +479,7 @@ func TestServerGetProviderSchema(t *testing.T) {
 						},
 					},
 				},
+				ListResourceSchemas: map[string]*tfprotov5.Schema{},
 				Provider: &tfprotov5.Schema{
 					Block: &tfprotov5.SchemaBlock{},
 				},
@@ -521,8 +528,7 @@ func TestServerGetProviderSchema(t *testing.T) {
 			},
 			request: &tfprotov5.GetProviderSchemaRequest{},
 			expectedResponse: &tfprotov5.GetProviderSchemaResponse{
-				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
-				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
+				DataSourceSchemas: map[string]*tfprotov5.Schema{},
 				Diagnostics: []*tfprotov5.Diagnostic{
 					{
 						Severity: tfprotov5.DiagnosticSeverityError,
@@ -532,7 +538,9 @@ func TestServerGetProviderSchema(t *testing.T) {
 							"This is always an issue with the provider and should be reported to the provider developers.",
 					},
 				},
-				Functions: map[string]*tfprotov5.Function{},
+				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
+				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				Provider: &tfprotov5.Schema{
 					Block: &tfprotov5.SchemaBlock{},
 				},
@@ -564,8 +572,7 @@ func TestServerGetProviderSchema(t *testing.T) {
 			},
 			request: &tfprotov5.GetProviderSchemaRequest{},
 			expectedResponse: &tfprotov5.GetProviderSchemaResponse{
-				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
-				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
+				DataSourceSchemas: map[string]*tfprotov5.Schema{},
 				Diagnostics: []*tfprotov5.Diagnostic{
 					{
 						Severity: tfprotov5.DiagnosticSeverityError,
@@ -574,7 +581,9 @@ func TestServerGetProviderSchema(t *testing.T) {
 							"This is always an issue with the provider and should be reported to the provider developers.",
 					},
 				},
-				Functions: map[string]*tfprotov5.Function{},
+				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
+				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				Provider: &tfprotov5.Schema{
 					Block: &tfprotov5.SchemaBlock{},
 				},
@@ -607,6 +616,7 @@ func TestServerGetProviderSchema(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				Provider: &tfprotov5.Schema{
 					Block: &tfprotov5.SchemaBlock{
 						Attributes: []*tfprotov5.SchemaAttribute{
@@ -648,6 +658,7 @@ func TestServerGetProviderSchema(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				Provider: &tfprotov5.Schema{
 					Block: &tfprotov5.SchemaBlock{},
 				},
@@ -718,6 +729,7 @@ func TestServerGetProviderSchema(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				Provider: &tfprotov5.Schema{
 					Block: &tfprotov5.SchemaBlock{},
 				},
@@ -797,8 +809,7 @@ func TestServerGetProviderSchema(t *testing.T) {
 			},
 			request: &tfprotov5.GetProviderSchemaRequest{},
 			expectedResponse: &tfprotov5.GetProviderSchemaResponse{
-				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
-				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
+				DataSourceSchemas: map[string]*tfprotov5.Schema{},
 				Diagnostics: []*tfprotov5.Diagnostic{
 					{
 						Severity: tfprotov5.DiagnosticSeverityError,
@@ -808,7 +819,9 @@ func TestServerGetProviderSchema(t *testing.T) {
 							"This is always an issue with the provider and should be reported to the provider developers.",
 					},
 				},
-				Functions: map[string]*tfprotov5.Function{},
+				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
+				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				Provider: &tfprotov5.Schema{
 					Block: &tfprotov5.SchemaBlock{},
 				},
@@ -840,8 +853,7 @@ func TestServerGetProviderSchema(t *testing.T) {
 			},
 			request: &tfprotov5.GetProviderSchemaRequest{},
 			expectedResponse: &tfprotov5.GetProviderSchemaResponse{
-				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
-				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
+				DataSourceSchemas: map[string]*tfprotov5.Schema{},
 				Diagnostics: []*tfprotov5.Diagnostic{
 					{
 						Severity: tfprotov5.DiagnosticSeverityError,
@@ -850,7 +862,9 @@ func TestServerGetProviderSchema(t *testing.T) {
 							"This is always an issue with the provider and should be reported to the provider developers.",
 					},
 				},
-				Functions: map[string]*tfprotov5.Function{},
+				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
+				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				Provider: &tfprotov5.Schema{
 					Block: &tfprotov5.SchemaBlock{},
 				},

--- a/internal/proto5server/server_getproviderschema_test.go
+++ b/internal/proto5server/server_getproviderschema_test.go
@@ -6,6 +6,8 @@ package proto5server
 import (
 	"bytes"
 	"context"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -578,6 +580,376 @@ func TestServerGetProviderSchema(t *testing.T) {
 						Severity: tfprotov5.DiagnosticSeverityError,
 						Summary:  "Function Name Missing",
 						Detail: "The *testprovider.Function Function returned an empty string from the Metadata method. " +
+							"This is always an issue with the provider and should be reported to the provider developers.",
+					},
+				},
+				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
+				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
+				Provider: &tfprotov5.Schema{
+					Block: &tfprotov5.SchemaBlock{},
+				},
+				ResourceSchemas: map[string]*tfprotov5.Schema{},
+				ServerCapabilities: &tfprotov5.ServerCapabilities{
+					GetProviderSchemaOptional: true,
+					MoveResourceState:         true,
+					PlanDestroy:               true,
+				},
+			},
+		},
+		"listschemas": {
+			server: &Server{
+				FrameworkServer: fwserver.Server{
+					Provider: &testprovider.Provider{
+						ListResourcesMethod: func(_ context.Context) []func() list.ListResource {
+							return []func() list.ListResource{
+								func() list.ListResource {
+									return &testprovider.ListResource{
+										ListResourceConfigSchemaMethod: func(_ context.Context, _ list.ListResourceSchemaRequest, resp *list.ListResourceSchemaResponse) {
+											resp.Schema = listschema.Schema{
+												Attributes: map[string]listschema.Attribute{
+													"test1": listschema.StringAttribute{
+														Required: true,
+													},
+												},
+											}
+										},
+										MetadataMethod: func(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
+											resp.TypeName = "test_list_resource1"
+										},
+									}
+								},
+								func() list.ListResource {
+									return &testprovider.ListResource{
+										ListResourceConfigSchemaMethod: func(_ context.Context, _ list.ListResourceSchemaRequest, resp *list.ListResourceSchemaResponse) {
+											resp.Schema = listschema.Schema{
+												Attributes: map[string]listschema.Attribute{
+													"test2": listschema.StringAttribute{
+														Required: true,
+													},
+												},
+											}
+										},
+										MetadataMethod: func(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
+											resp.TypeName = "test_list_resource2"
+										},
+									}
+								},
+							}
+						},
+						ResourcesMethod: func(_ context.Context) []func() resource.Resource {
+							return []func() resource.Resource{
+								func() resource.Resource {
+									return &testprovider.Resource{
+										SchemaMethod: func(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+											resp.Schema = resourceschema.Schema{
+												Attributes: map[string]resourceschema.Attribute{
+													"test1": resourceschema.StringAttribute{
+														Required: true,
+													},
+												},
+											}
+										},
+										MetadataMethod: func(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
+											resp.TypeName = "test_list_resource1"
+										},
+									}
+								},
+								func() resource.Resource {
+									return &testprovider.Resource{
+										SchemaMethod: func(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+											resp.Schema = resourceschema.Schema{
+												Attributes: map[string]resourceschema.Attribute{
+													"test2": resourceschema.StringAttribute{
+														Required: true,
+													},
+												},
+											}
+										},
+										MetadataMethod: func(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
+											resp.TypeName = "test_list_resource2"
+										},
+									}
+								},
+							}
+						},
+					},
+				},
+			},
+			request: &tfprotov5.GetProviderSchemaRequest{},
+			expectedResponse: &tfprotov5.GetProviderSchemaResponse{
+				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
+				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
+				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas: map[string]*tfprotov5.Schema{
+					"test_list_resource1": {
+						Block: &tfprotov5.SchemaBlock{
+							Attributes: []*tfprotov5.SchemaAttribute{
+								{
+									Name:     "test1",
+									Required: true,
+									Type:     tftypes.String,
+								},
+							},
+						},
+					},
+					"test_list_resource2": {
+						Block: &tfprotov5.SchemaBlock{
+							Attributes: []*tfprotov5.SchemaAttribute{
+								{
+									Name:     "test2",
+									Required: true,
+									Type:     tftypes.String,
+								},
+							},
+						},
+					},
+				},
+				Provider: &tfprotov5.Schema{
+					Block: &tfprotov5.SchemaBlock{},
+				},
+				ResourceSchemas: map[string]*tfprotov5.Schema{
+					"test_list_resource1": {
+						Block: &tfprotov5.SchemaBlock{
+							Attributes: []*tfprotov5.SchemaAttribute{
+								{
+									Name:     "test1",
+									Required: true,
+									Type:     tftypes.String,
+								},
+							},
+						},
+					},
+					"test_list_resource2": {
+						Block: &tfprotov5.SchemaBlock{
+							Attributes: []*tfprotov5.SchemaAttribute{
+								{
+									Name:     "test2",
+									Required: true,
+									Type:     tftypes.String,
+								},
+							},
+						},
+					},
+				},
+				ServerCapabilities: &tfprotov5.ServerCapabilities{
+					GetProviderSchemaOptional: true,
+					MoveResourceState:         true,
+					PlanDestroy:               true,
+				},
+			},
+		},
+		"listschemas-duplicate-type-name": {
+			server: &Server{
+				FrameworkServer: fwserver.Server{
+					Provider: &testprovider.Provider{
+						ListResourcesMethod: func(_ context.Context) []func() list.ListResource {
+							return []func() list.ListResource{
+								func() list.ListResource {
+									return &testprovider.ListResource{
+										ListResourceConfigSchemaMethod: func(_ context.Context, _ list.ListResourceSchemaRequest, resp *list.ListResourceSchemaResponse) {
+											resp.Schema = listschema.Schema{
+												Attributes: map[string]listschema.Attribute{
+													"test1": listschema.StringAttribute{
+														Required: true,
+													},
+												},
+											}
+										},
+										MetadataMethod: func(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
+											resp.TypeName = "test_list_resource"
+										},
+									}
+								},
+								func() list.ListResource {
+									return &testprovider.ListResource{
+										ListResourceConfigSchemaMethod: func(_ context.Context, _ list.ListResourceSchemaRequest, resp *list.ListResourceSchemaResponse) {
+											resp.Schema = listschema.Schema{
+												Attributes: map[string]listschema.Attribute{
+													"test2": listschema.StringAttribute{
+														Required: true,
+													},
+												},
+											}
+										},
+										MetadataMethod: func(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
+											resp.TypeName = "test_list_resource"
+										},
+									}
+								},
+							}
+						},
+						ResourcesMethod: func(_ context.Context) []func() resource.Resource {
+							return []func() resource.Resource{
+								func() resource.Resource {
+									return &testprovider.Resource{
+										SchemaMethod: func(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+											resp.Schema = resourceschema.Schema{
+												Attributes: map[string]resourceschema.Attribute{
+													"test1": resourceschema.StringAttribute{
+														Required: true,
+													},
+												},
+											}
+										},
+										MetadataMethod: func(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
+											resp.TypeName = "test_list_resource"
+										},
+									}
+								},
+							}
+						},
+					},
+				},
+			},
+			request: &tfprotov5.GetProviderSchemaRequest{},
+			expectedResponse: &tfprotov5.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov5.Schema{},
+				Diagnostics: []*tfprotov5.Diagnostic{
+					{
+						Severity: tfprotov5.DiagnosticSeverityError,
+						Summary:  "Duplicate ListResource Type Defined",
+						Detail: "The test_list_resource ListResource type name was returned for multiple list resources. " +
+							"ListResource type names must be unique. " +
+							"This is always an issue with the provider and should be reported to the provider developers.",
+					},
+				},
+				Functions:                map[string]*tfprotov5.Function{},
+				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
+				Provider: &tfprotov5.Schema{
+					Block: &tfprotov5.SchemaBlock{},
+				},
+				ResourceSchemas: map[string]*tfprotov5.Schema{
+					"test_list_resource": {
+						Block: &tfprotov5.SchemaBlock{
+							Attributes: []*tfprotov5.SchemaAttribute{
+								{
+									Name:     "test1",
+									Required: true,
+									Type:     tftypes.String,
+								},
+							},
+						},
+					},
+				},
+				ServerCapabilities: &tfprotov5.ServerCapabilities{
+					GetProviderSchemaOptional: true,
+					MoveResourceState:         true,
+					PlanDestroy:               true,
+				},
+			},
+		},
+		"listschemas-empty-type-name": {
+			server: &Server{
+				FrameworkServer: fwserver.Server{
+					Provider: &testprovider.Provider{
+						ListResourcesMethod: func(_ context.Context) []func() list.ListResource {
+							return []func() list.ListResource{
+								func() list.ListResource {
+									return &testprovider.ListResource{
+										MetadataMethod: func(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
+											resp.TypeName = ""
+										},
+									}
+								},
+							}
+						},
+						ResourcesMethod: func(_ context.Context) []func() resource.Resource {
+							return []func() resource.Resource{
+								func() resource.Resource {
+									return &testprovider.Resource{
+										SchemaMethod: func(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+											resp.Schema = resourceschema.Schema{
+												Attributes: map[string]resourceschema.Attribute{
+													"test1": resourceschema.StringAttribute{
+														Required: true,
+													},
+												},
+											}
+										},
+										MetadataMethod: func(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
+											resp.TypeName = "test_list_resource"
+										},
+									}
+								},
+							}
+						},
+					},
+				},
+			},
+			request: &tfprotov5.GetProviderSchemaRequest{},
+			expectedResponse: &tfprotov5.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov5.Schema{},
+				Diagnostics: []*tfprotov5.Diagnostic{
+					{
+						Severity: tfprotov5.DiagnosticSeverityError,
+						Summary:  "ListResource Type Name Missing",
+						Detail: "The *testprovider.ListResource ListResource returned an empty string from the Metadata method. " +
+							"This is always an issue with the provider and should be reported to the provider developers.",
+					},
+				},
+				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
+				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
+				Provider: &tfprotov5.Schema{
+					Block: &tfprotov5.SchemaBlock{},
+				},
+				ResourceSchemas: map[string]*tfprotov5.Schema{
+					"test_list_resource": {
+						Block: &tfprotov5.SchemaBlock{
+							Attributes: []*tfprotov5.SchemaAttribute{
+								{
+									Name:     "test1",
+									Required: true,
+									Type:     tftypes.String,
+								},
+							},
+						},
+					},
+				},
+				ServerCapabilities: &tfprotov5.ServerCapabilities{
+					GetProviderSchemaOptional: true,
+					MoveResourceState:         true,
+					PlanDestroy:               true,
+				},
+			},
+		},
+		"listschemas-missing-resource-definition": {
+			server: &Server{
+				FrameworkServer: fwserver.Server{
+					Provider: &testprovider.Provider{
+						ListResourcesMethod: func(_ context.Context) []func() list.ListResource {
+							return []func() list.ListResource{
+								func() list.ListResource {
+									return &testprovider.ListResource{
+										ListResourceConfigSchemaMethod: func(_ context.Context, _ list.ListResourceSchemaRequest, resp *list.ListResourceSchemaResponse) {
+											resp.Schema = listschema.Schema{
+												Attributes: map[string]listschema.Attribute{
+													"test1": listschema.StringAttribute{
+														Required: true,
+													},
+												},
+											}
+										},
+										MetadataMethod: func(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
+											resp.TypeName = "test_list_resource"
+										},
+									}
+								},
+							}
+						},
+					},
+				},
+			},
+			request: &tfprotov5.GetProviderSchemaRequest{},
+			expectedResponse: &tfprotov5.GetProviderSchemaResponse{
+				DataSourceSchemas: map[string]*tfprotov5.Schema{},
+				Diagnostics: []*tfprotov5.Diagnostic{
+					{
+						Severity: tfprotov5.DiagnosticSeverityError,
+						Summary:  "ListResource Type Defined without a Matching Managed Resource Type",
+						Detail: "The test_list_resource ListResource type name was returned, but no matching managed Resource type was defined. " +
 							"This is always an issue with the provider and should be reported to the provider developers.",
 					},
 				},

--- a/internal/proto6server/server_getproviderschema_test.go
+++ b/internal/proto6server/server_getproviderschema_test.go
@@ -6,8 +6,6 @@ package proto6server
 import (
 	"bytes"
 	"context"
-	"github.com/hashicorp/terraform-plugin-framework/list"
-	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -19,6 +17,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
 	"github.com/hashicorp/terraform-plugin-framework/internal/logging"
 	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testprovider"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/provider/metaschema"
 	providerschema "github.com/hashicorp/terraform-plugin-framework/provider/schema"

--- a/internal/proto6server/server_getproviderschema_test.go
+++ b/internal/proto6server/server_getproviderschema_test.go
@@ -107,6 +107,7 @@ func TestServerGetProviderSchema(t *testing.T) {
 				},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				Provider: &tfprotov6.Schema{
 					Block: &tfprotov6.SchemaBlock{},
 				},
@@ -173,8 +174,9 @@ func TestServerGetProviderSchema(t *testing.T) {
 							"This is always an issue with the provider and should be reported to the provider developers.",
 					},
 				},
-				Functions:                map[string]*tfprotov6.Function{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				Provider: &tfprotov6.Schema{
 					Block: &tfprotov6.SchemaBlock{},
 				},
@@ -215,8 +217,9 @@ func TestServerGetProviderSchema(t *testing.T) {
 							"This is always an issue with the provider and should be reported to the provider developers.",
 					},
 				},
-				Functions:                map[string]*tfprotov6.Function{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				Provider: &tfprotov6.Schema{
 					Block: &tfprotov6.SchemaBlock{},
 				},
@@ -298,7 +301,8 @@ func TestServerGetProviderSchema(t *testing.T) {
 						},
 					},
 				},
-				Functions: map[string]*tfprotov6.Function{},
+				Functions:           map[string]*tfprotov6.Function{},
+				ListResourceSchemas: map[string]*tfprotov6.Schema{},
 				Provider: &tfprotov6.Schema{
 					Block: &tfprotov6.SchemaBlock{},
 				},
@@ -355,8 +359,7 @@ func TestServerGetProviderSchema(t *testing.T) {
 			},
 			request: &tfprotov6.GetProviderSchemaRequest{},
 			expectedResponse: &tfprotov6.GetProviderSchemaResponse{
-				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
-				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
 				Diagnostics: []*tfprotov6.Diagnostic{
 					{
 						Severity: tfprotov6.DiagnosticSeverityError,
@@ -366,7 +369,9 @@ func TestServerGetProviderSchema(t *testing.T) {
 							"This is always an issue with the provider and should be reported to the provider developers.",
 					},
 				},
-				Functions: map[string]*tfprotov6.Function{},
+				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				Provider: &tfprotov6.Schema{
 					Block: &tfprotov6.SchemaBlock{},
 				},
@@ -398,8 +403,7 @@ func TestServerGetProviderSchema(t *testing.T) {
 			},
 			request: &tfprotov6.GetProviderSchemaRequest{},
 			expectedResponse: &tfprotov6.GetProviderSchemaResponse{
-				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
-				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
 				Diagnostics: []*tfprotov6.Diagnostic{
 					{
 						Severity: tfprotov6.DiagnosticSeverityError,
@@ -408,7 +412,9 @@ func TestServerGetProviderSchema(t *testing.T) {
 							"This is always an issue with the provider and should be reported to the provider developers.",
 					},
 				},
-				Functions: map[string]*tfprotov6.Function{},
+				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				Provider: &tfprotov6.Schema{
 					Block: &tfprotov6.SchemaBlock{},
 				},
@@ -473,6 +479,7 @@ func TestServerGetProviderSchema(t *testing.T) {
 						},
 					},
 				},
+				ListResourceSchemas: map[string]*tfprotov6.Schema{},
 				Provider: &tfprotov6.Schema{
 					Block: &tfprotov6.SchemaBlock{},
 				},
@@ -521,8 +528,7 @@ func TestServerGetProviderSchema(t *testing.T) {
 			},
 			request: &tfprotov6.GetProviderSchemaRequest{},
 			expectedResponse: &tfprotov6.GetProviderSchemaResponse{
-				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
-				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
 				Diagnostics: []*tfprotov6.Diagnostic{
 					{
 						Severity: tfprotov6.DiagnosticSeverityError,
@@ -532,7 +538,9 @@ func TestServerGetProviderSchema(t *testing.T) {
 							"This is always an issue with the provider and should be reported to the provider developers.",
 					},
 				},
-				Functions: map[string]*tfprotov6.Function{},
+				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				Provider: &tfprotov6.Schema{
 					Block: &tfprotov6.SchemaBlock{},
 				},
@@ -564,8 +572,7 @@ func TestServerGetProviderSchema(t *testing.T) {
 			},
 			request: &tfprotov6.GetProviderSchemaRequest{},
 			expectedResponse: &tfprotov6.GetProviderSchemaResponse{
-				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
-				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
 				Diagnostics: []*tfprotov6.Diagnostic{
 					{
 						Severity: tfprotov6.DiagnosticSeverityError,
@@ -574,7 +581,9 @@ func TestServerGetProviderSchema(t *testing.T) {
 							"This is always an issue with the provider and should be reported to the provider developers.",
 					},
 				},
-				Functions: map[string]*tfprotov6.Function{},
+				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				Provider: &tfprotov6.Schema{
 					Block: &tfprotov6.SchemaBlock{},
 				},
@@ -607,6 +616,7 @@ func TestServerGetProviderSchema(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				Provider: &tfprotov6.Schema{
 					Block: &tfprotov6.SchemaBlock{
 						Attributes: []*tfprotov6.SchemaAttribute{
@@ -648,6 +658,7 @@ func TestServerGetProviderSchema(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				Provider: &tfprotov6.Schema{
 					Block: &tfprotov6.SchemaBlock{},
 				},
@@ -718,6 +729,7 @@ func TestServerGetProviderSchema(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				Provider: &tfprotov6.Schema{
 					Block: &tfprotov6.SchemaBlock{},
 				},
@@ -797,8 +809,7 @@ func TestServerGetProviderSchema(t *testing.T) {
 			},
 			request: &tfprotov6.GetProviderSchemaRequest{},
 			expectedResponse: &tfprotov6.GetProviderSchemaResponse{
-				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
-				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
 				Diagnostics: []*tfprotov6.Diagnostic{
 					{
 						Severity: tfprotov6.DiagnosticSeverityError,
@@ -808,7 +819,9 @@ func TestServerGetProviderSchema(t *testing.T) {
 							"This is always an issue with the provider and should be reported to the provider developers.",
 					},
 				},
-				Functions: map[string]*tfprotov6.Function{},
+				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				Provider: &tfprotov6.Schema{
 					Block: &tfprotov6.SchemaBlock{},
 				},
@@ -840,8 +853,7 @@ func TestServerGetProviderSchema(t *testing.T) {
 			},
 			request: &tfprotov6.GetProviderSchemaRequest{},
 			expectedResponse: &tfprotov6.GetProviderSchemaResponse{
-				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
-				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
+				DataSourceSchemas: map[string]*tfprotov6.Schema{},
 				Diagnostics: []*tfprotov6.Diagnostic{
 					{
 						Severity: tfprotov6.DiagnosticSeverityError,
@@ -850,7 +862,9 @@ func TestServerGetProviderSchema(t *testing.T) {
 							"This is always an issue with the provider and should be reported to the provider developers.",
 					},
 				},
-				Functions: map[string]*tfprotov6.Function{},
+				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				Provider: &tfprotov6.Schema{
 					Block: &tfprotov6.SchemaBlock{},
 				},

--- a/internal/toproto5/getproviderschema.go
+++ b/internal/toproto5/getproviderschema.go
@@ -22,6 +22,7 @@ func GetProviderSchemaResponse(ctx context.Context, fw *fwserver.GetProviderSche
 		Diagnostics:              Diagnostics(ctx, fw.Diagnostics),
 		EphemeralResourceSchemas: make(map[string]*tfprotov5.Schema, len(fw.EphemeralResourceSchemas)),
 		Functions:                make(map[string]*tfprotov5.Function, len(fw.FunctionDefinitions)),
+		ListResourceSchemas:      make(map[string]*tfprotov5.Schema, len(fw.ListResourceSchemas)),
 		ResourceSchemas:          make(map[string]*tfprotov5.Schema, len(fw.ResourceSchemas)),
 		ServerCapabilities:       ServerCapabilities(ctx, fw.ServerCapabilities),
 	}
@@ -95,6 +96,18 @@ func GetProviderSchemaResponse(ctx context.Context, fw *fwserver.GetProviderSche
 			})
 
 			return protov5
+		}
+	}
+
+	for listResourceType, listResourceSchema := range fw.ListResourceSchemas {
+		protov5.ListResourceSchemas[listResourceType], err = Schema(ctx, listResourceSchema)
+
+		if err != nil {
+			protov5.Diagnostics = append(protov5.Diagnostics, &tfprotov5.Diagnostic{
+				Severity: tfprotov5.DiagnosticSeverityError,
+				Summary:  "Error converting list resource schema",
+				Detail:   "The schema for the list resource \"" + listResourceType + "\" couldn't be converted into a usable type. This is always a problem with the provider. Please report the following to the provider developer:\n\n" + err.Error(),
+			})
 		}
 	}
 

--- a/internal/toproto5/getproviderschema_test.go
+++ b/internal/toproto5/getproviderschema_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
 	"github.com/hashicorp/terraform-plugin-framework/internal/toproto5"
+	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
 	"github.com/hashicorp/terraform-plugin-framework/provider/metaschema"
 	providerschema "github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	resourceschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -83,6 +84,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ResourceSchemas:          map[string]*tfprotov5.Schema{},
 			},
 		},
@@ -114,6 +116,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ResourceSchemas:          map[string]*tfprotov5.Schema{},
 			},
 		},
@@ -147,6 +150,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ResourceSchemas:          map[string]*tfprotov5.Schema{},
 			},
 		},
@@ -178,6 +182,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ResourceSchemas:          map[string]*tfprotov5.Schema{},
 			},
 		},
@@ -211,6 +216,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ResourceSchemas:          map[string]*tfprotov5.Schema{},
 			},
 		},
@@ -242,6 +248,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ResourceSchemas:          map[string]*tfprotov5.Schema{},
 			},
 		},
@@ -275,6 +282,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ResourceSchemas:          map[string]*tfprotov5.Schema{},
 			},
 		},
@@ -307,6 +315,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ResourceSchemas:          map[string]*tfprotov5.Schema{},
 			},
 		},
@@ -338,6 +347,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ResourceSchemas:          map[string]*tfprotov5.Schema{},
 			},
 		},
@@ -369,6 +379,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ResourceSchemas:          map[string]*tfprotov5.Schema{},
 			},
 		},
@@ -400,6 +411,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ResourceSchemas:          map[string]*tfprotov5.Schema{},
 			},
 		},
@@ -431,6 +443,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ResourceSchemas:          map[string]*tfprotov5.Schema{},
 			},
 		},
@@ -462,6 +475,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ResourceSchemas:          map[string]*tfprotov5.Schema{},
 			},
 		},
@@ -500,6 +514,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ResourceSchemas:          map[string]*tfprotov5.Schema{},
 			},
 		},
@@ -535,6 +550,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ResourceSchemas:          map[string]*tfprotov5.Schema{},
 			},
 		},
@@ -577,6 +593,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ResourceSchemas:          map[string]*tfprotov5.Schema{},
 			},
 		},
@@ -611,6 +628,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ResourceSchemas:          map[string]*tfprotov5.Schema{},
 			},
 		},
@@ -646,6 +664,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ResourceSchemas:          map[string]*tfprotov5.Schema{},
 			},
 		},
@@ -680,6 +699,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ResourceSchemas:          map[string]*tfprotov5.Schema{},
 			},
 		},
@@ -711,6 +731,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ResourceSchemas:          map[string]*tfprotov5.Schema{},
 			},
 		},
@@ -749,6 +770,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ResourceSchemas:          map[string]*tfprotov5.Schema{},
 			},
 		},
@@ -784,6 +806,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ResourceSchemas:          map[string]*tfprotov5.Schema{},
 			},
 		},
@@ -826,6 +849,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ResourceSchemas:          map[string]*tfprotov5.Schema{},
 			},
 		},
@@ -864,6 +888,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ResourceSchemas:          map[string]*tfprotov5.Schema{},
 			},
 		},
@@ -898,6 +923,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ResourceSchemas:          map[string]*tfprotov5.Schema{},
 			},
 		},
@@ -931,6 +957,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ResourceSchemas:          map[string]*tfprotov5.Schema{},
 			},
 		},
@@ -962,6 +989,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ResourceSchemas:          map[string]*tfprotov5.Schema{},
 			},
 		},
@@ -993,6 +1021,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ResourceSchemas:          map[string]*tfprotov5.Schema{},
 			},
 		},
@@ -1038,6 +1067,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ResourceSchemas:          map[string]*tfprotov5.Schema{},
 			},
 		},
@@ -1083,6 +1113,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ResourceSchemas:          map[string]*tfprotov5.Schema{},
 			},
 		},
@@ -1126,6 +1157,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ResourceSchemas:          map[string]*tfprotov5.Schema{},
 			},
 		},
@@ -1174,8 +1206,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:       map[string]*tfprotov5.Function{},
-				ResourceSchemas: map[string]*tfprotov5.Schema{},
+				Functions:           map[string]*tfprotov5.Function{},
+				ListResourceSchemas: map[string]*tfprotov5.Schema{},
+				ResourceSchemas:     map[string]*tfprotov5.Schema{},
 			},
 		},
 		"ephemeral-resource-attribute-computed": {
@@ -1205,8 +1238,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:       map[string]*tfprotov5.Function{},
-				ResourceSchemas: map[string]*tfprotov5.Schema{},
+				Functions:           map[string]*tfprotov5.Function{},
+				ListResourceSchemas: map[string]*tfprotov5.Schema{},
+				ResourceSchemas:     map[string]*tfprotov5.Schema{},
 			},
 		},
 		"ephemeral-resource-attribute-deprecated": {
@@ -1238,8 +1272,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:       map[string]*tfprotov5.Function{},
-				ResourceSchemas: map[string]*tfprotov5.Schema{},
+				Functions:           map[string]*tfprotov5.Function{},
+				ListResourceSchemas: map[string]*tfprotov5.Schema{},
+				ResourceSchemas:     map[string]*tfprotov5.Schema{},
 			},
 		},
 		"ephemeral-resource-attribute-optional": {
@@ -1269,8 +1304,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:       map[string]*tfprotov5.Function{},
-				ResourceSchemas: map[string]*tfprotov5.Schema{},
+				Functions:           map[string]*tfprotov5.Function{},
+				ListResourceSchemas: map[string]*tfprotov5.Schema{},
+				ResourceSchemas:     map[string]*tfprotov5.Schema{},
 			},
 		},
 		"ephemeral-resource-attribute-optional-computed": {
@@ -1302,8 +1338,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:       map[string]*tfprotov5.Function{},
-				ResourceSchemas: map[string]*tfprotov5.Schema{},
+				Functions:           map[string]*tfprotov5.Function{},
+				ListResourceSchemas: map[string]*tfprotov5.Schema{},
+				ResourceSchemas:     map[string]*tfprotov5.Schema{},
 			},
 		},
 		"ephemeral-resource-attribute-required": {
@@ -1333,8 +1370,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:       map[string]*tfprotov5.Function{},
-				ResourceSchemas: map[string]*tfprotov5.Schema{},
+				Functions:           map[string]*tfprotov5.Function{},
+				ListResourceSchemas: map[string]*tfprotov5.Schema{},
+				ResourceSchemas:     map[string]*tfprotov5.Schema{},
 			},
 		},
 		"ephemeral-resource-attribute-sensitive": {
@@ -1366,8 +1404,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:       map[string]*tfprotov5.Function{},
-				ResourceSchemas: map[string]*tfprotov5.Schema{},
+				Functions:           map[string]*tfprotov5.Function{},
+				ListResourceSchemas: map[string]*tfprotov5.Schema{},
+				ResourceSchemas:     map[string]*tfprotov5.Schema{},
 			},
 		},
 		"ephemeral-resource-attribute-write-only": {
@@ -1398,8 +1437,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:       map[string]*tfprotov5.Function{},
-				ResourceSchemas: map[string]*tfprotov5.Schema{},
+				Functions:           map[string]*tfprotov5.Function{},
+				ListResourceSchemas: map[string]*tfprotov5.Schema{},
+				ResourceSchemas:     map[string]*tfprotov5.Schema{},
 			},
 		},
 		"ephemeral-resource-attribute-type-bool": {
@@ -1429,8 +1469,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:       map[string]*tfprotov5.Function{},
-				ResourceSchemas: map[string]*tfprotov5.Schema{},
+				Functions:           map[string]*tfprotov5.Function{},
+				ListResourceSchemas: map[string]*tfprotov5.Schema{},
+				ResourceSchemas:     map[string]*tfprotov5.Schema{},
 			},
 		},
 		"ephemeral-resource-attribute-type-float32": {
@@ -1460,8 +1501,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:       map[string]*tfprotov5.Function{},
-				ResourceSchemas: map[string]*tfprotov5.Schema{},
+				Functions:           map[string]*tfprotov5.Function{},
+				ListResourceSchemas: map[string]*tfprotov5.Schema{},
+				ResourceSchemas:     map[string]*tfprotov5.Schema{},
 			},
 		},
 		"ephemeral-resource-attribute-type-float64": {
@@ -1491,8 +1533,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:       map[string]*tfprotov5.Function{},
-				ResourceSchemas: map[string]*tfprotov5.Schema{},
+				Functions:           map[string]*tfprotov5.Function{},
+				ListResourceSchemas: map[string]*tfprotov5.Schema{},
+				ResourceSchemas:     map[string]*tfprotov5.Schema{},
 			},
 		},
 		"ephemeral-resource-attribute-type-int32": {
@@ -1522,8 +1565,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:       map[string]*tfprotov5.Function{},
-				ResourceSchemas: map[string]*tfprotov5.Schema{},
+				Functions:           map[string]*tfprotov5.Function{},
+				ListResourceSchemas: map[string]*tfprotov5.Schema{},
+				ResourceSchemas:     map[string]*tfprotov5.Schema{},
 			},
 		},
 		"ephemeral-resource-attribute-type-int64": {
@@ -1553,8 +1597,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:       map[string]*tfprotov5.Function{},
-				ResourceSchemas: map[string]*tfprotov5.Schema{},
+				Functions:           map[string]*tfprotov5.Function{},
+				ListResourceSchemas: map[string]*tfprotov5.Schema{},
+				ResourceSchemas:     map[string]*tfprotov5.Schema{},
 			},
 		},
 		"ephemeral-resource-attribute-type-list-list-string": {
@@ -1591,8 +1636,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:       map[string]*tfprotov5.Function{},
-				ResourceSchemas: map[string]*tfprotov5.Schema{},
+				Functions:           map[string]*tfprotov5.Function{},
+				ListResourceSchemas: map[string]*tfprotov5.Schema{},
+				ResourceSchemas:     map[string]*tfprotov5.Schema{},
 			},
 		},
 		"ephemeral-resource-attribute-type-list-nested-attributes": {
@@ -1626,8 +1672,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						Detail:   "The schema for the ephemeral resource \"test_ephemeral_resource\" couldn't be converted into a usable type. This is always a problem with the provider. Please report the following to the provider developer:\n\nAttributeName(\"test_attribute\"): protocol version 5 cannot have Attributes set",
 					},
 				},
-				Functions:       map[string]*tfprotov5.Function{},
-				ResourceSchemas: map[string]*tfprotov5.Schema{},
+				Functions:           map[string]*tfprotov5.Function{},
+				ListResourceSchemas: map[string]*tfprotov5.Schema{},
+				ResourceSchemas:     map[string]*tfprotov5.Schema{},
 			},
 		},
 		"ephemeral-resource-attribute-type-list-object": {
@@ -1668,8 +1715,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:       map[string]*tfprotov5.Function{},
-				ResourceSchemas: map[string]*tfprotov5.Schema{},
+				Functions:           map[string]*tfprotov5.Function{},
+				ListResourceSchemas: map[string]*tfprotov5.Schema{},
+				ResourceSchemas:     map[string]*tfprotov5.Schema{},
 			},
 		},
 		"ephemeral-resource-attribute-type-list-string": {
@@ -1702,8 +1750,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:       map[string]*tfprotov5.Function{},
-				ResourceSchemas: map[string]*tfprotov5.Schema{},
+				Functions:           map[string]*tfprotov5.Function{},
+				ListResourceSchemas: map[string]*tfprotov5.Schema{},
+				ResourceSchemas:     map[string]*tfprotov5.Schema{},
 			},
 		},
 		"ephemeral-resource-attribute-type-map-nested-attributes": {
@@ -1737,8 +1786,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						Detail:   "The schema for the ephemeral resource \"test_ephemeral_resource\" couldn't be converted into a usable type. This is always a problem with the provider. Please report the following to the provider developer:\n\nAttributeName(\"test_attribute\"): protocol version 5 cannot have Attributes set",
 					},
 				},
-				Functions:       map[string]*tfprotov5.Function{},
-				ResourceSchemas: map[string]*tfprotov5.Schema{},
+				Functions:           map[string]*tfprotov5.Function{},
+				ListResourceSchemas: map[string]*tfprotov5.Schema{},
+				ResourceSchemas:     map[string]*tfprotov5.Schema{},
 			},
 		},
 		"ephemeral-resource-attribute-type-map-string": {
@@ -1771,8 +1821,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:       map[string]*tfprotov5.Function{},
-				ResourceSchemas: map[string]*tfprotov5.Schema{},
+				Functions:           map[string]*tfprotov5.Function{},
+				ListResourceSchemas: map[string]*tfprotov5.Schema{},
+				ResourceSchemas:     map[string]*tfprotov5.Schema{},
 			},
 		},
 		"ephemeral-resource-attribute-type-number": {
@@ -1802,8 +1853,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:       map[string]*tfprotov5.Function{},
-				ResourceSchemas: map[string]*tfprotov5.Schema{},
+				Functions:           map[string]*tfprotov5.Function{},
+				ListResourceSchemas: map[string]*tfprotov5.Schema{},
+				ResourceSchemas:     map[string]*tfprotov5.Schema{},
 			},
 		},
 		"ephemeral-resource-attribute-type-object": {
@@ -1840,8 +1892,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:       map[string]*tfprotov5.Function{},
-				ResourceSchemas: map[string]*tfprotov5.Schema{},
+				Functions:           map[string]*tfprotov5.Function{},
+				ListResourceSchemas: map[string]*tfprotov5.Schema{},
+				ResourceSchemas:     map[string]*tfprotov5.Schema{},
 			},
 		},
 		"ephemeral-resource-attribute-type-set-nested-attributes": {
@@ -1875,8 +1928,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						Detail:   "The schema for the ephemeral resource \"test_ephemeral_resource\" couldn't be converted into a usable type. This is always a problem with the provider. Please report the following to the provider developer:\n\nAttributeName(\"test_attribute\"): protocol version 5 cannot have Attributes set",
 					},
 				},
-				Functions:       map[string]*tfprotov5.Function{},
-				ResourceSchemas: map[string]*tfprotov5.Schema{},
+				Functions:           map[string]*tfprotov5.Function{},
+				ListResourceSchemas: map[string]*tfprotov5.Schema{},
+				ResourceSchemas:     map[string]*tfprotov5.Schema{},
 			},
 		},
 		"ephemeral-resource-attribute-type-set-object": {
@@ -1917,8 +1971,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:       map[string]*tfprotov5.Function{},
-				ResourceSchemas: map[string]*tfprotov5.Schema{},
+				Functions:           map[string]*tfprotov5.Function{},
+				ListResourceSchemas: map[string]*tfprotov5.Schema{},
+				ResourceSchemas:     map[string]*tfprotov5.Schema{},
 			},
 		},
 		"ephemeral-resource-attribute-type-set-set-string": {
@@ -1955,8 +2010,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:       map[string]*tfprotov5.Function{},
-				ResourceSchemas: map[string]*tfprotov5.Schema{},
+				Functions:           map[string]*tfprotov5.Function{},
+				ListResourceSchemas: map[string]*tfprotov5.Schema{},
+				ResourceSchemas:     map[string]*tfprotov5.Schema{},
 			},
 		},
 		"ephemeral-resource-attribute-type-set-string": {
@@ -1989,8 +2045,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:       map[string]*tfprotov5.Function{},
-				ResourceSchemas: map[string]*tfprotov5.Schema{},
+				Functions:           map[string]*tfprotov5.Function{},
+				ListResourceSchemas: map[string]*tfprotov5.Schema{},
+				ResourceSchemas:     map[string]*tfprotov5.Schema{},
 			},
 		},
 		"ephemeral-resource-attribute-type-single-nested-attributes": {
@@ -2022,8 +2079,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						Detail:   "The schema for the ephemeral resource \"test_ephemeral_resource\" couldn't be converted into a usable type. This is always a problem with the provider. Please report the following to the provider developer:\n\nAttributeName(\"test_attribute\"): protocol version 5 cannot have Attributes set",
 					},
 				},
-				Functions:       map[string]*tfprotov5.Function{},
-				ResourceSchemas: map[string]*tfprotov5.Schema{},
+				Functions:           map[string]*tfprotov5.Function{},
+				ListResourceSchemas: map[string]*tfprotov5.Schema{},
+				ResourceSchemas:     map[string]*tfprotov5.Schema{},
 			},
 		},
 		"ephemeral-resource-attribute-type-string": {
@@ -2053,8 +2111,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:       map[string]*tfprotov5.Function{},
-				ResourceSchemas: map[string]*tfprotov5.Schema{},
+				Functions:           map[string]*tfprotov5.Function{},
+				ListResourceSchemas: map[string]*tfprotov5.Schema{},
+				ResourceSchemas:     map[string]*tfprotov5.Schema{},
 			},
 		},
 		"ephemeral-resource-attribute-type-dynamic": {
@@ -2084,8 +2143,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:       map[string]*tfprotov5.Function{},
-				ResourceSchemas: map[string]*tfprotov5.Schema{},
+				Functions:           map[string]*tfprotov5.Function{},
+				ListResourceSchemas: map[string]*tfprotov5.Schema{},
+				ResourceSchemas:     map[string]*tfprotov5.Schema{},
 			},
 		},
 		"ephemeral-resource-block-list": {
@@ -2129,8 +2189,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:       map[string]*tfprotov5.Function{},
-				ResourceSchemas: map[string]*tfprotov5.Schema{},
+				Functions:           map[string]*tfprotov5.Function{},
+				ListResourceSchemas: map[string]*tfprotov5.Schema{},
+				ResourceSchemas:     map[string]*tfprotov5.Schema{},
 			},
 		},
 		"ephemeral-resource-block-set": {
@@ -2174,8 +2235,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:       map[string]*tfprotov5.Function{},
-				ResourceSchemas: map[string]*tfprotov5.Schema{},
+				Functions:           map[string]*tfprotov5.Function{},
+				ListResourceSchemas: map[string]*tfprotov5.Schema{},
+				ResourceSchemas:     map[string]*tfprotov5.Schema{},
 			},
 		},
 		"ephemeral-resource-block-single": {
@@ -2217,8 +2279,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:       map[string]*tfprotov5.Function{},
-				ResourceSchemas: map[string]*tfprotov5.Schema{},
+				Functions:           map[string]*tfprotov5.Function{},
+				ListResourceSchemas: map[string]*tfprotov5.Schema{},
+				ResourceSchemas:     map[string]*tfprotov5.Schema{},
 			},
 		},
 		"functions": {
@@ -2249,7 +2312,8 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				ResourceSchemas: map[string]*tfprotov5.Schema{},
+				ListResourceSchemas: map[string]*tfprotov5.Schema{},
+				ResourceSchemas:     map[string]*tfprotov5.Schema{},
 			},
 		},
 		"functions-deprecationmessage": {
@@ -2273,7 +2337,8 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				ResourceSchemas: map[string]*tfprotov5.Schema{},
+				ListResourceSchemas: map[string]*tfprotov5.Schema{},
+				ResourceSchemas:     map[string]*tfprotov5.Schema{},
 			},
 		},
 		"functions-description": {
@@ -2297,7 +2362,8 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				ResourceSchemas: map[string]*tfprotov5.Schema{},
+				ListResourceSchemas: map[string]*tfprotov5.Schema{},
+				ResourceSchemas:     map[string]*tfprotov5.Schema{},
 			},
 		},
 		"functions-parameters": {
@@ -2334,7 +2400,8 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				ResourceSchemas: map[string]*tfprotov5.Schema{},
+				ListResourceSchemas: map[string]*tfprotov5.Schema{},
+				ResourceSchemas:     map[string]*tfprotov5.Schema{},
 			},
 		},
 		"functions-result": {
@@ -2356,7 +2423,8 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				ResourceSchemas: map[string]*tfprotov5.Schema{},
+				ListResourceSchemas: map[string]*tfprotov5.Schema{},
+				ResourceSchemas:     map[string]*tfprotov5.Schema{},
 			},
 		},
 		"functions-summary": {
@@ -2380,7 +2448,8 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						Summary: "test summary",
 					},
 				},
-				ResourceSchemas: map[string]*tfprotov5.Schema{},
+				ListResourceSchemas: map[string]*tfprotov5.Schema{},
+				ResourceSchemas:     map[string]*tfprotov5.Schema{},
 			},
 		},
 		"functions-variadicparameter": {
@@ -2406,6 +2475,187 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
+				ListResourceSchemas: map[string]*tfprotov5.Schema{},
+				ResourceSchemas:     map[string]*tfprotov5.Schema{},
+			},
+		},
+		"list-resource-multiple-list-resources": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ListResourceSchemas: map[string]fwschema.Schema{
+					"test_list_resource_1": listschema.Schema{
+						Attributes: map[string]listschema.Attribute{
+							"test_attribute": listschema.StringAttribute{
+								Required: true,
+							},
+						},
+					},
+					"test_list_resource_2": listschema.Schema{
+						Attributes: map[string]listschema.Attribute{
+							"test_attribute": listschema.StringAttribute{
+								Required: true,
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov5.GetProviderSchemaResponse{
+				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
+				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
+				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas: map[string]*tfprotov5.Schema{
+					"test_list_resource_1": {
+						Block: &tfprotov5.SchemaBlock{
+							Attributes: []*tfprotov5.SchemaAttribute{
+								{
+									Required: true,
+									Name:     "test_attribute",
+									Type:     tftypes.String,
+								},
+							},
+						},
+					},
+					"test_list_resource_2": {
+						Block: &tfprotov5.SchemaBlock{
+							Attributes: []*tfprotov5.SchemaAttribute{
+								{
+									Required: true,
+									Name:     "test_attribute",
+									Type:     tftypes.String,
+								},
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov5.Schema{},
+			},
+		},
+		"list-resource-attribute-deprecated": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ListResourceSchemas: map[string]fwschema.Schema{
+					"test_list_resource": listschema.Schema{
+						Attributes: map[string]listschema.Attribute{
+							"test_attribute": listschema.StringAttribute{
+								DeprecationMessage: "deprecated",
+								Optional:           true,
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov5.GetProviderSchemaResponse{
+				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
+				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
+				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas: map[string]*tfprotov5.Schema{
+					"test_list_resource": {
+						Block: &tfprotov5.SchemaBlock{
+							Attributes: []*tfprotov5.SchemaAttribute{
+								{
+									Deprecated: true,
+									Name:       "test_attribute",
+									Optional:   true,
+									Type:       tftypes.String,
+								},
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov5.Schema{},
+			},
+		},
+		"list-resource-attribute-optional": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ListResourceSchemas: map[string]fwschema.Schema{
+					"test_list_resource": listschema.Schema{
+						Attributes: map[string]listschema.Attribute{
+							"test_attribute": listschema.StringAttribute{
+								Optional: true,
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov5.GetProviderSchemaResponse{
+				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
+				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
+				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas: map[string]*tfprotov5.Schema{
+					"test_list_resource": {
+						Block: &tfprotov5.SchemaBlock{
+							Attributes: []*tfprotov5.SchemaAttribute{
+								{
+									Name:     "test_attribute",
+									Optional: true,
+									Type:     tftypes.String,
+								},
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov5.Schema{},
+			},
+		},
+		"list-resource-attribute-required": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ListResourceSchemas: map[string]fwschema.Schema{
+					"test_list_resource": listschema.Schema{
+						Attributes: map[string]listschema.Attribute{
+							"test_attribute": listschema.StringAttribute{
+								Required: true,
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov5.GetProviderSchemaResponse{
+				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
+				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
+				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas: map[string]*tfprotov5.Schema{
+					"test_list_resource": {
+						Block: &tfprotov5.SchemaBlock{
+							Attributes: []*tfprotov5.SchemaAttribute{
+								{
+									Name:     "test_attribute",
+									Type:     tftypes.String,
+									Required: true,
+								},
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov5.Schema{},
+			},
+		},
+		"list-resource-attribute-type-string": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ListResourceSchemas: map[string]fwschema.Schema{
+					"test_list_resource": listschema.Schema{
+						Attributes: map[string]listschema.Attribute{
+							"test_attribute": listschema.StringAttribute{
+								Required: true,
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov5.GetProviderSchemaResponse{
+				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
+				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
+				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas: map[string]*tfprotov5.Schema{
+					"test_list_resource": {
+						Block: &tfprotov5.SchemaBlock{
+							Attributes: []*tfprotov5.SchemaAttribute{
+								{
+									Required: true,
+									Name:     "test_attribute",
+									Type:     tftypes.String,
+								},
+							},
+						},
+					},
+				},
 				ResourceSchemas: map[string]*tfprotov5.Schema{},
 			},
 		},
@@ -2424,6 +2674,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				Provider: &tfprotov5.Schema{
 					Block: &tfprotov5.SchemaBlock{
 						Attributes: []*tfprotov5.SchemaAttribute{
@@ -2453,6 +2704,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				Provider: &tfprotov5.Schema{
 					Block: &tfprotov5.SchemaBlock{
 						Attributes: []*tfprotov5.SchemaAttribute{
@@ -2481,6 +2733,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				Provider: &tfprotov5.Schema{
 					Block: &tfprotov5.SchemaBlock{
 						Attributes: []*tfprotov5.SchemaAttribute{
@@ -2510,6 +2763,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				Provider: &tfprotov5.Schema{
 					Block: &tfprotov5.SchemaBlock{
 						Attributes: []*tfprotov5.SchemaAttribute{
@@ -2539,6 +2793,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				Provider: &tfprotov5.Schema{
 					Block: &tfprotov5.SchemaBlock{
 						Attributes: []*tfprotov5.SchemaAttribute{
@@ -2568,6 +2823,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				Provider: &tfprotov5.Schema{
 					Block: &tfprotov5.SchemaBlock{
 						Attributes: []*tfprotov5.SchemaAttribute{
@@ -2596,6 +2852,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				Provider: &tfprotov5.Schema{
 					Block: &tfprotov5.SchemaBlock{
 						Attributes: []*tfprotov5.SchemaAttribute{
@@ -2624,6 +2881,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				Provider: &tfprotov5.Schema{
 					Block: &tfprotov5.SchemaBlock{
 						Attributes: []*tfprotov5.SchemaAttribute{
@@ -2652,6 +2910,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				Provider: &tfprotov5.Schema{
 					Block: &tfprotov5.SchemaBlock{
 						Attributes: []*tfprotov5.SchemaAttribute{
@@ -2680,6 +2939,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				Provider: &tfprotov5.Schema{
 					Block: &tfprotov5.SchemaBlock{
 						Attributes: []*tfprotov5.SchemaAttribute{
@@ -2711,6 +2971,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				Provider: &tfprotov5.Schema{
 					Block: &tfprotov5.SchemaBlock{
 						Attributes: []*tfprotov5.SchemaAttribute{
@@ -2756,8 +3017,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						Detail:   "The provider schema couldn't be converted into a usable type. This is always a problem with the provider. Please report the following to the provider developer:\n\nAttributeName(\"test_attribute\"): protocol version 5 cannot have Attributes set",
 					},
 				},
-				Functions:       map[string]*tfprotov5.Function{},
-				ResourceSchemas: map[string]*tfprotov5.Schema{},
+				Functions:           map[string]*tfprotov5.Function{},
+				ListResourceSchemas: map[string]*tfprotov5.Schema{},
+				ResourceSchemas:     map[string]*tfprotov5.Schema{},
 			},
 		},
 		"provider-attribute-type-list-object": {
@@ -2779,6 +3041,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				Provider: &tfprotov5.Schema{
 					Block: &tfprotov5.SchemaBlock{
 						Attributes: []*tfprotov5.SchemaAttribute{
@@ -2814,6 +3077,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				Provider: &tfprotov5.Schema{
 					Block: &tfprotov5.SchemaBlock{
 						Attributes: []*tfprotov5.SchemaAttribute{
@@ -2857,8 +3121,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						Detail:   "The provider schema couldn't be converted into a usable type. This is always a problem with the provider. Please report the following to the provider developer:\n\nAttributeName(\"test_attribute\"): protocol version 5 cannot have Attributes set",
 					},
 				},
-				Functions:       map[string]*tfprotov5.Function{},
-				ResourceSchemas: map[string]*tfprotov5.Schema{},
+				Functions:           map[string]*tfprotov5.Function{},
+				ListResourceSchemas: map[string]*tfprotov5.Schema{},
+				ResourceSchemas:     map[string]*tfprotov5.Schema{},
 			},
 		},
 		"provider-attribute-type-map-string": {
@@ -2876,6 +3141,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				Provider: &tfprotov5.Schema{
 					Block: &tfprotov5.SchemaBlock{
 						Attributes: []*tfprotov5.SchemaAttribute{
@@ -2906,6 +3172,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				Provider: &tfprotov5.Schema{
 					Block: &tfprotov5.SchemaBlock{
 						Attributes: []*tfprotov5.SchemaAttribute{
@@ -2937,6 +3204,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				Provider: &tfprotov5.Schema{
 					Block: &tfprotov5.SchemaBlock{
 						Attributes: []*tfprotov5.SchemaAttribute{
@@ -2982,8 +3250,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						Detail:   "The provider schema couldn't be converted into a usable type. This is always a problem with the provider. Please report the following to the provider developer:\n\nAttributeName(\"test_attribute\"): protocol version 5 cannot have Attributes set",
 					},
 				},
-				Functions:       map[string]*tfprotov5.Function{},
-				ResourceSchemas: map[string]*tfprotov5.Schema{},
+				Functions:           map[string]*tfprotov5.Function{},
+				ListResourceSchemas: map[string]*tfprotov5.Schema{},
+				ResourceSchemas:     map[string]*tfprotov5.Schema{},
 			},
 		},
 		"provider-attribute-type-set-object": {
@@ -3005,6 +3274,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				Provider: &tfprotov5.Schema{
 					Block: &tfprotov5.SchemaBlock{
 						Attributes: []*tfprotov5.SchemaAttribute{
@@ -3042,6 +3312,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				Provider: &tfprotov5.Schema{
 					Block: &tfprotov5.SchemaBlock{
 						Attributes: []*tfprotov5.SchemaAttribute{
@@ -3075,6 +3346,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				Provider: &tfprotov5.Schema{
 					Block: &tfprotov5.SchemaBlock{
 						Attributes: []*tfprotov5.SchemaAttribute{
@@ -3116,8 +3388,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						Detail:   "The provider schema couldn't be converted into a usable type. This is always a problem with the provider. Please report the following to the provider developer:\n\nAttributeName(\"test_attribute\"): protocol version 5 cannot have Attributes set",
 					},
 				},
-				Functions:       map[string]*tfprotov5.Function{},
-				ResourceSchemas: map[string]*tfprotov5.Schema{},
+				Functions:           map[string]*tfprotov5.Function{},
+				ListResourceSchemas: map[string]*tfprotov5.Schema{},
+				ResourceSchemas:     map[string]*tfprotov5.Schema{},
 			},
 		},
 		"provider-attribute-type-string": {
@@ -3134,6 +3407,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				Provider: &tfprotov5.Schema{
 					Block: &tfprotov5.SchemaBlock{
 						Attributes: []*tfprotov5.SchemaAttribute{
@@ -3162,6 +3436,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				Provider: &tfprotov5.Schema{
 					Block: &tfprotov5.SchemaBlock{
 						Attributes: []*tfprotov5.SchemaAttribute{
@@ -3196,6 +3471,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				Provider: &tfprotov5.Schema{
 					Block: &tfprotov5.SchemaBlock{
 						BlockTypes: []*tfprotov5.SchemaNestedBlock{
@@ -3238,6 +3514,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				Provider: &tfprotov5.Schema{
 					Block: &tfprotov5.SchemaBlock{
 						BlockTypes: []*tfprotov5.SchemaNestedBlock{
@@ -3278,6 +3555,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				Provider: &tfprotov5.Schema{
 					Block: &tfprotov5.SchemaBlock{
 						BlockTypes: []*tfprotov5.SchemaNestedBlock{
@@ -3314,6 +3592,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ProviderMeta: &tfprotov5.Schema{
 					Block: &tfprotov5.SchemaBlock{
 						Attributes: []*tfprotov5.SchemaAttribute{
@@ -3342,6 +3621,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ProviderMeta: &tfprotov5.Schema{
 					Block: &tfprotov5.SchemaBlock{
 						Attributes: []*tfprotov5.SchemaAttribute{
@@ -3370,6 +3650,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ProviderMeta: &tfprotov5.Schema{
 					Block: &tfprotov5.SchemaBlock{
 						Attributes: []*tfprotov5.SchemaAttribute{
@@ -3398,6 +3679,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ProviderMeta: &tfprotov5.Schema{
 					Block: &tfprotov5.SchemaBlock{
 						Attributes: []*tfprotov5.SchemaAttribute{
@@ -3426,6 +3708,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ProviderMeta: &tfprotov5.Schema{
 					Block: &tfprotov5.SchemaBlock{
 						Attributes: []*tfprotov5.SchemaAttribute{
@@ -3457,6 +3740,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ProviderMeta: &tfprotov5.Schema{
 					Block: &tfprotov5.SchemaBlock{
 						Attributes: []*tfprotov5.SchemaAttribute{
@@ -3502,8 +3786,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						Detail:   "The provider_meta schema couldn't be converted into a usable type. This is always a problem with the provider. Please report the following to the provider developer:\n\nAttributeName(\"test_attribute\"): protocol version 5 cannot have Attributes set",
 					},
 				},
-				Functions:       map[string]*tfprotov5.Function{},
-				ResourceSchemas: map[string]*tfprotov5.Schema{},
+				Functions:           map[string]*tfprotov5.Function{},
+				ListResourceSchemas: map[string]*tfprotov5.Schema{},
+				ResourceSchemas:     map[string]*tfprotov5.Schema{},
 			},
 		},
 		"provider-meta-attribute-type-list-object": {
@@ -3541,8 +3826,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:       map[string]*tfprotov5.Function{},
-				ResourceSchemas: map[string]*tfprotov5.Schema{},
+				Functions:           map[string]*tfprotov5.Function{},
+				ListResourceSchemas: map[string]*tfprotov5.Schema{},
+				ResourceSchemas:     map[string]*tfprotov5.Schema{},
 			},
 		},
 		"provider-meta-attribute-type-list-string": {
@@ -3560,6 +3846,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ProviderMeta: &tfprotov5.Schema{
 					Block: &tfprotov5.SchemaBlock{
 						Attributes: []*tfprotov5.SchemaAttribute{
@@ -3603,8 +3890,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						Detail:   "The provider_meta schema couldn't be converted into a usable type. This is always a problem with the provider. Please report the following to the provider developer:\n\nAttributeName(\"test_attribute\"): protocol version 5 cannot have Attributes set",
 					},
 				},
-				Functions:       map[string]*tfprotov5.Function{},
-				ResourceSchemas: map[string]*tfprotov5.Schema{},
+				Functions:           map[string]*tfprotov5.Function{},
+				ListResourceSchemas: map[string]*tfprotov5.Schema{},
+				ResourceSchemas:     map[string]*tfprotov5.Schema{},
 			},
 		},
 		"provider-meta-attribute-type-map-string": {
@@ -3622,6 +3910,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ProviderMeta: &tfprotov5.Schema{
 					Block: &tfprotov5.SchemaBlock{
 						Attributes: []*tfprotov5.SchemaAttribute{
@@ -3652,6 +3941,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ProviderMeta: &tfprotov5.Schema{
 					Block: &tfprotov5.SchemaBlock{
 						Attributes: []*tfprotov5.SchemaAttribute{
@@ -3683,6 +3973,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ProviderMeta: &tfprotov5.Schema{
 					Block: &tfprotov5.SchemaBlock{
 						Attributes: []*tfprotov5.SchemaAttribute{
@@ -3728,8 +4019,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						Detail:   "The provider_meta schema couldn't be converted into a usable type. This is always a problem with the provider. Please report the following to the provider developer:\n\nAttributeName(\"test_attribute\"): protocol version 5 cannot have Attributes set",
 					},
 				},
-				Functions:       map[string]*tfprotov5.Function{},
-				ResourceSchemas: map[string]*tfprotov5.Schema{},
+				Functions:           map[string]*tfprotov5.Function{},
+				ListResourceSchemas: map[string]*tfprotov5.Schema{},
+				ResourceSchemas:     map[string]*tfprotov5.Schema{},
 			},
 		},
 		"provider-meta-attribute-type-set-object": {
@@ -3751,6 +4043,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ProviderMeta: &tfprotov5.Schema{
 					Block: &tfprotov5.SchemaBlock{
 						Attributes: []*tfprotov5.SchemaAttribute{
@@ -3788,6 +4081,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ProviderMeta: &tfprotov5.Schema{
 					Block: &tfprotov5.SchemaBlock{
 						Attributes: []*tfprotov5.SchemaAttribute{
@@ -3821,6 +4115,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ProviderMeta: &tfprotov5.Schema{
 					Block: &tfprotov5.SchemaBlock{
 						Attributes: []*tfprotov5.SchemaAttribute{
@@ -3862,8 +4157,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						Detail:   "The provider_meta schema couldn't be converted into a usable type. This is always a problem with the provider. Please report the following to the provider developer:\n\nAttributeName(\"test_attribute\"): protocol version 5 cannot have Attributes set",
 					},
 				},
-				Functions:       map[string]*tfprotov5.Function{},
-				ResourceSchemas: map[string]*tfprotov5.Schema{},
+				Functions:           map[string]*tfprotov5.Function{},
+				ListResourceSchemas: map[string]*tfprotov5.Schema{},
+				ResourceSchemas:     map[string]*tfprotov5.Schema{},
 			},
 		},
 		"provider-meta-attribute-type-string": {
@@ -3880,6 +4176,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ProviderMeta: &tfprotov5.Schema{
 					Block: &tfprotov5.SchemaBlock{
 						Attributes: []*tfprotov5.SchemaAttribute{
@@ -3917,6 +4214,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ResourceSchemas: map[string]*tfprotov5.Schema{
 					"test_resource_1": {
 						Block: &tfprotov5.SchemaBlock{
@@ -3959,6 +4257,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ResourceSchemas: map[string]*tfprotov5.Schema{
 					"test_resource": {
 						Block: &tfprotov5.SchemaBlock{
@@ -3991,6 +4290,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ResourceSchemas: map[string]*tfprotov5.Schema{
 					"test_resource": {
 						Block: &tfprotov5.SchemaBlock{
@@ -4023,6 +4323,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ResourceSchemas: map[string]*tfprotov5.Schema{
 					"test_resource": {
 						Block: &tfprotov5.SchemaBlock{
@@ -4055,6 +4356,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ResourceSchemas: map[string]*tfprotov5.Schema{
 					"test_resource": {
 						Block: &tfprotov5.SchemaBlock{
@@ -4087,6 +4389,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ResourceSchemas: map[string]*tfprotov5.Schema{
 					"test_resource": {
 						Block: &tfprotov5.SchemaBlock{
@@ -4119,6 +4422,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ResourceSchemas: map[string]*tfprotov5.Schema{
 					"test_resource": {
 						Block: &tfprotov5.SchemaBlock{
@@ -4152,6 +4456,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ResourceSchemas: map[string]*tfprotov5.Schema{
 					"test_resource": {
 						Block: &tfprotov5.SchemaBlock{
@@ -4184,6 +4489,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ResourceSchemas: map[string]*tfprotov5.Schema{
 					"test_resource": {
 						Block: &tfprotov5.SchemaBlock{
@@ -4215,6 +4521,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ResourceSchemas: map[string]*tfprotov5.Schema{
 					"test_resource": {
 						Block: &tfprotov5.SchemaBlock{
@@ -4246,6 +4553,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ResourceSchemas: map[string]*tfprotov5.Schema{
 					"test_resource": {
 						Block: &tfprotov5.SchemaBlock{
@@ -4277,6 +4585,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ResourceSchemas: map[string]*tfprotov5.Schema{
 					"test_resource": {
 						Block: &tfprotov5.SchemaBlock{
@@ -4308,6 +4617,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ResourceSchemas: map[string]*tfprotov5.Schema{
 					"test_resource": {
 						Block: &tfprotov5.SchemaBlock{
@@ -4342,6 +4652,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ResourceSchemas: map[string]*tfprotov5.Schema{
 					"test_resource": {
 						Block: &tfprotov5.SchemaBlock{
@@ -4390,7 +4701,8 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						Detail:   "The schema for the resource \"test_resource\" couldn't be converted into a usable type. This is always a problem with the provider. Please report the following to the provider developer:\n\nAttributeName(\"test_attribute\"): protocol version 5 cannot have Attributes set",
 					},
 				},
-				Functions: map[string]*tfprotov5.Function{},
+				Functions:           map[string]*tfprotov5.Function{},
+				ListResourceSchemas: map[string]*tfprotov5.Schema{},
 				ResourceSchemas: map[string]*tfprotov5.Schema{
 					"test_resource": nil,
 				},
@@ -4417,6 +4729,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ResourceSchemas: map[string]*tfprotov5.Schema{
 					"test_resource": {
 						Block: &tfprotov5.SchemaBlock{
@@ -4455,6 +4768,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ResourceSchemas: map[string]*tfprotov5.Schema{
 					"test_resource": {
 						Block: &tfprotov5.SchemaBlock{
@@ -4501,7 +4815,8 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						Detail:   "The schema for the resource \"test_resource\" couldn't be converted into a usable type. This is always a problem with the provider. Please report the following to the provider developer:\n\nAttributeName(\"test_attribute\"): protocol version 5 cannot have Attributes set",
 					},
 				},
-				Functions: map[string]*tfprotov5.Function{},
+				Functions:           map[string]*tfprotov5.Function{},
+				ListResourceSchemas: map[string]*tfprotov5.Schema{},
 				ResourceSchemas: map[string]*tfprotov5.Schema{
 					"test_resource": nil,
 				},
@@ -4524,6 +4839,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ResourceSchemas: map[string]*tfprotov5.Schema{
 					"test_resource": {
 						Block: &tfprotov5.SchemaBlock{
@@ -4557,6 +4873,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ResourceSchemas: map[string]*tfprotov5.Schema{
 					"test_resource": {
 						Block: &tfprotov5.SchemaBlock{
@@ -4591,6 +4908,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ResourceSchemas: map[string]*tfprotov5.Schema{
 					"test_resource": {
 						Block: &tfprotov5.SchemaBlock{
@@ -4639,7 +4957,8 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						Detail:   "The schema for the resource \"test_resource\" couldn't be converted into a usable type. This is always a problem with the provider. Please report the following to the provider developer:\n\nAttributeName(\"test_attribute\"): protocol version 5 cannot have Attributes set",
 					},
 				},
-				Functions: map[string]*tfprotov5.Function{},
+				Functions:           map[string]*tfprotov5.Function{},
+				ListResourceSchemas: map[string]*tfprotov5.Schema{},
 				ResourceSchemas: map[string]*tfprotov5.Schema{
 					"test_resource": nil,
 				},
@@ -4666,6 +4985,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ResourceSchemas: map[string]*tfprotov5.Schema{
 					"test_resource": {
 						Block: &tfprotov5.SchemaBlock{
@@ -4706,6 +5026,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ResourceSchemas: map[string]*tfprotov5.Schema{
 					"test_resource": {
 						Block: &tfprotov5.SchemaBlock{
@@ -4742,6 +5063,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ResourceSchemas: map[string]*tfprotov5.Schema{
 					"test_resource": {
 						Block: &tfprotov5.SchemaBlock{
@@ -4786,7 +5108,8 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						Detail:   "The schema for the resource \"test_resource\" couldn't be converted into a usable type. This is always a problem with the provider. Please report the following to the provider developer:\n\nAttributeName(\"test_attribute\"): protocol version 5 cannot have Attributes set",
 					},
 				},
-				Functions: map[string]*tfprotov5.Function{},
+				Functions:           map[string]*tfprotov5.Function{},
+				ListResourceSchemas: map[string]*tfprotov5.Schema{},
 				ResourceSchemas: map[string]*tfprotov5.Schema{
 					"test_resource": nil,
 				},
@@ -4808,6 +5131,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ResourceSchemas: map[string]*tfprotov5.Schema{
 					"test_resource": {
 						Block: &tfprotov5.SchemaBlock{
@@ -4839,6 +5163,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ResourceSchemas: map[string]*tfprotov5.Schema{
 					"test_resource": {
 						Block: &tfprotov5.SchemaBlock{
@@ -4876,6 +5201,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ResourceSchemas: map[string]*tfprotov5.Schema{
 					"test_resource": {
 						Block: &tfprotov5.SchemaBlock{
@@ -4921,6 +5247,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ResourceSchemas: map[string]*tfprotov5.Schema{
 					"test_resource": {
 						Block: &tfprotov5.SchemaBlock{
@@ -4964,6 +5291,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ResourceSchemas: map[string]*tfprotov5.Schema{
 					"test_resource": {
 						Block: &tfprotov5.SchemaBlock{
@@ -4999,6 +5327,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov5.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov5.Schema{},
 				Functions:                map[string]*tfprotov5.Function{},
+				ListResourceSchemas:      map[string]*tfprotov5.Schema{},
 				ResourceSchemas: map[string]*tfprotov5.Schema{
 					"test_resource": {
 						Block:   &tfprotov5.SchemaBlock{},

--- a/internal/toproto6/getproviderschema.go
+++ b/internal/toproto6/getproviderschema.go
@@ -22,6 +22,7 @@ func GetProviderSchemaResponse(ctx context.Context, fw *fwserver.GetProviderSche
 		Diagnostics:              Diagnostics(ctx, fw.Diagnostics),
 		EphemeralResourceSchemas: make(map[string]*tfprotov6.Schema, len(fw.EphemeralResourceSchemas)),
 		Functions:                make(map[string]*tfprotov6.Function, len(fw.FunctionDefinitions)),
+		ListResourceSchemas:      make(map[string]*tfprotov6.Schema, len(fw.ListResourceSchemas)),
 		ResourceSchemas:          make(map[string]*tfprotov6.Schema, len(fw.ResourceSchemas)),
 		ServerCapabilities:       ServerCapabilities(ctx, fw.ServerCapabilities),
 	}
@@ -92,6 +93,20 @@ func GetProviderSchemaResponse(ctx context.Context, fw *fwserver.GetProviderSche
 				Severity: tfprotov6.DiagnosticSeverityError,
 				Summary:  "Error converting ephemeral resource schema",
 				Detail:   "The schema for the ephemeral resource \"" + ephemeralResourceType + "\" couldn't be converted into a usable type. This is always a problem with the provider. Please report the following to the provider developer:\n\n" + err.Error(),
+			})
+
+			return protov6
+		}
+	}
+
+	for listResourceType, listResourceSchema := range fw.ListResourceSchemas {
+		protov6.ListResourceSchemas[listResourceType], err = Schema(ctx, listResourceSchema)
+
+		if err != nil {
+			protov6.Diagnostics = append(protov6.Diagnostics, &tfprotov6.Diagnostic{
+				Severity: tfprotov6.DiagnosticSeverityError,
+				Summary:  "Error converting list resource schema",
+				Detail:   "The schema for the list resource \"" + listResourceType + "\" couldn't be converted into a usable type. This is always a problem with the provider. Please report the following to the provider developer:\n\n" + err.Error(),
 			})
 
 			return protov6

--- a/internal/toproto6/getproviderschema_test.go
+++ b/internal/toproto6/getproviderschema_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
 	"github.com/hashicorp/terraform-plugin-framework/internal/toproto6"
+	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
 	"github.com/hashicorp/terraform-plugin-framework/provider/metaschema"
 	providerschema "github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	resourceschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -83,6 +84,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas:          map[string]*tfprotov6.Schema{},
 			},
 		},
@@ -112,8 +114,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:                map[string]*tfprotov6.Function{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas:          map[string]*tfprotov6.Schema{},
 			},
 		},
@@ -145,8 +148,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:                map[string]*tfprotov6.Function{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas:          map[string]*tfprotov6.Schema{},
 			},
 		},
@@ -176,8 +180,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:                map[string]*tfprotov6.Function{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas:          map[string]*tfprotov6.Schema{},
 			},
 		},
@@ -209,8 +214,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:                map[string]*tfprotov6.Function{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas:          map[string]*tfprotov6.Schema{},
 			},
 		},
@@ -240,8 +246,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:                map[string]*tfprotov6.Function{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas:          map[string]*tfprotov6.Schema{},
 			},
 		},
@@ -273,8 +280,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:                map[string]*tfprotov6.Function{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas:          map[string]*tfprotov6.Schema{},
 			},
 		},
@@ -305,8 +313,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:                map[string]*tfprotov6.Function{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas:          map[string]*tfprotov6.Schema{},
 			},
 		},
@@ -336,8 +345,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:                map[string]*tfprotov6.Function{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas:          map[string]*tfprotov6.Schema{},
 			},
 		},
@@ -367,8 +377,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:                map[string]*tfprotov6.Function{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas:          map[string]*tfprotov6.Schema{},
 			},
 		},
@@ -398,8 +409,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:                map[string]*tfprotov6.Function{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas:          map[string]*tfprotov6.Schema{},
 			},
 		},
@@ -429,8 +441,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:                map[string]*tfprotov6.Function{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas:          map[string]*tfprotov6.Schema{},
 			},
 		},
@@ -467,8 +480,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:                map[string]*tfprotov6.Function{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas:          map[string]*tfprotov6.Schema{},
 			},
 		},
@@ -514,8 +528,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:                map[string]*tfprotov6.Function{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas:          map[string]*tfprotov6.Schema{},
 			},
 		},
@@ -556,8 +571,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:                map[string]*tfprotov6.Function{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas:          map[string]*tfprotov6.Schema{},
 			},
 		},
@@ -590,8 +606,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:                map[string]*tfprotov6.Function{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas:          map[string]*tfprotov6.Schema{},
 			},
 		},
@@ -637,8 +654,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:                map[string]*tfprotov6.Function{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas:          map[string]*tfprotov6.Schema{},
 			},
 		},
@@ -671,8 +689,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:                map[string]*tfprotov6.Function{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas:          map[string]*tfprotov6.Schema{},
 			},
 		},
@@ -702,8 +721,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:                map[string]*tfprotov6.Function{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas:          map[string]*tfprotov6.Schema{},
 			},
 		},
@@ -740,8 +760,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:                map[string]*tfprotov6.Function{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas:          map[string]*tfprotov6.Schema{},
 			},
 		},
@@ -787,8 +808,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:                map[string]*tfprotov6.Function{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas:          map[string]*tfprotov6.Schema{},
 			},
 		},
@@ -829,8 +851,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:                map[string]*tfprotov6.Function{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas:          map[string]*tfprotov6.Schema{},
 			},
 		},
@@ -867,8 +890,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:                map[string]*tfprotov6.Function{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas:          map[string]*tfprotov6.Schema{},
 			},
 		},
@@ -901,8 +925,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:                map[string]*tfprotov6.Function{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas:          map[string]*tfprotov6.Schema{},
 			},
 		},
@@ -946,8 +971,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:                map[string]*tfprotov6.Function{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas:          map[string]*tfprotov6.Schema{},
 			},
 		},
@@ -977,8 +1003,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:                map[string]*tfprotov6.Function{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas:          map[string]*tfprotov6.Schema{},
 			},
 		},
@@ -1008,8 +1035,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:                map[string]*tfprotov6.Function{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas:          map[string]*tfprotov6.Schema{},
 			},
 		},
@@ -1053,8 +1081,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:                map[string]*tfprotov6.Function{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas:          map[string]*tfprotov6.Schema{},
 			},
 		},
@@ -1098,8 +1127,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:                map[string]*tfprotov6.Function{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas:          map[string]*tfprotov6.Schema{},
 			},
 		},
@@ -1141,8 +1171,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:                map[string]*tfprotov6.Function{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas:          map[string]*tfprotov6.Schema{},
 			},
 		},
@@ -1191,8 +1222,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:       map[string]*tfprotov6.Function{},
-				ResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:           map[string]*tfprotov6.Function{},
+				ListResourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas:     map[string]*tfprotov6.Schema{},
 			},
 		},
 		"ephemeral-resource-attribute-computed": {
@@ -1222,8 +1254,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:       map[string]*tfprotov6.Function{},
-				ResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:           map[string]*tfprotov6.Function{},
+				ListResourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas:     map[string]*tfprotov6.Schema{},
 			},
 		},
 		"ephemeral-resource-attribute-deprecated": {
@@ -1255,8 +1288,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:       map[string]*tfprotov6.Function{},
-				ResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:           map[string]*tfprotov6.Function{},
+				ListResourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas:     map[string]*tfprotov6.Schema{},
 			},
 		},
 		"ephemeral-resource-attribute-optional": {
@@ -1286,8 +1320,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:       map[string]*tfprotov6.Function{},
-				ResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:           map[string]*tfprotov6.Function{},
+				ListResourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas:     map[string]*tfprotov6.Schema{},
 			},
 		},
 		"ephemeral-resource-attribute-optional-computed": {
@@ -1319,8 +1354,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:       map[string]*tfprotov6.Function{},
-				ResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:           map[string]*tfprotov6.Function{},
+				ListResourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas:     map[string]*tfprotov6.Schema{},
 			},
 		},
 		"ephemeral-resource-attribute-required": {
@@ -1350,8 +1386,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:       map[string]*tfprotov6.Function{},
-				ResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:           map[string]*tfprotov6.Function{},
+				ListResourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas:     map[string]*tfprotov6.Schema{},
 			},
 		},
 		"ephemeral-resource-attribute-sensitive": {
@@ -1383,8 +1420,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:       map[string]*tfprotov6.Function{},
-				ResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:           map[string]*tfprotov6.Function{},
+				ListResourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas:     map[string]*tfprotov6.Schema{},
 			},
 		},
 		"ephemeral-resource-attribute-type-bool": {
@@ -1414,8 +1452,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:       map[string]*tfprotov6.Function{},
-				ResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:           map[string]*tfprotov6.Function{},
+				ListResourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas:     map[string]*tfprotov6.Schema{},
 			},
 		},
 		"ephemeral-resource-attribute-type-float32": {
@@ -1445,8 +1484,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:       map[string]*tfprotov6.Function{},
-				ResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:           map[string]*tfprotov6.Function{},
+				ListResourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas:     map[string]*tfprotov6.Schema{},
 			},
 		},
 		"ephemeral-resource-attribute-type-float64": {
@@ -1476,8 +1516,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:       map[string]*tfprotov6.Function{},
-				ResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:           map[string]*tfprotov6.Function{},
+				ListResourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas:     map[string]*tfprotov6.Schema{},
 			},
 		},
 		"ephemeral-resource-attribute-type-int32": {
@@ -1507,8 +1548,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:       map[string]*tfprotov6.Function{},
-				ResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:           map[string]*tfprotov6.Function{},
+				ListResourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas:     map[string]*tfprotov6.Schema{},
 			},
 		},
 		"ephemeral-resource-attribute-type-int64": {
@@ -1538,8 +1580,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:       map[string]*tfprotov6.Function{},
-				ResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:           map[string]*tfprotov6.Function{},
+				ListResourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas:     map[string]*tfprotov6.Schema{},
 			},
 		},
 		"ephemeral-resource-attribute-type-list-list-string": {
@@ -1576,8 +1619,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:       map[string]*tfprotov6.Function{},
-				ResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:           map[string]*tfprotov6.Function{},
+				ListResourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas:     map[string]*tfprotov6.Schema{},
 			},
 		},
 		"ephemeral-resource-attribute-type-list-nested-attributes": {
@@ -1623,8 +1667,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:       map[string]*tfprotov6.Function{},
-				ResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:           map[string]*tfprotov6.Function{},
+				ListResourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas:     map[string]*tfprotov6.Schema{},
 			},
 		},
 		"ephemeral-resource-attribute-type-list-object": {
@@ -1665,8 +1710,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:       map[string]*tfprotov6.Function{},
-				ResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:           map[string]*tfprotov6.Function{},
+				ListResourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas:     map[string]*tfprotov6.Schema{},
 			},
 		},
 		"ephemeral-resource-attribute-type-list-string": {
@@ -1699,8 +1745,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:       map[string]*tfprotov6.Function{},
-				ResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:           map[string]*tfprotov6.Function{},
+				ListResourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas:     map[string]*tfprotov6.Schema{},
 			},
 		},
 		"ephemeral-resource-attribute-type-map-nested-attributes": {
@@ -1746,8 +1793,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:       map[string]*tfprotov6.Function{},
-				ResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:           map[string]*tfprotov6.Function{},
+				ListResourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas:     map[string]*tfprotov6.Schema{},
 			},
 		},
 		"ephemeral-resource-attribute-type-map-string": {
@@ -1780,8 +1828,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:       map[string]*tfprotov6.Function{},
-				ResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:           map[string]*tfprotov6.Function{},
+				ListResourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas:     map[string]*tfprotov6.Schema{},
 			},
 		},
 		"ephemeral-resource-attribute-type-number": {
@@ -1811,8 +1860,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:       map[string]*tfprotov6.Function{},
-				ResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:           map[string]*tfprotov6.Function{},
+				ListResourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas:     map[string]*tfprotov6.Schema{},
 			},
 		},
 		"ephemeral-resource-attribute-type-object": {
@@ -1849,8 +1899,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:       map[string]*tfprotov6.Function{},
-				ResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:           map[string]*tfprotov6.Function{},
+				ListResourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas:     map[string]*tfprotov6.Schema{},
 			},
 		},
 		"ephemeral-resource-attribute-type-set-nested-attributes": {
@@ -1896,8 +1947,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:       map[string]*tfprotov6.Function{},
-				ResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:           map[string]*tfprotov6.Function{},
+				ListResourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas:     map[string]*tfprotov6.Schema{},
 			},
 		},
 		"ephemeral-resource-attribute-type-set-object": {
@@ -1938,8 +1990,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:       map[string]*tfprotov6.Function{},
-				ResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:           map[string]*tfprotov6.Function{},
+				ListResourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas:     map[string]*tfprotov6.Schema{},
 			},
 		},
 		"ephemeral-resource-attribute-type-set-set-string": {
@@ -1976,8 +2029,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:       map[string]*tfprotov6.Function{},
-				ResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:           map[string]*tfprotov6.Function{},
+				ListResourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas:     map[string]*tfprotov6.Schema{},
 			},
 		},
 		"ephemeral-resource-attribute-type-set-string": {
@@ -2010,8 +2064,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:       map[string]*tfprotov6.Function{},
-				ResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:           map[string]*tfprotov6.Function{},
+				ListResourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas:     map[string]*tfprotov6.Schema{},
 			},
 		},
 		"ephemeral-resource-attribute-type-single-nested-attributes": {
@@ -2055,8 +2110,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:       map[string]*tfprotov6.Function{},
-				ResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:           map[string]*tfprotov6.Function{},
+				ListResourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas:     map[string]*tfprotov6.Schema{},
 			},
 		},
 		"ephemeral-resource-attribute-type-string": {
@@ -2086,8 +2142,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:       map[string]*tfprotov6.Function{},
-				ResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:           map[string]*tfprotov6.Function{},
+				ListResourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas:     map[string]*tfprotov6.Schema{},
 			},
 		},
 		"ephemeral-resource-attribute-type-dynamic": {
@@ -2117,8 +2174,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:       map[string]*tfprotov6.Function{},
-				ResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:           map[string]*tfprotov6.Function{},
+				ListResourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas:     map[string]*tfprotov6.Schema{},
 			},
 		},
 		"ephemeral-resource-block-list": {
@@ -2162,8 +2220,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:       map[string]*tfprotov6.Function{},
-				ResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:           map[string]*tfprotov6.Function{},
+				ListResourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas:     map[string]*tfprotov6.Schema{},
 			},
 		},
 		"ephemeral-resource-block-set": {
@@ -2207,8 +2266,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:       map[string]*tfprotov6.Function{},
-				ResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:           map[string]*tfprotov6.Function{},
+				ListResourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas:     map[string]*tfprotov6.Schema{},
 			},
 		},
 		"ephemeral-resource-block-single": {
@@ -2250,8 +2310,9 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				Functions:       map[string]*tfprotov6.Function{},
-				ResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:           map[string]*tfprotov6.Function{},
+				ListResourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas:     map[string]*tfprotov6.Schema{},
 			},
 		},
 		"functions": {
@@ -2282,7 +2343,8 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				ResourceSchemas: map[string]*tfprotov6.Schema{},
+				ListResourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas:     map[string]*tfprotov6.Schema{},
 			},
 		},
 		"functions-deprecationmessage": {
@@ -2306,7 +2368,8 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				ResourceSchemas: map[string]*tfprotov6.Schema{},
+				ListResourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas:     map[string]*tfprotov6.Schema{},
 			},
 		},
 		"functions-description": {
@@ -2330,7 +2393,8 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				ResourceSchemas: map[string]*tfprotov6.Schema{},
+				ListResourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas:     map[string]*tfprotov6.Schema{},
 			},
 		},
 		"functions-parameters": {
@@ -2367,7 +2431,8 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				ResourceSchemas: map[string]*tfprotov6.Schema{},
+				ListResourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas:     map[string]*tfprotov6.Schema{},
 			},
 		},
 		"functions-result": {
@@ -2389,7 +2454,8 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
-				ResourceSchemas: map[string]*tfprotov6.Schema{},
+				ListResourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas:     map[string]*tfprotov6.Schema{},
 			},
 		},
 		"functions-summary": {
@@ -2413,7 +2479,8 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						Summary: "test summary",
 					},
 				},
-				ResourceSchemas: map[string]*tfprotov6.Schema{},
+				ListResourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas:     map[string]*tfprotov6.Schema{},
 			},
 		},
 		"functions-variadicparameter": {
@@ -2439,6 +2506,187 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 						},
 					},
 				},
+				ListResourceSchemas: map[string]*tfprotov6.Schema{},
+				ResourceSchemas:     map[string]*tfprotov6.Schema{},
+			},
+		},
+		"list-resource-multiple-list-resources": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ListResourceSchemas: map[string]fwschema.Schema{
+					"test_list_resource_1": listschema.Schema{
+						Attributes: map[string]listschema.Attribute{
+							"test_attribute": listschema.StringAttribute{
+								Optional: true,
+							},
+						},
+					},
+					"test_list_resource_2": listschema.Schema{
+						Attributes: map[string]listschema.Attribute{
+							"test_attribute": ephemeralschema.StringAttribute{
+								Optional: true,
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
+				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas: map[string]*tfprotov6.Schema{
+					"test_list_resource_1": {
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Optional: true,
+									Name:     "test_attribute",
+									Type:     tftypes.String,
+								},
+							},
+						},
+					},
+					"test_list_resource_2": {
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Optional: true,
+									Name:     "test_attribute",
+									Type:     tftypes.String,
+								},
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"list-resource-attribute-deprecated": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ListResourceSchemas: map[string]fwschema.Schema{
+					"test_list_resource": listschema.Schema{
+						Attributes: map[string]listschema.Attribute{
+							"test_attribute": listschema.StringAttribute{
+								DeprecationMessage: "deprecated",
+								Optional:           true,
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
+				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas: map[string]*tfprotov6.Schema{
+					"test_list_resource": {
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Deprecated: true,
+									Name:       "test_attribute",
+									Optional:   true,
+									Type:       tftypes.String,
+								},
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"list-resource-attribute-optional": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ListResourceSchemas: map[string]fwschema.Schema{
+					"test_list_resource": listschema.Schema{
+						Attributes: map[string]listschema.Attribute{
+							"test_attribute": listschema.StringAttribute{
+								Optional: true,
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
+				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas: map[string]*tfprotov6.Schema{
+					"test_list_resource": {
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Name:     "test_attribute",
+									Optional: true,
+									Type:     tftypes.String,
+								},
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"list-resource-attribute-required": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ListResourceSchemas: map[string]fwschema.Schema{
+					"test_list_resource": listschema.Schema{
+						Attributes: map[string]listschema.Attribute{
+							"test_attribute": listschema.StringAttribute{
+								Required: true,
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
+				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas: map[string]*tfprotov6.Schema{
+					"test_list_resource": {
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Name:     "test_attribute",
+									Type:     tftypes.String,
+									Required: true,
+								},
+							},
+						},
+					},
+				},
+				ResourceSchemas: map[string]*tfprotov6.Schema{},
+			},
+		},
+		"list-resource-attribute-type-string": {
+			input: &fwserver.GetProviderSchemaResponse{
+				ListResourceSchemas: map[string]fwschema.Schema{
+					"test_list_resource": listschema.Schema{
+						Attributes: map[string]listschema.Attribute{
+							"test_attribute": listschema.StringAttribute{
+								Required: true,
+							},
+						},
+					},
+				},
+			},
+			expected: &tfprotov6.GetProviderSchemaResponse{
+				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
+				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
+				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas: map[string]*tfprotov6.Schema{
+					"test_list_resource": {
+						Block: &tfprotov6.SchemaBlock{
+							Attributes: []*tfprotov6.SchemaAttribute{
+								{
+									Name:     "test_attribute",
+									Required: true,
+									Type:     tftypes.String,
+								},
+							},
+						},
+					},
+				},
 				ResourceSchemas: map[string]*tfprotov6.Schema{},
 			},
 		},
@@ -2457,6 +2705,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				Provider: &tfprotov6.Schema{
 					Block: &tfprotov6.SchemaBlock{
 						Attributes: []*tfprotov6.SchemaAttribute{
@@ -2486,6 +2735,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				Provider: &tfprotov6.Schema{
 					Block: &tfprotov6.SchemaBlock{
 						Attributes: []*tfprotov6.SchemaAttribute{
@@ -2514,6 +2764,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				Provider: &tfprotov6.Schema{
 					Block: &tfprotov6.SchemaBlock{
 						Attributes: []*tfprotov6.SchemaAttribute{
@@ -2543,6 +2794,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				Provider: &tfprotov6.Schema{
 					Block: &tfprotov6.SchemaBlock{
 						Attributes: []*tfprotov6.SchemaAttribute{
@@ -2572,6 +2824,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				Provider: &tfprotov6.Schema{
 					Block: &tfprotov6.SchemaBlock{
 						Attributes: []*tfprotov6.SchemaAttribute{
@@ -2601,6 +2854,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				Provider: &tfprotov6.Schema{
 					Block: &tfprotov6.SchemaBlock{
 						Attributes: []*tfprotov6.SchemaAttribute{
@@ -2629,6 +2883,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				Provider: &tfprotov6.Schema{
 					Block: &tfprotov6.SchemaBlock{
 						Attributes: []*tfprotov6.SchemaAttribute{
@@ -2657,6 +2912,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				Provider: &tfprotov6.Schema{
 					Block: &tfprotov6.SchemaBlock{
 						Attributes: []*tfprotov6.SchemaAttribute{
@@ -2685,6 +2941,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				Provider: &tfprotov6.Schema{
 					Block: &tfprotov6.SchemaBlock{
 						Attributes: []*tfprotov6.SchemaAttribute{
@@ -2716,6 +2973,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				Provider: &tfprotov6.Schema{
 					Block: &tfprotov6.SchemaBlock{
 						Attributes: []*tfprotov6.SchemaAttribute{
@@ -2755,6 +3013,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				Provider: &tfprotov6.Schema{
 					Block: &tfprotov6.SchemaBlock{
 						Attributes: []*tfprotov6.SchemaAttribute{
@@ -2797,6 +3056,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				Provider: &tfprotov6.Schema{
 					Block: &tfprotov6.SchemaBlock{
 						Attributes: []*tfprotov6.SchemaAttribute{
@@ -2832,6 +3092,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				Provider: &tfprotov6.Schema{
 					Block: &tfprotov6.SchemaBlock{
 						Attributes: []*tfprotov6.SchemaAttribute{
@@ -2869,6 +3130,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				Provider: &tfprotov6.Schema{
 					Block: &tfprotov6.SchemaBlock{
 						Attributes: []*tfprotov6.SchemaAttribute{
@@ -2907,6 +3169,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				Provider: &tfprotov6.Schema{
 					Block: &tfprotov6.SchemaBlock{
 						Attributes: []*tfprotov6.SchemaAttribute{
@@ -2937,6 +3200,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				Provider: &tfprotov6.Schema{
 					Block: &tfprotov6.SchemaBlock{
 						Attributes: []*tfprotov6.SchemaAttribute{
@@ -2968,6 +3232,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				Provider: &tfprotov6.Schema{
 					Block: &tfprotov6.SchemaBlock{
 						Attributes: []*tfprotov6.SchemaAttribute{
@@ -3007,6 +3272,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				Provider: &tfprotov6.Schema{
 					Block: &tfprotov6.SchemaBlock{
 						Attributes: []*tfprotov6.SchemaAttribute{
@@ -3049,6 +3315,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				Provider: &tfprotov6.Schema{
 					Block: &tfprotov6.SchemaBlock{
 						Attributes: []*tfprotov6.SchemaAttribute{
@@ -3086,6 +3353,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				Provider: &tfprotov6.Schema{
 					Block: &tfprotov6.SchemaBlock{
 						Attributes: []*tfprotov6.SchemaAttribute{
@@ -3119,6 +3387,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				Provider: &tfprotov6.Schema{
 					Block: &tfprotov6.SchemaBlock{
 						Attributes: []*tfprotov6.SchemaAttribute{
@@ -3154,6 +3423,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				Provider: &tfprotov6.Schema{
 					Block: &tfprotov6.SchemaBlock{
 						Attributes: []*tfprotov6.SchemaAttribute{
@@ -3191,6 +3461,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				Provider: &tfprotov6.Schema{
 					Block: &tfprotov6.SchemaBlock{
 						Attributes: []*tfprotov6.SchemaAttribute{
@@ -3219,6 +3490,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				Provider: &tfprotov6.Schema{
 					Block: &tfprotov6.SchemaBlock{
 						Attributes: []*tfprotov6.SchemaAttribute{
@@ -3253,6 +3525,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				Provider: &tfprotov6.Schema{
 					Block: &tfprotov6.SchemaBlock{
 						BlockTypes: []*tfprotov6.SchemaNestedBlock{
@@ -3295,6 +3568,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				Provider: &tfprotov6.Schema{
 					Block: &tfprotov6.SchemaBlock{
 						BlockTypes: []*tfprotov6.SchemaNestedBlock{
@@ -3335,6 +3609,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				Provider: &tfprotov6.Schema{
 					Block: &tfprotov6.SchemaBlock{
 						BlockTypes: []*tfprotov6.SchemaNestedBlock{
@@ -3371,6 +3646,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ProviderMeta: &tfprotov6.Schema{
 					Block: &tfprotov6.SchemaBlock{
 						Attributes: []*tfprotov6.SchemaAttribute{
@@ -3399,6 +3675,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ProviderMeta: &tfprotov6.Schema{
 					Block: &tfprotov6.SchemaBlock{
 						Attributes: []*tfprotov6.SchemaAttribute{
@@ -3427,6 +3704,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ProviderMeta: &tfprotov6.Schema{
 					Block: &tfprotov6.SchemaBlock{
 						Attributes: []*tfprotov6.SchemaAttribute{
@@ -3455,6 +3733,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ProviderMeta: &tfprotov6.Schema{
 					Block: &tfprotov6.SchemaBlock{
 						Attributes: []*tfprotov6.SchemaAttribute{
@@ -3483,6 +3762,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ProviderMeta: &tfprotov6.Schema{
 					Block: &tfprotov6.SchemaBlock{
 						Attributes: []*tfprotov6.SchemaAttribute{
@@ -3514,6 +3794,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ProviderMeta: &tfprotov6.Schema{
 					Block: &tfprotov6.SchemaBlock{
 						Attributes: []*tfprotov6.SchemaAttribute{
@@ -3553,6 +3834,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ProviderMeta: &tfprotov6.Schema{
 					Block: &tfprotov6.SchemaBlock{
 						Attributes: []*tfprotov6.SchemaAttribute{
@@ -3595,6 +3877,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ProviderMeta: &tfprotov6.Schema{
 					Block: &tfprotov6.SchemaBlock{
 						Attributes: []*tfprotov6.SchemaAttribute{
@@ -3630,6 +3913,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ProviderMeta: &tfprotov6.Schema{
 					Block: &tfprotov6.SchemaBlock{
 						Attributes: []*tfprotov6.SchemaAttribute{
@@ -3667,6 +3951,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ProviderMeta: &tfprotov6.Schema{
 					Block: &tfprotov6.SchemaBlock{
 						Attributes: []*tfprotov6.SchemaAttribute{
@@ -3705,6 +3990,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ProviderMeta: &tfprotov6.Schema{
 					Block: &tfprotov6.SchemaBlock{
 						Attributes: []*tfprotov6.SchemaAttribute{
@@ -3735,6 +4021,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ProviderMeta: &tfprotov6.Schema{
 					Block: &tfprotov6.SchemaBlock{
 						Attributes: []*tfprotov6.SchemaAttribute{
@@ -3766,6 +4053,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ProviderMeta: &tfprotov6.Schema{
 					Block: &tfprotov6.SchemaBlock{
 						Attributes: []*tfprotov6.SchemaAttribute{
@@ -3805,6 +4093,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ProviderMeta: &tfprotov6.Schema{
 					Block: &tfprotov6.SchemaBlock{
 						Attributes: []*tfprotov6.SchemaAttribute{
@@ -3847,6 +4136,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ProviderMeta: &tfprotov6.Schema{
 					Block: &tfprotov6.SchemaBlock{
 						Attributes: []*tfprotov6.SchemaAttribute{
@@ -3884,6 +4174,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ProviderMeta: &tfprotov6.Schema{
 					Block: &tfprotov6.SchemaBlock{
 						Attributes: []*tfprotov6.SchemaAttribute{
@@ -3917,6 +4208,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ProviderMeta: &tfprotov6.Schema{
 					Block: &tfprotov6.SchemaBlock{
 						Attributes: []*tfprotov6.SchemaAttribute{
@@ -3952,6 +4244,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ProviderMeta: &tfprotov6.Schema{
 					Block: &tfprotov6.SchemaBlock{
 						Attributes: []*tfprotov6.SchemaAttribute{
@@ -3989,6 +4282,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ProviderMeta: &tfprotov6.Schema{
 					Block: &tfprotov6.SchemaBlock{
 						Attributes: []*tfprotov6.SchemaAttribute{
@@ -4026,6 +4320,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas: map[string]*tfprotov6.Schema{
 					"test_resource_1": {
 						Block: &tfprotov6.SchemaBlock{
@@ -4068,6 +4363,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas: map[string]*tfprotov6.Schema{
 					"test_resource": {
 						Block: &tfprotov6.SchemaBlock{
@@ -4100,6 +4396,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas: map[string]*tfprotov6.Schema{
 					"test_resource": {
 						Block: &tfprotov6.SchemaBlock{
@@ -4132,6 +4429,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas: map[string]*tfprotov6.Schema{
 					"test_resource": {
 						Block: &tfprotov6.SchemaBlock{
@@ -4164,6 +4462,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas: map[string]*tfprotov6.Schema{
 					"test_resource": {
 						Block: &tfprotov6.SchemaBlock{
@@ -4196,6 +4495,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas: map[string]*tfprotov6.Schema{
 					"test_resource": {
 						Block: &tfprotov6.SchemaBlock{
@@ -4228,6 +4528,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas: map[string]*tfprotov6.Schema{
 					"test_resource": {
 						Block: &tfprotov6.SchemaBlock{
@@ -4261,6 +4562,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas: map[string]*tfprotov6.Schema{
 					"test_resource": {
 						Block: &tfprotov6.SchemaBlock{
@@ -4293,6 +4595,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas: map[string]*tfprotov6.Schema{
 					"test_resource": {
 						Block: &tfprotov6.SchemaBlock{
@@ -4324,6 +4627,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas: map[string]*tfprotov6.Schema{
 					"test_resource": {
 						Block: &tfprotov6.SchemaBlock{
@@ -4355,6 +4659,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas: map[string]*tfprotov6.Schema{
 					"test_resource": {
 						Block: &tfprotov6.SchemaBlock{
@@ -4386,6 +4691,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas: map[string]*tfprotov6.Schema{
 					"test_resource": {
 						Block: &tfprotov6.SchemaBlock{
@@ -4420,6 +4726,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas: map[string]*tfprotov6.Schema{
 					"test_resource": {
 						Block: &tfprotov6.SchemaBlock{
@@ -4462,6 +4769,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas: map[string]*tfprotov6.Schema{
 					"test_resource": {
 						Block: &tfprotov6.SchemaBlock{
@@ -4507,6 +4815,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas: map[string]*tfprotov6.Schema{
 					"test_resource": {
 						Block: &tfprotov6.SchemaBlock{
@@ -4545,6 +4854,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas: map[string]*tfprotov6.Schema{
 					"test_resource": {
 						Block: &tfprotov6.SchemaBlock{
@@ -4585,6 +4895,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas: map[string]*tfprotov6.Schema{
 					"test_resource": {
 						Block: &tfprotov6.SchemaBlock{
@@ -4626,6 +4937,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas: map[string]*tfprotov6.Schema{
 					"test_resource": {
 						Block: &tfprotov6.SchemaBlock{
@@ -4659,6 +4971,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas: map[string]*tfprotov6.Schema{
 					"test_resource": {
 						Block: &tfprotov6.SchemaBlock{
@@ -4693,6 +5006,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas: map[string]*tfprotov6.Schema{
 					"test_resource": {
 						Block: &tfprotov6.SchemaBlock{
@@ -4735,6 +5049,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas: map[string]*tfprotov6.Schema{
 					"test_resource": {
 						Block: &tfprotov6.SchemaBlock{
@@ -4780,6 +5095,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas: map[string]*tfprotov6.Schema{
 					"test_resource": {
 						Block: &tfprotov6.SchemaBlock{
@@ -4820,6 +5136,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas: map[string]*tfprotov6.Schema{
 					"test_resource": {
 						Block: &tfprotov6.SchemaBlock{
@@ -4856,6 +5173,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas: map[string]*tfprotov6.Schema{
 					"test_resource": {
 						Block: &tfprotov6.SchemaBlock{
@@ -4894,6 +5212,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas: map[string]*tfprotov6.Schema{
 					"test_resource": {
 						Block: &tfprotov6.SchemaBlock{
@@ -4934,6 +5253,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas: map[string]*tfprotov6.Schema{
 					"test_resource": {
 						Block: &tfprotov6.SchemaBlock{
@@ -4965,6 +5285,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas: map[string]*tfprotov6.Schema{
 					"test_resource": {
 						Block: &tfprotov6.SchemaBlock{
@@ -5002,6 +5323,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas: map[string]*tfprotov6.Schema{
 					"test_resource": {
 						Block: &tfprotov6.SchemaBlock{
@@ -5047,6 +5369,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas: map[string]*tfprotov6.Schema{
 					"test_resource": {
 						Block: &tfprotov6.SchemaBlock{
@@ -5090,6 +5413,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas: map[string]*tfprotov6.Schema{
 					"test_resource": {
 						Block: &tfprotov6.SchemaBlock{
@@ -5125,6 +5449,7 @@ func TestGetProviderSchemaResponse(t *testing.T) {
 				DataSourceSchemas:        map[string]*tfprotov6.Schema{},
 				EphemeralResourceSchemas: map[string]*tfprotov6.Schema{},
 				Functions:                map[string]*tfprotov6.Function{},
+				ListResourceSchemas:      map[string]*tfprotov6.Schema{},
 				ResourceSchemas: map[string]*tfprotov6.Schema{
 					"test_resource": {
 						Block:   &tfprotov6.SchemaBlock{},


### PR DESCRIPTION
## Description

Populates and return `ListResourceSchemas` in the `GetProviderSchemaResponse` method for the `GetProviderSchema` RPC for both protov5 and protov6. 

Performed some alphabetical reorderings in the expected objects as well..

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

None
