### PR TITLE
list: add map, list and single nested blocks and attributes

### DIFF
--- a/list/schema/attribute.go
+++ b/list/schema/attribute.go
@@ -17,7 +17,15 @@ import (
 //   - ListAttribute
 //   - MapAttribute
 //   - NumberAttribute
+//   - ObjectAttribute
 //   - StringAttribute
+//
+// Additionally, the NestedAttribute interface extends Attribute with nested
+// attributes. Only supported in protocol version 6. Implementations in this
+// package include:
+//   - ListNestedAttribute
+//   - MapNestedAttribute
+//   - SingleNestedAttribute
 //
 // In practitioner configurations, an equals sign (=) is required to set
 // the value. [Configuration Reference]

--- a/list/schema/bool_attribute.go
+++ b/list/schema/bool_attribute.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
 
-// Ensure the implementation satisifies the desired interfaces.
+// Ensure the implementation satisfies the desired interfaces.
 var (
 	_ Attribute                             = BoolAttribute{}
 	_ fwxschema.AttributeWithBoolValidators = BoolAttribute{}

--- a/list/schema/dynamic_attribute.go
+++ b/list/schema/dynamic_attribute.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
 
-// Ensure the implementation satisifies the desired interfaces.
+// Ensure the implementation satisfies the desired interfaces.
 var (
 	_ Attribute                                = DynamicAttribute{}
 	_ fwxschema.AttributeWithDynamicValidators = DynamicAttribute{}
@@ -163,8 +163,7 @@ func (a DynamicAttribute) IsSensitive() bool {
 	return false
 }
 
-// IsWriteOnly returns false as write-only attributes are not relevant to ephemeral resource schemas,
-// as these schemas describe data that is explicitly not saved to any artifact.
+// IsWriteOnly returns false because it does not apply to ListResource schemas.
 func (a DynamicAttribute) IsWriteOnly() bool {
 	return false
 }

--- a/list/schema/float32_attribute.go
+++ b/list/schema/float32_attribute.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
 
-// Ensure the implementation satisifies the desired interfaces.
+// Ensure the implementation satisfies the desired interfaces.
 var (
 	_ Attribute                                = Float32Attribute{}
 	_ fwxschema.AttributeWithFloat32Validators = Float32Attribute{}

--- a/list/schema/float64_attribute.go
+++ b/list/schema/float64_attribute.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
 
-// Ensure the implementation satisifies the desired interfaces.
+// Ensure the implementation satisfies the desired interfaces.
 var (
 	_ Attribute                                = Float64Attribute{}
 	_ fwxschema.AttributeWithFloat64Validators = Float64Attribute{}

--- a/list/schema/int64_attribute.go
+++ b/list/schema/int64_attribute.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
 
-// Ensure the implementation satisifies the desired interfaces.
+// Ensure the implementation satisfies the desired interfaces.
 var (
 	_ Attribute                              = Int64Attribute{}
 	_ fwxschema.AttributeWithInt64Validators = Int64Attribute{}
@@ -170,7 +170,7 @@ func (a Int64Attribute) IsRequired() bool {
 	return a.Required
 }
 
-// IsSensitive returns false because it does not apply to ephemeral resource schemas.
+// IsSensitive returns false because it does not apply to ListResource schemas.
 func (a Int64Attribute) IsSensitive() bool {
 	return false
 }

--- a/list/schema/list_attribute.go
+++ b/list/schema/list_attribute.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
 
-// Ensure the implementation satisifies the desired interfaces.
+// Ensure the implementation satisfies the desired interfaces.
 var (
 	_ Attribute                                    = ListAttribute{}
 	_ fwschema.AttributeWithValidateImplementation = ListAttribute{}

--- a/list/schema/list_nested_attribute.go
+++ b/list/schema/list_nested_attribute.go
@@ -4,11 +4,15 @@
 package schema
 
 import (
+	"context"
+	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema/fwxschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwtype"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -16,30 +20,52 @@ import (
 
 // Ensure the implementation satisfies the desired interfaces.
 var (
-	_ Attribute                              = Int32Attribute{}
-	_ fwxschema.AttributeWithInt32Validators = Int32Attribute{}
+	_ NestedAttribute                              = ListNestedAttribute{}
+	_ fwschema.AttributeWithValidateImplementation = ListNestedAttribute{}
+	_ fwxschema.AttributeWithListValidators        = ListNestedAttribute{}
 )
 
-// Int32Attribute represents a schema attribute that is a 32-bit integer.
-// When retrieving the value for this attribute, use types.Int32 as the value
-// type unless the CustomType field is set.
+// ListNestedAttribute represents an attribute that is a list of objects where
+// the object attributes can be fully defined, including further nested
+// attributes. When retrieving the value for this attribute, use types.List
+// as the value type unless the CustomType field is set. The NestedObject field
+// must be set. Nested attributes are only compatible with protocol version 6.
 //
-// Use Float32Attribute for 32-bit floating point number attributes or
-// NumberAttribute for 512-bit generic number attributes.
+// Use ListAttribute if the underlying elements are of a single type and do
+// not require definition beyond type information.
 //
 // Terraform configurations configure this attribute using expressions that
-// return a number or directly via an integer value.
+// return a list of objects or directly via square and curly brace syntax.
 //
-//	example_attribute = 123
+//	# list of objects
+//	example_attribute = [
+//		{
+//			nested_attribute = #...
+//		},
+//	]
 //
-// Terraform configurations reference this attribute using the attribute name.
+// Terraform configurations reference this attribute using expressions that
+// accept a list of objects or an element directly via square brace 0-based
+// index syntax:
 //
-//	.example_attribute
-type Int32Attribute struct {
+//	# first known object
+//	.example_attribute[0]
+//	# first known object nested_attribute value
+//	.example_attribute[0].nested_attribute
+type ListNestedAttribute struct {
+	// NestedObject is the underlying object that contains nested attributes.
+	// This field must be set.
+	//
+	// Nested attributes that contain a dynamic type (i.e. DynamicAttribute) are not supported.
+	// If underlying dynamic values are required, replace this attribute definition with
+	// DynamicAttribute instead.
+	NestedObject NestedAttributeObject
+
 	// CustomType enables the use of a custom attribute type in place of the
-	// default basetypes.Int32Type. When retrieving data, the basetypes.Int32Valuable
-	// associated with this custom type must be used in place of types.Int32.
-	CustomType basetypes.Int32Typable
+	// default types.ListType of types.ObjectType. When retrieving data, the
+	// basetypes.ListValuable associated with this custom type must be used in
+	// place of types.List.
+	CustomType basetypes.ListTypable
 
 	// Required indicates whether the practitioner must enter a value for
 	// this attribute or not. Required and Optional cannot both be true.
@@ -107,87 +133,117 @@ type Int32Attribute struct {
 	// If the Type field points to a custom type that implements the
 	// xattr.TypeWithValidate interface, the validators defined in this field
 	// are run in addition to the validation defined by the type.
-	Validators []validator.Int32
+	Validators []validator.List
 }
 
-// ApplyTerraform5AttributePathStep always returns an error as it is not
-// possible to step further into a Int32Attribute.
-func (a Int32Attribute) ApplyTerraform5AttributePathStep(step tftypes.AttributePathStep) (interface{}, error) {
-	return a.GetType().ApplyTerraform5AttributePathStep(step)
+// ApplyTerraform5AttributePathStep returns the Attributes field value if step
+// is ElementKeyInt, otherwise returns an error.
+func (a ListNestedAttribute) ApplyTerraform5AttributePathStep(step tftypes.AttributePathStep) (interface{}, error) {
+	_, ok := step.(tftypes.ElementKeyInt)
+
+	if !ok {
+		return nil, fmt.Errorf("cannot apply step %T to ListNestedAttribute", step)
+	}
+
+	return a.NestedObject, nil
 }
 
-// Equal returns true if the given Attribute is a Int32Attribute
+// Equal returns true if the given Attribute is a ListNestedAttribute
 // and all fields are equal.
-func (a Int32Attribute) Equal(o fwschema.Attribute) bool {
-	if _, ok := o.(Int32Attribute); !ok {
+func (a ListNestedAttribute) Equal(o fwschema.Attribute) bool {
+	other, ok := o.(ListNestedAttribute)
+
+	if !ok {
 		return false
 	}
 
-	return fwschema.AttributesEqual(a, o)
+	return fwschema.NestedAttributesEqual(a, other)
 }
 
 // GetDeprecationMessage returns the DeprecationMessage field value.
-func (a Int32Attribute) GetDeprecationMessage() string {
+func (a ListNestedAttribute) GetDeprecationMessage() string {
 	return a.DeprecationMessage
 }
 
 // GetDescription returns the Description field value.
-func (a Int32Attribute) GetDescription() string {
+func (a ListNestedAttribute) GetDescription() string {
 	return a.Description
 }
 
 // GetMarkdownDescription returns the MarkdownDescription field value.
-func (a Int32Attribute) GetMarkdownDescription() string {
+func (a ListNestedAttribute) GetMarkdownDescription() string {
 	return a.MarkdownDescription
 }
 
-// GetType returns types.Int32Type or the CustomType field value if defined.
-func (a Int32Attribute) GetType() attr.Type {
+// GetNestedObject returns the NestedObject field value.
+func (a ListNestedAttribute) GetNestedObject() fwschema.NestedAttributeObject {
+	return a.NestedObject
+}
+
+// GetNestingMode always returns NestingModeList.
+func (a ListNestedAttribute) GetNestingMode() fwschema.NestingMode {
+	return fwschema.NestingModeList
+}
+
+// GetType returns ListType of ObjectType or CustomType.
+func (a ListNestedAttribute) GetType() attr.Type {
 	if a.CustomType != nil {
 		return a.CustomType
 	}
 
-	return types.Int32Type
-}
-
-// Int32Validators returns the Validators field value.
-func (a Int32Attribute) Int32Validators() []validator.Int32 {
-	return a.Validators
+	return types.ListType{
+		ElemType: a.NestedObject.Type(),
+	}
 }
 
 // IsComputed returns false because it does not apply to ListResource schemas.
-func (a Int32Attribute) IsComputed() bool {
+func (a ListNestedAttribute) IsComputed() bool {
 	return false
 }
 
 // IsOptional returns the Optional field value.
-func (a Int32Attribute) IsOptional() bool {
+func (a ListNestedAttribute) IsOptional() bool {
 	return a.Optional
 }
 
 // IsRequired returns the Required field value.
-func (a Int32Attribute) IsRequired() bool {
+func (a ListNestedAttribute) IsRequired() bool {
 	return a.Required
 }
 
 // IsSensitive returns false because it does not apply to ListResource schemas.
-func (a Int32Attribute) IsSensitive() bool {
+func (a ListNestedAttribute) IsSensitive() bool {
 	return false
 }
 
 // IsWriteOnly returns false because it does not apply to ListResource schemas.
-func (a Int32Attribute) IsWriteOnly() bool {
+func (a ListNestedAttribute) IsWriteOnly() bool {
 	return false
 }
 
 // IsRequiredForImport returns false as this behavior is only relevant
 // for managed resource identity schema attributes.
-func (a Int32Attribute) IsRequiredForImport() bool {
+func (a ListNestedAttribute) IsRequiredForImport() bool {
 	return false
 }
 
 // IsOptionalForImport returns false as this behavior is only relevant
 // for managed resource identity schema attributes.
-func (a Int32Attribute) IsOptionalForImport() bool {
+func (a ListNestedAttribute) IsOptionalForImport() bool {
 	return false
+}
+
+// ListValidators returns the Validators field value.
+func (a ListNestedAttribute) ListValidators() []validator.List {
+	return a.Validators
+}
+
+// ValidateImplementation contains logic for validating the
+// provider-defined implementation of the attribute to prevent unexpected
+// errors or panics. This logic runs during the GetProviderSchema RPC and
+// should never include false positives.
+func (a ListNestedAttribute) ValidateImplementation(ctx context.Context, req fwschema.ValidateImplementationRequest, resp *fwschema.ValidateImplementationResponse) {
+	if a.CustomType == nil && fwtype.ContainsCollectionWithDynamic(a.GetType()) {
+		resp.Diagnostics.Append(fwtype.AttributeCollectionWithDynamicTypeDiag(req.Path))
+	}
 }

--- a/list/schema/list_nested_attribute_test.go
+++ b/list/schema/list_nested_attribute_test.go
@@ -1,0 +1,725 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schema_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testtypes"
+	"github.com/hashicorp/terraform-plugin-framework/list/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func TestListNestedAttributeApplyTerraform5AttributePathStep(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute     schema.ListNestedAttribute
+		step          tftypes.AttributePathStep
+		expected      any
+		expectedError error
+	}{
+		"AttributeName": {
+			attribute: schema.ListNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{},
+					},
+				},
+			},
+			step:          tftypes.AttributeName("test"),
+			expected:      nil,
+			expectedError: fmt.Errorf("cannot apply step tftypes.AttributeName to ListNestedAttribute"),
+		},
+		"ElementKeyInt": {
+			attribute: schema.ListNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{},
+					},
+				},
+			},
+			step: tftypes.ElementKeyInt(1),
+			expected: schema.NestedAttributeObject{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+			},
+			expectedError: nil,
+		},
+		"ElementKeyString": {
+			attribute: schema.ListNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{},
+					},
+				},
+			},
+			step:          tftypes.ElementKeyString("test"),
+			expected:      nil,
+			expectedError: fmt.Errorf("cannot apply step tftypes.ElementKeyString to ListNestedAttribute"),
+		},
+		"ElementKeyValue": {
+			attribute: schema.ListNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{},
+					},
+				},
+			},
+			step:          tftypes.ElementKeyValue(tftypes.NewValue(tftypes.String, "test")),
+			expected:      nil,
+			expectedError: fmt.Errorf("cannot apply step tftypes.ElementKeyValue to ListNestedAttribute"),
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := testCase.attribute.ApplyTerraform5AttributePathStep(testCase.step)
+
+			if err != nil {
+				if testCase.expectedError == nil {
+					t.Fatalf("expected no error, got: %s", err)
+				}
+
+				if !strings.Contains(err.Error(), testCase.expectedError.Error()) {
+					t.Fatalf("expected error %q, got: %s", testCase.expectedError, err)
+				}
+			}
+
+			if err == nil && testCase.expectedError != nil {
+				t.Fatalf("got no error, expected: %s", testCase.expectedError)
+			}
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestListNestedAttributeGetDeprecationMessage(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.ListNestedAttribute
+		expected  string
+	}{
+		"no-deprecation-message": {
+			attribute: schema.ListNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{},
+					},
+				},
+			},
+			expected: "",
+		},
+		"deprecation-message": {
+			attribute: schema.ListNestedAttribute{
+				DeprecationMessage: "test deprecation message",
+			},
+			expected: "test deprecation message",
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.attribute.GetDeprecationMessage()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestListNestedAttributeEqual(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.ListNestedAttribute
+		other     fwschema.Attribute
+		expected  bool
+	}{
+		"different-type": {
+			attribute: schema.ListNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{},
+					},
+				},
+			},
+			other:    testschema.AttributeWithListValidators{},
+			expected: false,
+		},
+		"different-attributes-definitions": {
+			attribute: schema.ListNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{
+							Optional: true,
+						},
+					},
+				},
+			},
+			other: schema.ListNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{
+							Required: true,
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		"different-attributes-types": {
+			attribute: schema.ListNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{},
+					},
+				},
+			},
+			other: schema.ListNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.BoolAttribute{},
+					},
+				},
+			},
+			expected: false,
+		},
+		"equal": {
+			attribute: schema.ListNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{},
+					},
+				},
+			},
+			other: schema.ListNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{},
+					},
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.attribute.Equal(testCase.other)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestListNestedAttributeGetDescription(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.ListNestedAttribute
+		expected  string
+	}{
+		"no-description": {
+			attribute: schema.ListNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{},
+					},
+				},
+			},
+			expected: "",
+		},
+		"description": {
+			attribute: schema.ListNestedAttribute{
+				Description: "test description",
+			},
+			expected: "test description",
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.attribute.GetDescription()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestListNestedAttributeGetMarkdownDescription(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.ListNestedAttribute
+		expected  string
+	}{
+		"no-markdown-description": {
+			attribute: schema.ListNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{},
+					},
+				},
+			},
+			expected: "",
+		},
+		"markdown-description": {
+			attribute: schema.ListNestedAttribute{
+				MarkdownDescription: "test description",
+			},
+			expected: "test description",
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.attribute.GetMarkdownDescription()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestListNestedAttributeGetNestedObject(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.ListNestedAttribute
+		expected  schema.NestedAttributeObject
+	}{
+		"nested-object": {
+			attribute: schema.ListNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{},
+					},
+				},
+			},
+			expected: schema.NestedAttributeObject{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.attribute.GetNestedObject()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestListNestedAttributeGetType(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.ListNestedAttribute
+		expected  attr.Type
+	}{
+		"base": {
+			attribute: schema.ListNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{},
+					},
+				},
+			},
+			expected: types.ListType{
+				ElemType: types.ObjectType{
+					AttrTypes: map[string]attr.Type{
+						"testattr": types.StringType,
+					},
+				},
+			},
+		},
+		"custom-type": {
+			attribute: schema.ListNestedAttribute{
+				CustomType: testtypes.ListType{ListType: types.ListType{ElemType: types.StringType}},
+			},
+			expected: testtypes.ListType{ListType: types.ListType{ElemType: types.StringType}},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.attribute.GetType()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestListNestedAttributeIsComputed(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.ListNestedAttribute
+		expected  bool
+	}{
+		"not-computed": {
+			attribute: schema.ListNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{},
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.attribute.IsComputed()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestListNestedAttributeIsOptional(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.ListNestedAttribute
+		expected  bool
+	}{
+		"not-optional": {
+			attribute: schema.ListNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{},
+					},
+				},
+			},
+			expected: false,
+		},
+		"optional": {
+			attribute: schema.ListNestedAttribute{
+				Optional: true,
+			},
+			expected: true,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.attribute.IsOptional()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestListNestedAttributeIsRequired(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.ListNestedAttribute
+		expected  bool
+	}{
+		"not-required": {
+			attribute: schema.ListNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{},
+					},
+				},
+			},
+			expected: false,
+		},
+		"required": {
+			attribute: schema.ListNestedAttribute{
+				Required: true,
+			},
+			expected: true,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.attribute.IsRequired()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestListNestedAttributeIsSensitive(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.ListNestedAttribute
+		expected  bool
+	}{
+		"not-sensitive": {
+			attribute: schema.ListNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{},
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.attribute.IsSensitive()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestListNestedAttributeIsWriteOnly(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.ListNestedAttribute
+		expected  bool
+	}{
+		"not-writeOnly": {
+			attribute: schema.ListNestedAttribute{},
+			expected:  false,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.attribute.IsWriteOnly()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestListNestedAttributeListValidators(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.ListNestedAttribute
+		expected  []validator.List
+	}{
+		"no-validators": {
+			attribute: schema.ListNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{},
+					},
+				},
+			},
+			expected: nil,
+		},
+		"validators": {
+			attribute: schema.ListNestedAttribute{
+				Validators: []validator.List{},
+			},
+			expected: []validator.List{},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.attribute.ListValidators()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestListNestedAttributeValidateImplementation(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.ListNestedAttribute
+		request   fwschema.ValidateImplementationRequest
+		expected  *fwschema.ValidateImplementationResponse
+	}{
+		"customtype": {
+			attribute: schema.ListNestedAttribute{
+				CustomType: testtypes.ListType{},
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{},
+		},
+		"nestedobject": {
+			attribute: schema.ListNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"test_attr": schema.StringAttribute{},
+					},
+				},
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{},
+		},
+		"nestedobject-dynamic": {
+			attribute: schema.ListNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"test_dyn": schema.DynamicAttribute{},
+					},
+				},
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic(
+						"Invalid Schema Implementation",
+						"When validating the schema, an implementation issue was found. "+
+							"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+							"\"test\" is an attribute that contains a collection type with a nested dynamic type.\n\n"+
+							"Dynamic types inside of collections are not currently supported in terraform-plugin-framework. "+
+							"If underlying dynamic values are required, replace the \"test\" attribute definition with DynamicAttribute instead.",
+					),
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := &fwschema.ValidateImplementationResponse{}
+			testCase.attribute.ValidateImplementation(context.Background(), testCase.request, got)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestListNestedAttributeIsRequiredForImport(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.ListNestedAttribute
+		expected  bool
+	}{
+		"not-requiredForImport": {
+			attribute: schema.ListNestedAttribute{},
+			expected:  false,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.attribute.IsRequiredForImport()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestListNestedAttributeIsOptionalForImport(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.ListNestedAttribute
+		expected  bool
+	}{
+		"not-optionalForImport": {
+			attribute: schema.ListNestedAttribute{},
+			expected:  false,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.attribute.IsOptionalForImport()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}

--- a/list/schema/list_nested_block.go
+++ b/list/schema/list_nested_block.go
@@ -1,0 +1,205 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schema
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema/fwxschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwtype"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// Ensure the implementation satisfies the desired interfaces.
+var (
+	_ Block                                    = ListNestedBlock{}
+	_ fwschema.BlockWithValidateImplementation = ListNestedBlock{}
+	_ fwxschema.BlockWithListValidators        = ListNestedBlock{}
+)
+
+// ListNestedBlock represents a block that is a list of objects where
+// the object attributes can be fully defined, including further attributes
+// or blocks. When retrieving the value for this block, use types.List
+// as the value type unless the CustomType field is set. The NestedObject field
+// must be set.
+//
+// Prefer ListNestedAttribute over ListNestedBlock if the provider is
+// using protocol version 6. Nested attributes allow practitioners to configure
+// values directly with expressions.
+//
+// Terraform configurations configure this block repeatedly using curly brace
+// syntax without an equals (=) sign or [Dynamic Block Expressions].
+//
+//	# list of blocks with two elements
+//	example_block {
+//		nested_attribute = #...
+//	}
+//	example_block {
+//		nested_attribute = #...
+//	}
+//
+// Terraform configurations reference this block using expressions that
+// accept a list of objects or an element directly via square brace 0-based
+// index syntax:
+//
+//	# first known object
+//	.example_block[0]
+//	# first known object nested_attribute value
+//	.example_block[0].nested_attribute
+//
+// [Dynamic Block Expressions]: https://developer.hashicorp.com/terraform/language/expressions/dynamic-blocks
+type ListNestedBlock struct {
+	// NestedObject is the underlying object that contains nested attributes or
+	// blocks. This field must be set.
+	//
+	// Nested attributes that contain a dynamic type (i.e. DynamicAttribute) are not supported.
+	// If underlying dynamic values are required, replace this block definition with
+	// a DynamicAttribute.
+	NestedObject NestedBlockObject
+
+	// CustomType enables the use of a custom attribute type in place of the
+	// default types.ListType of types.ObjectType. When retrieving data, the
+	// basetypes.ListValuable associated with this custom type must be used in
+	// place of types.List.
+	CustomType basetypes.ListTypable
+
+	// Description is used in various tooling, like the language server, to
+	// give practitioners more information about what this attribute is,
+	// what it's for, and how it should be used. It should be written as
+	// plain text, with no special formatting.
+	Description string
+
+	// MarkdownDescription is used in various tooling, like the
+	// documentation generator, to give practitioners more information
+	// about what this attribute is, what it's for, and how it should be
+	// used. It should be formatted using Markdown.
+	MarkdownDescription string
+
+	// DeprecationMessage defines warning diagnostic details to display when
+	// practitioner configurations use this Attribute. The warning diagnostic
+	// summary is automatically set to "Attribute Deprecated" along with
+	// configuration source file and line information.
+	//
+	// Set this field to a practitioner actionable message such as:
+	//
+	//  - "Configure other_attribute instead. This attribute will be removed
+	//    in the next major version of the provider."
+	//  - "Remove this attribute's configuration as it no longer is used and
+	//    the attribute will be removed in the next major version of the
+	//    provider."
+	//
+	// In Terraform 1.2.7 and later, this warning diagnostic is displayed any
+	// time a practitioner attempts to configure a value for this attribute and
+	// certain scenarios where this attribute is referenced.
+	//
+	// In Terraform 1.2.6 and earlier, this warning diagnostic is only
+	// displayed when the Attribute is Required or Optional, and if the
+	// practitioner configuration sets the value to a known or unknown value
+	// (which may eventually be null). It has no effect when the Attribute is
+	// Computed-only (read-only; not Required or Optional).
+	//
+	// Across any Terraform version, there are no warnings raised for
+	// practitioner configuration values set directly to null, as there is no
+	// way for the framework to differentiate between an unset and null
+	// configuration due to how Terraform sends configuration information
+	// across the protocol.
+	//
+	// Additional information about deprecation enhancements for read-only
+	// attributes can be found in:
+	//
+	//  - https://github.com/hashicorp/terraform/issues/7569
+	//
+	DeprecationMessage string
+
+	// Validators define value validation functionality for the attribute. All
+	// elements of the slice of AttributeValidator are run, regardless of any
+	// previous error diagnostics.
+	//
+	// Many common use case validators can be found in the
+	// github.com/hashicorp/terraform-plugin-framework-validators Go module.
+	//
+	// If the Type field points to a custom type that implements the
+	// xattr.TypeWithValidate interface, the validators defined in this field
+	// are run in addition to the validation defined by the type.
+	Validators []validator.List
+}
+
+// ApplyTerraform5AttributePathStep returns the NestedObject field value if step
+// is ElementKeyInt, otherwise returns an error.
+func (b ListNestedBlock) ApplyTerraform5AttributePathStep(step tftypes.AttributePathStep) (interface{}, error) {
+	_, ok := step.(tftypes.ElementKeyInt)
+
+	if !ok {
+		return nil, fmt.Errorf("cannot apply step %T to ListNestedBlock", step)
+	}
+
+	return b.NestedObject, nil
+}
+
+// Equal returns true if the given Block is ListNestedBlock
+// and all fields are equal.
+func (b ListNestedBlock) Equal(o fwschema.Block) bool {
+	if _, ok := o.(ListNestedBlock); !ok {
+		return false
+	}
+
+	return fwschema.BlocksEqual(b, o)
+}
+
+// GetDeprecationMessage returns the DeprecationMessage field value.
+func (b ListNestedBlock) GetDeprecationMessage() string {
+	return b.DeprecationMessage
+}
+
+// GetDescription returns the Description field value.
+func (b ListNestedBlock) GetDescription() string {
+	return b.Description
+}
+
+// GetMarkdownDescription returns the MarkdownDescription field value.
+func (b ListNestedBlock) GetMarkdownDescription() string {
+	return b.MarkdownDescription
+}
+
+// GetNestedObject returns the NestedObject field value.
+func (b ListNestedBlock) GetNestedObject() fwschema.NestedBlockObject {
+	return b.NestedObject
+}
+
+// GetNestingMode always returns BlockNestingModeList.
+func (b ListNestedBlock) GetNestingMode() fwschema.BlockNestingMode {
+	return fwschema.BlockNestingModeList
+}
+
+// ListValidators returns the Validators field value.
+func (b ListNestedBlock) ListValidators() []validator.List {
+	return b.Validators
+}
+
+// Type returns ListType of ObjectType or CustomType.
+func (b ListNestedBlock) Type() attr.Type {
+	if b.CustomType != nil {
+		return b.CustomType
+	}
+
+	return types.ListType{
+		ElemType: b.NestedObject.Type(),
+	}
+}
+
+// ValidateImplementation contains logic for validating the
+// provider-defined implementation of the block to prevent unexpected
+// errors or panics. This logic runs during the GetProviderSchema RPC and
+// should never include false positives.
+func (b ListNestedBlock) ValidateImplementation(ctx context.Context, req fwschema.ValidateImplementationRequest, resp *fwschema.ValidateImplementationResponse) {
+	if b.CustomType == nil && fwtype.ContainsCollectionWithDynamic(b.Type()) {
+		resp.Diagnostics.Append(fwtype.BlockCollectionWithDynamicTypeDiag(req.Path))
+	}
+}

--- a/list/schema/list_nested_block_test.go
+++ b/list/schema/list_nested_block_test.go
@@ -1,0 +1,548 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schema_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testtypes"
+	"github.com/hashicorp/terraform-plugin-framework/list/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func TestListNestedBlockApplyTerraform5AttributePathStep(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		block         schema.ListNestedBlock
+		step          tftypes.AttributePathStep
+		expected      any
+		expectedError error
+	}{
+		"AttributeName": {
+			block: schema.ListNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{},
+					},
+				},
+			},
+			step:          tftypes.AttributeName("test"),
+			expected:      nil,
+			expectedError: fmt.Errorf("cannot apply step tftypes.AttributeName to ListNestedBlock"),
+		},
+		"ElementKeyInt": {
+			block: schema.ListNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{},
+					},
+				},
+			},
+			step: tftypes.ElementKeyInt(1),
+			expected: schema.NestedBlockObject{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+			},
+			expectedError: nil,
+		},
+		"ElementKeyString": {
+			block: schema.ListNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{},
+					},
+				},
+			},
+			step:          tftypes.ElementKeyString("test"),
+			expected:      nil,
+			expectedError: fmt.Errorf("cannot apply step tftypes.ElementKeyString to ListNestedBlock"),
+		},
+		"ElementKeyValue": {
+			block: schema.ListNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{},
+					},
+				},
+			},
+			step:          tftypes.ElementKeyValue(tftypes.NewValue(tftypes.String, "test")),
+			expected:      nil,
+			expectedError: fmt.Errorf("cannot apply step tftypes.ElementKeyValue to ListNestedBlock"),
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := testCase.block.ApplyTerraform5AttributePathStep(testCase.step)
+
+			if err != nil {
+				if testCase.expectedError == nil {
+					t.Fatalf("expected no error, got: %s", err)
+				}
+
+				if !strings.Contains(err.Error(), testCase.expectedError.Error()) {
+					t.Fatalf("expected error %q, got: %s", testCase.expectedError, err)
+				}
+			}
+
+			if err == nil && testCase.expectedError != nil {
+				t.Fatalf("got no error, expected: %s", testCase.expectedError)
+			}
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestListNestedBlockGetDeprecationMessage(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		block    schema.ListNestedBlock
+		expected string
+	}{
+		"no-deprecation-message": {
+			block: schema.ListNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{},
+					},
+				},
+			},
+			expected: "",
+		},
+		"deprecation-message": {
+			block: schema.ListNestedBlock{
+				DeprecationMessage: "test deprecation message",
+			},
+			expected: "test deprecation message",
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.block.GetDeprecationMessage()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestListNestedBlockEqual(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		block    schema.ListNestedBlock
+		other    fwschema.Block
+		expected bool
+	}{
+		"different-type": {
+			block: schema.ListNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{},
+					},
+				},
+			},
+			other:    testschema.BlockWithListValidators{},
+			expected: false,
+		},
+		"different-attributes-definitions": {
+			block: schema.ListNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{
+							Optional: true,
+						},
+					},
+				},
+			},
+			other: schema.ListNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{
+							Required: true,
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		"different-attributes-types": {
+			block: schema.ListNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{},
+					},
+				},
+			},
+			other: schema.ListNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.BoolAttribute{},
+					},
+				},
+			},
+			expected: false,
+		},
+		"different-blocks-definitions": {
+			block: schema.ListNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Blocks: map[string]schema.Block{
+						"testblock": schema.SingleNestedBlock{
+							Attributes: map[string]schema.Attribute{
+								"testattr": schema.StringAttribute{
+									Optional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			other: schema.ListNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Blocks: map[string]schema.Block{
+						"testblock": schema.SingleNestedBlock{
+							Attributes: map[string]schema.Attribute{
+								"testattr": schema.StringAttribute{
+									Required: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		"equal": {
+			block: schema.ListNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{},
+					},
+				},
+			},
+			other: schema.ListNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{},
+					},
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.block.Equal(testCase.other)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestListNestedBlockGetDescription(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		block    schema.ListNestedBlock
+		expected string
+	}{
+		"no-description": {
+			block: schema.ListNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{},
+					},
+				},
+			},
+			expected: "",
+		},
+		"description": {
+			block: schema.ListNestedBlock{
+				Description: "test description",
+			},
+			expected: "test description",
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.block.GetDescription()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestListNestedBlockGetMarkdownDescription(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		block    schema.ListNestedBlock
+		expected string
+	}{
+		"no-markdown-description": {
+			block: schema.ListNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{},
+					},
+				},
+			},
+			expected: "",
+		},
+		"markdown-description": {
+			block: schema.ListNestedBlock{
+				MarkdownDescription: "test description",
+			},
+			expected: "test description",
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.block.GetMarkdownDescription()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestListNestedBlockGetNestedObject(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		block    schema.ListNestedBlock
+		expected schema.NestedBlockObject
+	}{
+		"nested-object": {
+			block: schema.ListNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{},
+					},
+				},
+			},
+			expected: schema.NestedBlockObject{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.block.GetNestedObject()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestListNestedBlockListValidators(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		block    schema.ListNestedBlock
+		expected []validator.List
+	}{
+		"no-validators": {
+			block: schema.ListNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{},
+					},
+				},
+			},
+			expected: nil,
+		},
+		"validators": {
+			block: schema.ListNestedBlock{
+				Validators: []validator.List{},
+			},
+			expected: []validator.List{},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.block.ListValidators()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestListNestedBlockType(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		block    schema.ListNestedBlock
+		expected attr.Type
+	}{
+		"base": {
+			block: schema.ListNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{},
+					},
+					Blocks: map[string]schema.Block{
+						"testblock": schema.SingleNestedBlock{
+							Attributes: map[string]schema.Attribute{
+								"testattr": schema.StringAttribute{},
+							},
+						},
+					},
+				},
+			},
+			expected: types.ListType{
+				ElemType: types.ObjectType{
+					AttrTypes: map[string]attr.Type{
+						"testattr": types.StringType,
+						"testblock": types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"testattr": types.StringType,
+							},
+						},
+					},
+				},
+			},
+		},
+		"custom-type": {
+			block: schema.ListNestedBlock{
+				CustomType: testtypes.ListType{ListType: types.ListType{ElemType: types.StringType}},
+			},
+			expected: testtypes.ListType{ListType: types.ListType{ElemType: types.StringType}},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.block.Type()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestListNestedBlockValidateImplementation(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		block    schema.ListNestedBlock
+		request  fwschema.ValidateImplementationRequest
+		expected *fwschema.ValidateImplementationResponse
+	}{
+		"customtype": {
+			block: schema.ListNestedBlock{
+				CustomType: testtypes.ListType{},
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{},
+		},
+		"nestedobject": {
+			block: schema.ListNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"test_attr": schema.StringAttribute{},
+					},
+				},
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{},
+		},
+		"nestedobject-dynamic": {
+			block: schema.ListNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"test_dyn": schema.DynamicAttribute{},
+					},
+				},
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic(
+						"Invalid Schema Implementation",
+						"When validating the schema, an implementation issue was found. "+
+							"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+							"\"test\" is a block that contains a collection type with a nested dynamic type.\n\n"+
+							"Dynamic types inside of collections are not currently supported in terraform-plugin-framework. "+
+							"If underlying dynamic values are required, replace the \"test\" block definition with a DynamicAttribute.",
+					),
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := &fwschema.ValidateImplementationResponse{}
+			testCase.block.ValidateImplementation(context.Background(), testCase.request, got)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}

