### PR TITLE
resource: extract `ResourceMetadata` interface

### DIFF
--- a/list/list_resource.go
+++ b/list/list_resource.go
@@ -22,15 +22,13 @@ import (
 //   - Validation: Schema-based or entire configuration via
 //     ListResourceWithConfigValidators or ListResourceWithValidateConfig.
 type ListResource interface {
-	// Metadata should return the full name of the list resource such as
-	// examplecloud_thing. This name should match the full name of the managed
-	// resource to be listed; otherwise, the GetMetadata RPC will return an
-	// error diagnostic.
-	//
-	// The method signature is intended to be compatible with the Metadata
-	// method signature in the Resource interface. One implementation of
-	// Metadata can satisfy both interfaces.
-	Metadata(context.Context, resource.MetadataRequest, *resource.MetadataResponse)
+	// A single provider-defined type can implement the
+	// Create-Read-Update-Delete (CRUD) operations ([resource.Resource]) and
+	// the List (L) operation ([list.ListResource]). The
+	// [resource.ResourceMetadata] interface is embedded in both interfaces.
+	// This allows a single implementation of `Metadata()` to satisfy both
+	// interfaces without code duplication.
+	resource.ResourceMetadata
 
 	// ListResourceConfigSchema should return the schema for list blocks.
 	ListResourceConfigSchema(context.Context, ListResourceSchemaRequest, *ListResourceSchemaResponse)

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -26,9 +26,7 @@ import (
 // Although not required, it is conventional for resources to implement the
 // ResourceWithImportState interface.
 type Resource interface {
-	// Metadata should return the full name of the resource, such as
-	// examplecloud_thing.
-	Metadata(context.Context, MetadataRequest, *MetadataResponse)
+	ResourceMetadata
 
 	// Schema should return the schema for this resource.
 	Schema(context.Context, SchemaRequest, *SchemaResponse)
@@ -55,6 +53,12 @@ type Resource interface {
 	// call DeleteResponse.State.RemoveResource(), so it can be omitted
 	// from provider logic.
 	Delete(context.Context, DeleteRequest, *DeleteResponse)
+}
+
+type ResourceMetadata interface {
+	// Metadata should return the full name of the resource, such as
+	// examplecloud_thing.
+	Metadata(context.Context, MetadataRequest, *MetadataResponse)
 }
 
 // ResourceWithConfigure is an interface type that extends Resource to


### PR DESCRIPTION
## Description

A refactoring from an impromptu pairing with @gdavison last week on the topic of finer-grained Framework interfaces https://github.com/hashicorp/terraform-plugin-framework/issues/1159.

This change does not specifically address #1159. It does remove a bit of duplication & it aims to be more intent-revealing re: the "overlap" between the `resource.Resource` and `list.ListResource` interfaces.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

None.