### PR TITLE
list: add and set list resource configure data

### DIFF
--- a/internal/fwserver/server_configureprovider.go
+++ b/internal/fwserver/server_configureprovider.go
@@ -39,4 +39,5 @@ func (s *Server) ConfigureProvider(ctx context.Context, req *provider.ConfigureR
 	s.ResourceConfigureData = resp.ResourceData
 	s.EphemeralResourceConfigureData = resp.EphemeralResourceData
 	s.ActionConfigureData = resp.ActionData
+	s.ListResourceConfigureData = resp.ListResourceData
 }

--- a/provider/configure.go
+++ b/provider/configure.go
@@ -72,6 +72,11 @@ type ConfigureResponse struct {
 	// Action type that implements the Configure method.
 	ActionData any
 
+	// ListResourceData is provider-defined data, clients, etc. that is
+	// passed to [action.ConfigureRequest.ProviderData] for each
+	// Action type that implements the Configure method.
+	ListResourceData any
+
 	// Deferred indicates that Terraform should automatically defer
 	// all resources and data sources for this provider.
 	//


### PR DESCRIPTION
## Description

* Extends `ConfigureResponse` to support `ListResourceData`
* Copies `ListResourceData` over in the `ConfigureProvider` RPC call

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Nerp
