### PR TITLE
`release/1.15.x`: Backport of #1161

### DIFF
--- a/.changes/unreleased/BUG FIXES-20250612-115411.yaml
+++ b/.changes/unreleased/BUG FIXES-20250612-115411.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'all: Fixed bug with `UseStateForUnknown` where known null state values were not preserved during update plans.'
+time: 2025-06-12T11:54:11.818923-04:00
+custom:
+    Issue: "1117"

--- a/internal/fwserver/attribute_plan_modification_test.go
+++ b/internal/fwserver/attribute_plan_modification_test.go
@@ -641,6 +641,44 @@ func TestAttributeModifyPlan(t *testing.T) {
 						},
 					},
 				),
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_computed": tftypes.NewValue(tftypes.String, "statevalue1"),
+										},
+									),
+								},
+							),
+						},
+					),
+				},
 				AttributeState: types.ListValueMust(
 					types.ObjectType{
 						AttrTypes: map[string]attr.Type{
@@ -720,6 +758,44 @@ func TestAttributeModifyPlan(t *testing.T) {
 							AttrTypes: map[string]attr.Type{
 								"nested_computed": types.StringType,
 							},
+						},
+					),
+				},
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_computed": tftypes.NewValue(tftypes.String, "statevalue1"),
+										},
+									),
+								},
+							),
 						},
 					),
 				},
@@ -979,6 +1055,60 @@ func TestAttributeModifyPlan(t *testing.T) {
 						),
 					},
 				),
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+											"nested_required": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+											"nested_required": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed": tftypes.String,
+												"nested_required": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_computed": tftypes.NewValue(tftypes.String, "statevalue1"),
+											"nested_required": tftypes.NewValue(tftypes.String, "testvalue1"),
+										},
+									),
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed": tftypes.String,
+												"nested_required": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_computed": tftypes.NewValue(tftypes.String, "statevalue2"),
+											"nested_required": tftypes.NewValue(tftypes.String, "testvalue2"),
+										},
+									),
+								},
+							),
+						},
+					),
+				},
 				AttributeState: types.ListValueMust(
 					types.ObjectType{
 						AttrTypes: map[string]attr.Type{
@@ -1537,6 +1667,44 @@ func TestAttributeModifyPlan(t *testing.T) {
 						},
 					},
 				),
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_computed": tftypes.NewValue(tftypes.String, "statevalue1"),
+										},
+									),
+								},
+							),
+						},
+					),
+				},
 				AttributeState: types.SetValueMust(
 					types.ObjectType{
 						AttrTypes: map[string]attr.Type{
@@ -1616,6 +1784,44 @@ func TestAttributeModifyPlan(t *testing.T) {
 							AttrTypes: map[string]attr.Type{
 								"nested_computed": types.StringType,
 							},
+						},
+					),
+				},
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_computed": tftypes.NewValue(tftypes.String, "statevalue1"),
+										},
+									),
+								},
+							),
 						},
 					),
 				},
@@ -1742,6 +1948,60 @@ func TestAttributeModifyPlan(t *testing.T) {
 						),
 					},
 				),
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+											"nested_required": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+											"nested_required": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed": tftypes.String,
+												"nested_required": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_computed": tftypes.NewValue(tftypes.String, "statevalue1"),
+											"nested_required": tftypes.NewValue(tftypes.String, "testvalue1"),
+										},
+									),
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed": tftypes.String,
+												"nested_required": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_computed": tftypes.NewValue(tftypes.String, "statevalue2"),
+											"nested_required": tftypes.NewValue(tftypes.String, "testvalue2"),
+										},
+									),
+								},
+							),
+						},
+					),
+				},
 				AttributeState: types.SetValueMust(
 					types.ObjectType{
 						AttrTypes: map[string]attr.Type{
@@ -1887,6 +2147,60 @@ func TestAttributeModifyPlan(t *testing.T) {
 						),
 					},
 				),
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+											"nested_required": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+											"nested_required": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed": tftypes.String,
+												"nested_required": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_computed": tftypes.NewValue(tftypes.String, "statevalue1"),
+											"nested_required": tftypes.NewValue(tftypes.String, "testvalue1"),
+										},
+									),
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed": tftypes.String,
+												"nested_required": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_computed": tftypes.NewValue(tftypes.String, "statevalue2"),
+											"nested_required": tftypes.NewValue(tftypes.String, "testvalue2"),
+										},
+									),
+								},
+							),
+						},
+					),
+				},
 				AttributeState: types.SetValueMust(
 					types.ObjectType{
 						AttrTypes: map[string]attr.Type{
@@ -2016,6 +2330,60 @@ func TestAttributeModifyPlan(t *testing.T) {
 						),
 					},
 				),
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+											"nested_required": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+											"nested_required": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed": tftypes.String,
+												"nested_required": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_computed": tftypes.NewValue(tftypes.String, "statevalue1"),
+											"nested_required": tftypes.NewValue(tftypes.String, "testvalue1"),
+										},
+									),
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed": tftypes.String,
+												"nested_required": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_computed": tftypes.NewValue(tftypes.String, "statevalue2"),
+											"nested_required": tftypes.NewValue(tftypes.String, "testvalue2"),
+										},
+									),
+								},
+							),
+						},
+					),
+				},
 				AttributeState: types.SetValueMust(
 					types.ObjectType{
 						AttrTypes: map[string]attr.Type{
@@ -2581,6 +2949,44 @@ func TestAttributeModifyPlan(t *testing.T) {
 						},
 					},
 				),
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Map{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Map{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+										},
+									},
+								},
+								map[string]tftypes.Value{
+									"key1": tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_computed": tftypes.NewValue(tftypes.String, "statevalue1"),
+										},
+									),
+								},
+							),
+						},
+					),
+				},
 				AttributeState: types.MapValueMust(
 					types.ObjectType{
 						AttrTypes: map[string]attr.Type{
@@ -2660,6 +3066,44 @@ func TestAttributeModifyPlan(t *testing.T) {
 							AttrTypes: map[string]attr.Type{
 								"nested_computed": types.StringType,
 							},
+						},
+					),
+				},
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Map{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Map{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+										},
+									},
+								},
+								map[string]tftypes.Value{
+									"key1": tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_computed": tftypes.NewValue(tftypes.String, "statevalue1"),
+										},
+									),
+								},
+							),
 						},
 					),
 				},
