### PR TITLE
Sync changelog after `v1.15.1` release

### DIFF
--- a/.changes/1.15.1.md
+++ b/.changes/1.15.1.md
@@ -1,0 +1,6 @@
+## 1.15.1 (July 31, 2025)
+
+BUG FIXES:
+
+* all: Fixed bug with `UseStateForUnknown` where known null state values were not preserved during update plans. ([#1117](https://github.com/hashicorp/terraform-plugin-framework/issues/1117))
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+
+## 1.15.1 (July 31, 2025)
+
+BUG FIXES:
+
+* all: Fixed bug with `UseStateForUnknown` where known null state values were not preserved during update plans. ([#1117](https://github.com/hashicorp/terraform-plugin-framework/issues/1117))
+
 ## 1.16.0-alpha.1 (July 22, 2025)
 
 NOTES:


### PR DESCRIPTION
## Related Issue

N/A

## Description

This change brings over the release/changelog commit from the `release/v1.15.x` branch:
```bash
git cherry-pick 4781d1307f8d7b39e789717261b8f7791ac62e53
```

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No
