### PR TITLE
list: update list result validation to check if identity is fully null

### DIFF
--- a/.changes/unreleased/BUG FIXES-20251001-152300.yaml
+++ b/.changes/unreleased/BUG FIXES-20251001-152300.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'fwserver: update validation list result validation to check if an identity''s values are all null'
+time: 2025-10-01T15:23:00.976476+02:00
+custom:
+    Issue: "1230"

--- a/internal/fwserver/server_listresource.go
+++ b/internal/fwserver/server_listresource.go
@@ -100,7 +100,6 @@ func (s *Server) ListResource(ctx context.Context, fwReq *ListRequest, fwStream 
 		}
 	}
 
-	// TODO verdict is still out on how to handle diagnostics that pertain to the List call as a whole and not individual list results
 	diagsStream := &list.ListResultsStream{}
 
 	if listResourceWithConfigure, ok := listResource.(list.ListResourceWithConfigure); ok {
@@ -191,12 +190,12 @@ func processListResult(req list.ListRequest, result list.ListResult) ListResult 
 		return ListResult(result)
 	}
 
-	if result.Identity == nil || result.Identity.Raw.IsNull() {
+	if result.Identity == nil || result.Identity.Raw.IsFullyNull() {
 		return ListResultError(
 			"Incomplete List Result",
 			"When listing resources, an implementation issue was found. "+
 				"This is always a problem with the provider. Please report this to the provider developers.\n\n"+
-				"The \"Identity\" field is nil.\n\n",
+				"The \"Identity\" field is nil or the values are nil.\n\n",
 		)
 	}
 

--- a/internal/fwserver/server_listresource_test.go
+++ b/internal/fwserver/server_listresource_test.go
@@ -250,6 +250,42 @@ func TestServerListResource(t *testing.T) {
 			},
 			expectedStreamEvents: []fwserver.ListResult{},
 		},
+		"null-identity": {
+			server: &fwserver.Server{
+				Provider: &testprovider.Provider{},
+			},
+			request: &fwserver.ListRequest{
+				Config: &tfsdk.Config{},
+				ListResource: &testprovider.ListResource{
+					ListMethod: func(ctx context.Context, req list.ListRequest, resp *list.ListResultsStream) {
+						resp.Results = slices.Values([]list.ListResult{
+							{
+								Identity: &tfsdk.ResourceIdentity{
+									Schema: testIdentitySchema,
+									Raw: tftypes.NewValue(testIdentityType, map[string]tftypes.Value{
+										"test_id": tftypes.NewValue(tftypes.String, nil),
+									}),
+								},
+								Resource: &tfsdk.Resource{
+									Schema: testSchema,
+									Raw:    testResourceValue1,
+								},
+								DisplayName: "Test Resource 1",
+								Diagnostics: diag.Diagnostics{},
+							},
+						})
+					},
+				},
+			},
+			expectedStreamEvents: []fwserver.ListResult{
+				{
+					DisplayName: "",
+					Diagnostics: diag.Diagnostics{
+						diag.NewErrorDiagnostic("Incomplete List Result", "When listing resources, an implementation issue was found. This is always a problem with the provider. Please report this to the provider developers.\n\nThe \"Identity\" field is nil or the values are nil.\n\n"),
+					},
+				},
+			},
+		},
 	}
 
 	for name, testCase := range testCases {


### PR DESCRIPTION
## Description

Semi-related to validation added in:

https://github.com/hashicorp/terraform-plugin-framework/pull/1193
https://github.com/hashicorp/terraform-plugin-sdk/pull/1513

Framework allows list results with identities containing all null values, meaning providers may inadvertently forget or incorrectly set identity data. This PR changes the validation performed to also check that the values of the list result's identity are not all null.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

None