@@ -2977,6 +3421,31 @@ func TestAttributeModifyPlan(t *testing.T) {
 						"nested_computed": types.StringType,
 					},
 				),
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"nested_computed": tftypes.String,
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"nested_computed": tftypes.String,
+									},
+								},
+								map[string]tftypes.Value{
+									"nested_computed": tftypes.NewValue(tftypes.String, "statevalue1"),
+								},
+							),
+						},
+					),
+				},
 				AttributeState: types.ObjectValueMust(
 					map[string]attr.Type{
 						"nested_computed": types.StringType,
@@ -3032,6 +3501,31 @@ func TestAttributeModifyPlan(t *testing.T) {
 					ObjectValue: types.ObjectUnknown(
 						map[string]attr.Type{
 							"nested_computed": types.StringType,
+						},
+					),
+				},
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"nested_computed": tftypes.String,
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"nested_computed": tftypes.String,
+									},
+								},
+								map[string]tftypes.Value{
+									"nested_computed": tftypes.NewValue(tftypes.String, "statevalue1"),
+								},
+							),
 						},
 					),
 				},

--- a/internal/fwserver/block_plan_modification_test.go
+++ b/internal/fwserver/block_plan_modification_test.go
@@ -996,6 +996,44 @@ func TestBlockModifyPlan(t *testing.T) {
 						},
 					},
 				),
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_computed": tftypes.NewValue(tftypes.String, "statevalue1"),
+										},
+									),
+								},
+							),
+						},
+					),
+				},
 				AttributeState: types.ListValueMust(
 					types.ObjectType{
 						AttrTypes: map[string]attr.Type{
@@ -1072,6 +1110,44 @@ func TestBlockModifyPlan(t *testing.T) {
 							AttrTypes: map[string]attr.Type{
 								"nested_computed": types.StringType,
 							},
+						},
+					),
+				},
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_computed": tftypes.NewValue(tftypes.String, "statevalue1"),
+										},
+									),
+								},
+							),
 						},
 					),
 				},
