### PR TITLE
list: set empty objects in `NewListResult`

### DIFF
--- a/internal/proto5server/server_listresource_test.go
+++ b/internal/proto5server/server_listresource_test.go
@@ -105,7 +105,7 @@ func TestServerListResource(t *testing.T) {
 						continue
 					}
 
-					result := req.NewListResult()
+					result := req.NewListResult(ctx)
 					result.DisplayName = name
 
 					diags = result.Identity.Set(ctx, resources[name].ThingResourceIdentity)

--- a/internal/proto6server/server_listresource_test.go
+++ b/internal/proto6server/server_listresource_test.go
@@ -105,7 +105,7 @@ func TestServerListResource(t *testing.T) {
 						continue
 					}
 
-					result := req.NewListResult()
+					result := req.NewListResult(ctx)
 					result.DisplayName = name
 
 					diags = result.Identity.Set(ctx, resources[name].ThingResourceIdentity)
@@ -131,7 +131,7 @@ func TestServerListResource(t *testing.T) {
 		}
 
 		r.ListMethod = func(ctx context.Context, req list.ListRequest, resp *list.ListResultsStream) {
-			result := req.NewListResult()
+			result := req.NewListResult(ctx)
 			result.DisplayName = "plateau"
 
 			diags := result.Identity.Set(ctx, resources["plateau"].ThingResourceIdentity)

--- a/list/list_resource.go
+++ b/list/list_resource.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
 // ListResource represents an implementation of listing instances of a managed resource
@@ -109,9 +110,15 @@ type ListRequest struct {
 
 // NewListResult creates a new [ListResult] with convenient defaults
 // for each field.
-func (r ListRequest) NewListResult() ListResult {
-	identity := &tfsdk.ResourceIdentity{Schema: r.ResourceIdentitySchema}
-	resource := &tfsdk.Resource{Schema: r.ResourceSchema}
+func (r ListRequest) NewListResult(ctx context.Context) ListResult {
+	identity := &tfsdk.ResourceIdentity{
+		Raw:    tftypes.NewValue(r.ResourceIdentitySchema.Type().TerraformType(ctx), nil),
+		Schema: r.ResourceIdentitySchema,
+	}
+	resource := &tfsdk.Resource{
+		Raw:    tftypes.NewValue(r.ResourceSchema.Type().TerraformType(ctx), nil),
+		Schema: r.ResourceSchema,
+	}
 
 	return ListResult{
 		DisplayName: "",


### PR DESCRIPTION
## Description

- Sets an empty object into `ResourceIdentity` and `Resource` in the `NewListResult` method

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

None
