### PR TITLE
statestore: Add additional information on behavior of Terraform for "new states" and `Read`

### DIFF
--- a/statestore/read.go
+++ b/statestore/read.go
@@ -8,6 +8,10 @@ import (
 )
 
 // ReadRequest represents a request to read the contents of a given state ([ReadRequest.StateID]) in the state store.
+//
+// Terraform will always attempt to read the state prior to writing, even in the initial case of writing the first state
+// for a new workspace. If the given [ReadRequest.StateID] does not exist in the configured state store, [ReadResponse.StateBytes]
+// should be kept empty and returned with no diagnostics.
 type ReadRequest struct {
 	// StateID is the ID of the state to read.
 	//
@@ -15,6 +19,9 @@ type ReadRequest struct {
 	// running Terraform in: https://developer.hashicorp.com/terraform/language/state/workspaces .
 	//
 	// If the practitioner hasn't explicitly selected a workspace, StateID will be set to "default".
+	//
+	// If the StateID does not exist in the configured state store, [ReadResponse.StateBytes] should be
+	// kept empty and returned with no diagnostics.
 	StateID string
 }
 

--- a/statestore/statestore.go
+++ b/statestore/statestore.go
@@ -48,6 +48,10 @@ type StateStore interface {
 	Unlock(context.Context, UnlockRequest, *UnlockResponse)
 
 	// Read returns the given state as bytes from a state store.
+	//
+	// Terraform will always attempt to read the state prior to writing, even in the initial case of writing the first state
+	// for a new workspace. If the given [ReadRequest.StateID] does not exist in the configured state store, [ReadResponse.StateBytes]
+	// should be kept empty and returned with no diagnostics.
 	Read(context.Context, ReadRequest, *ReadResponse)
 
 	// Write is called by Terraform to write state data to a given state ID in a state store.


### PR DESCRIPTION
## Related Issue

N/A

## Description

This PR adds some doc comments sparked from an internal slack convo with @SarahFrench about Terraform's expectations for `Read`. We don't have actual website documentation ATM, but eventually this should make it's way there as well 👍🏻 

Example of this behavior being implemented: https://github.com/hashicorp/terraform-plugin-testing/blob/00a2cce7fdd86ad45eda9669fbc2c252cdc353c4/helper/resource/statestore/examplecloud_statestore_test.go#L147-L150

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No