@@ -1874,6 +1950,92 @@ func TestBlockModifyPlan(t *testing.T) {
 						),
 					},
 				),
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"id": tftypes.String,
+											"list": tftypes.List{
+												ElementType: tftypes.Object{
+													AttributeTypes: map[string]tftypes.Type{
+														"nested_computed": tftypes.String,
+														"nested_required": tftypes.String,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"id": tftypes.String,
+											"list": tftypes.List{
+												ElementType: tftypes.Object{
+													AttributeTypes: map[string]tftypes.Type{
+														"nested_computed": tftypes.String,
+														"nested_required": tftypes.String,
+													},
+												},
+											},
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"id": tftypes.String,
+												"list": tftypes.List{
+													ElementType: tftypes.Object{
+														AttributeTypes: map[string]tftypes.Type{
+															"nested_computed": tftypes.String,
+															"nested_required": tftypes.String,
+														},
+													},
+												},
+											},
+										},
+										map[string]tftypes.Value{
+											"id": tftypes.NewValue(tftypes.String, "one"),
+											"list": tftypes.NewValue(
+												tftypes.List{
+													ElementType: tftypes.Object{
+														AttributeTypes: map[string]tftypes.Type{
+															"nested_computed": tftypes.String,
+															"nested_required": tftypes.String,
+														},
+													},
+												},
+												[]tftypes.Value{
+													tftypes.NewValue(
+														tftypes.Object{
+															AttributeTypes: map[string]tftypes.Type{
+																"nested_computed": tftypes.String,
+																"nested_required": tftypes.String,
+															},
+														},
+														map[string]tftypes.Value{
+															"nested_computed": tftypes.NewValue(tftypes.String, "statevalue"),
+															"nested_required": tftypes.NewValue(tftypes.String, "configvalue"),
+														},
+													),
+												},
+											),
+										},
+									),
+								},
+							),
+						},
+					),
+				},
 				AttributeState: types.ListValueMust(
 					types.ObjectType{
 						AttrTypes: map[string]attr.Type{
@@ -1989,7 +2151,7 @@ func TestBlockModifyPlan(t *testing.T) {
 				NestedObject: testschema.NestedBlockObject{
 					Attributes: map[string]fwschema.Attribute{
 						"nested_computed": testschema.AttributeWithStringPlanModifiers{
-							Required: true,
+							Computed: true,
 							PlanModifiers: []planmodifier.String{
 								stringplanmodifier.UseStateForUnknown(),
 							},
@@ -2065,6 +2227,60 @@ func TestBlockModifyPlan(t *testing.T) {
 						),
 					},
 				),
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+											"nested_required": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+											"nested_required": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed": tftypes.String,
+												"nested_required": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_computed": tftypes.NewValue(tftypes.String, "statevalue1"),
+											"nested_required": tftypes.NewValue(tftypes.String, "testvalue1"),
+										},
+									),
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed": tftypes.String,
+												"nested_required": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_computed": tftypes.NewValue(tftypes.String, "statevalue2"),
+											"nested_required": tftypes.NewValue(tftypes.String, "testvalue2"),
+										},
+									),
+								},
+							),
+						},
+					),
+				},
 				AttributeState: types.ListValueMust(
 					types.ObjectType{
 						AttrTypes: map[string]attr.Type{
@@ -2138,7 +2354,7 @@ func TestBlockModifyPlan(t *testing.T) {
 				NestedObject: testschema.NestedBlockObject{
 					Attributes: map[string]fwschema.Attribute{
 						"nested_computed": testschema.AttributeWithStringPlanModifiers{
-							Required: true,
+							Computed: true,
 							PlanModifiers: []planmodifier.String{
 								stringplanmodifier.UseStateForUnknown(),
 							},
@@ -2194,6 +2410,60 @@ func TestBlockModifyPlan(t *testing.T) {
 						),
 					},
 				),
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+											"nested_required": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.List{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+											"nested_required": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed": tftypes.String,
+												"nested_required": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_computed": tftypes.NewValue(tftypes.String, "statevalue1"),
+											"nested_required": tftypes.NewValue(tftypes.String, "testvalue1"),
+										},
+									),
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed": tftypes.String,
+												"nested_required": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_computed": tftypes.NewValue(tftypes.String, "statevalue2"),
+											"nested_required": tftypes.NewValue(tftypes.String, "testvalue2"),
+										},
+									),
+								},
+							),
+						},
+					),
+				},
 				AttributeState: types.ListValueMust(
 					types.ObjectType{
 						AttrTypes: map[string]attr.Type{
@@ -2255,7 +2525,7 @@ func TestBlockModifyPlan(t *testing.T) {
 				NestedObject: testschema.NestedBlockObject{
 					Attributes: map[string]fwschema.Attribute{
 						"nested_computed": testschema.AttributeWithStringPlanModifiers{
-							Required: true,
+							Computed: true,
 							PlanModifiers: []planmodifier.String{
 								stringplanmodifier.UseStateForUnknown(),
 							},
@@ -2331,6 +2601,60 @@ func TestBlockModifyPlan(t *testing.T) {
 						),
 					},
 				),
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+											"nested_required": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+											"nested_required": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed": tftypes.String,
+												"nested_required": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_computed": tftypes.NewValue(tftypes.String, "statevalue1"),
+											"nested_required": tftypes.NewValue(tftypes.String, "testvalue1"),
+										},
+									),
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed": tftypes.String,
+												"nested_required": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_computed": tftypes.NewValue(tftypes.String, "statevalue2"),
+											"nested_required": tftypes.NewValue(tftypes.String, "testvalue2"),
+										},
+									),
+								},
+							),
+						},
+					),
+				},
 				AttributeState: types.SetValueMust(
 					types.ObjectType{
 						AttrTypes: map[string]attr.Type{
@@ -2476,6 +2800,60 @@ func TestBlockModifyPlan(t *testing.T) {
 						),
 					},
 				),
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+											"nested_required": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+											"nested_required": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed": tftypes.String,
+												"nested_required": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_computed": tftypes.NewValue(tftypes.String, "statevalue1"),
+											"nested_required": tftypes.NewValue(tftypes.String, "testvalue1"),
+										},
+									),
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed": tftypes.String,
+												"nested_required": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_computed": tftypes.NewValue(tftypes.String, "statevalue2"),
+											"nested_required": tftypes.NewValue(tftypes.String, "testvalue2"),
+										},
+									),
+								},
+							),
+						},
+					),
+				},
 				AttributeState: types.SetValueMust(
 					types.ObjectType{
 						AttrTypes: map[string]attr.Type{
@@ -2605,6 +2983,60 @@ func TestBlockModifyPlan(t *testing.T) {
 						),
 					},
 				),
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+											"nested_required": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+											"nested_required": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed": tftypes.String,
+												"nested_required": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_computed": tftypes.NewValue(tftypes.String, "statevalue1"),
+											"nested_required": tftypes.NewValue(tftypes.String, "testvalue1"),
+										},
+									),
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed": tftypes.String,
+												"nested_required": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_computed": tftypes.NewValue(tftypes.String, "statevalue2"),
+											"nested_required": tftypes.NewValue(tftypes.String, "testvalue2"),
+										},
+									),
+								},
+							),
+						},
+					),
+				},
 				AttributeState: types.SetValueMust(
 					types.ObjectType{
 						AttrTypes: map[string]attr.Type{
@@ -2689,6 +3121,44 @@ func TestBlockModifyPlan(t *testing.T) {
 						},
 					},
 				),
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_computed": tftypes.NewValue(tftypes.String, "statevalue1"),
+										},
+									),
+								},
+							),
+						},
+					),
+				},
 				AttributeState: types.SetValueMust(
 					types.ObjectType{
 						AttrTypes: map[string]attr.Type{
@@ -2765,6 +3235,44 @@ func TestBlockModifyPlan(t *testing.T) {
 							AttrTypes: map[string]attr.Type{
 								"nested_computed": types.StringType,
 							},
+						},
+					),
+				},
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Set{
+									ElementType: tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"nested_computed": tftypes.String,
+										},
+									},
+								},
+								[]tftypes.Value{
+									tftypes.NewValue(
+										tftypes.Object{
+											AttributeTypes: map[string]tftypes.Type{
+												"nested_computed": tftypes.String,
+											},
+										},
+										map[string]tftypes.Value{
+											"nested_computed": tftypes.NewValue(tftypes.String, "statevalue1"),
+										},
+									),
+								},
+							),
 						},
 					),
 				},
