### PR TITLE
list: add `Limit` field to `ListResult`

### DIFF
--- a/internal/fwserver/server_listresource.go
+++ b/internal/fwserver/server_listresource.go
@@ -29,6 +29,10 @@ type ListRequest struct {
 	// Resource field in the ListResult struct.
 	IncludeResource bool
 
+	// Limit specifies the maximum number of results that Terraform is
+	// expecting.
+	Limit int64
+
 	ResourceSchema         fwschema.Schema
 	ResourceIdentitySchema fwschema.Schema
 }
@@ -91,6 +95,7 @@ func (s *Server) ListResource(ctx context.Context, fwReq *ListRequest, fwStream 
 	req := list.ListRequest{
 		Config:                 *fwReq.Config,
 		IncludeResource:        fwReq.IncludeResource,
+		Limit:                  fwReq.Limit,
 		ResourceSchema:         fwReq.ResourceSchema,
 		ResourceIdentitySchema: fwReq.ResourceIdentitySchema,
 	}

--- a/internal/proto5server/server_listresource.go
+++ b/internal/proto5server/server_listresource.go
@@ -65,6 +65,7 @@ func (s *Server) ListResource(ctx context.Context, protoReq *tfprotov5.ListResou
 		ResourceSchema:         resourceSchema,
 		ResourceIdentitySchema: identitySchema,
 		IncludeResource:        protoReq.IncludeResource,
+		Limit:                  protoReq.Limit,
 	}
 	stream := &fwserver.ListResultsStream{}
 

--- a/internal/proto6server/server_listresource.go
+++ b/internal/proto6server/server_listresource.go
@@ -65,6 +65,7 @@ func (s *Server) ListResource(ctx context.Context, protoReq *tfprotov6.ListResou
 		ResourceSchema:         resourceSchema,
 		ResourceIdentitySchema: identitySchema,
 		IncludeResource:        protoReq.IncludeResource,
+		Limit:                  protoReq.Limit,
 	}
 	stream := &fwserver.ListResultsStream{}
 

--- a/list/list_resource.go
+++ b/list/list_resource.go
@@ -99,6 +99,10 @@ type ListRequest struct {
 	// [ListResult.Resource] field.
 	IncludeResource bool
 
+	// Limit specifies the maximum number of results that Terraform is
+	// expecting.
+	Limit int64
+
 	ResourceSchema         fwschema.Schema
 	ResourceIdentitySchema fwschema.Schema
 }


### PR DESCRIPTION
## Description

This pull request adds a `Limit int64` field to `list.ListResult` & propagates the `Limit` value through a `ListResource` call.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

None.