### PR TITLE
action: Add changelogs for upcoming release

### DIFF
--- a/.changes/unreleased/ENHANCEMENTS-20250916-113054.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20250916-113054.yaml
@@ -1,0 +1,5 @@
+kind: ENHANCEMENTS
+body: 'provider: Added `ProviderWithActions` interface for implementing actions.'
+time: 2025-09-16T11:30:54.216323-04:00
+custom:
+    Issue: "1181"

--- a/.changes/unreleased/ENHANCEMENTS-20250916-113254.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20250916-113254.yaml
@@ -1,0 +1,5 @@
+kind: ENHANCEMENTS
+body: 'provider: Added `ActionData` to `ConfigureResponse`, to pass provider-defined data to `action.Action` implementations.'
+time: 2025-09-16T11:32:54.371817-04:00
+custom:
+    Issue: "1185"

--- a/.changes/unreleased/FEATURES-20250916-112534.yaml
+++ b/.changes/unreleased/FEATURES-20250916-112534.yaml
@@ -1,0 +1,5 @@
+kind: FEATURES
+body: 'action: New package for implementing actions.'
+time: 2025-09-16T11:25:34.765409-04:00
+custom:
+    Issue: "1181"

--- a/.changes/unreleased/FEATURES-20250916-112643.yaml
+++ b/.changes/unreleased/FEATURES-20250916-112643.yaml
@@ -1,0 +1,5 @@
+kind: FEATURES
+body: 'action/schema: New package for implementing action schemas.'
+time: 2025-09-16T11:26:43.331918-04:00
+custom:
+    Issue: "1183"

--- a/.changes/unreleased/FEATURES-20250916-113807.yaml
+++ b/.changes/unreleased/FEATURES-20250916-113807.yaml
@@ -1,0 +1,5 @@
+kind: FEATURES
+body: 'types: Exported a previously internal function, `TerraformTypeToFrameworkType`, which converts `tftypes.Type` to a known framework type.'
+time: 2025-09-16T11:38:07.879695-04:00
+custom:
+    Issue: "1200"

--- a/.changes/unreleased/NOTES-20250916-112826.yaml
+++ b/.changes/unreleased/NOTES-20250916-112826.yaml
@@ -1,0 +1,5 @@
+kind: NOTES
+body: Action support is in technical preview and offered without compatibility promises until Terraform 1.14 is generally available.
+time: 2025-09-16T11:28:26.181249-04:00
+custom:
+    Issue: "1181"

--- a/.changes/unreleased/NOTES-20250916-114232.yaml
+++ b/.changes/unreleased/NOTES-20250916-114232.yaml
@@ -1,0 +1,7 @@
+kind: NOTES
+body: 'action: This release contains a new interface (`action.Action`) and packages for implemention action types, available in Terraform 1.14+.
+    An action in Terraform can be defined by providers to model side-effects that practitioners can reference in their configurations via the
+    `lifecycle.action_trigger` block.'
+time: 2025-09-16T11:42:32.468477-04:00
+custom:
+    Issue: "1181"


### PR DESCRIPTION
## Related Issue

n/a

## Description

This PR adds changelogs for the upcoming `v1.16.0` release, which includes action type support for Terraform 1.14+

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No