@@ -3188,6 +3696,34 @@ func TestBlockModifyPlan(t *testing.T) {
 						"nested_required": types.StringValue("testvalue"),
 					},
 				),
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"nested_computed": tftypes.String,
+										"nested_required": tftypes.String,
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"nested_computed": tftypes.String,
+										"nested_required": tftypes.String,
+									},
+								},
+								map[string]tftypes.Value{
+									"nested_computed": tftypes.NewValue(tftypes.String, "statevalue"),
+									"nested_required": tftypes.NewValue(tftypes.String, "testvalue"),
+								},
+							),
+						},
+					),
+				},
 				AttributeState: types.ObjectValueMust(
 					map[string]attr.Type{
 						"nested_computed": types.StringType,
@@ -3236,6 +3772,31 @@ func TestBlockModifyPlan(t *testing.T) {
 						"nested_computed": types.StringType,
 					},
 				),
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"nested_computed": tftypes.String,
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"nested_computed": tftypes.String,
+									},
+								},
+								map[string]tftypes.Value{
+									"nested_computed": tftypes.NewValue(tftypes.String, "statevalue1"),
+								},
+							),
+						},
+					),
+				},
 				AttributeState: types.ObjectValueMust(
 					map[string]attr.Type{
 						"nested_computed": types.StringType,
@@ -3288,6 +3849,31 @@ func TestBlockModifyPlan(t *testing.T) {
 					ObjectValue: types.ObjectUnknown(
 						map[string]attr.Type{
 							"nested_computed": types.StringType,
+						},
+					),
+				},
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"nested_computed": tftypes.String,
+									},
+								},
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(
+								tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"nested_computed": tftypes.String,
+									},
+								},
+								map[string]tftypes.Value{
+									"nested_computed": tftypes.NewValue(tftypes.String, "statevalue1"),
+								},
+							),
 						},
 					),
 				},

