### PR TITLE
Fix grammatical errors in error messages regarding identity changes

### DIFF
--- a/internal/fwserver/server_applyresourcechange_test.go
+++ b/internal/fwserver/server_applyresourcechange_test.go
@@ -1840,7 +1840,7 @@ func TestServerApplyResourceChange(t *testing.T) {
 				Diagnostics: diag.Diagnostics{
 					diag.NewErrorDiagnostic(
 						"Unexpected Identity Change",
-						"During the update operation, the Terraform Provider unexpectedly returned a different identity then the previously stored one.\n\n"+
+						"During the update operation, the Terraform Provider unexpectedly returned a different identity than the previously stored one.\n\n"+
 							"This is always a problem with the provider and should be reported to the provider developer.\n\n"+
 							"Planned Identity: tftypes.Object[\"test_id\":tftypes.String]<\"test_id\":tftypes.String<\"id-123\">>\n\n"+
 							"New Identity: tftypes.Object[\"test_id\":tftypes.String]<\"test_id\":tftypes.String<\"new-id-123\">>",

--- a/internal/fwserver/server_planresourcechange.go
+++ b/internal/fwserver/server_planresourcechange.go
@@ -386,7 +386,7 @@ func (s *Server) PlanResourceChange(ctx context.Context, req *PlanResourceChange
 		if !req.ResourceBehavior.MutableIdentity && !req.PriorState.Raw.IsNull() && !req.PriorIdentity.Raw.IsNull() && !req.PriorIdentity.Raw.Equal(resp.PlannedIdentity.Raw) {
 			resp.Diagnostics.AddError(
 				"Unexpected Identity Change",
-				"During the planning operation, the Terraform Provider unexpectedly returned a different identity then the previously stored one.\n\n"+
+				"During the planning operation, the Terraform Provider unexpectedly returned a different identity than the previously stored one.\n\n"+
 					"This is always a problem with the provider and should be reported to the provider developer.\n\n"+
 					fmt.Sprintf("Prior Identity: %s\n\n", req.PriorIdentity.Raw.String())+
 					fmt.Sprintf("Planned Identity: %s", resp.PlannedIdentity.Raw.String()),

--- a/internal/fwserver/server_planresourcechange_test.go
+++ b/internal/fwserver/server_planresourcechange_test.go
@@ -4075,7 +4075,7 @@ func TestServerPlanResourceChange(t *testing.T) {
 				Diagnostics: diag.Diagnostics{
 					diag.NewErrorDiagnostic(
 						"Unexpected Identity Change",
-						"During the planning operation, the Terraform Provider unexpectedly returned a different identity then the previously stored one.\n\n"+
+						"During the planning operation, the Terraform Provider unexpectedly returned a different identity than the previously stored one.\n\n"+
 							"This is always a problem with the provider and should be reported to the provider developer.\n\n"+
 							"Prior Identity: tftypes.Object[\"test_id\":tftypes.String]<\"test_id\":tftypes.String<\"id-123\">>\n\n"+
 							"Planned Identity: tftypes.Object[\"test_id\":tftypes.String]<\"test_id\":tftypes.String<\"new-id-123\">>",
@@ -6777,7 +6777,7 @@ func TestServerPlanResourceChange(t *testing.T) {
 				Diagnostics: diag.Diagnostics{
 					diag.NewErrorDiagnostic(
 						"Unexpected Identity Change",
-						"During the planning operation, the Terraform Provider unexpectedly returned a different identity then the previously stored one.\n\n"+
+						"During the planning operation, the Terraform Provider unexpectedly returned a different identity than the previously stored one.\n\n"+
 							"This is always a problem with the provider and should be reported to the provider developer.\n\n"+
 							"Prior Identity: tftypes.Object[\"test_id\":tftypes.String]<\"test_id\":tftypes.String<\"id-123\">>\n\n"+
 							"Planned Identity: tftypes.Object[\"test_id\":tftypes.String]<\"test_id\":tftypes.String<\"new-id-123\">>",

--- a/internal/fwserver/server_readresource.go
+++ b/internal/fwserver/server_readresource.go
@@ -188,7 +188,7 @@ func (s *Server) ReadResource(ctx context.Context, req *ReadResourceRequest, res
 		if !req.ResourceBehavior.MutableIdentity && !readFollowingImport && !req.CurrentIdentity.Raw.IsNull() && !req.CurrentIdentity.Raw.Equal(resp.NewIdentity.Raw) {
 			resp.Diagnostics.AddError(
 				"Unexpected Identity Change",
-				"During the read operation, the Terraform Provider unexpectedly returned a different identity then the previously stored one.\n\n"+
+				"During the read operation, the Terraform Provider unexpectedly returned a different identity than the previously stored one.\n\n"+
 					"This is always a problem with the provider and should be reported to the provider developer.\n\n"+
 					fmt.Sprintf("Current Identity: %s\n\n", req.CurrentIdentity.Raw.String())+
 					fmt.Sprintf("New Identity: %s", resp.NewIdentity.Raw.String()),

--- a/internal/fwserver/server_readresource_test.go
+++ b/internal/fwserver/server_readresource_test.go
@@ -725,7 +725,7 @@ func TestServerReadResource(t *testing.T) {
 				Diagnostics: diag.Diagnostics{
 					diag.NewErrorDiagnostic(
 						"Unexpected Identity Change",
-						"During the read operation, the Terraform Provider unexpectedly returned a different identity then the previously stored one.\n\n"+
+						"During the read operation, the Terraform Provider unexpectedly returned a different identity than the previously stored one.\n\n"+
 							"This is always a problem with the provider and should be reported to the provider developer.\n\n"+
 							"Current Identity: tftypes.Object[\"test_id\":tftypes.String]<\"test_id\":tftypes.String<\"id-123\">>\n\n"+
 							"New Identity: tftypes.Object[\"test_id\":tftypes.String]<\"test_id\":tftypes.String<\"new-id-123\">>",

--- a/internal/fwserver/server_updateresource.go
+++ b/internal/fwserver/server_updateresource.go
@@ -189,7 +189,7 @@ func (s *Server) UpdateResource(ctx context.Context, req *UpdateResourceRequest,
 		if !req.ResourceBehavior.MutableIdentity && !req.PlannedIdentity.Raw.IsNull() && !req.PlannedIdentity.Raw.Equal(resp.NewIdentity.Raw) {
 			resp.Diagnostics.AddError(
 				"Unexpected Identity Change",
-				"During the update operation, the Terraform Provider unexpectedly returned a different identity then the previously stored one.\n\n"+
+				"During the update operation, the Terraform Provider unexpectedly returned a different identity than the previously stored one.\n\n"+
 					"This is always a problem with the provider and should be reported to the provider developer.\n\n"+
 					fmt.Sprintf("Planned Identity: %s\n\n", req.PlannedIdentity.Raw.String())+
 					fmt.Sprintf("New Identity: %s", resp.NewIdentity.Raw.String()),


### PR DESCRIPTION
- Updated error message in `server_applyresourcechange_test.go` to correct "then" to "than" in the "Unexpected Identity Change" diagnostic message.
- Updated error message in `server_planresourcechange.go` to correct "then" to "than" in the "Unexpected Identity Change" diagnostic message.
- Updated error message in `server_planresourcechange_test.go` to correct "then" to "than" in multiple instances of the "Unexpected Identity Change" diagnostic message.
- Updated error message in `server_readresource.go` to correct "then" to "than" in the "Unexpected Identity Change" diagnostic message.
- Updated error message in `server_readresource_test.go` to correct "then" to "than" in the "Unexpected Identity Change" diagnostic message.
- Updated error message in `server_updateresource.go` to correct "then" to "than" in the "Unexpected Identity Change" diagnostic message.

Related: https://github.com/hashicorp/terraform-plugin-sdk/pull/1499