--- a/list/schema/map_attribute.go
+++ b/list/schema/map_attribute.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
 
-// Ensure the implementation satisifies the desired interfaces.
+// Ensure the implementation satisfies the desired interfaces.
 var (
 	_ Attribute                                    = MapAttribute{}
 	_ fwschema.AttributeWithValidateImplementation = MapAttribute{}

--- a/list/schema/map_nested_attribute.go
+++ b/list/schema/map_nested_attribute.go
@@ -4,11 +4,15 @@
 package schema
 
 import (
+	"context"
+	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema/fwxschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwtype"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -16,30 +20,52 @@ import (
 
 // Ensure the implementation satisfies the desired interfaces.
 var (
-	_ Attribute                              = Int32Attribute{}
-	_ fwxschema.AttributeWithInt32Validators = Int32Attribute{}
+	_ NestedAttribute                              = MapNestedAttribute{}
+	_ fwschema.AttributeWithValidateImplementation = MapNestedAttribute{}
+	_ fwxschema.AttributeWithMapValidators         = MapNestedAttribute{}
 )
 
-// Int32Attribute represents a schema attribute that is a 32-bit integer.
-// When retrieving the value for this attribute, use types.Int32 as the value
-// type unless the CustomType field is set.
+// MapNestedAttribute represents an attribute that is a map of objects where
+// the object attributes can be fully defined, including further nested
+// attributes. When retrieving the value for this attribute, use types.Map
+// as the value type unless the CustomType field is set. The NestedObject field
+// must be set. Nested attributes are only compatible with protocol version 6.
 //
-// Use Float32Attribute for 32-bit floating point number attributes or
-// NumberAttribute for 512-bit generic number attributes.
+// Use MapAttribute if the underlying elements are of a single type and do
+// not require definition beyond type information.
 //
 // Terraform configurations configure this attribute using expressions that
-// return a number or directly via an integer value.
+// return a map of objects or directly via curly brace syntax.
 //
-//	example_attribute = 123
+//	# map of objects
+//	example_attribute = {
+//		key = {
+//			nested_attribute = #...
+//		},
+//	]
 //
-// Terraform configurations reference this attribute using the attribute name.
+// Terraform configurations reference this attribute using expressions that
+// accept a map of objects or an element directly via square brace string
+// syntax:
 //
-//	.example_attribute
-type Int32Attribute struct {
+//	# known object at key
+//	.example_attribute["key"]
+//	# known object nested_attribute value at key
+//	.example_attribute["key"].nested_attribute
+type MapNestedAttribute struct {
+	// NestedObject is the underlying object that contains nested attributes.
+	// This field must be set.
+	//
+	// Nested attributes that contain a dynamic type (i.e. DynamicAttribute) are not supported.
+	// If underlying dynamic values are required, replace this attribute definition with
+	// DynamicAttribute instead.
+	NestedObject NestedAttributeObject
+
 	// CustomType enables the use of a custom attribute type in place of the
-	// default basetypes.Int32Type. When retrieving data, the basetypes.Int32Valuable
-	// associated with this custom type must be used in place of types.Int32.
-	CustomType basetypes.Int32Typable
+	// default types.MapType of types.ObjectType. When retrieving data, the
+	// basetypes.MapValuable associated with this custom type must be used in
+	// place of types.Map.
+	CustomType basetypes.MapTypable
 
 	// Required indicates whether the practitioner must enter a value for
 	// this attribute or not. Required and Optional cannot both be true.
@@ -107,87 +133,117 @@ type Int32Attribute struct {
 	// If the Type field points to a custom type that implements the
 	// xattr.TypeWithValidate interface, the validators defined in this field
 	// are run in addition to the validation defined by the type.
-	Validators []validator.Int32
+	Validators []validator.Map
 }
 
-// ApplyTerraform5AttributePathStep always returns an error as it is not
-// possible to step further into a Int32Attribute.
-func (a Int32Attribute) ApplyTerraform5AttributePathStep(step tftypes.AttributePathStep) (interface{}, error) {
-	return a.GetType().ApplyTerraform5AttributePathStep(step)
+// ApplyTerraform5AttributePathStep returns the Attributes field value if step
+// is ElementKeyString, otherwise returns an error.
+func (a MapNestedAttribute) ApplyTerraform5AttributePathStep(step tftypes.AttributePathStep) (interface{}, error) {
+	_, ok := step.(tftypes.ElementKeyString)
+
+	if !ok {
+		return nil, fmt.Errorf("cannot apply step %T to MapNestedAttribute", step)
+	}
+
+	return a.NestedObject, nil
 }
 
-// Equal returns true if the given Attribute is a Int32Attribute
+// Equal returns true if the given Attribute is a MapNestedAttribute
 // and all fields are equal.
-func (a Int32Attribute) Equal(o fwschema.Attribute) bool {
-	if _, ok := o.(Int32Attribute); !ok {
+func (a MapNestedAttribute) Equal(o fwschema.Attribute) bool {
+	other, ok := o.(MapNestedAttribute)
+
+	if !ok {
 		return false
 	}
 
-	return fwschema.AttributesEqual(a, o)
+	return fwschema.NestedAttributesEqual(a, other)
 }
 
 // GetDeprecationMessage returns the DeprecationMessage field value.
-func (a Int32Attribute) GetDeprecationMessage() string {
+func (a MapNestedAttribute) GetDeprecationMessage() string {
 	return a.DeprecationMessage
 }
 
 // GetDescription returns the Description field value.
-func (a Int32Attribute) GetDescription() string {
+func (a MapNestedAttribute) GetDescription() string {
 	return a.Description
 }
 
 // GetMarkdownDescription returns the MarkdownDescription field value.
-func (a Int32Attribute) GetMarkdownDescription() string {
+func (a MapNestedAttribute) GetMarkdownDescription() string {
 	return a.MarkdownDescription
 }
 
-// GetType returns types.Int32Type or the CustomType field value if defined.
-func (a Int32Attribute) GetType() attr.Type {
+// GetNestedObject returns the NestedObject field value.
+func (a MapNestedAttribute) GetNestedObject() fwschema.NestedAttributeObject {
+	return a.NestedObject
+}
+
+// GetNestingMode always returns NestingModeMap.
+func (a MapNestedAttribute) GetNestingMode() fwschema.NestingMode {
+	return fwschema.NestingModeMap
+}
+
+// GetType returns MapType of ObjectType or CustomType.
+func (a MapNestedAttribute) GetType() attr.Type {
 	if a.CustomType != nil {
 		return a.CustomType
 	}
 
-	return types.Int32Type
-}
-
-// Int32Validators returns the Validators field value.
-func (a Int32Attribute) Int32Validators() []validator.Int32 {
-	return a.Validators
+	return types.MapType{
+		ElemType: a.NestedObject.Type(),
+	}
 }
 
 // IsComputed returns false because it does not apply to ListResource schemas.
-func (a Int32Attribute) IsComputed() bool {
+func (a MapNestedAttribute) IsComputed() bool {
 	return false
 }
 
 // IsOptional returns the Optional field value.
-func (a Int32Attribute) IsOptional() bool {
+func (a MapNestedAttribute) IsOptional() bool {
 	return a.Optional
 }
 
 // IsRequired returns the Required field value.
-func (a Int32Attribute) IsRequired() bool {
+func (a MapNestedAttribute) IsRequired() bool {
 	return a.Required
 }
 
 // IsSensitive returns false because it does not apply to ListResource schemas.
-func (a Int32Attribute) IsSensitive() bool {
+func (a MapNestedAttribute) IsSensitive() bool {
 	return false
 }
 
 // IsWriteOnly returns false because it does not apply to ListResource schemas.
-func (a Int32Attribute) IsWriteOnly() bool {
+func (a MapNestedAttribute) IsWriteOnly() bool {
 	return false
 }
 
 // IsRequiredForImport returns false as this behavior is only relevant
 // for managed resource identity schema attributes.
-func (a Int32Attribute) IsRequiredForImport() bool {
+func (a MapNestedAttribute) IsRequiredForImport() bool {
 	return false
 }
 
 // IsOptionalForImport returns false as this behavior is only relevant
 // for managed resource identity schema attributes.
-func (a Int32Attribute) IsOptionalForImport() bool {
+func (a MapNestedAttribute) IsOptionalForImport() bool {
 	return false
+}
+
+// MapValidators returns the Validators field value.
+func (a MapNestedAttribute) MapValidators() []validator.Map {
+	return a.Validators
+}
+
+// ValidateImplementation contains logic for validating the
+// provider-defined implementation of the attribute to prevent unexpected
+// errors or panics. This logic runs during the GetProviderSchema RPC and
+// should never include false positives.
+func (a MapNestedAttribute) ValidateImplementation(ctx context.Context, req fwschema.ValidateImplementationRequest, resp *fwschema.ValidateImplementationResponse) {
+	if a.CustomType == nil && fwtype.ContainsCollectionWithDynamic(a.GetType()) {
+		resp.Diagnostics.Append(fwtype.AttributeCollectionWithDynamicTypeDiag(req.Path))
+	}
 }

--- a/list/schema/map_nested_attribute_test.go
+++ b/list/schema/map_nested_attribute_test.go
@@ -1,0 +1,725 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schema_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testtypes"
+	"github.com/hashicorp/terraform-plugin-framework/list/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func TestMapNestedAttributeApplyTerraform5AttributePathStep(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute     schema.MapNestedAttribute
+		step          tftypes.AttributePathStep
+		expected      any
+		expectedError error
+	}{
+		"AttributeName": {
+			attribute: schema.MapNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{},
+					},
+				},
+			},
+			step:          tftypes.AttributeName("test"),
+			expected:      nil,
+			expectedError: fmt.Errorf("cannot apply step tftypes.AttributeName to MapNestedAttribute"),
+		},
+		"ElementKeyInt": {
+			attribute: schema.MapNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{},
+					},
+				},
+			},
+			step:          tftypes.ElementKeyInt(1),
+			expected:      nil,
+			expectedError: fmt.Errorf("cannot apply step tftypes.ElementKeyInt to MapNestedAttribute"),
+		},
+		"ElementKeyString": {
+			attribute: schema.MapNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{},
+					},
+				},
+			},
+			step: tftypes.ElementKeyString("test"),
+			expected: schema.NestedAttributeObject{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+			},
+			expectedError: nil,
+		},
+		"ElementKeyValue": {
+			attribute: schema.MapNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{},
+					},
+				},
+			},
+			step:          tftypes.ElementKeyValue(tftypes.NewValue(tftypes.String, "test")),
+			expected:      nil,
+			expectedError: fmt.Errorf("cannot apply step tftypes.ElementKeyValue to MapNestedAttribute"),
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := testCase.attribute.ApplyTerraform5AttributePathStep(testCase.step)
+
+			if err != nil {
+				if testCase.expectedError == nil {
+					t.Fatalf("expected no error, got: %s", err)
+				}
+
+				if !strings.Contains(err.Error(), testCase.expectedError.Error()) {
+					t.Fatalf("expected error %q, got: %s", testCase.expectedError, err)
+				}
+			}
+
+			if err == nil && testCase.expectedError != nil {
+				t.Fatalf("got no error, expected: %s", testCase.expectedError)
+			}
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestMapNestedAttributeGetDeprecationMessage(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.MapNestedAttribute
+		expected  string
+	}{
+		"no-deprecation-message": {
+			attribute: schema.MapNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{},
+					},
+				},
+			},
+			expected: "",
+		},
+		"deprecation-message": {
+			attribute: schema.MapNestedAttribute{
+				DeprecationMessage: "test deprecation message",
+			},
+			expected: "test deprecation message",
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.attribute.GetDeprecationMessage()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestMapNestedAttributeEqual(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.MapNestedAttribute
+		other     fwschema.Attribute
+		expected  bool
+	}{
+		"different-type": {
+			attribute: schema.MapNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{},
+					},
+				},
+			},
+			other:    testschema.AttributeWithMapValidators{},
+			expected: false,
+		},
+		"different-attributes-definitions": {
+			attribute: schema.MapNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{
+							Optional: true,
+						},
+					},
+				},
+			},
+			other: schema.MapNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{
+							Required: true,
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		"different-attributes-types": {
+			attribute: schema.MapNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{},
+					},
+				},
+			},
+			other: schema.MapNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.BoolAttribute{},
+					},
+				},
+			},
+			expected: false,
+		},
+		"equal": {
+			attribute: schema.MapNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{},
+					},
+				},
+			},
+			other: schema.MapNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{},
+					},
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.attribute.Equal(testCase.other)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestMapNestedAttributeGetDescription(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.MapNestedAttribute
+		expected  string
+	}{
+		"no-description": {
+			attribute: schema.MapNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{},
+					},
+				},
+			},
+			expected: "",
+		},
+		"description": {
+			attribute: schema.MapNestedAttribute{
+				Description: "test description",
+			},
+			expected: "test description",
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.attribute.GetDescription()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestMapNestedAttributeGetMarkdownDescription(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.MapNestedAttribute
+		expected  string
+	}{
+		"no-markdown-description": {
+			attribute: schema.MapNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{},
+					},
+				},
+			},
+			expected: "",
+		},
+		"markdown-description": {
+			attribute: schema.MapNestedAttribute{
+				MarkdownDescription: "test description",
+			},
+			expected: "test description",
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.attribute.GetMarkdownDescription()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestMapNestedAttributeGetNestedObject(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.MapNestedAttribute
+		expected  schema.NestedAttributeObject
+	}{
+		"nested-object": {
+			attribute: schema.MapNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{},
+					},
+				},
+			},
+			expected: schema.NestedAttributeObject{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.attribute.GetNestedObject()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestMapNestedAttributeGetType(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.MapNestedAttribute
+		expected  attr.Type
+	}{
+		"base": {
+			attribute: schema.MapNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{},
+					},
+				},
+			},
+			expected: types.MapType{
+				ElemType: types.ObjectType{
+					AttrTypes: map[string]attr.Type{
+						"testattr": types.StringType,
+					},
+				},
+			},
+		},
+		"custom-type": {
+			attribute: schema.MapNestedAttribute{
+				CustomType: testtypes.MapType{MapType: types.MapType{ElemType: types.StringType}},
+			},
+			expected: testtypes.MapType{MapType: types.MapType{ElemType: types.StringType}},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.attribute.GetType()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestMapNestedAttributeIsComputed(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.MapNestedAttribute
+		expected  bool
+	}{
+		"not-computed": {
+			attribute: schema.MapNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{},
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.attribute.IsComputed()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestMapNestedAttributeIsOptional(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.MapNestedAttribute
+		expected  bool
+	}{
+		"not-optional": {
+			attribute: schema.MapNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{},
+					},
+				},
+			},
+			expected: false,
+		},
+		"optional": {
+			attribute: schema.MapNestedAttribute{
+				Optional: true,
+			},
+			expected: true,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.attribute.IsOptional()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestMapNestedAttributeIsRequired(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.MapNestedAttribute
+		expected  bool
+	}{
+		"not-required": {
+			attribute: schema.MapNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{},
+					},
+				},
+			},
+			expected: false,
+		},
+		"required": {
+			attribute: schema.MapNestedAttribute{
+				Required: true,
+			},
+			expected: true,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.attribute.IsRequired()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestMapNestedAttributeIsSensitive(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.MapNestedAttribute
+		expected  bool
+	}{
+		"not-sensitive": {
+			attribute: schema.MapNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{},
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.attribute.IsSensitive()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestMapNestedAttributeIsWriteOnly(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.MapNestedAttribute
+		expected  bool
+	}{
+		"not-writeOnly": {
+			attribute: schema.MapNestedAttribute{},
+			expected:  false,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.attribute.IsWriteOnly()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestMapNestedAttributeMapNestedValidators(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.MapNestedAttribute
+		expected  []validator.Map
+	}{
+		"no-validators": {
+			attribute: schema.MapNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{},
+					},
+				},
+			},
+			expected: nil,
+		},
+		"validators": {
+			attribute: schema.MapNestedAttribute{
+				Validators: []validator.Map{},
+			},
+			expected: []validator.Map{},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.attribute.MapValidators()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestMapNestedAttributeValidateImplementation(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.MapNestedAttribute
+		request   fwschema.ValidateImplementationRequest
+		expected  *fwschema.ValidateImplementationResponse
+	}{
+		"customtype": {
+			attribute: schema.MapNestedAttribute{
+				CustomType: testtypes.MapType{},
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{},
+		},
+		"nestedobject": {
+			attribute: schema.MapNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"test_attr": schema.StringAttribute{},
+					},
+				},
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{},
+		},
+		"nestedobject-dynamic": {
+			attribute: schema.MapNestedAttribute{
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"test_dyn": schema.DynamicAttribute{},
+					},
+				},
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic(
+						"Invalid Schema Implementation",
+						"When validating the schema, an implementation issue was found. "+
+							"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+							"\"test\" is an attribute that contains a collection type with a nested dynamic type.\n\n"+
+							"Dynamic types inside of collections are not currently supported in terraform-plugin-framework. "+
+							"If underlying dynamic values are required, replace the \"test\" attribute definition with DynamicAttribute instead.",
+					),
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := &fwschema.ValidateImplementationResponse{}
+			testCase.attribute.ValidateImplementation(context.Background(), testCase.request, got)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestMapNestedAttributeIsRequiredForImport(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.MapNestedAttribute
+		expected  bool
+	}{
+		"not-requiredForImport": {
+			attribute: schema.MapNestedAttribute{},
+			expected:  false,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.attribute.IsRequiredForImport()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestMapNestedAttributeIsOptionalForImport(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.MapNestedAttribute
+		expected  bool
+	}{
+		"not-optionalForImport": {
+			attribute: schema.MapNestedAttribute{},
+			expected:  false,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.attribute.IsOptionalForImport()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}

--- a/list/schema/nested_attribute.go
+++ b/list/schema/nested_attribute.go
@@ -1,0 +1,14 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schema
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
+)
+
+// Nested attributes are only compatible with protocol version 6.
+type NestedAttribute interface {
+	Attribute
+	fwschema.NestedAttribute
+}

--- a/list/schema/nested_attribute_object.go
+++ b/list/schema/nested_attribute_object.go
@@ -1,0 +1,82 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schema
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema/fwxschema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// Ensure the implementation satisfies the desired interfaces.
+var _ fwxschema.NestedAttributeObjectWithValidators = NestedAttributeObject{}
+
+// NestedAttributeObject is the object containing the underlying attributes
+// for a ListNestedAttribute, MapNestedAttribute, or
+// SingleNestedAttribute (automatically generated). When retrieving the value
+// for this attribute, use types.Object as the value type unless the CustomType
+// field is set. The Attributes field must be set. Nested attributes are only
+// compatible with protocol version 6.
+//
+// This object enables customizing and simplifying details within its parent
+// NestedAttribute, therefore it cannot have Terraform schema fields such as
+// Required, Description, etc.
+type NestedAttributeObject struct {
+	// Attributes is the mapping of underlying attribute names to attribute
+	// definitions. This field must be set.
+	Attributes map[string]Attribute
+
+	// CustomType enables the use of a custom attribute type in place of the
+	// default basetypes.ObjectType. When retrieving data, the basetypes.ObjectValuable
+	// associated with this custom type must be used in place of types.Object.
+	CustomType basetypes.ObjectTypable
+
+	// Validators define value validation functionality for the attribute. All
+	// elements of the slice of AttributeValidator are run, regardless of any
+	// previous error diagnostics.
+	//
+	// Many common use case validators can be found in the
+	// github.com/hashicorp/terraform-plugin-framework-validators Go module.
+	//
+	// If the Type field points to a custom type that implements the
+	// xattr.TypeWithValidate interface, the validators defined in this field
+	// are run in addition to the validation defined by the type.
+	Validators []validator.Object
+}
+
+// ApplyTerraform5AttributePathStep performs an AttributeName step on the
+// underlying attributes or returns an error.
+func (o NestedAttributeObject) ApplyTerraform5AttributePathStep(step tftypes.AttributePathStep) (any, error) {
+	return fwschema.NestedAttributeObjectApplyTerraform5AttributePathStep(o, step)
+}
+
+// Equal returns true if the given NestedAttributeObject is equivalent.
+func (o NestedAttributeObject) Equal(other fwschema.NestedAttributeObject) bool {
+	if _, ok := other.(NestedAttributeObject); !ok {
+		return false
+	}
+
+	return fwschema.NestedAttributeObjectEqual(o, other)
+}
+
+// GetAttributes returns the Attributes field value.
+func (o NestedAttributeObject) GetAttributes() fwschema.UnderlyingAttributes {
+	return schemaAttributes(o.Attributes)
+}
+
+// ObjectValidators returns the Validators field value.
+func (o NestedAttributeObject) ObjectValidators() []validator.Object {
+	return o.Validators
+}
+
+// Type returns the framework type of the NestedAttributeObject.
+func (o NestedAttributeObject) Type() basetypes.ObjectTypable {
+	if o.CustomType != nil {
+		return o.CustomType
+	}
+
+	return fwschema.NestedAttributeObjectType(o)
+}

--- a/list/schema/nested_attribute_object_test.go
+++ b/list/schema/nested_attribute_object_test.go
@@ -1,0 +1,270 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schema_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testtypes"
+	"github.com/hashicorp/terraform-plugin-framework/list/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func TestNestedAttributeObjectApplyTerraform5AttributePathStep(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		object        schema.NestedAttributeObject
+		step          tftypes.AttributePathStep
+		expected      any
+		expectedError error
+	}{
+		"AttributeName": {
+			object: schema.NestedAttributeObject{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+			},
+			step:          tftypes.AttributeName("testattr"),
+			expected:      schema.StringAttribute{},
+			expectedError: nil,
+		},
+		"AttributeName-missing": {
+			object: schema.NestedAttributeObject{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+			},
+			step:          tftypes.AttributeName("other"),
+			expected:      nil,
+			expectedError: fmt.Errorf("no attribute \"other\" on NestedAttributeObject"),
+		},
+		"ElementKeyInt": {
+			object: schema.NestedAttributeObject{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+			},
+			step:          tftypes.ElementKeyInt(1),
+			expected:      nil,
+			expectedError: fmt.Errorf("cannot apply AttributePathStep tftypes.ElementKeyInt to NestedAttributeObject"),
+		},
+		"ElementKeyString": {
+			object: schema.NestedAttributeObject{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+			},
+			step:          tftypes.ElementKeyString("test"),
+			expected:      nil,
+			expectedError: fmt.Errorf("cannot apply AttributePathStep tftypes.ElementKeyString to NestedAttributeObject"),
+		},
+		"ElementKeyValue": {
+			object: schema.NestedAttributeObject{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+			},
+			step:          tftypes.ElementKeyValue(tftypes.NewValue(tftypes.String, "test")),
+			expected:      nil,
+			expectedError: fmt.Errorf("cannot apply AttributePathStep tftypes.ElementKeyValue to NestedAttributeObject"),
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := testCase.object.ApplyTerraform5AttributePathStep(testCase.step)
+
+			if err != nil {
+				if testCase.expectedError == nil {
+					t.Fatalf("expected no error, got: %s", err)
+				}
+
+				if !strings.Contains(err.Error(), testCase.expectedError.Error()) {
+					t.Fatalf("expected error %q, got: %s", testCase.expectedError, err)
+				}
+			}
+
+			if err == nil && testCase.expectedError != nil {
+				t.Fatalf("got no error, expected: %s", testCase.expectedError)
+			}
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestNestedAttributeObjectEqual(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		object   schema.NestedAttributeObject
+		other    fwschema.NestedAttributeObject
+		expected bool
+	}{
+		"different-attributes": {
+			object: schema.NestedAttributeObject{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+			},
+			other: schema.NestedAttributeObject{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.BoolAttribute{},
+				},
+			},
+			expected: false,
+		},
+		"equal": {
+			object: schema.NestedAttributeObject{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+			},
+			other: schema.NestedAttributeObject{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.object.Equal(testCase.other)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestNestedAttributeObjectGetAttributes(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		object   schema.NestedAttributeObject
+		expected fwschema.UnderlyingAttributes
+	}{
+		"no-attributes": {
+			object:   schema.NestedAttributeObject{},
+			expected: fwschema.UnderlyingAttributes{},
+		},
+		"attributes": {
+			object: schema.NestedAttributeObject{
+				Attributes: map[string]schema.Attribute{
+					"testattr1": schema.StringAttribute{},
+					"testattr2": schema.StringAttribute{},
+				},
+			},
+			expected: fwschema.UnderlyingAttributes{
+				"testattr1": schema.StringAttribute{},
+				"testattr2": schema.StringAttribute{},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.object.GetAttributes()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestNestedAttributeObjectObjectValidators(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.NestedAttributeObject
+		expected  []validator.Object
+	}{
+		"no-validators": {
+			attribute: schema.NestedAttributeObject{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+			},
+			expected: nil,
+		},
+		"validators": {
+			attribute: schema.NestedAttributeObject{
+				Validators: []validator.Object{},
+			},
+			expected: []validator.Object{},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.attribute.ObjectValidators()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestNestedAttributeObjectType(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		object   schema.NestedAttributeObject
+		expected attr.Type
+	}{
+		"base": {
+			object: schema.NestedAttributeObject{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+			},
+			expected: types.ObjectType{
+				AttrTypes: map[string]attr.Type{
+					"testattr": types.StringType,
+				},
+			},
+		},
+		"custom-type": {
+			object: schema.NestedAttributeObject{
+				CustomType: testtypes.ObjectType{},
+			},
+			expected: testtypes.ObjectType{},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.object.Type()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}

--- a/list/schema/nested_block_object.go
+++ b/list/schema/nested_block_object.go
@@ -1,0 +1,94 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schema
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema/fwxschema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// Ensure the implementation satisfies the desired interfaces.
+var _ fwxschema.NestedBlockObjectWithValidators = NestedBlockObject{}
+
+// NestedBlockObject is the object containing the underlying attributes and
+// blocks for a ListNestedBlock. When retrieving the value
+// for this attribute, use types.Object as the value type unless the CustomType
+// field is set.
+//
+// This object enables customizing and simplifying details within its parent
+// Block, therefore it cannot have Terraform schema fields such as Description,
+// etc.
+type NestedBlockObject struct {
+	// Attributes is the mapping of underlying attribute names to attribute
+	// definitions.
+	//
+	// Names must only contain lowercase letters, numbers, and underscores.
+	// Names must not collide with any Blocks names.
+	Attributes map[string]Attribute
+
+	// Blocks is the mapping of underlying block names to block definitions.
+	//
+	// Names must only contain lowercase letters, numbers, and underscores.
+	// Names must not collide with any Attributes names.
+	Blocks map[string]Block
+
+	// CustomType enables the use of a custom attribute type in place of the
+	// default basetypes.ObjectType. When retrieving data, the basetypes.ObjectValuable
+	// associated with this custom type must be used in place of types.Object.
+	CustomType basetypes.ObjectTypable
+
+	// Validators define value validation functionality for the attribute. All
+	// elements of the slice of AttributeValidator are run, regardless of any
+	// previous error diagnostics.
+	//
+	// Many common use case validators can be found in the
+	// github.com/hashicorp/terraform-plugin-framework-validators Go module.
+	//
+	// If the Type field points to a custom type that implements the
+	// xattr.TypeWithValidate interface, the validators defined in this field
+	// are run in addition to the validation defined by the type.
+	Validators []validator.Object
+}
+
+// ApplyTerraform5AttributePathStep performs an AttributeName step on the
+// underlying attributes or returns an error.
+func (o NestedBlockObject) ApplyTerraform5AttributePathStep(step tftypes.AttributePathStep) (any, error) {
+	return fwschema.NestedBlockObjectApplyTerraform5AttributePathStep(o, step)
+}
+
+// Equal returns true if the given NestedBlockObject is equivalent.
+func (o NestedBlockObject) Equal(other fwschema.NestedBlockObject) bool {
+	if _, ok := other.(NestedBlockObject); !ok {
+		return false
+	}
+
+	return fwschema.NestedBlockObjectEqual(o, other)
+}
+
+// GetAttributes returns the Attributes field value.
+func (o NestedBlockObject) GetAttributes() fwschema.UnderlyingAttributes {
+	return schemaAttributes(o.Attributes)
+}
+
+// GetAttributes returns the Blocks field value.
+func (o NestedBlockObject) GetBlocks() map[string]fwschema.Block {
+	return schemaBlocks(o.Blocks)
+}
+
+// ObjectValidators returns the Validators field value.
+func (o NestedBlockObject) ObjectValidators() []validator.Object {
+	return o.Validators
+}
+
+// Type returns the framework type of the NestedBlockObject.
+func (o NestedBlockObject) Type() basetypes.ObjectTypable {
+	if o.CustomType != nil {
+		return o.CustomType
+	}
+
+	return fwschema.NestedBlockObjectType(o)
+}

--- a/list/schema/nested_block_object_test.go
+++ b/list/schema/nested_block_object_test.go
@@ -1,0 +1,354 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schema_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testtypes"
+	"github.com/hashicorp/terraform-plugin-framework/list/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func TestNestedBlockObjectApplyTerraform5AttributePathStep(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		object        schema.NestedBlockObject
+		step          tftypes.AttributePathStep
+		expected      any
+		expectedError error
+	}{
+		"AttributeName-attribute": {
+			object: schema.NestedBlockObject{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+			},
+			step:          tftypes.AttributeName("testattr"),
+			expected:      schema.StringAttribute{},
+			expectedError: nil,
+		},
+		"AttributeName-block": {
+			object: schema.NestedBlockObject{
+				Blocks: map[string]schema.Block{
+					"testblock": schema.SingleNestedBlock{
+						Attributes: map[string]schema.Attribute{
+							"testattr": schema.StringAttribute{},
+						},
+					},
+				},
+			},
+			step: tftypes.AttributeName("testblock"),
+			expected: schema.SingleNestedBlock{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+			},
+			expectedError: nil,
+		},
+		"AttributeName-missing": {
+			object: schema.NestedBlockObject{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+			},
+			step:          tftypes.AttributeName("other"),
+			expected:      nil,
+			expectedError: fmt.Errorf("no attribute or block \"other\" on NestedBlockObject"),
+		},
+		"ElementKeyInt": {
+			object: schema.NestedBlockObject{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+			},
+			step:          tftypes.ElementKeyInt(1),
+			expected:      nil,
+			expectedError: fmt.Errorf("cannot apply AttributePathStep tftypes.ElementKeyInt to NestedBlockObject"),
+		},
+		"ElementKeyString": {
+			object: schema.NestedBlockObject{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+			},
+			step:          tftypes.ElementKeyString("test"),
+			expected:      nil,
+			expectedError: fmt.Errorf("cannot apply AttributePathStep tftypes.ElementKeyString to NestedBlockObject"),
+		},
+		"ElementKeyValue": {
+			object: schema.NestedBlockObject{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+			},
+			step:          tftypes.ElementKeyValue(tftypes.NewValue(tftypes.String, "test")),
+			expected:      nil,
+			expectedError: fmt.Errorf("cannot apply AttributePathStep tftypes.ElementKeyValue to NestedBlockObject"),
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := testCase.object.ApplyTerraform5AttributePathStep(testCase.step)
+
+			if err != nil {
+				if testCase.expectedError == nil {
+					t.Fatalf("expected no error, got: %s", err)
+				}
+
+				if !strings.Contains(err.Error(), testCase.expectedError.Error()) {
+					t.Fatalf("expected error %q, got: %s", testCase.expectedError, err)
+				}
+			}
+
+			if err == nil && testCase.expectedError != nil {
+				t.Fatalf("got no error, expected: %s", testCase.expectedError)
+			}
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestNestedBlockObjectEqual(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		object   schema.NestedBlockObject
+		other    fwschema.NestedBlockObject
+		expected bool
+	}{
+		"different-attributes": {
+			object: schema.NestedBlockObject{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+			},
+			other: schema.NestedBlockObject{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.BoolAttribute{},
+				},
+			},
+			expected: false,
+		},
+		"equal": {
+			object: schema.NestedBlockObject{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+			},
+			other: schema.NestedBlockObject{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.object.Equal(testCase.other)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestNestedBlockObjectGetAttributes(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		object   schema.NestedBlockObject
+		expected fwschema.UnderlyingAttributes
+	}{
+		"no-attributes": {
+			object:   schema.NestedBlockObject{},
+			expected: fwschema.UnderlyingAttributes{},
+		},
+		"attributes": {
+			object: schema.NestedBlockObject{
+				Attributes: map[string]schema.Attribute{
+					"testattr1": schema.StringAttribute{},
+					"testattr2": schema.StringAttribute{},
+				},
+			},
+			expected: fwschema.UnderlyingAttributes{
+				"testattr1": schema.StringAttribute{},
+				"testattr2": schema.StringAttribute{},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.object.GetAttributes()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestNestedBlockObjectGetBlocks(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		object   schema.NestedBlockObject
+		expected map[string]fwschema.Block
+	}{
+		"no-blocks": {
+			object:   schema.NestedBlockObject{},
+			expected: map[string]fwschema.Block{},
+		},
+		"blocks": {
+			object: schema.NestedBlockObject{
+				Blocks: map[string]schema.Block{
+					"testblock1": schema.SingleNestedBlock{
+						Attributes: map[string]schema.Attribute{
+							"testattr": schema.StringAttribute{},
+						},
+					},
+					"testblock2": schema.SingleNestedBlock{
+						Attributes: map[string]schema.Attribute{
+							"testattr": schema.StringAttribute{},
+						},
+					},
+				},
+			},
+			expected: map[string]fwschema.Block{
+				"testblock1": schema.SingleNestedBlock{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{},
+					},
+				},
+				"testblock2": schema.SingleNestedBlock{
+					Attributes: map[string]schema.Attribute{
+						"testattr": schema.StringAttribute{},
+					},
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.object.GetBlocks()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestNestedBlockObjectObjectValidators(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.NestedBlockObject
+		expected  []validator.Object
+	}{
+		"no-validators": {
+			attribute: schema.NestedBlockObject{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+			},
+			expected: nil,
+		},
+		"validators": {
+			attribute: schema.NestedBlockObject{
+				Validators: []validator.Object{},
+			},
+			expected: []validator.Object{},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.attribute.ObjectValidators()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestNestedBlockObjectType(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		object   schema.NestedBlockObject
+		expected attr.Type
+	}{
+		"base": {
+			object: schema.NestedBlockObject{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+				Blocks: map[string]schema.Block{
+					"testblock": schema.SingleNestedBlock{
+						Attributes: map[string]schema.Attribute{
+							"testattr": schema.StringAttribute{},
+						},
+					},
+				},
+			},
+			expected: types.ObjectType{
+				AttrTypes: map[string]attr.Type{
+					"testattr": types.StringType,
+					"testblock": types.ObjectType{
+						AttrTypes: map[string]attr.Type{
+							"testattr": types.StringType,
+						},
+					},
+				},
+			},
+		},
+		"custom-type": {
+			object: schema.NestedBlockObject{
+				CustomType: testtypes.ObjectType{},
+			},
+			expected: testtypes.ObjectType{},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.object.Type()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}

--- a/list/schema/number_attribute.go
+++ b/list/schema/number_attribute.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
 
-// Ensure the implementation satisifies the desired interfaces.
+// Ensure the implementation satisfies the desired interfaces.
 var (
 	_ Attribute                               = NumberAttribute{}
 	_ fwxschema.AttributeWithNumberValidators = NumberAttribute{}

--- a/list/schema/object_attribute.go
+++ b/list/schema/object_attribute.go
@@ -4,11 +4,14 @@
 package schema
 
 import (
+	"context"
+
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema/fwxschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwtype"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -16,30 +19,45 @@ import (
 
 // Ensure the implementation satisfies the desired interfaces.
 var (
-	_ Attribute                              = Int32Attribute{}
-	_ fwxschema.AttributeWithInt32Validators = Int32Attribute{}
+	_ Attribute                                    = ObjectAttribute{}
+	_ fwschema.AttributeWithValidateImplementation = ObjectAttribute{}
+	_ fwxschema.AttributeWithObjectValidators      = ObjectAttribute{}
 )
 
-// Int32Attribute represents a schema attribute that is a 32-bit integer.
-// When retrieving the value for this attribute, use types.Int32 as the value
-// type unless the CustomType field is set.
+// ObjectAttribute represents a schema attribute that is an object with only
+// type information for underlying attributes. When retrieving the value for
+// this attribute, use types.Object as the value type unless the CustomType
+// field is set. The AttributeTypes field must be set.
 //
-// Use Float32Attribute for 32-bit floating point number attributes or
-// NumberAttribute for 512-bit generic number attributes.
+// Prefer SingleNestedAttribute over ObjectAttribute if the provider is
+// using protocol version 6 and full attribute functionality is needed.
 //
 // Terraform configurations configure this attribute using expressions that
-// return a number or directly via an integer value.
+// return an object or directly via curly brace syntax.
 //
-//	example_attribute = 123
+//	# object with one attribute
+//	example_attribute = {
+//		underlying_attribute = #...
+//	}
 //
-// Terraform configurations reference this attribute using the attribute name.
+// Terraform configurations reference this attribute using expressions that
+// accept an object or an attribute directly via period syntax:
 //
-//	.example_attribute
-type Int32Attribute struct {
+//	# underlying attribute
+//	.example_attribute.underlying_attribute
+type ObjectAttribute struct {
+	// AttributeTypes is the mapping of underlying attribute names to attribute
+	// types. This field must be set.
+	//
+	// Attribute types that contain a collection with a nested dynamic type (i.e. types.List[types.Dynamic]) are not supported.
+	// If underlying dynamic collection values are required, replace this attribute definition with
+	// DynamicAttribute instead.
+	AttributeTypes map[string]attr.Type
+
 	// CustomType enables the use of a custom attribute type in place of the
-	// default basetypes.Int32Type. When retrieving data, the basetypes.Int32Valuable
-	// associated with this custom type must be used in place of types.Int32.
-	CustomType basetypes.Int32Typable
+	// default basetypes.ObjectType. When retrieving data, the basetypes.ObjectValuable
+	// associated with this custom type must be used in place of types.Object.
+	CustomType basetypes.ObjectTypable
 
 	// Required indicates whether the practitioner must enter a value for
 	// this attribute or not. Required and Optional cannot both be true.
@@ -107,19 +125,19 @@ type Int32Attribute struct {
 	// If the Type field points to a custom type that implements the
 	// xattr.TypeWithValidate interface, the validators defined in this field
 	// are run in addition to the validation defined by the type.
-	Validators []validator.Int32
+	Validators []validator.Object
 }
 
-// ApplyTerraform5AttributePathStep always returns an error as it is not
-// possible to step further into a Int32Attribute.
-func (a Int32Attribute) ApplyTerraform5AttributePathStep(step tftypes.AttributePathStep) (interface{}, error) {
+// ApplyTerraform5AttributePathStep returns the result of stepping into an
+// attribute name or an error.
+func (a ObjectAttribute) ApplyTerraform5AttributePathStep(step tftypes.AttributePathStep) (interface{}, error) {
 	return a.GetType().ApplyTerraform5AttributePathStep(step)
 }
 
-// Equal returns true if the given Attribute is a Int32Attribute
+// Equal returns true if the given Attribute is a ObjectAttribute
 // and all fields are equal.
-func (a Int32Attribute) Equal(o fwschema.Attribute) bool {
-	if _, ok := o.(Int32Attribute); !ok {
+func (a ObjectAttribute) Equal(o fwschema.Attribute) bool {
+	if _, ok := o.(ObjectAttribute); !ok {
 		return false
 	}
 
@@ -127,67 +145,83 @@ func (a Int32Attribute) Equal(o fwschema.Attribute) bool {
 }
 
 // GetDeprecationMessage returns the DeprecationMessage field value.
-func (a Int32Attribute) GetDeprecationMessage() string {
+func (a ObjectAttribute) GetDeprecationMessage() string {
 	return a.DeprecationMessage
 }
 
 // GetDescription returns the Description field value.
-func (a Int32Attribute) GetDescription() string {
+func (a ObjectAttribute) GetDescription() string {
 	return a.Description
 }
 
 // GetMarkdownDescription returns the MarkdownDescription field value.
-func (a Int32Attribute) GetMarkdownDescription() string {
+func (a ObjectAttribute) GetMarkdownDescription() string {
 	return a.MarkdownDescription
 }
 
-// GetType returns types.Int32Type or the CustomType field value if defined.
-func (a Int32Attribute) GetType() attr.Type {
+// GetType returns types.ObjectType or the CustomType field value if defined.
+func (a ObjectAttribute) GetType() attr.Type {
 	if a.CustomType != nil {
 		return a.CustomType
 	}
 
-	return types.Int32Type
-}
-
-// Int32Validators returns the Validators field value.
-func (a Int32Attribute) Int32Validators() []validator.Int32 {
-	return a.Validators
+	return types.ObjectType{
+		AttrTypes: a.AttributeTypes,
+	}
 }
 
 // IsComputed returns false because it does not apply to ListResource schemas.
-func (a Int32Attribute) IsComputed() bool {
+func (a ObjectAttribute) IsComputed() bool {
 	return false
 }
 
 // IsOptional returns the Optional field value.
-func (a Int32Attribute) IsOptional() bool {
+func (a ObjectAttribute) IsOptional() bool {
 	return a.Optional
 }
 
 // IsRequired returns the Required field value.
-func (a Int32Attribute) IsRequired() bool {
+func (a ObjectAttribute) IsRequired() bool {
 	return a.Required
 }
 
 // IsSensitive returns false because it does not apply to ListResource schemas.
-func (a Int32Attribute) IsSensitive() bool {
+func (a ObjectAttribute) IsSensitive() bool {
 	return false
 }
 
 // IsWriteOnly returns false because it does not apply to ListResource schemas.
-func (a Int32Attribute) IsWriteOnly() bool {
+func (a ObjectAttribute) IsWriteOnly() bool {
 	return false
 }
 
 // IsRequiredForImport returns false as this behavior is only relevant
 // for managed resource identity schema attributes.
-func (a Int32Attribute) IsRequiredForImport() bool {
+func (a ObjectAttribute) IsRequiredForImport() bool {
 	return false
 }
 
 // IsOptionalForImport returns false as this behavior is only relevant
 // for managed resource identity schema attributes.
-func (a Int32Attribute) IsOptionalForImport() bool {
+func (a ObjectAttribute) IsOptionalForImport() bool {
 	return false
+}
+
+// ObjectValidators returns the Validators field value.
+func (a ObjectAttribute) ObjectValidators() []validator.Object {
+	return a.Validators
+}
+
+// ValidateImplementation contains logic for validating the
+// provider-defined implementation of the attribute to prevent unexpected
+// errors or panics. This logic runs during the GetProviderSchema RPC
+// and should never include false positives.
+func (a ObjectAttribute) ValidateImplementation(ctx context.Context, req fwschema.ValidateImplementationRequest, resp *fwschema.ValidateImplementationResponse) {
+	if a.AttributeTypes == nil && a.CustomType == nil {
+		resp.Diagnostics.Append(fwschema.AttributeMissingAttributeTypesDiag(req.Path))
+	}
+
+	if a.CustomType == nil && fwtype.ContainsCollectionWithDynamic(a.GetType()) {
+		resp.Diagnostics.Append(fwtype.AttributeCollectionWithDynamicTypeDiag(req.Path))
+	}
 }

--- a/list/schema/object_attribute_test.go
+++ b/list/schema/object_attribute_test.go
@@ -1,0 +1,593 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schema_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testtypes"
+	"github.com/hashicorp/terraform-plugin-framework/list/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestObjectAttributeApplyTerraform5AttributePathStep(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute     schema.ObjectAttribute
+		step          tftypes.AttributePathStep
+		expected      any
+		expectedError error
+	}{
+		"AttributeName": {
+			attribute:     schema.ObjectAttribute{AttributeTypes: map[string]attr.Type{"testattr": types.StringType}},
+			step:          tftypes.AttributeName("testattr"),
+			expected:      types.StringType,
+			expectedError: nil,
+		},
+		"AttributeName-missing": {
+			attribute:     schema.ObjectAttribute{AttributeTypes: map[string]attr.Type{"testattr": types.StringType}},
+			step:          tftypes.AttributeName("other"),
+			expected:      nil,
+			expectedError: fmt.Errorf("undefined attribute name other in ObjectType"),
+		},
+		"ElementKeyInt": {
+			attribute:     schema.ObjectAttribute{AttributeTypes: map[string]attr.Type{"testattr": types.StringType}},
+			step:          tftypes.ElementKeyInt(1),
+			expected:      nil,
+			expectedError: fmt.Errorf("cannot apply step tftypes.ElementKeyInt to ObjectType"),
+		},
+		"ElementKeyString": {
+			attribute:     schema.ObjectAttribute{AttributeTypes: map[string]attr.Type{"testattr": types.StringType}},
+			step:          tftypes.ElementKeyString("test"),
+			expected:      nil,
+			expectedError: fmt.Errorf("cannot apply step tftypes.ElementKeyString to ObjectType"),
+		},
+		"ElementKeyValue": {
+			attribute:     schema.ObjectAttribute{AttributeTypes: map[string]attr.Type{"testattr": types.StringType}},
+			step:          tftypes.ElementKeyValue(tftypes.NewValue(tftypes.String, "test")),
+			expected:      nil,
+			expectedError: fmt.Errorf("cannot apply step tftypes.ElementKeyValue to ObjectType"),
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := testCase.attribute.ApplyTerraform5AttributePathStep(testCase.step)
+
+			if err != nil {
+				if testCase.expectedError == nil {
+					t.Fatalf("expected no error, got: %s", err)
+				}
+
+				if !strings.Contains(err.Error(), testCase.expectedError.Error()) {
+					t.Fatalf("expected error %q, got: %s", testCase.expectedError, err)
+				}
+			}
+
+			if err == nil && testCase.expectedError != nil {
+				t.Fatalf("got no error, expected: %s", testCase.expectedError)
+			}
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestObjectAttributeGetDeprecationMessage(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.ObjectAttribute
+		expected  string
+	}{
+		"no-deprecation-message": {
+			attribute: schema.ObjectAttribute{AttributeTypes: map[string]attr.Type{"testattr": types.StringType}},
+			expected:  "",
+		},
+		"deprecation-message": {
+			attribute: schema.ObjectAttribute{
+				DeprecationMessage: "test deprecation message",
+			},
+			expected: "test deprecation message",
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.attribute.GetDeprecationMessage()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestObjectAttributeEqual(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.ObjectAttribute
+		other     fwschema.Attribute
+		expected  bool
+	}{
+		"different-type": {
+			attribute: schema.ObjectAttribute{AttributeTypes: map[string]attr.Type{"testattr": types.StringType}},
+			other:     testschema.AttributeWithObjectValidators{},
+			expected:  false,
+		},
+		"different-attribute-type": {
+			attribute: schema.ObjectAttribute{AttributeTypes: map[string]attr.Type{"testattr": types.StringType}},
+			other:     schema.ObjectAttribute{AttributeTypes: map[string]attr.Type{"testattr": types.BoolType}},
+			expected:  false,
+		},
+		"equal": {
+			attribute: schema.ObjectAttribute{AttributeTypes: map[string]attr.Type{"testattr": types.StringType}},
+			other:     schema.ObjectAttribute{AttributeTypes: map[string]attr.Type{"testattr": types.StringType}},
+			expected:  true,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.attribute.Equal(testCase.other)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestObjectAttributeGetDescription(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.ObjectAttribute
+		expected  string
+	}{
+		"no-description": {
+			attribute: schema.ObjectAttribute{AttributeTypes: map[string]attr.Type{"testattr": types.StringType}},
+			expected:  "",
+		},
+		"description": {
+			attribute: schema.ObjectAttribute{
+				Description: "test description",
+			},
+			expected: "test description",
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.attribute.GetDescription()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestObjectAttributeGetMarkdownDescription(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.ObjectAttribute
+		expected  string
+	}{
+		"no-markdown-description": {
+			attribute: schema.ObjectAttribute{AttributeTypes: map[string]attr.Type{"testattr": types.StringType}},
+			expected:  "",
+		},
+		"markdown-description": {
+			attribute: schema.ObjectAttribute{
+				MarkdownDescription: "test description",
+			},
+			expected: "test description",
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.attribute.GetMarkdownDescription()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestObjectAttributeGetType(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.ObjectAttribute
+		expected  attr.Type
+	}{
+		"base": {
+			attribute: schema.ObjectAttribute{AttributeTypes: map[string]attr.Type{"testattr": types.StringType}},
+			expected:  types.ObjectType{AttrTypes: map[string]attr.Type{"testattr": types.StringType}},
+		},
+		"custom-type": {
+			attribute: schema.ObjectAttribute{
+				CustomType: testtypes.ObjectType{},
+			},
+			expected: testtypes.ObjectType{},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.attribute.GetType()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestObjectAttributeIsComputed(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.ObjectAttribute
+		expected  bool
+	}{
+		"not-computed": {
+			attribute: schema.ObjectAttribute{AttributeTypes: map[string]attr.Type{"testattr": types.StringType}},
+			expected:  false,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.attribute.IsComputed()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestObjectAttributeIsOptional(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.ObjectAttribute
+		expected  bool
+	}{
+		"not-optional": {
+			attribute: schema.ObjectAttribute{AttributeTypes: map[string]attr.Type{"testattr": types.StringType}},
+			expected:  false,
+		},
+		"optional": {
+			attribute: schema.ObjectAttribute{
+				Optional: true,
+			},
+			expected: true,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.attribute.IsOptional()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestObjectAttributeIsRequired(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.ObjectAttribute
+		expected  bool
+	}{
+		"not-required": {
+			attribute: schema.ObjectAttribute{AttributeTypes: map[string]attr.Type{"testattr": types.StringType}},
+			expected:  false,
+		},
+		"required": {
+			attribute: schema.ObjectAttribute{
+				Required: true,
+			},
+			expected: true,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.attribute.IsRequired()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestObjectAttributeIsSensitive(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.ObjectAttribute
+		expected  bool
+	}{
+		"not-sensitive": {
+			attribute: schema.ObjectAttribute{AttributeTypes: map[string]attr.Type{"testattr": types.StringType}},
+			expected:  false,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.attribute.IsSensitive()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestObjectAttributeObjectValidators(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.ObjectAttribute
+		expected  []validator.Object
+	}{
+		"no-validators": {
+			attribute: schema.ObjectAttribute{AttributeTypes: map[string]attr.Type{"testattr": types.StringType}},
+			expected:  nil,
+		},
+		"validators": {
+			attribute: schema.ObjectAttribute{
+				Validators: []validator.Object{},
+			},
+			expected: []validator.Object{},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.attribute.ObjectValidators()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestObjectAttributeIsWriteOnly(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.ObjectAttribute
+		expected  bool
+	}{
+		"not-writeOnly": {
+			attribute: schema.ObjectAttribute{},
+			expected:  false,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.attribute.IsWriteOnly()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestObjectAttributeValidateImplementation(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.ObjectAttribute
+		request   fwschema.ValidateImplementationRequest
+		expected  *fwschema.ValidateImplementationResponse
+	}{
+		"attributetypes": {
+			attribute: schema.ObjectAttribute{
+				AttributeTypes: map[string]attr.Type{
+					"test_attr": types.StringType,
+				},
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{},
+		},
+		"attributetypes-dynamic": {
+			attribute: schema.ObjectAttribute{
+				AttributeTypes: map[string]attr.Type{
+					"test_attr": types.DynamicType,
+					"test_list": types.ListType{
+						ElemType: types.StringType,
+					},
+					"test_obj": types.ObjectType{
+						AttrTypes: map[string]attr.Type{
+							"test_attr": types.DynamicType,
+						},
+					},
+				},
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{},
+		},
+		"attributetypes-nested-collection-dynamic": {
+			attribute: schema.ObjectAttribute{
+				AttributeTypes: map[string]attr.Type{
+					"test_attr": types.ListType{
+						ElemType: types.DynamicType,
+					},
+				},
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic(
+						"Invalid Schema Implementation",
+						"When validating the schema, an implementation issue was found. "+
+							"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+							"\"test\" is an attribute that contains a collection type with a nested dynamic type.\n\n"+
+							"Dynamic types inside of collections are not currently supported in terraform-plugin-framework. "+
+							"If underlying dynamic values are required, replace the \"test\" attribute definition with DynamicAttribute instead.",
+					),
+				},
+			},
+		},
+		"attributetypes-missing": {
+			attribute: schema.ObjectAttribute{},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewErrorDiagnostic(
+						"Invalid Attribute Implementation",
+						"When validating the schema, an implementation issue was found. "+
+							"This is always an issue with the provider and should be reported to the provider developers.\n\n"+
+							"\"test\" is missing the AttributeTypes or CustomType field on an object Attribute. "+
+							"One of these fields is required to prevent other unexpected errors or panics.",
+					),
+				},
+			},
+		},
+		"customtype": {
+			attribute: schema.ObjectAttribute{
+				CustomType: testtypes.ObjectType{},
+			},
+			request: fwschema.ValidateImplementationRequest{
+				Name: "test",
+				Path: path.Root("test"),
+			},
+			expected: &fwschema.ValidateImplementationResponse{},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := &fwschema.ValidateImplementationResponse{}
+			testCase.attribute.ValidateImplementation(context.Background(), testCase.request, got)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestObjectAttributeIsRequiredForImport(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.ObjectAttribute
+		expected  bool
+	}{
+		"not-requiredForImport": {
+			attribute: schema.ObjectAttribute{},
+			expected:  false,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.attribute.IsRequiredForImport()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestObjectAttributeIsOptionalForImport(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.ObjectAttribute
+		expected  bool
+	}{
+		"not-optionalForImport": {
+			attribute: schema.ObjectAttribute{},
+			expected:  false,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.attribute.IsOptionalForImport()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}

--- a/list/schema/single_nested_attribute_test.go
+++ b/list/schema/single_nested_attribute_test.go
@@ -1,0 +1,611 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schema_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testtypes"
+	"github.com/hashicorp/terraform-plugin-framework/list/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func TestSingleNestedAttributeApplyTerraform5AttributePathStep(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute     schema.SingleNestedAttribute
+		step          tftypes.AttributePathStep
+		expected      any
+		expectedError error
+	}{
+		"AttributeName": {
+			attribute: schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+			},
+			step:          tftypes.AttributeName("testattr"),
+			expected:      schema.StringAttribute{},
+			expectedError: nil,
+		},
+		"AttributeName-missing": {
+			attribute: schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+			},
+			step:          tftypes.AttributeName("other"),
+			expected:      nil,
+			expectedError: fmt.Errorf("no attribute \"other\" on SingleNestedAttribute"),
+		},
+		"ElementKeyInt": {
+			attribute: schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+			},
+			step:          tftypes.ElementKeyInt(1),
+			expected:      nil,
+			expectedError: fmt.Errorf("cannot apply step tftypes.ElementKeyInt to SingleNestedAttribute"),
+		},
+		"ElementKeyString": {
+			attribute: schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+			},
+			step:          tftypes.ElementKeyString("test"),
+			expected:      nil,
+			expectedError: fmt.Errorf("cannot apply step tftypes.ElementKeyString to SingleNestedAttribute"),
+		},
+		"ElementKeyValue": {
+			attribute: schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+			},
+			step:          tftypes.ElementKeyValue(tftypes.NewValue(tftypes.String, "test")),
+			expected:      nil,
+			expectedError: fmt.Errorf("cannot apply step tftypes.ElementKeyValue to SingleNestedAttribute"),
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := testCase.attribute.ApplyTerraform5AttributePathStep(testCase.step)
+
+			if err != nil {
+				if testCase.expectedError == nil {
+					t.Fatalf("expected no error, got: %s", err)
+				}
+
+				if !strings.Contains(err.Error(), testCase.expectedError.Error()) {
+					t.Fatalf("expected error %q, got: %s", testCase.expectedError, err)
+				}
+			}
+
+			if err == nil && testCase.expectedError != nil {
+				t.Fatalf("got no error, expected: %s", testCase.expectedError)
+			}
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestSingleNestedAttributeEqual(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.SingleNestedAttribute
+		other     fwschema.Attribute
+		expected  bool
+	}{
+		"different-type": {
+			attribute: schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+			},
+			other:    testschema.AttributeWithObjectValidators{},
+			expected: false,
+		},
+		"different-attributes-definitions": {
+			attribute: schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{
+						Optional: true,
+					},
+				},
+			},
+			other: schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{
+						Required: true,
+					},
+				},
+			},
+			expected: false,
+		},
+		"different-attributes-types": {
+			attribute: schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+			},
+			other: schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.BoolAttribute{},
+				},
+			},
+			expected: false,
+		},
+		"equal": {
+			attribute: schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+			},
+			other: schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.attribute.Equal(testCase.other)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestSingleNestedAttributeGetDeprecationMessage(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.SingleNestedAttribute
+		expected  string
+	}{
+		"no-deprecation-message": {
+			attribute: schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+			},
+			expected: "",
+		},
+		"deprecation-message": {
+			attribute: schema.SingleNestedAttribute{
+				DeprecationMessage: "test deprecation message",
+			},
+			expected: "test deprecation message",
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.attribute.GetDeprecationMessage()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestSingleNestedAttributeGetDescription(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.SingleNestedAttribute
+		expected  string
+	}{
+		"no-description": {
+			attribute: schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+			},
+			expected: "",
+		},
+		"description": {
+			attribute: schema.SingleNestedAttribute{
+				Description: "test description",
+			},
+			expected: "test description",
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.attribute.GetDescription()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestSingleNestedAttributeGetMarkdownDescription(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.SingleNestedAttribute
+		expected  string
+	}{
+		"no-markdown-description": {
+			attribute: schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+			},
+			expected: "",
+		},
+		"markdown-description": {
+			attribute: schema.SingleNestedAttribute{
+				MarkdownDescription: "test description",
+			},
+			expected: "test description",
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.attribute.GetMarkdownDescription()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestSingleNestedAttributeGetNestedObject(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.SingleNestedAttribute
+		expected  schema.NestedAttributeObject
+	}{
+		"nested-object": {
+			attribute: schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+			},
+			expected: schema.NestedAttributeObject{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.attribute.GetNestedObject()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestSingleNestedAttributeGetType(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.SingleNestedAttribute
+		expected  attr.Type
+	}{
+		"base": {
+			attribute: schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+			},
+			expected: types.ObjectType{
+				AttrTypes: map[string]attr.Type{
+					"testattr": types.StringType,
+				},
+			},
+		},
+		"custom-type": {
+			attribute: schema.SingleNestedAttribute{
+				CustomType: testtypes.ObjectType{},
+			},
+			expected: testtypes.ObjectType{},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.attribute.GetType()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestSingleNestedAttributeIsComputed(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.SingleNestedAttribute
+		expected  bool
+	}{
+		"not-computed": {
+			attribute: schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.attribute.IsComputed()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestSingleNestedAttributeIsOptional(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.SingleNestedAttribute
+		expected  bool
+	}{
+		"not-optional": {
+			attribute: schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+			},
+			expected: false,
+		},
+		"optional": {
+			attribute: schema.SingleNestedAttribute{
+				Optional: true,
+			},
+			expected: true,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.attribute.IsOptional()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestSingleNestedAttributeIsRequired(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.SingleNestedAttribute
+		expected  bool
+	}{
+		"not-required": {
+			attribute: schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+			},
+			expected: false,
+		},
+		"required": {
+			attribute: schema.SingleNestedAttribute{
+				Required: true,
+			},
+			expected: true,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.attribute.IsRequired()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestSingleNestedAttributeIsSensitive(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.SingleNestedAttribute
+		expected  bool
+	}{
+		"not-sensitive": {
+			attribute: schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.attribute.IsSensitive()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestSingleNestedAttributeIsWriteOnly(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.SingleNestedAttribute
+		expected  bool
+	}{
+		"not-writeOnly": {
+			attribute: schema.SingleNestedAttribute{},
+			expected:  false,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.attribute.IsWriteOnly()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestSingleNestedAttributeObjectValidators(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.SingleNestedAttribute
+		expected  []validator.Object
+	}{
+		"no-validators": {
+			attribute: schema.SingleNestedAttribute{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+			},
+			expected: nil,
+		},
+		"validators": {
+			attribute: schema.SingleNestedAttribute{
+				Validators: []validator.Object{},
+			},
+			expected: []validator.Object{},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.attribute.ObjectValidators()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestSingleNestedAttributeIsRequiredForImport(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.SingleNestedAttribute
+		expected  bool
+	}{
+		"not-requiredForImport": {
+			attribute: schema.SingleNestedAttribute{},
+			expected:  false,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.attribute.IsRequiredForImport()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestSingleNestedAttributeIsOptionalForImport(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		attribute schema.SingleNestedAttribute
+		expected  bool
+	}{
+		"not-optionalForImport": {
+			attribute: schema.SingleNestedAttribute{},
+			expected:  false,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.attribute.IsOptionalForImport()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}

--- a/list/schema/single_nested_block.go
+++ b/list/schema/single_nested_block.go
@@ -1,0 +1,213 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schema
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema/fwxschema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// Ensure the implementation satisfies the desired interfaces.
+var (
+	_ Block                               = SingleNestedBlock{}
+	_ fwxschema.BlockWithObjectValidators = SingleNestedBlock{}
+)
+
+// SingleNestedBlock represents a block that is a single object where
+// the object attributes can be fully defined, including further attributes
+// or blocks. When retrieving the value for this block, use types.Object
+// as the value type unless the CustomType field is set.
+//
+// Prefer SingleNestedAttribute over SingleNestedBlock if the provider is
+// using protocol version 6. Nested attributes allow practitioners to configure
+// values directly with expressions.
+//
+// Terraform configurations configure this block only once using curly brace
+// syntax without an equals (=) sign or [Dynamic Block Expressions].
+//
+//	# single block
+//	example_block {
+//		nested_attribute = #...
+//	}
+//
+// Terraform configurations reference this block using expressions that
+// accept an object or an attribute name directly via period syntax:
+//
+//	# object nested_attribute value
+//	.example_block.nested_attribute
+//
+// [Dynamic Block Expressions]: https://developer.hashicorp.com/terraform/language/expressions/dynamic-blocks
+type SingleNestedBlock struct {
+	// Attributes is the mapping of underlying attribute names to attribute
+	// definitions.
+	//
+	// Names must only contain lowercase letters, numbers, and underscores.
+	// Names must not collide with any Blocks names.
+	Attributes map[string]Attribute
+
+	// Blocks is the mapping of underlying block names to block definitions.
+	//
+	// Names must only contain lowercase letters, numbers, and underscores.
+	// Names must not collide with any Attributes names.
+	Blocks map[string]Block
+
+	// CustomType enables the use of a custom attribute type in place of the
+	// default basetypes.ObjectType. When retrieving data, the basetypes.ObjectValuable
+	// associated with this custom type must be used in place of types.Object.
+	CustomType basetypes.ObjectTypable
+
+	// Description is used in various tooling, like the language server, to
+	// give practitioners more information about what this attribute is,
+	// what it's for, and how it should be used. It should be written as
+	// plain text, with no special formatting.
+	Description string
+
+	// MarkdownDescription is used in various tooling, like the
+	// documentation generator, to give practitioners more information
+	// about what this attribute is, what it's for, and how it should be
+	// used. It should be formatted using Markdown.
+	MarkdownDescription string
+
+	// DeprecationMessage defines warning diagnostic details to display when
+	// practitioner configurations use this Attribute. The warning diagnostic
+	// summary is automatically set to "Attribute Deprecated" along with
+	// configuration source file and line information.
+	//
+	// Set this field to a practitioner actionable message such as:
+	//
+	//  - "Configure other_attribute instead. This attribute will be removed
+	//    in the next major version of the provider."
+	//  - "Remove this attribute's configuration as it no longer is used and
+	//    the attribute will be removed in the next major version of the
+	//    provider."
+	//
+	// In Terraform 1.2.7 and later, this warning diagnostic is displayed any
+	// time a practitioner attempts to configure a value for this attribute and
+	// certain scenarios where this attribute is referenced.
+	//
+	// In Terraform 1.2.6 and earlier, this warning diagnostic is only
+	// displayed when the Attribute is Required or Optional, and if the
+	// practitioner configuration sets the value to a known or unknown value
+	// (which may eventually be null). It has no effect when the Attribute is
+	// Computed-only (read-only; not Required or Optional).
+	//
+	// Across any Terraform version, there are no warnings raised for
+	// practitioner configuration values set directly to null, as there is no
+	// way for the framework to differentiate between an unset and null
+	// configuration due to how Terraform sends configuration information
+	// across the protocol.
+	//
+	// Additional information about deprecation enhancements for read-only
+	// attributes can be found in:
+	//
+	//  - https://github.com/hashicorp/terraform/issues/7569
+	//
+	DeprecationMessage string
+
+	// Validators define value validation functionality for the attribute. All
+	// elements of the slice of AttributeValidator are run, regardless of any
+	// previous error diagnostics.
+	//
+	// Many common use case validators can be found in the
+	// github.com/hashicorp/terraform-plugin-framework-validators Go module.
+	//
+	// If the Type field points to a custom type that implements the
+	// xattr.TypeWithValidate interface, the validators defined in this field
+	// are run in addition to the validation defined by the type.
+	Validators []validator.Object
+}
+
+// ApplyTerraform5AttributePathStep returns the Attributes field value if step
+// is AttributeName, otherwise returns an error.
+func (b SingleNestedBlock) ApplyTerraform5AttributePathStep(step tftypes.AttributePathStep) (interface{}, error) {
+	name, ok := step.(tftypes.AttributeName)
+
+	if !ok {
+		return nil, fmt.Errorf("cannot apply step %T to SingleNestedBlock", step)
+	}
+
+	if attribute, ok := b.Attributes[string(name)]; ok {
+		return attribute, nil
+	}
+
+	if block, ok := b.Blocks[string(name)]; ok {
+		return block, nil
+	}
+
+	return nil, fmt.Errorf("no attribute or block %q on SingleNestedBlock", name)
+}
+
+// Equal returns true if the given Attribute is b SingleNestedBlock
+// and all fields are equal.
+func (b SingleNestedBlock) Equal(o fwschema.Block) bool {
+	if _, ok := o.(SingleNestedBlock); !ok {
+		return false
+	}
+
+	return fwschema.BlocksEqual(b, o)
+}
+
+// GetDeprecationMessage returns the DeprecationMessage field value.
+func (b SingleNestedBlock) GetDeprecationMessage() string {
+	return b.DeprecationMessage
+}
+
+// GetDescription returns the Description field value.
+func (b SingleNestedBlock) GetDescription() string {
+	return b.Description
+}
+
+// GetMarkdownDescription returns the MarkdownDescription field value.
+func (b SingleNestedBlock) GetMarkdownDescription() string {
+	return b.MarkdownDescription
+}
+
+// GetNestedObject returns a generated NestedBlockObject from the
+// Attributes, CustomType, and Validators field values.
+func (b SingleNestedBlock) GetNestedObject() fwschema.NestedBlockObject {
+	return NestedBlockObject{
+		Attributes: b.Attributes,
+		Blocks:     b.Blocks,
+		CustomType: b.CustomType,
+		Validators: b.Validators,
+	}
+}
+
+// GetNestingMode always returns BlockNestingModeSingle.
+func (b SingleNestedBlock) GetNestingMode() fwschema.BlockNestingMode {
+	return fwschema.BlockNestingModeSingle
+}
+
+// ObjectValidators returns the Validators field value.
+func (b SingleNestedBlock) ObjectValidators() []validator.Object {
+	return b.Validators
+}
+
+// Type returns ObjectType or CustomType.
+func (b SingleNestedBlock) Type() attr.Type {
+	if b.CustomType != nil {
+		return b.CustomType
+	}
+
+	attrTypes := make(map[string]attr.Type, len(b.Attributes)+len(b.Blocks))
+
+	for name, attribute := range b.Attributes {
+		attrTypes[name] = attribute.GetType()
+	}
+
+	for name, block := range b.Blocks {
+		attrTypes[name] = block.Type()
+	}
+
+	return types.ObjectType{
+		AttrTypes: attrTypes,
+	}
+}

--- a/list/schema/single_nested_block_test.go
+++ b/list/schema/single_nested_block_test.go
@@ -1,0 +1,470 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schema_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testtypes"
+	"github.com/hashicorp/terraform-plugin-framework/list/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func TestSingleNestedBlockApplyTerraform5AttributePathStep(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		block         schema.SingleNestedBlock
+		step          tftypes.AttributePathStep
+		expected      any
+		expectedError error
+	}{
+		"AttributeName-attribute": {
+			block: schema.SingleNestedBlock{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+			},
+			step:          tftypes.AttributeName("testattr"),
+			expected:      schema.StringAttribute{},
+			expectedError: nil,
+		},
+		"AttributeName-block": {
+			block: schema.SingleNestedBlock{
+				Blocks: map[string]schema.Block{
+					"testblock": schema.SingleNestedBlock{
+						Attributes: map[string]schema.Attribute{
+							"testattr": schema.StringAttribute{},
+						},
+					},
+				},
+			},
+			step: tftypes.AttributeName("testblock"),
+			expected: schema.SingleNestedBlock{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+			},
+			expectedError: nil,
+		},
+		"AttributeName-missing": {
+			block: schema.SingleNestedBlock{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+			},
+			step:          tftypes.AttributeName("other"),
+			expected:      nil,
+			expectedError: fmt.Errorf("no attribute or block \"other\" on SingleNestedBlock"),
+		},
+		"ElementKeyInt": {
+			block: schema.SingleNestedBlock{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+			},
+			step:          tftypes.ElementKeyInt(1),
+			expected:      nil,
+			expectedError: fmt.Errorf("cannot apply step tftypes.ElementKeyInt to SingleNestedBlock"),
+		},
+		"ElementKeyString": {
+			block: schema.SingleNestedBlock{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+			},
+			step:          tftypes.ElementKeyString("test"),
+			expected:      nil,
+			expectedError: fmt.Errorf("cannot apply step tftypes.ElementKeyString to SingleNestedBlock"),
+		},
+		"ElementKeyValue": {
+			block: schema.SingleNestedBlock{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+			},
+			step:          tftypes.ElementKeyValue(tftypes.NewValue(tftypes.String, "test")),
+			expected:      nil,
+			expectedError: fmt.Errorf("cannot apply step tftypes.ElementKeyValue to SingleNestedBlock"),
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := testCase.block.ApplyTerraform5AttributePathStep(testCase.step)
+
+			if err != nil {
+				if testCase.expectedError == nil {
+					t.Fatalf("expected no error, got: %s", err)
+				}
+
+				if !strings.Contains(err.Error(), testCase.expectedError.Error()) {
+					t.Fatalf("expected error %q, got: %s", testCase.expectedError, err)
+				}
+			}
+
+			if err == nil && testCase.expectedError != nil {
+				t.Fatalf("got no error, expected: %s", testCase.expectedError)
+			}
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestSingleNestedBlockGetDeprecationMessage(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		block    schema.SingleNestedBlock
+		expected string
+	}{
+		"no-deprecation-message": {
+			block: schema.SingleNestedBlock{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+			},
+			expected: "",
+		},
+		"deprecation-message": {
+			block: schema.SingleNestedBlock{
+				DeprecationMessage: "test deprecation message",
+			},
+			expected: "test deprecation message",
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.block.GetDeprecationMessage()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestSingleNestedBlockEqual(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		block    schema.SingleNestedBlock
+		other    fwschema.Block
+		expected bool
+	}{
+		"different-type": {
+			block: schema.SingleNestedBlock{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+			},
+			other:    testschema.BlockWithObjectValidators{},
+			expected: false,
+		},
+		"different-attributes-definitions": {
+			block: schema.SingleNestedBlock{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{
+						Optional: true,
+					},
+				},
+			},
+			other: schema.SingleNestedBlock{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{
+						Required: true,
+					},
+				},
+			},
+			expected: false,
+		},
+		"different-attributes-types": {
+			block: schema.SingleNestedBlock{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+			},
+			other: schema.SingleNestedBlock{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.BoolAttribute{},
+				},
+			},
+			expected: false,
+		},
+		"different-blocks-definitions": {
+			block: schema.SingleNestedBlock{
+				Blocks: map[string]schema.Block{
+					"testblock": schema.SingleNestedBlock{
+						Attributes: map[string]schema.Attribute{
+							"testattr": schema.StringAttribute{
+								Optional: true,
+							},
+						},
+					},
+				},
+			},
+			other: schema.SingleNestedBlock{
+				Blocks: map[string]schema.Block{
+					"testblock": schema.SingleNestedBlock{
+						Attributes: map[string]schema.Attribute{
+							"testattr": schema.StringAttribute{
+								Required: true,
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		"equal": {
+			block: schema.SingleNestedBlock{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+			},
+			other: schema.SingleNestedBlock{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.block.Equal(testCase.other)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestSingleNestedBlockGetDescription(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		block    schema.SingleNestedBlock
+		expected string
+	}{
+		"no-description": {
+			block: schema.SingleNestedBlock{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+			},
+			expected: "",
+		},
+		"description": {
+			block: schema.SingleNestedBlock{
+				Description: "test description",
+			},
+			expected: "test description",
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.block.GetDescription()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestSingleNestedBlockGetMarkdownDescription(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		block    schema.SingleNestedBlock
+		expected string
+	}{
+		"no-markdown-description": {
+			block: schema.SingleNestedBlock{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+			},
+			expected: "",
+		},
+		"markdown-description": {
+			block: schema.SingleNestedBlock{
+				MarkdownDescription: "test description",
+			},
+			expected: "test description",
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.block.GetMarkdownDescription()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestSingleNestedBlockGetNestedObject(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		block    schema.SingleNestedBlock
+		expected schema.NestedBlockObject
+	}{
+		"nested-object": {
+			block: schema.SingleNestedBlock{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+				Blocks: map[string]schema.Block{
+					"testblock": schema.SingleNestedBlock{
+						Attributes: map[string]schema.Attribute{
+							"testattr": schema.StringAttribute{},
+						},
+					},
+				},
+			},
+			expected: schema.NestedBlockObject{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+				Blocks: map[string]schema.Block{
+					"testblock": schema.SingleNestedBlock{
+						Attributes: map[string]schema.Attribute{
+							"testattr": schema.StringAttribute{},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.block.GetNestedObject()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestSingleNestedBlockObjectValidators(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		block    schema.SingleNestedBlock
+		expected []validator.Object
+	}{
+		"no-validators": {
+			block: schema.SingleNestedBlock{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+			},
+			expected: nil,
+		},
+		"validators": {
+			block: schema.SingleNestedBlock{
+				Validators: []validator.Object{},
+			},
+			expected: []validator.Object{},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.block.ObjectValidators()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+func TestSingleNestedBlockType(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		block    schema.SingleNestedBlock
+		expected attr.Type
+	}{
+		"base": {
+			block: schema.SingleNestedBlock{
+				Attributes: map[string]schema.Attribute{
+					"testattr": schema.StringAttribute{},
+				},
+				Blocks: map[string]schema.Block{
+					"testblock": schema.SingleNestedBlock{
+						Attributes: map[string]schema.Attribute{
+							"testattr": schema.StringAttribute{},
+						},
+					},
+				},
+			},
+			expected: types.ObjectType{
+				AttrTypes: map[string]attr.Type{
+					"testattr": types.StringType,
+					"testblock": types.ObjectType{
+						AttrTypes: map[string]attr.Type{
+							"testattr": types.StringType,
+						},
+					},
+				},
+			},
+		},
+		"custom-type": {
+			block: schema.SingleNestedBlock{
+				CustomType: testtypes.ObjectType{},
+			},
+			expected: testtypes.ObjectType{},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.block.Type()
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Adds map, list and single nested blocks and attributes. Deliberately left out support for sets but we could look into adding these if/when there is a specific request for them.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

None