--- a/resource/schema/boolplanmodifier/use_state_for_unknown.go
+++ b/resource/schema/boolplanmodifier/use_state_for_unknown.go
@@ -36,8 +36,8 @@ func (m useStateForUnknownModifier) MarkdownDescription(_ context.Context) strin
 
 // PlanModifyBool implements the plan modification logic.
 func (m useStateForUnknownModifier) PlanModifyBool(_ context.Context, req planmodifier.BoolRequest, resp *planmodifier.BoolResponse) {
-	// Do nothing if there is no state value.
-	if req.StateValue.IsNull() {
+	// Do nothing if there is no state (resource is being created).
+	if req.State.Raw.IsNull() {
 		return
 	}
 

--- a/resource/schema/dynamicplanmodifier/use_state_for_unknown.go
+++ b/resource/schema/dynamicplanmodifier/use_state_for_unknown.go
@@ -36,9 +36,8 @@ func (m useStateForUnknownModifier) MarkdownDescription(_ context.Context) strin
 
 // PlanModifyDynamic implements the plan modification logic.
 func (m useStateForUnknownModifier) PlanModifyDynamic(ctx context.Context, req planmodifier.DynamicRequest, resp *planmodifier.DynamicResponse) {
-	// Do nothing if there is no state value.
-	// This also requires checking if the underlying value is null.
-	if req.StateValue.IsNull() || req.StateValue.IsUnderlyingValueNull() {
+	// Do nothing if there is no state (resource is being created).
+	if req.State.Raw.IsNull() {
 		return
 	}
 

--- a/resource/schema/float32planmodifier/use_state_for_unknown.go
+++ b/resource/schema/float32planmodifier/use_state_for_unknown.go
@@ -36,8 +36,8 @@ func (m useStateForUnknownModifier) MarkdownDescription(_ context.Context) strin
 
 // PlanModifyFloat32 implements the plan modification logic.
 func (m useStateForUnknownModifier) PlanModifyFloat32(_ context.Context, req planmodifier.Float32Request, resp *planmodifier.Float32Response) {
-	// Do nothing if there is no state value.
-	if req.StateValue.IsNull() {
+	// Do nothing if there is no state (resource is being created).
+	if req.State.Raw.IsNull() {
 		return
 	}
 

--- a/resource/schema/float32planmodifier/use_state_for_unknown_test.go
+++ b/resource/schema/float32planmodifier/use_state_for_unknown_test.go
@@ -8,11 +8,11 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-framework/attr"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/float32planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
 func TestUseStateForUnknownModifierPlanModifyFloat32(t *testing.T) {
@@ -26,6 +26,16 @@ func TestUseStateForUnknownModifierPlanModifyFloat32(t *testing.T) {
 			// when we first create the resource, use the unknown
 			// value
 			request: planmodifier.Float32Request{
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"attr": tftypes.Number,
+							},
+						},
+						nil,
+					),
+				},
 				StateValue:  types.Float32Null(),
 				PlanValue:   types.Float32Unknown(),
 				ConfigValue: types.Float32Null(),
@@ -42,6 +52,18 @@ func TestUseStateForUnknownModifierPlanModifyFloat32(t *testing.T) {
 			// but we still want to preserve that value, in this
 			// case
 			request: planmodifier.Float32Request{
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"attr": tftypes.Number,
+							},
+						},
+						map[string]tftypes.Value{
+							"attr": tftypes.NewValue(tftypes.Number, 2.4),
+						},
+					),
+				},
 				StateValue:  types.Float32Value(2.4),
 				PlanValue:   types.Float32Value(1.2),
 				ConfigValue: types.Float32Null(),
@@ -50,16 +72,51 @@ func TestUseStateForUnknownModifierPlanModifyFloat32(t *testing.T) {
 				PlanValue: types.Float32Value(1.2),
 			},
 		},
-		"non-null-state-unknown-plan": {
+		"non-null-state-value-unknown-plan": {
 			// this is the situation we want to preserve the state
 			// in
 			request: planmodifier.Float32Request{
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"attr": tftypes.Number,
+							},
+						},
+						map[string]tftypes.Value{
+							"attr": tftypes.NewValue(tftypes.Number, 1.2),
+						},
+					),
+				},
 				StateValue:  types.Float32Value(1.2),
 				PlanValue:   types.Float32Unknown(),
 				ConfigValue: types.Float32Null(),
 			},
 			expected: &planmodifier.Float32Response{
 				PlanValue: types.Float32Value(1.2),
+			},
+		},
+		"null-state-value-unknown-plan": {
+			// Null state values are still known, so we should preserve this as well.
+			request: planmodifier.Float32Request{
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"attr": tftypes.Number,
+							},
+						},
+						map[string]tftypes.Value{
+							"attr": tftypes.NewValue(tftypes.Number, nil),
+						},
+					),
+				},
+				StateValue:  types.Float32Null(),
+				PlanValue:   types.Float32Unknown(),
+				ConfigValue: types.Float32Null(),
+			},
+			expected: &planmodifier.Float32Response{
+				PlanValue: types.Float32Null(),
 			},
 		},
 		"unknown-config": {
@@ -73,46 +130,6 @@ func TestUseStateForUnknownModifierPlanModifyFloat32(t *testing.T) {
 				StateValue:  types.Float32Value(1.2),
 				PlanValue:   types.Float32Unknown(),
 				ConfigValue: types.Float32Unknown(),
-			},
-			expected: &planmodifier.Float32Response{
-				PlanValue: types.Float32Unknown(),
-			},
-		},
-		"under-list": {
-			request: planmodifier.Float32Request{
-				ConfigValue: types.Float32Null(),
-				Path:        path.Root("test").AtListIndex(0).AtName("nested_test"),
-				PlanValue:   types.Float32Unknown(),
-				StateValue:  types.Float32Null(),
-			},
-			expected: &planmodifier.Float32Response{
-				PlanValue: types.Float32Unknown(),
-			},
-		},
-		"under-set": {
-			request: planmodifier.Float32Request{
-				ConfigValue: types.Float32Null(),
-				Path: path.Root("test").AtSetValue(
-					types.SetValueMust(
-						types.ObjectType{
-							AttrTypes: map[string]attr.Type{
-								"nested_test": types.Float32Type,
-							},
-						},
-						[]attr.Value{
-							types.ObjectValueMust(
-								map[string]attr.Type{
-									"nested_test": types.Float32Type,
-								},
-								map[string]attr.Value{
-									"nested_test": types.Float32Unknown(),
-								},
-							),
-						},
-					),
-				).AtName("nested_test"),
-				PlanValue:  types.Float32Unknown(),
-				StateValue: types.Float32Null(),
 			},
 			expected: &planmodifier.Float32Response{
 				PlanValue: types.Float32Unknown(),

--- a/resource/schema/float64planmodifier/use_state_for_unknown.go
+++ b/resource/schema/float64planmodifier/use_state_for_unknown.go
@@ -36,8 +36,8 @@ func (m useStateForUnknownModifier) MarkdownDescription(_ context.Context) strin
 
 // PlanModifyFloat64 implements the plan modification logic.
 func (m useStateForUnknownModifier) PlanModifyFloat64(_ context.Context, req planmodifier.Float64Request, resp *planmodifier.Float64Response) {
-	// Do nothing if there is no state value.
-	if req.StateValue.IsNull() {
+	// Do nothing if there is no state (resource is being created).
+	if req.State.Raw.IsNull() {
 		return
 	}
 

--- a/resource/schema/int32planmodifier/use_state_for_unknown.go
+++ b/resource/schema/int32planmodifier/use_state_for_unknown.go
@@ -36,8 +36,8 @@ func (m useStateForUnknownModifier) MarkdownDescription(_ context.Context) strin
 
 // PlanModifyInt32 implements the plan modification logic.
 func (m useStateForUnknownModifier) PlanModifyInt32(_ context.Context, req planmodifier.Int32Request, resp *planmodifier.Int32Response) {
-	// Do nothing if there is no state value.
-	if req.StateValue.IsNull() {
+	// Do nothing if there is no state (resource is being created).
+	if req.State.Raw.IsNull() {
 		return
 	}
 

--- a/resource/schema/int64planmodifier/use_state_for_unknown.go
+++ b/resource/schema/int64planmodifier/use_state_for_unknown.go
@@ -36,8 +36,8 @@ func (m useStateForUnknownModifier) MarkdownDescription(_ context.Context) strin
 
 // PlanModifyInt64 implements the plan modification logic.
 func (m useStateForUnknownModifier) PlanModifyInt64(_ context.Context, req planmodifier.Int64Request, resp *planmodifier.Int64Response) {
-	// Do nothing if there is no state value.
-	if req.StateValue.IsNull() {
+	// Do nothing if there is no state (resource is being created).
+	if req.State.Raw.IsNull() {
 		return
 	}
 

--- a/resource/schema/listplanmodifier/use_state_for_unknown.go
+++ b/resource/schema/listplanmodifier/use_state_for_unknown.go
@@ -36,8 +36,8 @@ func (m useStateForUnknownModifier) MarkdownDescription(_ context.Context) strin
 
 // PlanModifyList implements the plan modification logic.
 func (m useStateForUnknownModifier) PlanModifyList(_ context.Context, req planmodifier.ListRequest, resp *planmodifier.ListResponse) {
-	// Do nothing if there is no state value.
-	if req.StateValue.IsNull() {
+	// Do nothing if there is no state (resource is being created).
+	if req.State.Raw.IsNull() {
 		return
 	}
 

--- a/resource/schema/listplanmodifier/use_state_for_unknown_test.go
+++ b/resource/schema/listplanmodifier/use_state_for_unknown_test.go
@@ -9,10 +9,11 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
 func TestUseStateForUnknownModifierPlanModifyList(t *testing.T) {
@@ -26,6 +27,16 @@ func TestUseStateForUnknownModifierPlanModifyList(t *testing.T) {
 			// when we first create the resource, use the unknown
 			// value
 			request: planmodifier.ListRequest{
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"attr": tftypes.List{ElementType: tftypes.String},
+							},
+						},
+						nil,
+					),
+				},
 				StateValue:  types.ListNull(types.StringType),
 				PlanValue:   types.ListUnknown(types.StringType),
 				ConfigValue: types.ListNull(types.StringType),
@@ -42,6 +53,23 @@ func TestUseStateForUnknownModifierPlanModifyList(t *testing.T) {
 			// but we still want to preserve that value, in this
 			// case
 			request: planmodifier.ListRequest{
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"attr": tftypes.List{ElementType: tftypes.String},
+							},
+						},
+						map[string]tftypes.Value{
+							"attr": tftypes.NewValue(
+								tftypes.List{ElementType: tftypes.String},
+								[]tftypes.Value{
+									tftypes.NewValue(tftypes.String, "other"),
+								},
+							),
+						},
+					),
+				},
 				StateValue:  types.ListValueMust(types.StringType, []attr.Value{types.StringValue("other")}),
 				PlanValue:   types.ListValueMust(types.StringType, []attr.Value{types.StringValue("test")}),
 				ConfigValue: types.ListNull(types.StringType),
@@ -50,16 +78,59 @@ func TestUseStateForUnknownModifierPlanModifyList(t *testing.T) {
 				PlanValue: types.ListValueMust(types.StringType, []attr.Value{types.StringValue("test")}),
 			},
 		},
-		"non-null-state-unknown-plan": {
+		"non-null-state-value-unknown-plan": {
 			// this is the situation we want to preserve the state
 			// in
 			request: planmodifier.ListRequest{
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"attr": tftypes.List{ElementType: tftypes.String},
+							},
+						},
+						map[string]tftypes.Value{
+							"attr": tftypes.NewValue(
+								tftypes.List{ElementType: tftypes.String},
+								[]tftypes.Value{
+									tftypes.NewValue(tftypes.String, "test"),
+								},
+							),
+						},
+					),
+				},
 				StateValue:  types.ListValueMust(types.StringType, []attr.Value{types.StringValue("test")}),
 				PlanValue:   types.ListUnknown(types.StringType),
 				ConfigValue: types.ListNull(types.StringType),
 			},
 			expected: &planmodifier.ListResponse{
 				PlanValue: types.ListValueMust(types.StringType, []attr.Value{types.StringValue("test")}),
+			},
+		},
+		"null-state-value-unknown-plan": {
+			// Null state values are still known, so we should preserve this as well.
+			request: planmodifier.ListRequest{
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"attr": tftypes.List{ElementType: tftypes.String},
+							},
+						},
+						map[string]tftypes.Value{
+							"attr": tftypes.NewValue(
+								tftypes.List{ElementType: tftypes.String},
+								nil,
+							),
+						},
+					),
+				},
+				StateValue:  types.ListNull(types.StringType),
+				PlanValue:   types.ListUnknown(types.StringType),
+				ConfigValue: types.ListNull(types.StringType),
+			},
+			expected: &planmodifier.ListResponse{
+				PlanValue: types.ListNull(types.StringType),
 			},
 		},
 		"unknown-config": {
@@ -73,46 +144,6 @@ func TestUseStateForUnknownModifierPlanModifyList(t *testing.T) {
 				StateValue:  types.ListValueMust(types.StringType, []attr.Value{types.StringValue("test")}),
 				PlanValue:   types.ListUnknown(types.StringType),
 				ConfigValue: types.ListUnknown(types.StringType),
-			},
-			expected: &planmodifier.ListResponse{
-				PlanValue: types.ListUnknown(types.StringType),
-			},
-		},
-		"under-list": {
-			request: planmodifier.ListRequest{
-				ConfigValue: types.ListNull(types.StringType),
-				Path:        path.Root("test").AtListIndex(0).AtName("nested_test"),
-				PlanValue:   types.ListUnknown(types.StringType),
-				StateValue:  types.ListNull(types.StringType),
-			},
-			expected: &planmodifier.ListResponse{
-				PlanValue: types.ListUnknown(types.StringType),
-			},
-		},
-		"under-set": {
-			request: planmodifier.ListRequest{
-				ConfigValue: types.ListNull(types.StringType),
-				Path: path.Root("test").AtSetValue(
-					types.SetValueMust(
-						types.ObjectType{
-							AttrTypes: map[string]attr.Type{
-								"nested_test": types.ListType{ElemType: types.StringType},
-							},
-						},
-						[]attr.Value{
-							types.ObjectValueMust(
-								map[string]attr.Type{
-									"nested_test": types.ListType{ElemType: types.StringType},
-								},
-								map[string]attr.Value{
-									"nested_test": types.ListUnknown(types.StringType),
-								},
-							),
-						},
-					),
-				).AtName("nested_test"),
-				PlanValue:  types.ListUnknown(types.StringType),
-				StateValue: types.ListNull(types.StringType),
 			},
 			expected: &planmodifier.ListResponse{
 				PlanValue: types.ListUnknown(types.StringType),

--- a/resource/schema/mapplanmodifier/use_state_for_unknown.go
+++ b/resource/schema/mapplanmodifier/use_state_for_unknown.go
@@ -36,8 +36,8 @@ func (m useStateForUnknownModifier) MarkdownDescription(_ context.Context) strin
 
 // PlanModifyMap implements the plan modification logic.
 func (m useStateForUnknownModifier) PlanModifyMap(_ context.Context, req planmodifier.MapRequest, resp *planmodifier.MapResponse) {
-	// Do nothing if there is no state value.
-	if req.StateValue.IsNull() {
+	// Do nothing if there is no state (resource is being created).
+	if req.State.Raw.IsNull() {
 		return
 	}
 

--- a/resource/schema/numberplanmodifier/use_state_for_unknown.go
+++ b/resource/schema/numberplanmodifier/use_state_for_unknown.go
@@ -36,8 +36,8 @@ func (m useStateForUnknownModifier) MarkdownDescription(_ context.Context) strin
 
 // PlanModifyNumber implements the plan modification logic.
 func (m useStateForUnknownModifier) PlanModifyNumber(_ context.Context, req planmodifier.NumberRequest, resp *planmodifier.NumberResponse) {
-	// Do nothing if there is no state value.
-	if req.StateValue.IsNull() {
+	// Do nothing if there is no state (resource is being created).
+	if req.State.Raw.IsNull() {
 		return
 	}
 

--- a/resource/schema/objectplanmodifier/use_state_for_unknown.go
+++ b/resource/schema/objectplanmodifier/use_state_for_unknown.go
@@ -36,8 +36,8 @@ func (m useStateForUnknownModifier) MarkdownDescription(_ context.Context) strin
 
 // PlanModifyObject implements the plan modification logic.
 func (m useStateForUnknownModifier) PlanModifyObject(_ context.Context, req planmodifier.ObjectRequest, resp *planmodifier.ObjectResponse) {
-	// Do nothing if there is no state value.
-	if req.StateValue.IsNull() {
+	// Do nothing if there is no state (resource is being created).
+	if req.State.Raw.IsNull() {
 		return
 	}
 

--- a/resource/schema/setplanmodifier/use_state_for_unknown.go
+++ b/resource/schema/setplanmodifier/use_state_for_unknown.go
@@ -36,8 +36,8 @@ func (m useStateForUnknownModifier) MarkdownDescription(_ context.Context) strin
 
 // PlanModifySet implements the plan modification logic.
 func (m useStateForUnknownModifier) PlanModifySet(_ context.Context, req planmodifier.SetRequest, resp *planmodifier.SetResponse) {
-	// Do nothing if there is no state value.
-	if req.StateValue.IsNull() {
+	// Do nothing if there is no state (resource is being created).
+	if req.State.Raw.IsNull() {
 		return
 	}
 

--- a/resource/schema/stringplanmodifier/use_state_for_unknown.go
+++ b/resource/schema/stringplanmodifier/use_state_for_unknown.go
@@ -36,8 +36,8 @@ func (m useStateForUnknownModifier) MarkdownDescription(_ context.Context) strin
 
 // PlanModifyString implements the plan modification logic.
 func (m useStateForUnknownModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
-	// Do nothing if there is no state value.
-	if req.StateValue.IsNull() {
+	// Do nothing if there is no state (resource is being created).
+	if req.State.Raw.IsNull() {
 		return
 	}
 


### PR DESCRIPTION
## Related Issue

Related #1161

## Description

This PR backports #1161 into the `release/1.15.x` branch so we can release a `v1.15.1` module with just this change (as main currently has a couple unreleased features in it and these changes are isolated.

```bash
git cherry-pick c83bd4e010fffbbdf8147c91291776d27684fda4
```

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No
