### PR TITLE
statestore: Add experimental notes + changelog

### DIFF
--- a/.changes/unreleased/ENHANCEMENTS-20260216-151551.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20260216-151551.yaml
@@ -1,0 +1,5 @@
+kind: ENHANCEMENTS
+body: 'provider: Added `ProviderWithStateStores` interface for implementing state stores'
+time: 2026-02-16T15:15:51.783658-05:00
+custom:
+    Issue: "1259"

--- a/.changes/unreleased/ENHANCEMENTS-20260216-151646.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20260216-151646.yaml
@@ -1,0 +1,5 @@
+kind: ENHANCEMENTS
+body: 'provider: Added `StateStoreData` to `ConfigureResponse`, to pass provider-defined data to `(statestore.StateStore).Initialize` methods'
+time: 2026-02-16T15:16:46.375269-05:00
+custom:
+    Issue: "1262"

--- a/.changes/unreleased/FEATURES-20260216-150444.yaml
+++ b/.changes/unreleased/FEATURES-20260216-150444.yaml
@@ -1,0 +1,5 @@
+kind: FEATURES
+body: 'statestore: New package for implementing state stores'
+time: 2026-02-16T15:04:44.812342-05:00
+custom:
+    Issue: "1259"

--- a/.changes/unreleased/FEATURES-20260216-151518.yaml
+++ b/.changes/unreleased/FEATURES-20260216-151518.yaml
@@ -1,0 +1,5 @@
+kind: FEATURES
+body: 'statestore/schema: New package for implementing state store schemas'
+time: 2026-02-16T15:15:18.148949-05:00
+custom:
+    Issue: "1259"

--- a/.changes/unreleased/NOTES-20260216-150451.yaml
+++ b/.changes/unreleased/NOTES-20260216-150451.yaml
@@ -1,0 +1,6 @@
+kind: NOTES
+body: 'State store support is considered experimental and offered without compatibility
+    promises until support for `state_store` in Terraform core is generally available.'
+time: 2026-02-16T15:04:51.956532-05:00
+custom:
+    Issue: "1259"

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -167,7 +167,9 @@ type ProviderWithValidateConfig interface {
 }
 
 // ProviderWithStateStores is an interface type that extends Provider to include state stores.
-// TODO: Add supported Terraform version note
+//
+// NOTE: State store support is experimental and exposed without compatibility promises until
+// these notices are removed.
 type ProviderWithStateStores interface {
 	Provider
 

--- a/statestore/schema/doc.go
+++ b/statestore/schema/doc.go
@@ -4,4 +4,7 @@
 // Package schema contains all available schema functionality for state stores.
 // State store schemas define the structure and value types for configuration data.
 // Schemas are implemented via the statestore.StateStore type Schema method.
+//
+// NOTE: State store support is experimental and exposed without compatibility promises until
+// these notices are removed.
 package schema

--- a/statestore/statestore.go
+++ b/statestore/statestore.go
@@ -7,6 +7,8 @@ import (
 	"context"
 )
 
+// NOTE: State store support is experimental and exposed without compatibility promises until
+// these notices are removed.
 type StateStore interface {
 	// Metadata should return the full name of the state store, such
 	// as examplecloud_store.


### PR DESCRIPTION
## Related Issue

#1259 
https://github.com/hashicorp/terraform-plugin-go/pull/604

## Description

PSS support hasn't landed in a GA release of Terraform yet and we're likely to release this Go module before it does, so this PR just adds some verbiage to help set expectations in the rare case that we choose to change some of the state store types before PSS itself is considered GA.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No
