### PR TITLE
Add context setup to `proto{5,6}server` `ListResource()`

### DIFF
--- a/internal/proto5server/server_listresource.go
+++ b/internal/proto5server/server_listresource.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fromproto5"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
+	"github.com/hashicorp/terraform-plugin-framework/internal/logging"
 	"github.com/hashicorp/terraform-plugin-framework/internal/toproto5"
 	"github.com/hashicorp/terraform-plugin-framework/list"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
@@ -27,6 +28,9 @@ func ListRequestErrorDiagnostics(ctx context.Context, diags ...diag.Diagnostic) 
 }
 
 func (s *Server) ListResource(ctx context.Context, protoReq *tfprotov5.ListResourceRequest) (*tfprotov5.ListResourceServerStream, error) {
+	ctx = s.registerContext(ctx)
+	ctx = logging.InitContext(ctx)
+
 	protoStream := &tfprotov5.ListResourceServerStream{Results: tfprotov5.NoListResults}
 	allDiags := diag.Diagnostics{}
 

--- a/internal/proto5server/server_validatelistresourceconfig.go
+++ b/internal/proto5server/server_validatelistresourceconfig.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/internal/fromproto5"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
+	"github.com/hashicorp/terraform-plugin-framework/internal/logging"
 	"github.com/hashicorp/terraform-plugin-framework/internal/toproto5"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
 )
@@ -15,6 +16,7 @@ import (
 // ValidateListResourceConfig satisfies the tfprotov5.ProviderServer interface.
 func (s *Server) ValidateListResourceConfig(ctx context.Context, proto5Req *tfprotov5.ValidateListResourceConfigRequest) (*tfprotov5.ValidateListResourceConfigResponse, error) {
 	ctx = s.registerContext(ctx)
+	ctx = logging.InitContext(ctx)
 
 	fwResp := &fwserver.ValidateListResourceConfigResponse{}
 

--- a/internal/proto6server/server_listresource.go
+++ b/internal/proto6server/server_listresource.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fromproto6"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
+	"github.com/hashicorp/terraform-plugin-framework/internal/logging"
 	"github.com/hashicorp/terraform-plugin-framework/internal/toproto6"
 	"github.com/hashicorp/terraform-plugin-framework/list"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
@@ -27,6 +28,9 @@ func ListRequestErrorDiagnostics(ctx context.Context, diags ...diag.Diagnostic) 
 }
 
 func (s *Server) ListResource(ctx context.Context, protoReq *tfprotov6.ListResourceRequest) (*tfprotov6.ListResourceServerStream, error) {
+	ctx = s.registerContext(ctx)
+	ctx = logging.InitContext(ctx)
+
 	protoStream := &tfprotov6.ListResourceServerStream{Results: tfprotov6.NoListResults}
 	allDiags := diag.Diagnostics{}
 

--- a/internal/proto6server/server_validatelistresourceconfig.go
+++ b/internal/proto6server/server_validatelistresourceconfig.go
@@ -5,8 +5,10 @@ package proto6server
 
 import (
 	"context"
+
 	"github.com/hashicorp/terraform-plugin-framework/internal/fromproto6"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
+	"github.com/hashicorp/terraform-plugin-framework/internal/logging"
 	"github.com/hashicorp/terraform-plugin-framework/internal/toproto6"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 )
@@ -14,6 +16,7 @@ import (
 // ValidateListResourceConfig satisfies the tfprotov6.ProviderServer interface.
 func (s *Server) ValidateListResourceConfig(ctx context.Context, proto6Req *tfprotov6.ValidateListResourceConfigRequest) (*tfprotov6.ValidateListResourceConfigResponse, error) {
 	ctx = s.registerContext(ctx)
+	ctx = logging.InitContext(ctx)
 
 	fwResp := &fwserver.ValidateListResourceConfigResponse{}
 


### PR DESCRIPTION
## Description

I noticed something was missing when I ran `TF_LOG=trace terraform query` today:
```
2025-09-16T14:23:38.070-0400 [TRACE] provider.terraform-provider-cloudlite: Checking ResourceTypes lock: @caller=/Users/baraa.basata/go/pkg/mod
/github.com/hashicorp/terraform-plugin-framework@v1.16.0-beta.1.0.20250911064719-2607d454c868/internal/logging/framework.go:29 @module=sdk.framework new_logger_warning="This log was generated by an SDK subsystem logger that wasn't created before being used. Use tflog.NewSubsystem to create this logger before it is used." timestamp=2025-09-16T14:23:36.190-0400
```

This pull request adds common Go context setup to the Framework implementations of `ListResource()` and `ValidateListResourceConfig()`. These two lines result in more correct behavior re: context cancellation and logging.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

None.