### PR TITLE
generate config new algo

### DIFF
--- a/internal/fromproto5/generateresourceconfig.go
+++ b/internal/fromproto5/generateresourceconfig.go
@@ -11,11 +11,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
 )
 
 // GenerateResourceConfigRequest returns the *fwserver.GenerateResourceConfigRequest
 // equivalent of a *tfprotov5.GenerateResourceConfigRequest.
-func GenerateResourceConfigRequest(ctx context.Context, proto5 *tfprotov5.GenerateResourceConfigRequest, resourceSchema fwschema.Schema) (*fwserver.GenerateResourceConfigRequest, diag.Diagnostics) {
+func GenerateResourceConfigRequest(ctx context.Context, proto5 *tfprotov5.GenerateResourceConfigRequest, resource resource.Resource, resourceSchema fwschema.Schema) (*fwserver.GenerateResourceConfigRequest, diag.Diagnostics) {
 	if proto5 == nil {
 		return nil, nil
 	}
@@ -41,6 +42,7 @@ func GenerateResourceConfigRequest(ctx context.Context, proto5 *tfprotov5.Genera
 	diags.Append(stateDiags...)
 
 	fw := &fwserver.GenerateResourceConfigRequest{
+		Resource:       resource,
 		ResourceSchema: resourceSchema,
 		State:          state,
 	}

--- a/internal/fromproto5/generateresourceconfig_test.go
+++ b/internal/fromproto5/generateresourceconfig_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/internal/fromproto5"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testprovider"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 )
@@ -93,6 +94,7 @@ func TestGenerateResourceConfigRequest(t *testing.T) {
 					Raw:    testProto5Value,
 					Schema: testSchema,
 				},
+				Resource:       &testprovider.Resource{},
 				ResourceSchema: testSchema,
 			},
 		},
@@ -102,7 +104,7 @@ func TestGenerateResourceConfigRequest(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			got, diags := fromproto5.GenerateResourceConfigRequest(t.Context(), testCase.input, testCase.resourceSchema)
+			got, diags := fromproto5.GenerateResourceConfigRequest(t.Context(), testCase.input, &testprovider.Resource{}, testCase.resourceSchema)
 
 			if diff := cmp.Diff(got, testCase.expected); diff != "" {
 				t.Errorf("unexpected difference: %s", diff)

--- a/internal/fromproto6/generateresourceconfig.go
+++ b/internal/fromproto6/generateresourceconfig.go
@@ -11,11 +11,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
 )
 
 // GenerateResourceConfigRequest returns the *fwserver.GenerateResourceConfigRequest
 // equivalent of a *tfprotov6.GenerateResourceConfigRequest.
-func GenerateResourceConfigRequest(ctx context.Context, proto6 *tfprotov6.GenerateResourceConfigRequest, resourceSchema fwschema.Schema) (*fwserver.GenerateResourceConfigRequest, diag.Diagnostics) {
+func GenerateResourceConfigRequest(ctx context.Context, proto6 *tfprotov6.GenerateResourceConfigRequest, resource resource.Resource, resourceSchema fwschema.Schema) (*fwserver.GenerateResourceConfigRequest, diag.Diagnostics) {
 	if proto6 == nil {
 		return nil, nil
 	}
@@ -41,6 +42,7 @@ func GenerateResourceConfigRequest(ctx context.Context, proto6 *tfprotov6.Genera
 	diags.Append(stateDiags...)
 
 	fw := &fwserver.GenerateResourceConfigRequest{
+		Resource:       resource,
 		ResourceSchema: resourceSchema,
 		State:          state,
 	}

--- a/internal/fromproto6/generateresourceconfig_test.go
+++ b/internal/fromproto6/generateresourceconfig_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/internal/fromproto6"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testprovider"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 )
@@ -93,6 +94,7 @@ func TestGenerateResourceConfigRequest(t *testing.T) {
 					Raw:    testProto6Value,
 					Schema: testSchema,
 				},
+				Resource:       &testprovider.Resource{},
 				ResourceSchema: testSchema,
 			},
 		},
@@ -102,7 +104,7 @@ func TestGenerateResourceConfigRequest(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			got, diags := fromproto6.GenerateResourceConfigRequest(t.Context(), testCase.input, testCase.resourceSchema)
+			got, diags := fromproto6.GenerateResourceConfigRequest(t.Context(), testCase.input, &testprovider.Resource{}, testCase.resourceSchema)
 
 			if diff := cmp.Diff(got, testCase.expected); diff != "" {
 				t.Errorf("unexpected difference: %s", diff)

--- a/internal/fromproto6/upgraderesourceidentity_test.go
+++ b/internal/fromproto6/upgraderesourceidentity_test.go
@@ -5,9 +5,10 @@ package fromproto6_test
 
 import (
 	"context"
+	"testing"
+
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/identityschema"
-	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-framework/diag"

--- a/internal/fwserver/attribute_defaults.go
+++ b/internal/fwserver/attribute_defaults.go
@@ -1,0 +1,245 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package fwserver
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/defaults"
+)
+
+func setDefaultValueAtPath(ctx context.Context, config tftypes.Value, schema fwschema.Schema, attributePath path.Path, diags diag.Diagnostics) (tftypes.Value, bool, diag.Diagnostics) {
+	tfPath := terraformPathFromPath(ctx, attributePath)
+	if tfPath == nil {
+		return config, false, diags
+	}
+
+	attr, err := schema.AttributeAtTerraformPath(ctx, tfPath)
+	if err != nil {
+		return config, false, diags
+	}
+
+	defaultValue, hasDefault, diags := attributeDefaultValue(ctx, attr, attributePath, diags)
+	if !hasDefault || defaultValue.IsNull() {
+		return config, false, diags
+	}
+
+	config, err = replaceValueAtPath(config, tfPath, defaultValue)
+	if err != nil {
+		diags.AddError(
+			"Generate Resource Config Error",
+			"An unexpected error was encountered setting a default value for attribute "+attributePath.String()+": "+err.Error(),
+		)
+		return config, false, diags
+	}
+
+	return config, true, diags
+}
+
+func attributeDefaultValue(ctx context.Context, attr fwschema.Attribute, fwPath path.Path, diags diag.Diagnostics) (tftypes.Value, bool, diag.Diagnostics) {
+	var (
+		result tftypes.Value
+		err    error
+	)
+
+	switch a := attr.(type) {
+	case fwschema.AttributeWithBoolDefaultValue:
+		defaultValue := a.BoolDefaultValue()
+		if defaultValue == nil {
+			return result, false, diags
+		}
+
+		resp := defaults.BoolResponse{}
+		defaultValue.DefaultBool(ctx, defaults.BoolRequest{Path: fwPath}, &resp)
+		diags.Append(resp.Diagnostics...)
+
+		if resp.Diagnostics.HasError() {
+			return result, false, diags
+		}
+
+		result, err = resp.PlanValue.ToTerraformValue(ctx)
+	case fwschema.AttributeWithFloat32DefaultValue:
+		defaultValue := a.Float32DefaultValue()
+		if defaultValue == nil {
+			return result, false, diags
+		}
+
+		resp := defaults.Float32Response{}
+		defaultValue.DefaultFloat32(ctx, defaults.Float32Request{Path: fwPath}, &resp)
+		diags.Append(resp.Diagnostics...)
+
+		if resp.Diagnostics.HasError() {
+			return result, false, diags
+		}
+
+		result, err = resp.PlanValue.ToTerraformValue(ctx)
+	case fwschema.AttributeWithFloat64DefaultValue:
+		defaultValue := a.Float64DefaultValue()
+		if defaultValue == nil {
+			return result, false, diags
+		}
+
+		resp := defaults.Float64Response{}
+		defaultValue.DefaultFloat64(ctx, defaults.Float64Request{Path: fwPath}, &resp)
+		diags.Append(resp.Diagnostics...)
+
+		if resp.Diagnostics.HasError() {
+			return result, false, diags
+		}
+
+		result, err = resp.PlanValue.ToTerraformValue(ctx)
+	case fwschema.AttributeWithInt32DefaultValue:
+		defaultValue := a.Int32DefaultValue()
+		if defaultValue == nil {
+			return result, false, diags
+		}
+
+		resp := defaults.Int32Response{}
+		defaultValue.DefaultInt32(ctx, defaults.Int32Request{Path: fwPath}, &resp)
+		diags.Append(resp.Diagnostics...)
+
+		if resp.Diagnostics.HasError() {
+			return result, false, diags
+		}
+
+		result, err = resp.PlanValue.ToTerraformValue(ctx)
+	case fwschema.AttributeWithInt64DefaultValue:
+		defaultValue := a.Int64DefaultValue()
+		if defaultValue == nil {
+			return result, false, diags
+		}
+
+		resp := defaults.Int64Response{}
+		defaultValue.DefaultInt64(ctx, defaults.Int64Request{Path: fwPath}, &resp)
+		diags.Append(resp.Diagnostics...)
+
+		if resp.Diagnostics.HasError() {
+			return result, false, diags
+		}
+
+		result, err = resp.PlanValue.ToTerraformValue(ctx)
+	case fwschema.AttributeWithListDefaultValue:
+		defaultValue := a.ListDefaultValue()
+		if defaultValue == nil {
+			return result, false, diags
+		}
+
+		resp := defaults.ListResponse{}
+		defaultValue.DefaultList(ctx, defaults.ListRequest{Path: fwPath}, &resp)
+		diags.Append(resp.Diagnostics...)
+
+		if resp.Diagnostics.HasError() || resp.PlanValue.ElementType(ctx) == nil {
+			return result, false, diags
+		}
+
+		result, err = resp.PlanValue.ToTerraformValue(ctx)
+	case fwschema.AttributeWithMapDefaultValue:
+		defaultValue := a.MapDefaultValue()
+		if defaultValue == nil {
+			return result, false, diags
+		}
+
+		resp := defaults.MapResponse{}
+		defaultValue.DefaultMap(ctx, defaults.MapRequest{Path: fwPath}, &resp)
+		diags.Append(resp.Diagnostics...)
+
+		if resp.Diagnostics.HasError() || resp.PlanValue.ElementType(ctx) == nil {
+			return result, false, diags
+		}
+
+		result, err = resp.PlanValue.ToTerraformValue(ctx)
+	case fwschema.AttributeWithNumberDefaultValue:
+		defaultValue := a.NumberDefaultValue()
+		if defaultValue == nil {
+			return result, false, diags
+		}
+
+		resp := defaults.NumberResponse{}
+		defaultValue.DefaultNumber(ctx, defaults.NumberRequest{Path: fwPath}, &resp)
+		diags.Append(resp.Diagnostics...)
+
+		if resp.Diagnostics.HasError() {
+			return result, false, diags
+		}
+
+		result, err = resp.PlanValue.ToTerraformValue(ctx)
+	case fwschema.AttributeWithObjectDefaultValue:
+		defaultValue := a.ObjectDefaultValue()
+		if defaultValue == nil {
+			return result, false, diags
+		}
+
+		resp := defaults.ObjectResponse{}
+		defaultValue.DefaultObject(ctx, defaults.ObjectRequest{Path: fwPath}, &resp)
+		diags.Append(resp.Diagnostics...)
+
+		if resp.Diagnostics.HasError() {
+			return result, false, diags
+		}
+
+		result, err = resp.PlanValue.ToTerraformValue(ctx)
+	case fwschema.AttributeWithSetDefaultValue:
+		defaultValue := a.SetDefaultValue()
+		if defaultValue == nil {
+			return result, false, diags
+		}
+
+		resp := defaults.SetResponse{}
+		defaultValue.DefaultSet(ctx, defaults.SetRequest{Path: fwPath}, &resp)
+		diags.Append(resp.Diagnostics...)
+
+		if resp.Diagnostics.HasError() || resp.PlanValue.ElementType(ctx) == nil {
+			return result, false, diags
+		}
+
+		result, err = resp.PlanValue.ToTerraformValue(ctx)
+	case fwschema.AttributeWithStringDefaultValue:
+		defaultValue := a.StringDefaultValue()
+		if defaultValue == nil {
+			return result, false, diags
+		}
+
+		resp := defaults.StringResponse{}
+		defaultValue.DefaultString(ctx, defaults.StringRequest{Path: fwPath}, &resp)
+		diags.Append(resp.Diagnostics...)
+
+		if resp.Diagnostics.HasError() {
+			return result, false, diags
+		}
+
+		result, err = resp.PlanValue.ToTerraformValue(ctx)
+	case fwschema.AttributeWithDynamicDefaultValue:
+		defaultValue := a.DynamicDefaultValue()
+		if defaultValue == nil {
+			return result, false, diags
+		}
+
+		resp := defaults.DynamicResponse{}
+		defaultValue.DefaultDynamic(ctx, defaults.DynamicRequest{Path: fwPath}, &resp)
+		diags.Append(resp.Diagnostics...)
+
+		if resp.Diagnostics.HasError() {
+			return result, false, diags
+		}
+
+		result, err = resp.PlanValue.ToTerraformValue(ctx)
+	default:
+		return result, false, diags
+	}
+
+	if err != nil {
+		diags.AddError(
+			"Generate Resource Config Error",
+			"An unexpected error was encountered converting a default value at "+fwPath.String()+": "+err.Error(),
+		)
+		return tftypes.Value{}, false, diags
+	}
+
+	return result, true, diags
+}

--- a/internal/fwserver/attribute_defaults_test.go
+++ b/internal/fwserver/attribute_defaults_test.go
@@ -5,11 +5,11 @@ package fwserver
 
 import (
 	"context"
+	"math/big"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/terraform-plugin-go/tftypes"
-
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testdefaults"
@@ -17,40 +17,187 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/defaults"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
-func TestSetDefaultValueAtPathAppliesStringDefault(t *testing.T) {
+func TestSetDefaultValueAtPath(t *testing.T) {
 	t.Parallel()
 
+	listDefaultValue := types.ListValueMust(types.StringType, []attr.Value{
+		types.StringValue("alpha"),
+		types.StringValue("beta"),
+	})
+
+	objectDefaultValue := types.ObjectValueMust(
+		map[string]attr.Type{
+			"enabled": types.BoolType,
+		},
+		map[string]attr.Value{
+			"enabled": types.BoolValue(true),
+		},
+	)
+
 	testType := tftypes.Object{AttributeTypes: map[string]tftypes.Type{
-		"alpha": tftypes.String,
+		"alpha": tftypes.Bool,
+		"beta":  tftypes.Number,
+		"gamma": tftypes.List{ElementType: tftypes.String},
+		"delta": tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+			"enabled": tftypes.Bool,
+		}},
+		"epsilon": tftypes.DynamicPseudoType,
+		"zeta":    tftypes.String,
 	}}
 
 	testSchema := testschema.Schema{Attributes: map[string]fwschema.Attribute{
-		"alpha": testschema.AttributeWithStringDefaultValue{
+		"alpha": testschema.AttributeWithBoolDefaultValue{
+			Optional: true,
+			Default: testdefaults.Bool{DefaultBoolMethod: func(_ context.Context, _ defaults.BoolRequest, resp *defaults.BoolResponse) {
+				resp.PlanValue = types.BoolValue(true)
+			}},
+		},
+		"beta": testschema.AttributeWithNumberDefaultValue{
+			Optional: true,
+			Default: testdefaults.Number{DefaultNumberMethod: func(_ context.Context, _ defaults.NumberRequest, resp *defaults.NumberResponse) {
+				resp.PlanValue = types.NumberValue(big.NewFloat(42))
+			}},
+		},
+		"gamma": testschema.AttributeWithListDefaultValue{
+			Optional:    true,
+			ElementType: types.StringType,
+			Default: testdefaults.List{DefaultListMethod: func(_ context.Context, _ defaults.ListRequest, resp *defaults.ListResponse) {
+				resp.PlanValue = listDefaultValue
+			}},
+		},
+		"delta": testschema.AttributeWithObjectDefaultValue{
+			Optional: true,
+			AttributeTypes: map[string]attr.Type{
+				"enabled": types.BoolType,
+			},
+			Default: testdefaults.Object{DefaultObjectMethod: func(_ context.Context, _ defaults.ObjectRequest, resp *defaults.ObjectResponse) {
+				resp.PlanValue = objectDefaultValue
+			}},
+		},
+		"epsilon": testschema.AttributeWithDynamicDefaultValue{
+			Optional: true,
+			Default: testdefaults.Dynamic{DefaultDynamicMethod: func(_ context.Context, _ defaults.DynamicRequest, resp *defaults.DynamicResponse) {
+				resp.PlanValue = types.DynamicValue(types.StringValue("dynamic-default"))
+			}},
+		},
+		"zeta": testschema.AttributeWithStringDefaultValue{
 			Optional: true,
 			Default: testdefaults.String{DefaultStringMethod: func(_ context.Context, _ defaults.StringRequest, resp *defaults.StringResponse) {
-				resp.PlanValue = types.StringValue("alpha-default")
+				resp.Diagnostics.AddError("default failed", "string default diagnostic")
 			}},
 		},
 	}}
 
-	config := tftypes.NewValue(testType, map[string]tftypes.Value{
-		"alpha": tftypes.NewValue(tftypes.String, nil),
+	baseConfig := tftypes.NewValue(testType, map[string]tftypes.Value{
+		"alpha":   tftypes.NewValue(tftypes.Bool, nil),
+		"beta":    tftypes.NewValue(tftypes.Number, nil),
+		"gamma":   tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, nil),
+		"delta":   tftypes.NewValue(testType.AttributeTypes["delta"], nil),
+		"epsilon": tftypes.NewValue(tftypes.DynamicPseudoType, nil),
+		"zeta":    tftypes.NewValue(tftypes.String, nil),
 	})
 
-	got, applied, gotDiags := setDefaultValueAtPath(t.Context(), config, testSchema, path.Root("alpha"), diag.Diagnostics{})
-	if !applied {
-		t.Fatal("expected default to be applied")
-	}
-	if len(gotDiags) != 0 {
-		t.Fatalf("unexpected diagnostics: %v", gotDiags)
+	testCases := map[string]struct {
+		attributePath   path.Path
+		expected        tftypes.Value
+		expectedApplied bool
+		expectedDiags   diag.Diagnostics
+	}{
+		"applies bool default": {
+			attributePath: path.Root("alpha"),
+			expected: tftypes.NewValue(testType, map[string]tftypes.Value{
+				"alpha":   tftypes.NewValue(tftypes.Bool, true),
+				"beta":    tftypes.NewValue(tftypes.Number, nil),
+				"gamma":   tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, nil),
+				"delta":   tftypes.NewValue(testType.AttributeTypes["delta"], nil),
+				"epsilon": tftypes.NewValue(tftypes.DynamicPseudoType, nil),
+				"zeta":    tftypes.NewValue(tftypes.String, nil),
+			}),
+			expectedApplied: true,
+		},
+		"applies number default": {
+			attributePath: path.Root("beta"),
+			expected: tftypes.NewValue(testType, map[string]tftypes.Value{
+				"alpha":   tftypes.NewValue(tftypes.Bool, nil),
+				"beta":    tftypes.NewValue(tftypes.Number, big.NewFloat(42)),
+				"gamma":   tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, nil),
+				"delta":   tftypes.NewValue(testType.AttributeTypes["delta"], nil),
+				"epsilon": tftypes.NewValue(tftypes.DynamicPseudoType, nil),
+				"zeta":    tftypes.NewValue(tftypes.String, nil),
+			}),
+			expectedApplied: true,
+		},
+		"applies list default": {
+			attributePath: path.Root("gamma"),
+			expected: tftypes.NewValue(testType, map[string]tftypes.Value{
+				"alpha": tftypes.NewValue(tftypes.Bool, nil),
+				"beta":  tftypes.NewValue(tftypes.Number, nil),
+				"gamma": tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, []tftypes.Value{
+					tftypes.NewValue(tftypes.String, "alpha"),
+					tftypes.NewValue(tftypes.String, "beta"),
+				}),
+				"delta":   tftypes.NewValue(testType.AttributeTypes["delta"], nil),
+				"epsilon": tftypes.NewValue(tftypes.DynamicPseudoType, nil),
+				"zeta":    tftypes.NewValue(tftypes.String, nil),
+			}),
+			expectedApplied: true,
+		},
+		"applies object default": {
+			attributePath: path.Root("delta"),
+			expected: tftypes.NewValue(testType, map[string]tftypes.Value{
+				"alpha": tftypes.NewValue(tftypes.Bool, nil),
+				"beta":  tftypes.NewValue(tftypes.Number, nil),
+				"gamma": tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, nil),
+				"delta": tftypes.NewValue(testType.AttributeTypes["delta"], map[string]tftypes.Value{
+					"enabled": tftypes.NewValue(tftypes.Bool, true),
+				}),
+				"epsilon": tftypes.NewValue(tftypes.DynamicPseudoType, nil),
+				"zeta":    tftypes.NewValue(tftypes.String, nil),
+			}),
+			expectedApplied: true,
+		},
+		"applies dynamic default": {
+			attributePath: path.Root("epsilon"),
+			expected: tftypes.NewValue(testType, map[string]tftypes.Value{
+				"alpha":   tftypes.NewValue(tftypes.Bool, nil),
+				"beta":    tftypes.NewValue(tftypes.Number, nil),
+				"gamma":   tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, nil),
+				"delta":   tftypes.NewValue(testType.AttributeTypes["delta"], nil),
+				"epsilon": tftypes.NewValue(tftypes.String, "dynamic-default"),
+				"zeta":    tftypes.NewValue(tftypes.String, nil),
+			}),
+			expectedApplied: true,
+		},
+		"returns diagnostics and skips apply when default errors": {
+			attributePath:   path.Root("zeta"),
+			expected:        baseConfig,
+			expectedApplied: false,
+			expectedDiags: diag.Diagnostics{
+				diag.NewErrorDiagnostic("default failed", "string default diagnostic"),
+			},
+		},
 	}
 
-	expected := tftypes.NewValue(testType, map[string]tftypes.Value{
-		"alpha": tftypes.NewValue(tftypes.String, "alpha-default"),
-	})
-	if diff := cmp.Diff(expected, got); diff != "" {
-		t.Fatalf("unexpected config diff: %s", diff)
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, applied, gotDiags := setDefaultValueAtPath(t.Context(), baseConfig, testSchema, testCase.attributePath, nil)
+
+			if applied != testCase.expectedApplied {
+				t.Fatalf("unexpected applied value: got %t want %t", applied, testCase.expectedApplied)
+			}
+
+			if diff := cmp.Diff(testCase.expected, got); diff != "" {
+				t.Fatalf("unexpected config diff: %s", diff)
+			}
+
+			if diff := cmp.Diff(testCase.expectedDiags, gotDiags); diff != "" {
+				t.Fatalf("unexpected diagnostics diff: %s", diff)
+			}
+		})
 	}
 }

--- a/internal/fwserver/attribute_defaults_test.go
+++ b/internal/fwserver/attribute_defaults_test.go
@@ -1,0 +1,56 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package fwserver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testdefaults"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/defaults"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestSetDefaultValueAtPathAppliesStringDefault(t *testing.T) {
+	t.Parallel()
+
+	testType := tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		"alpha": tftypes.String,
+	}}
+
+	testSchema := testschema.Schema{Attributes: map[string]fwschema.Attribute{
+		"alpha": testschema.AttributeWithStringDefaultValue{
+			Optional: true,
+			Default: testdefaults.String{DefaultStringMethod: func(_ context.Context, _ defaults.StringRequest, resp *defaults.StringResponse) {
+				resp.PlanValue = types.StringValue("alpha-default")
+			}},
+		},
+	}}
+
+	config := tftypes.NewValue(testType, map[string]tftypes.Value{
+		"alpha": tftypes.NewValue(tftypes.String, nil),
+	})
+
+	got, applied, gotDiags := setDefaultValueAtPath(t.Context(), config, testSchema, path.Root("alpha"), diag.Diagnostics{})
+	if !applied {
+		t.Fatal("expected default to be applied")
+	}
+	if len(gotDiags) != 0 {
+		t.Fatalf("unexpected diagnostics: %v", gotDiags)
+	}
+
+	expected := tftypes.NewValue(testType, map[string]tftypes.Value{
+		"alpha": tftypes.NewValue(tftypes.String, "alpha-default"),
+	})
+	if diff := cmp.Diff(expected, got); diff != "" {
+		t.Fatalf("unexpected config diff: %s", diff)
+	}
+}

--- a/internal/fwserver/server_generateresourceconfig.go
+++ b/internal/fwserver/server_generateresourceconfig.go
@@ -5,14 +5,16 @@ package fwserver
 
 import (
 	"context"
-	"errors"
+	"sort"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/internal/fromtftypes"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
-	"github.com/hashicorp/terraform-plugin-framework/internal/logging"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema/fwxschema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 )
 
@@ -36,11 +38,6 @@ type GenerateResourceConfigResponse struct {
 }
 
 // GenerateResourceConfig implements the framework server GenerateResourceConfig RPC.
-// MAINTAINER NOTE:
-// The current logic is transcribed from Terraform Core's default generate resource config logic:
-// https://github.com/hashicorp/terraform/blob/2274026c68260dd7be6ca77e72c355a0da6db1b6/internal/genconfig/generate_config.go#L668
-// This is meant to introduce the `GenerateResourceConfig` RPC implementation with no functionality changes to
-// providers in v1.19.0. This logic will be replaced in a future release.
 func (s *Server) GenerateResourceConfig(ctx context.Context, req *GenerateResourceConfigRequest, resp *GenerateResourceConfigResponse) {
 	if req == nil {
 		return
@@ -55,129 +52,69 @@ func (s *Server) GenerateResourceConfig(ctx context.Context, req *GenerateResour
 		return
 	}
 
-	config := req.State.Raw
+	// copy as we'll modify in place
+	config := req.State.Raw.Copy()
 	var diags diag.Diagnostics
+	// TODO: make sure all error cases are reflected in diags and not just ignored, maybe some need to be caught?
 
 	resp.GeneratedConfig = stateToConfig(*req.State)
 
-	// Errors are handled using diags.Diagnostics instead
-	config, err := tftypes.Transform(config, func(path *tftypes.AttributePath, value tftypes.Value) (tftypes.Value, error) {
-		if value.IsNull() {
-			return value, nil
+	// smarter algorithm steps:
+	// 1) Set top level properties named id and timeouts to null
+	idPath := tftypes.NewAttributePath().WithAttributeName("id")
+
+	idAttribute, err := req.State.Schema.AttributeAtTerraformPath(ctx, idPath)
+	if err == nil && idAttribute.IsComputed() && idAttribute.IsOptional() {
+		config = nullValueAtPath(config, idPath)
+	} // else: no id attribute, ignoring
+
+	// timeouts
+	timeoutPath := tftypes.NewAttributePath().WithAttributeName("timeouts")
+	config, err = tftypes.Transform(config, func(path *tftypes.AttributePath, value tftypes.Value) (tftypes.Value, error) {
+		if path.Equal(timeoutPath) {
+			return tftypes.NewValue(value.Type(), nil), nil
 		}
-
-		if len(path.Steps()) == 0 {
-			return value, nil
-		}
-
-		ty := value.Type()
-		null := tftypes.NewValue(ty, nil)
-
-		attr, err := req.ResourceSchema.AttributeAtTerraformPath(ctx, path)
-		if err != nil {
-			if !errors.Is(err, fwschema.ErrPathIsBlock) && !errors.Is(err, fwschema.ErrPathInsideDynamicAttribute) && !errors.Is(err, fwschema.ErrPathInsideAtomicAttribute) {
-				logging.FrameworkError(ctx, "couldn't find attribute in resource schema")
-
-				fwPath, fwPathDiags := fromtftypes.AttributePath(ctx, path, req.ResourceSchema)
-
-				diags.Append(fwPathDiags...)
-
-				diags.AddAttributeError(
-					fwPath,
-					"Generate Resource Config Error",
-					"An unexpected error was encountered trying to generate the resource config for import. "+
-						"This likely indicates a bug in the Terraform provider framework or Terraform Core. Please report the following to the provider developer:\n\n"+err.Error(),
-				)
-				return value, err
-			}
-		} else {
-			if attr.GetDeprecationMessage() != "" {
-				return null, nil
-			}
-
-			// read-only attributes are not written in the configuration
-			if attr.IsComputed() && !attr.IsOptional() {
-				return null, nil
-			}
-
-			// MAINTAINER NOTE:
-			// This is SDKv2 compatibility logic that was present in
-			// Core's default logic and is left here for functional
-			// parity. This logic can be safely removed in a future release.
-			//
-			// The SDKv2 adds an Optional+Computed "id" attribute to the
-			// resource schema even if it is not defined in provider code.
-			// This will cause a validation error in Core, so it should be
-			// removed.
-			if path.Equal(tftypes.NewAttributePath().WithAttributeName("id")) && attr.IsComputed() && attr.IsOptional() {
-				return null, nil
-			}
-
-			// MAINTAINER NOTE:
-			// This is SDKv2 compatibility logic that was present in
-			// Core's default logic and is left here for functional
-			// parity. This logic can be safely removed in a future release.
-			//
-			// The SDKv2 doesn't differentiate between null and empty value strings, so
-			// if we have "" for an optional value, assume it is actually null.
-			if ty.Is(tftypes.String) {
-				var stringVal string
-				err := value.As(&stringVal)
-				if err != nil {
-					fwPath, fwPathDiags := fromtftypes.AttributePath(ctx, path, req.ResourceSchema)
-
-					diags.Append(fwPathDiags...)
-
-					diags.AddAttributeError(
-						fwPath,
-						"Generate Resource Config Error",
-						"An unexpected error was encountered trying to generate the resource config for import. "+
-							"This likely indicates a bug in the Terraform provider framework or Terraform Core. Please report the following to the provider developer:\n\n"+err.Error(),
-					)
-					return value, err
-				}
-				if !value.IsNull() && attr.IsOptional() && len(stringVal) == 0 {
-					return null, nil
-				}
-			}
-		}
-
-		block, err := fwschema.SchemaBlockAtTerraformPath(ctx, req.ResourceSchema, path)
-		if err != nil {
-			if !errors.Is(err, fwschema.ErrPathIsAttribute) && !errors.Is(err, fwschema.ErrPathInsideDynamicAttribute) && !errors.Is(err, fwschema.ErrPathInsideAtomicAttribute) {
-				logging.FrameworkError(ctx, "couldn't find block in resource schema")
-
-				fwPath, fwPathDiags := fromtftypes.AttributePath(ctx, path, req.ResourceSchema)
-
-				diags.Append(fwPathDiags...)
-
-				diags.AddAttributeError(
-					fwPath,
-					"Generate Resource Config Error",
-					"An unexpected error was encountered trying to generate the resource config for import. "+
-						"This likely indicates a bug in the Terraform provider framework or Terraform Core. Please report the following to the provider developer:\n\n"+err.Error(),
-				)
-				return value, err
-			}
-		} else {
-			if block.GetDeprecationMessage() != "" {
-				return null, nil
-			}
-		}
-
 		return value, nil
 	})
-	// Errors in the Transform callback function should be handled in diagnostics,
-	// if we see an error here, it should be from the Transform function itself
-	// so we will log those errors for now.
-	if err != nil {
-		logging.FrameworkError(ctx,
-			"Error transforming state value during resource config generation",
-			map[string]any{
-				logging.KeyError: err.Error(),
-			},
-		)
-	}
+
+	// 2) Set Computed only properties to null
+	config, err = tftypes.Transform(config, func(path *tftypes.AttributePath, value tftypes.Value) (tftypes.Value, error) {
+		if value.IsNull() || len(path.Steps()) == 0 {
+			return value, nil
+		}
+		attr, err := req.ResourceSchema.AttributeAtTerraformPath(ctx, path)
+		if err == nil && attr.IsComputed() && !attr.IsOptional() {
+			return tftypes.NewValue(value.Type(), nil), nil
+		}
+		return value, nil
+	})
+
+	// 3) Set empty Optional properties to null.
+	// Unlike the SDKv2 implementation, we do not set schema-defined default values
+	// into the generated config. In the Framework, defaults can only be set on
+	// Optional+Computed attributes, and if we placed a default value in the config
+	// it would be treated as a practitioner-set Optional value rather than a
+	// provider-set Computed value, which could have implications during planning.
+	// Instead, we null out empty values and let the Framework apply defaults
+	// during the plan phase as usual.
+	// (Note that for boolean properties the empty value false will be kept instead of setting it to null)
+	config, diags = nullEmptyOptionalValues(ctx, config, req.ResourceSchema, diags)
+
+	// 4) Construct a mapping of ConflictsWith properties to iterate over alphabetically.
+	// If a group of ConflictsWith properties has more than one value set, the property
+	// names are sorted and the first non-null value is retained while the others are
+	// set to null
+	config, diags = resolveConflictsWithGroups(ctx, config, req.ResourceSchema, diags)
+	// TODO: also handle resource level validators!
+
+	// 5) Construct a mapping of ExactlyOneOf properties to iterate over alphabetically.
+	// If a group of ExactlyOneOf properties has more than one value set, the property
+	// names are sorted and the first non-null value is retained while the others are
+	// set to null. If all are null, we attempt to set one in the group by checking
+	// for a default value
+	// 6) Construct a mapping of AlsoRequires (RequiredWith in SDKv2) properties to
+	// iterate over alphabetically. If a group of AlsoRequires properties are not
+	// all set, we set all properties in the group to null
 
 	resp.GeneratedConfig.Raw = config
 	resp.Diagnostics = diags
@@ -189,4 +126,214 @@ func stateToConfig(state tfsdk.State) *tfsdk.Config {
 		Raw:    state.Raw.Copy(),
 		Schema: state.Schema,
 	}
+}
+
+// nullEmptyOptionalValues transforms a config value by replacing empty optional
+// attribute values with null. Boolean false values are kept as-is since false
+// is the empty value for booleans.
+func nullEmptyOptionalValues(ctx context.Context, config tftypes.Value, schema fwschema.Schema, diags diag.Diagnostics) (tftypes.Value, diag.Diagnostics) {
+	newConfig, err := tftypes.Transform(config, func(attrPath *tftypes.AttributePath, value tftypes.Value) (tftypes.Value, error) {
+		if value.IsNull() || len(attrPath.Steps()) == 0 {
+			return value, nil
+		}
+
+		attr, err := schema.AttributeAtTerraformPath(ctx, attrPath)
+		if err != nil || !attr.IsOptional() {
+			return value, nil
+		}
+
+		tfType := attr.GetType().TerraformType(ctx)
+		if tfType == nil {
+			return value, nil
+		}
+
+		null := tftypes.NewValue(tfType, nil)
+
+		switch {
+		case tfType.Equal(tftypes.Bool):
+			var boolVal bool
+			if err := value.As(&boolVal); err != nil {
+				return value, err
+			}
+			// Keep false (empty bool) as-is rather than nulling it out
+			if !boolVal {
+				return value, nil
+			}
+		case tfType.Equal(tftypes.String):
+			var stringVal string
+			if err := value.As(&stringVal); err != nil {
+				return value, err
+			}
+			if len(stringVal) == 0 {
+				return null, nil
+			}
+		case tfType.Equal(tftypes.Number):
+			var numVal float64
+			if err := value.As(&numVal); err != nil {
+				return value, err
+			}
+			if numVal == 0 {
+				return null, nil
+			}
+		}
+
+		return value, nil
+	})
+
+	if err != nil {
+		diags.AddError(
+			"Generate Resource Config Error",
+			"An unexpected error was encountered replacing empty optional values: "+err.Error(),
+		)
+		return config, diags
+	}
+
+	return newConfig, diags
+}
+
+// resolveConflictsWithGroups finds all ConflictsWith validator groups in the schema.
+// For each group where more than one attribute has a non-null value, the attribute
+// names are sorted alphabetically and the first non-null value is retained while
+// the others are set to null.
+func resolveConflictsWithGroups(ctx context.Context, config tftypes.Value, schema fwschema.Schema, diags diag.Diagnostics) (tftypes.Value, diag.Diagnostics) {
+	// Phase 1: Build conflict groups from schema attributes.
+	// Each ConflictsWith validator defines a group: the attribute itself + the paths it conflicts with.
+	// Groups are deduplicated by sorting member names and using the joined string as a key.
+	groups := map[string][]string{}
+
+	for name, attr := range schema.GetAttributes() {
+		conflictExprs := getConflictsWithExpressions(attr)
+		if len(conflictExprs) == 0 {
+			continue
+		}
+
+		members := []string{name}
+		for _, expr := range conflictExprs {
+			members = append(members, expr.String())
+		}
+		sort.Strings(members)
+
+		key := strings.Join(members, ",")
+		groups[key] = members
+	}
+
+	// Phase 2: For each group, find which attributes have non-null values.
+	// If more than one is set, keep the first (alphabetically) and null the rest.
+	for _, members := range groups {
+		var nonNullMembers []string
+		for _, memberName := range members {
+			attrPath := tftypes.NewAttributePath().WithAttributeName(memberName)
+			rawVal, _, err := tftypes.WalkAttributePath(config, attrPath)
+			if err != nil {
+				continue
+			}
+			if tfVal, ok := rawVal.(tftypes.Value); ok && !tfVal.IsNull() {
+				nonNullMembers = append(nonNullMembers, memberName)
+			}
+		}
+
+		if len(nonNullMembers) <= 1 {
+			continue
+		}
+
+		// Members are already sorted; null all but the first non-null
+		for _, memberName := range nonNullMembers[1:] {
+			attrPath := tftypes.NewAttributePath().WithAttributeName(memberName)
+			config = nullValueAtPath(config, attrPath)
+		}
+	}
+
+	return config, diags
+}
+
+// getConflictsWithExpressions extracts ConflictsWith path expressions from an attribute's
+// validators. It checks all typed validator interfaces (String, Bool, Int64, etc.) and
+// returns the paths from any validator that implements validator.ConflictsWithValidator.
+func getConflictsWithExpressions(attr fwschema.Attribute) path.Expressions {
+	var result path.Expressions
+
+	checkValidator := func(v interface{}) {
+		if cv, ok := v.(validator.ConflictsWithValidator); ok {
+			result = append(result, cv.Paths()...)
+		}
+	}
+
+	if a, ok := attr.(fwxschema.AttributeWithBoolValidators); ok {
+		for _, v := range a.BoolValidators() {
+			checkValidator(v)
+		}
+	}
+	if a, ok := attr.(fwxschema.AttributeWithFloat32Validators); ok {
+		for _, v := range a.Float32Validators() {
+			checkValidator(v)
+		}
+	}
+	if a, ok := attr.(fwxschema.AttributeWithFloat64Validators); ok {
+		for _, v := range a.Float64Validators() {
+			checkValidator(v)
+		}
+	}
+	if a, ok := attr.(fwxschema.AttributeWithInt32Validators); ok {
+		for _, v := range a.Int32Validators() {
+			checkValidator(v)
+		}
+	}
+	if a, ok := attr.(fwxschema.AttributeWithInt64Validators); ok {
+		for _, v := range a.Int64Validators() {
+			checkValidator(v)
+		}
+	}
+	if a, ok := attr.(fwxschema.AttributeWithListValidators); ok {
+		for _, v := range a.ListValidators() {
+			checkValidator(v)
+		}
+	}
+	if a, ok := attr.(fwxschema.AttributeWithMapValidators); ok {
+		for _, v := range a.MapValidators() {
+			checkValidator(v)
+		}
+	}
+	if a, ok := attr.(fwxschema.AttributeWithNumberValidators); ok {
+		for _, v := range a.NumberValidators() {
+			checkValidator(v)
+		}
+	}
+	if a, ok := attr.(fwxschema.AttributeWithObjectValidators); ok {
+		for _, v := range a.ObjectValidators() {
+			checkValidator(v)
+		}
+	}
+	if a, ok := attr.(fwxschema.AttributeWithSetValidators); ok {
+		for _, v := range a.SetValidators() {
+			checkValidator(v)
+		}
+	}
+	if a, ok := attr.(fwxschema.AttributeWithStringValidators); ok {
+		for _, v := range a.StringValidators() {
+			checkValidator(v)
+		}
+	}
+	if a, ok := attr.(fwxschema.AttributeWithDynamicValidators); ok {
+		for _, v := range a.DynamicValidators() {
+			checkValidator(v)
+		}
+	}
+
+	return result
+}
+
+// nulls the value at the given path in the value and returns the modified value. If the path does not exist, the original value is returned unmodified.
+func nullValueAtPath(value tftypes.Value, path *tftypes.AttributePath) tftypes.Value {
+	newValue, err := tftypes.Transform(value, func(p *tftypes.AttributePath, v tftypes.Value) (tftypes.Value, error) {
+		if p.Equal(path) {
+			return tftypes.NewValue(v.Type(), nil), nil
+		}
+		return v, nil
+	})
+
+	if err != nil {
+		return value
+	}
+
+	return newValue
 }

--- a/internal/fwserver/server_generateresourceconfig.go
+++ b/internal/fwserver/server_generateresourceconfig.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/defaults"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 )
@@ -22,6 +23,8 @@ import (
 type GenerateResourceConfigRequest struct {
 	// State is the resource's state value.
 	State *tfsdk.State
+	// Resource is the resource implementation.
+	Resource resource.Resource
 
 	// ResourceSchema is the resource's schema.
 	ResourceSchema fwschema.Schema
@@ -104,20 +107,19 @@ func (s *Server) GenerateResourceConfig(ctx context.Context, req *GenerateResour
 	// If a group of ConflictsWith properties has more than one value set, the property
 	// names are sorted and the first non-null value is retained while the others are
 	// set to null
-	config, diags = resolveConflictsWithGroups(ctx, config, req.ResourceSchema, diags)
-	// TODO: also handle resource level validators!
+	config, diags = resolveConflictsWithGroups(ctx, config, req.ResourceSchema, req.Resource, diags)
 
 	// 5) Construct a mapping of ExactlyOneOf properties to iterate over alphabetically.
 	// If a group of ExactlyOneOf properties has more than one value set, the property
 	// names are sorted and the first non-null value is retained while the others are
 	// set to null. If all are null, we attempt to set one in the group by checking
 	// for a default value
-	config, diags = resolveExactlyOneOfGroups(ctx, config, req.ResourceSchema, diags)
+	config, diags = resolveExactlyOneOfGroups(ctx, config, req.ResourceSchema, req.Resource, diags)
 
 	// 6) Construct a mapping of AlsoRequires (RequiredWith in SDKv2) properties to
 	// iterate over alphabetically. If a group of AlsoRequires properties are not
 	// all set, we set all properties in the group to null
-	config, diags = resolveAlsoRequiresGroups(ctx, config, req.ResourceSchema, diags)
+	config, diags = resolveAlsoRequiresGroups(ctx, config, req.ResourceSchema, req.Resource, diags)
 
 	resp.GeneratedConfig.Raw = config
 	resp.Diagnostics = diags
@@ -198,19 +200,19 @@ func nullEmptyOptionalValues(ctx context.Context, config tftypes.Value, schema f
 // For each group where more than one attribute has a non-null value, the attribute
 // names are sorted alphabetically and the first non-null value is retained while
 // the others are set to null.
-func resolveConflictsWithGroups(ctx context.Context, config tftypes.Value, schema fwschema.Schema, diags diag.Diagnostics) (tftypes.Value, diag.Diagnostics) {
-	groups := buildAttributeValidatorGroups(schema, getConflictsWithExpressions)
+func resolveConflictsWithGroups(ctx context.Context, config tftypes.Value, schema fwschema.Schema, res resource.Resource, diags diag.Diagnostics) (tftypes.Value, diag.Diagnostics) {
+	groups := buildValidatorGroups(ctx, config, schema, res, getConflictsWithExpressions)
 
 	for _, key := range sortedGroupKeys(groups) {
 		members := groups[key]
-		nonNullMembers := nonNullGroupMembers(config, members)
+		nonNullMembers := nonNullGroupMembers(ctx, config, members)
 
 		if len(nonNullMembers) <= 1 {
 			continue
 		}
 
-		for _, memberName := range nonNullMembers[1:] {
-			config = nullValueAtPath(config, rootAttributePath(memberName))
+		for _, memberPath := range nonNullMembers[1:] {
+			config = nullValueAtPath(config, terraformPathFromPath(ctx, memberPath))
 		}
 	}
 
@@ -221,19 +223,19 @@ func resolveConflictsWithGroups(ctx context.Context, config tftypes.Value, schem
 // For each group with more than one non-null value, the first non-null value is
 // retained and the others are set to null. If all values are null, the first
 // attribute in alphabetical order with a default value is set.
-func resolveExactlyOneOfGroups(ctx context.Context, config tftypes.Value, schema fwschema.Schema, diags diag.Diagnostics) (tftypes.Value, diag.Diagnostics) {
-	groups := buildAttributeValidatorGroups(schema, getExactlyOneOfExpressions)
+func resolveExactlyOneOfGroups(ctx context.Context, config tftypes.Value, schema fwschema.Schema, res resource.Resource, diags diag.Diagnostics) (tftypes.Value, diag.Diagnostics) {
+	groups := buildValidatorGroups(ctx, config, schema, res, getExactlyOneOfExpressions)
 
 	for _, key := range sortedGroupKeys(groups) {
 		members := groups[key]
-		nonNullMembers := nonNullGroupMembers(config, members)
+		nonNullMembers := nonNullGroupMembers(ctx, config, members)
 
 		switch len(nonNullMembers) {
 		case 0:
-			for _, memberName := range members {
+			for _, memberPath := range members {
 				var applied bool
 
-				config, applied, diags = setDefaultValueAtAttribute(ctx, config, schema, memberName, diags)
+				config, applied, diags = setDefaultValueAtPath(ctx, config, schema, memberPath, diags)
 
 				if applied {
 					break
@@ -242,8 +244,8 @@ func resolveExactlyOneOfGroups(ctx context.Context, config tftypes.Value, schema
 		case 1:
 			continue
 		default:
-			for _, memberName := range nonNullMembers[1:] {
-				config = nullValueAtPath(config, rootAttributePath(memberName))
+			for _, memberPath := range nonNullMembers[1:] {
+				config = nullValueAtPath(config, terraformPathFromPath(ctx, memberPath))
 			}
 		}
 	}
@@ -255,8 +257,8 @@ func resolveExactlyOneOfGroups(ctx context.Context, config tftypes.Value, schema
 // If some, but not all, values in a group are set then the set values are nulled.
 // The process is repeated until no group changes so transitive requirements are
 // also cleared.
-func resolveAlsoRequiresGroups(_ context.Context, config tftypes.Value, schema fwschema.Schema, diags diag.Diagnostics) (tftypes.Value, diag.Diagnostics) {
-	groups := buildAttributeValidatorGroups(schema, getAlsoRequiresExpressions)
+func resolveAlsoRequiresGroups(ctx context.Context, config tftypes.Value, schema fwschema.Schema, res resource.Resource, diags diag.Diagnostics) (tftypes.Value, diag.Diagnostics) {
+	groups := buildValidatorGroups(ctx, config, schema, res, getAlsoRequiresExpressions)
 	groupKeys := sortedGroupKeys(groups)
 
 	for {
@@ -264,14 +266,14 @@ func resolveAlsoRequiresGroups(_ context.Context, config tftypes.Value, schema f
 
 		for _, key := range groupKeys {
 			members := groups[key]
-			nonNullMembers := nonNullGroupMembers(config, members)
+			nonNullMembers := nonNullGroupMembers(ctx, config, members)
 
 			if len(nonNullMembers) == 0 || len(nonNullMembers) == len(members) {
 				continue
 			}
 
-			for _, memberName := range nonNullMembers {
-				config = nullValueAtPath(config, rootAttributePath(memberName))
+			for _, memberPath := range nonNullMembers {
+				config = nullValueAtPath(config, terraformPathFromPath(ctx, memberPath))
 			}
 
 			changed = true
@@ -285,7 +287,7 @@ func resolveAlsoRequiresGroups(_ context.Context, config tftypes.Value, schema f
 	return config, diags
 }
 
-func sortedGroupKeys(groups map[string][]string) []string {
+func sortedGroupKeys(groups map[string]path.Paths) []string {
 	keys := make([]string, 0, len(groups))
 
 	for key := range groups {
@@ -297,17 +299,17 @@ func sortedGroupKeys(groups map[string][]string) []string {
 	return keys
 }
 
-func nonNullGroupMembers(config tftypes.Value, members []string) []string {
-	result := make([]string, 0, len(members))
+func nonNullGroupMembers(ctx context.Context, config tftypes.Value, members path.Paths) path.Paths {
+	result := make(path.Paths, 0, len(members))
 
-	for _, memberName := range members {
-		value, ok := valueAtPath(config, rootAttributePath(memberName))
+	for _, memberPath := range members {
+		value, ok := valueAtPath(config, terraformPathFromPath(ctx, memberPath))
 
 		if !ok || value.IsNull() {
 			continue
 		}
 
-		result = append(result, memberName)
+		result = append(result, memberPath)
 	}
 
 	return result
@@ -328,22 +330,27 @@ func rootAttributePath(name string) *tftypes.AttributePath {
 	return tftypes.NewAttributePath().WithAttributeName(name)
 }
 
-func setDefaultValueAtAttribute(ctx context.Context, config tftypes.Value, schema fwschema.Schema, attributeName string, diags diag.Diagnostics) (tftypes.Value, bool, diag.Diagnostics) {
-	attr, ok := schema.GetAttributes()[attributeName]
-	if !ok {
+func setDefaultValueAtPath(ctx context.Context, config tftypes.Value, schema fwschema.Schema, attributePath path.Path, diags diag.Diagnostics) (tftypes.Value, bool, diag.Diagnostics) {
+	tfPath := terraformPathFromPath(ctx, attributePath)
+	if tfPath == nil {
 		return config, false, diags
 	}
 
-	defaultValue, hasDefault, diags := attributeDefaultValue(ctx, attr, path.Root(attributeName), diags)
+	attr, err := schema.AttributeAtTerraformPath(ctx, tfPath)
+	if err != nil {
+		return config, false, diags
+	}
+
+	defaultValue, hasDefault, diags := attributeDefaultValue(ctx, attr, attributePath, diags)
 	if !hasDefault || defaultValue.IsNull() {
 		return config, false, diags
 	}
 
-	config, err := replaceValueAtPath(config, rootAttributePath(attributeName), defaultValue)
+	config, err = replaceValueAtPath(config, tfPath, defaultValue)
 	if err != nil {
 		diags.AddError(
 			"Generate Resource Config Error",
-			"An unexpected error was encountered setting a default value for attribute "+attributeName+": "+err.Error(),
+			"An unexpected error was encountered setting a default value for attribute "+attributePath.String()+": "+err.Error(),
 		)
 		return config, false, diags
 	}

--- a/internal/fwserver/server_generateresourceconfig.go
+++ b/internal/fwserver/server_generateresourceconfig.go
@@ -5,16 +5,15 @@ package fwserver
 
 import (
 	"context"
+	"maps"
 	"sort"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
-	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema/fwxschema"
 	"github.com/hashicorp/terraform-plugin-framework/path"
-	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/defaults"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 )
 
@@ -63,6 +62,7 @@ func (s *Server) GenerateResourceConfig(ctx context.Context, req *GenerateResour
 	// 1) Set top level properties named id and timeouts to null
 	idPath := tftypes.NewAttributePath().WithAttributeName("id")
 
+	// id
 	idAttribute, err := req.State.Schema.AttributeAtTerraformPath(ctx, idPath)
 	if err == nil && idAttribute.IsComputed() && idAttribute.IsOptional() {
 		config = nullValueAtPath(config, idPath)
@@ -112,9 +112,12 @@ func (s *Server) GenerateResourceConfig(ctx context.Context, req *GenerateResour
 	// names are sorted and the first non-null value is retained while the others are
 	// set to null. If all are null, we attempt to set one in the group by checking
 	// for a default value
+	config, diags = resolveExactlyOneOfGroups(ctx, config, req.ResourceSchema, diags)
+
 	// 6) Construct a mapping of AlsoRequires (RequiredWith in SDKv2) properties to
 	// iterate over alphabetically. If a group of AlsoRequires properties are not
 	// all set, we set all properties in the group to null
+	config, diags = resolveAlsoRequiresGroups(ctx, config, req.ResourceSchema, diags)
 
 	resp.GeneratedConfig.Raw = config
 	resp.Diagnostics = diags
@@ -196,144 +199,401 @@ func nullEmptyOptionalValues(ctx context.Context, config tftypes.Value, schema f
 // names are sorted alphabetically and the first non-null value is retained while
 // the others are set to null.
 func resolveConflictsWithGroups(ctx context.Context, config tftypes.Value, schema fwschema.Schema, diags diag.Diagnostics) (tftypes.Value, diag.Diagnostics) {
-	// Phase 1: Build conflict groups from schema attributes.
-	// Each ConflictsWith validator defines a group: the attribute itself + the paths it conflicts with.
-	// Groups are deduplicated by sorting member names and using the joined string as a key.
-	groups := map[string][]string{}
+	groups := buildAttributeValidatorGroups(schema, getConflictsWithExpressions)
 
-	for name, attr := range schema.GetAttributes() {
-		conflictExprs := getConflictsWithExpressions(attr)
-		if len(conflictExprs) == 0 {
-			continue
-		}
-
-		members := []string{name}
-		for _, expr := range conflictExprs {
-			members = append(members, expr.String())
-		}
-		sort.Strings(members)
-
-		key := strings.Join(members, ",")
-		groups[key] = members
-	}
-
-	// Phase 2: For each group, find which attributes have non-null values.
-	// If more than one is set, keep the first (alphabetically) and null the rest.
-	for _, members := range groups {
-		var nonNullMembers []string
-		for _, memberName := range members {
-			attrPath := tftypes.NewAttributePath().WithAttributeName(memberName)
-			rawVal, _, err := tftypes.WalkAttributePath(config, attrPath)
-			if err != nil {
-				continue
-			}
-			if tfVal, ok := rawVal.(tftypes.Value); ok && !tfVal.IsNull() {
-				nonNullMembers = append(nonNullMembers, memberName)
-			}
-		}
+	for _, key := range sortedGroupKeys(groups) {
+		members := groups[key]
+		nonNullMembers := nonNullGroupMembers(config, members)
 
 		if len(nonNullMembers) <= 1 {
 			continue
 		}
 
-		// Members are already sorted; null all but the first non-null
 		for _, memberName := range nonNullMembers[1:] {
-			attrPath := tftypes.NewAttributePath().WithAttributeName(memberName)
-			config = nullValueAtPath(config, attrPath)
+			config = nullValueAtPath(config, rootAttributePath(memberName))
 		}
 	}
 
 	return config, diags
 }
 
-// getConflictsWithExpressions extracts ConflictsWith path expressions from an attribute's
-// validators. It checks all typed validator interfaces (String, Bool, Int64, etc.) and
-// returns the paths from any validator that implements validator.ConflictsWithValidator.
-func getConflictsWithExpressions(attr fwschema.Attribute) path.Expressions {
-	var result path.Expressions
+// resolveExactlyOneOfGroups finds all ExactlyOneOf validator groups in the schema.
+// For each group with more than one non-null value, the first non-null value is
+// retained and the others are set to null. If all values are null, the first
+// attribute in alphabetical order with a default value is set.
+func resolveExactlyOneOfGroups(ctx context.Context, config tftypes.Value, schema fwschema.Schema, diags diag.Diagnostics) (tftypes.Value, diag.Diagnostics) {
+	groups := buildAttributeValidatorGroups(schema, getExactlyOneOfExpressions)
 
-	checkValidator := func(v interface{}) {
-		if cv, ok := v.(validator.ConflictsWithValidator); ok {
-			result = append(result, cv.Paths()...)
+	for _, key := range sortedGroupKeys(groups) {
+		members := groups[key]
+		nonNullMembers := nonNullGroupMembers(config, members)
+
+		switch len(nonNullMembers) {
+		case 0:
+			for _, memberName := range members {
+				var applied bool
+
+				config, applied, diags = setDefaultValueAtAttribute(ctx, config, schema, memberName, diags)
+
+				if applied {
+					break
+				}
+			}
+		case 1:
+			continue
+		default:
+			for _, memberName := range nonNullMembers[1:] {
+				config = nullValueAtPath(config, rootAttributePath(memberName))
+			}
 		}
 	}
 
-	if a, ok := attr.(fwxschema.AttributeWithBoolValidators); ok {
-		for _, v := range a.BoolValidators() {
-			checkValidator(v)
+	return config, diags
+}
+
+// resolveAlsoRequiresGroups finds all AlsoRequires validator groups in the schema.
+// If some, but not all, values in a group are set then the set values are nulled.
+// The process is repeated until no group changes so transitive requirements are
+// also cleared.
+func resolveAlsoRequiresGroups(_ context.Context, config tftypes.Value, schema fwschema.Schema, diags diag.Diagnostics) (tftypes.Value, diag.Diagnostics) {
+	groups := buildAttributeValidatorGroups(schema, getAlsoRequiresExpressions)
+	groupKeys := sortedGroupKeys(groups)
+
+	for {
+		changed := false
+
+		for _, key := range groupKeys {
+			members := groups[key]
+			nonNullMembers := nonNullGroupMembers(config, members)
+
+			if len(nonNullMembers) == 0 || len(nonNullMembers) == len(members) {
+				continue
+			}
+
+			for _, memberName := range nonNullMembers {
+				config = nullValueAtPath(config, rootAttributePath(memberName))
+			}
+
+			changed = true
+		}
+
+		if !changed {
+			break
 		}
 	}
-	if a, ok := attr.(fwxschema.AttributeWithFloat32Validators); ok {
-		for _, v := range a.Float32Validators() {
-			checkValidator(v)
-		}
+
+	return config, diags
+}
+
+func sortedGroupKeys(groups map[string][]string) []string {
+	keys := make([]string, 0, len(groups))
+
+	for key := range groups {
+		keys = append(keys, key)
 	}
-	if a, ok := attr.(fwxschema.AttributeWithFloat64Validators); ok {
-		for _, v := range a.Float64Validators() {
-			checkValidator(v)
+
+	sort.Strings(keys)
+
+	return keys
+}
+
+func nonNullGroupMembers(config tftypes.Value, members []string) []string {
+	result := make([]string, 0, len(members))
+
+	for _, memberName := range members {
+		value, ok := valueAtPath(config, rootAttributePath(memberName))
+
+		if !ok || value.IsNull() {
+			continue
 		}
-	}
-	if a, ok := attr.(fwxschema.AttributeWithInt32Validators); ok {
-		for _, v := range a.Int32Validators() {
-			checkValidator(v)
-		}
-	}
-	if a, ok := attr.(fwxschema.AttributeWithInt64Validators); ok {
-		for _, v := range a.Int64Validators() {
-			checkValidator(v)
-		}
-	}
-	if a, ok := attr.(fwxschema.AttributeWithListValidators); ok {
-		for _, v := range a.ListValidators() {
-			checkValidator(v)
-		}
-	}
-	if a, ok := attr.(fwxschema.AttributeWithMapValidators); ok {
-		for _, v := range a.MapValidators() {
-			checkValidator(v)
-		}
-	}
-	if a, ok := attr.(fwxschema.AttributeWithNumberValidators); ok {
-		for _, v := range a.NumberValidators() {
-			checkValidator(v)
-		}
-	}
-	if a, ok := attr.(fwxschema.AttributeWithObjectValidators); ok {
-		for _, v := range a.ObjectValidators() {
-			checkValidator(v)
-		}
-	}
-	if a, ok := attr.(fwxschema.AttributeWithSetValidators); ok {
-		for _, v := range a.SetValidators() {
-			checkValidator(v)
-		}
-	}
-	if a, ok := attr.(fwxschema.AttributeWithStringValidators); ok {
-		for _, v := range a.StringValidators() {
-			checkValidator(v)
-		}
-	}
-	if a, ok := attr.(fwxschema.AttributeWithDynamicValidators); ok {
-		for _, v := range a.DynamicValidators() {
-			checkValidator(v)
-		}
+
+		result = append(result, memberName)
 	}
 
 	return result
 }
 
+func valueAtPath(value tftypes.Value, attrPath *tftypes.AttributePath) (tftypes.Value, bool) {
+	rawValue, _, err := tftypes.WalkAttributePath(value, attrPath)
+	if err != nil {
+		return tftypes.Value{}, false
+	}
+
+	tfValue, ok := rawValue.(tftypes.Value)
+
+	return tfValue, ok
+}
+
+func rootAttributePath(name string) *tftypes.AttributePath {
+	return tftypes.NewAttributePath().WithAttributeName(name)
+}
+
+func setDefaultValueAtAttribute(ctx context.Context, config tftypes.Value, schema fwschema.Schema, attributeName string, diags diag.Diagnostics) (tftypes.Value, bool, diag.Diagnostics) {
+	attr, ok := schema.GetAttributes()[attributeName]
+	if !ok {
+		return config, false, diags
+	}
+
+	defaultValue, hasDefault, diags := attributeDefaultValue(ctx, attr, path.Root(attributeName), diags)
+	if !hasDefault || defaultValue.IsNull() {
+		return config, false, diags
+	}
+
+	config, err := replaceValueAtPath(config, rootAttributePath(attributeName), defaultValue)
+	if err != nil {
+		diags.AddError(
+			"Generate Resource Config Error",
+			"An unexpected error was encountered setting a default value for attribute "+attributeName+": "+err.Error(),
+		)
+		return config, false, diags
+	}
+
+	return config, true, diags
+}
+
+func attributeDefaultValue(ctx context.Context, attr fwschema.Attribute, fwPath path.Path, diags diag.Diagnostics) (tftypes.Value, bool, diag.Diagnostics) {
+	var (
+		result tftypes.Value
+		err    error
+	)
+
+	switch a := attr.(type) {
+	case fwschema.AttributeWithBoolDefaultValue:
+		defaultValue := a.BoolDefaultValue()
+		if defaultValue == nil {
+			return result, false, diags
+		}
+
+		resp := defaults.BoolResponse{}
+		defaultValue.DefaultBool(ctx, defaults.BoolRequest{Path: fwPath}, &resp)
+		diags.Append(resp.Diagnostics...)
+
+		if resp.Diagnostics.HasError() {
+			return result, false, diags
+		}
+
+		result, err = resp.PlanValue.ToTerraformValue(ctx)
+	case fwschema.AttributeWithFloat32DefaultValue:
+		defaultValue := a.Float32DefaultValue()
+		if defaultValue == nil {
+			return result, false, diags
+		}
+
+		resp := defaults.Float32Response{}
+		defaultValue.DefaultFloat32(ctx, defaults.Float32Request{Path: fwPath}, &resp)
+		diags.Append(resp.Diagnostics...)
+
+		if resp.Diagnostics.HasError() {
+			return result, false, diags
+		}
+
+		result, err = resp.PlanValue.ToTerraformValue(ctx)
+	case fwschema.AttributeWithFloat64DefaultValue:
+		defaultValue := a.Float64DefaultValue()
+		if defaultValue == nil {
+			return result, false, diags
+		}
+
+		resp := defaults.Float64Response{}
+		defaultValue.DefaultFloat64(ctx, defaults.Float64Request{Path: fwPath}, &resp)
+		diags.Append(resp.Diagnostics...)
+
+		if resp.Diagnostics.HasError() {
+			return result, false, diags
+		}
+
+		result, err = resp.PlanValue.ToTerraformValue(ctx)
+	case fwschema.AttributeWithInt32DefaultValue:
+		defaultValue := a.Int32DefaultValue()
+		if defaultValue == nil {
+			return result, false, diags
+		}
+
+		resp := defaults.Int32Response{}
+		defaultValue.DefaultInt32(ctx, defaults.Int32Request{Path: fwPath}, &resp)
+		diags.Append(resp.Diagnostics...)
+
+		if resp.Diagnostics.HasError() {
+			return result, false, diags
+		}
+
+		result, err = resp.PlanValue.ToTerraformValue(ctx)
+	case fwschema.AttributeWithInt64DefaultValue:
+		defaultValue := a.Int64DefaultValue()
+		if defaultValue == nil {
+			return result, false, diags
+		}
+
+		resp := defaults.Int64Response{}
+		defaultValue.DefaultInt64(ctx, defaults.Int64Request{Path: fwPath}, &resp)
+		diags.Append(resp.Diagnostics...)
+
+		if resp.Diagnostics.HasError() {
+			return result, false, diags
+		}
+
+		result, err = resp.PlanValue.ToTerraformValue(ctx)
+	case fwschema.AttributeWithListDefaultValue:
+		defaultValue := a.ListDefaultValue()
+		if defaultValue == nil {
+			return result, false, diags
+		}
+
+		resp := defaults.ListResponse{}
+		defaultValue.DefaultList(ctx, defaults.ListRequest{Path: fwPath}, &resp)
+		diags.Append(resp.Diagnostics...)
+
+		if resp.Diagnostics.HasError() || resp.PlanValue.ElementType(ctx) == nil {
+			return result, false, diags
+		}
+
+		result, err = resp.PlanValue.ToTerraformValue(ctx)
+	case fwschema.AttributeWithMapDefaultValue:
+		defaultValue := a.MapDefaultValue()
+		if defaultValue == nil {
+			return result, false, diags
+		}
+
+		resp := defaults.MapResponse{}
+		defaultValue.DefaultMap(ctx, defaults.MapRequest{Path: fwPath}, &resp)
+		diags.Append(resp.Diagnostics...)
+
+		if resp.Diagnostics.HasError() || resp.PlanValue.ElementType(ctx) == nil {
+			return result, false, diags
+		}
+
+		result, err = resp.PlanValue.ToTerraformValue(ctx)
+	case fwschema.AttributeWithNumberDefaultValue:
+		defaultValue := a.NumberDefaultValue()
+		if defaultValue == nil {
+			return result, false, diags
+		}
+
+		resp := defaults.NumberResponse{}
+		defaultValue.DefaultNumber(ctx, defaults.NumberRequest{Path: fwPath}, &resp)
+		diags.Append(resp.Diagnostics...)
+
+		if resp.Diagnostics.HasError() {
+			return result, false, diags
+		}
+
+		result, err = resp.PlanValue.ToTerraformValue(ctx)
+	case fwschema.AttributeWithObjectDefaultValue:
+		defaultValue := a.ObjectDefaultValue()
+		if defaultValue == nil {
+			return result, false, diags
+		}
+
+		resp := defaults.ObjectResponse{}
+		defaultValue.DefaultObject(ctx, defaults.ObjectRequest{Path: fwPath}, &resp)
+		diags.Append(resp.Diagnostics...)
+
+		if resp.Diagnostics.HasError() {
+			return result, false, diags
+		}
+
+		result, err = resp.PlanValue.ToTerraformValue(ctx)
+	case fwschema.AttributeWithSetDefaultValue:
+		defaultValue := a.SetDefaultValue()
+		if defaultValue == nil {
+			return result, false, diags
+		}
+
+		resp := defaults.SetResponse{}
+		defaultValue.DefaultSet(ctx, defaults.SetRequest{Path: fwPath}, &resp)
+		diags.Append(resp.Diagnostics...)
+
+		if resp.Diagnostics.HasError() || resp.PlanValue.ElementType(ctx) == nil {
+			return result, false, diags
+		}
+
+		result, err = resp.PlanValue.ToTerraformValue(ctx)
+	case fwschema.AttributeWithStringDefaultValue:
+		defaultValue := a.StringDefaultValue()
+		if defaultValue == nil {
+			return result, false, diags
+		}
+
+		resp := defaults.StringResponse{}
+		defaultValue.DefaultString(ctx, defaults.StringRequest{Path: fwPath}, &resp)
+		diags.Append(resp.Diagnostics...)
+
+		if resp.Diagnostics.HasError() {
+			return result, false, diags
+		}
+
+		result, err = resp.PlanValue.ToTerraformValue(ctx)
+	case fwschema.AttributeWithDynamicDefaultValue:
+		defaultValue := a.DynamicDefaultValue()
+		if defaultValue == nil {
+			return result, false, diags
+		}
+
+		resp := defaults.DynamicResponse{}
+		defaultValue.DefaultDynamic(ctx, defaults.DynamicRequest{Path: fwPath}, &resp)
+		diags.Append(resp.Diagnostics...)
+
+		if resp.Diagnostics.HasError() {
+			return result, false, diags
+		}
+
+		result, err = resp.PlanValue.ToTerraformValue(ctx)
+	default:
+		return result, false, diags
+	}
+
+	if err != nil {
+		diags.AddError(
+			"Generate Resource Config Error",
+			"An unexpected error was encountered converting a default value at "+fwPath.String()+": "+err.Error(),
+		)
+		return tftypes.Value{}, false, diags
+	}
+
+	return result, true, diags
+}
+
 // nulls the value at the given path in the value and returns the modified value. If the path does not exist, the original value is returned unmodified.
 func nullValueAtPath(value tftypes.Value, path *tftypes.AttributePath) tftypes.Value {
-	newValue, err := tftypes.Transform(value, func(p *tftypes.AttributePath, v tftypes.Value) (tftypes.Value, error) {
-		if p.Equal(path) {
-			return tftypes.NewValue(v.Type(), nil), nil
-		}
-		return v, nil
-	})
+	currentValue, ok := valueAtPath(value, path)
+	if !ok {
+		return value
+	}
+
+	newValue, err := replaceValueAtPath(value, path, tftypes.NewValue(currentValue.Type(), nil))
 
 	if err != nil {
 		return value
 	}
 
 	return newValue
+}
+
+func replaceValueAtPath(value tftypes.Value, path *tftypes.AttributePath, replaceWith tftypes.Value) (tftypes.Value, error) {
+	steps := path.Steps()
+
+	// Top-level attribute replacement needs special handling. During transform the
+	// root object is visited at the empty path, so replacing a single-step path
+	// means rebuilding that root object with one field swapped out.
+	if len(steps) == 1 {
+		if attributeName, ok := steps[0].(tftypes.AttributeName); ok {
+			var objectValue map[string]tftypes.Value
+			if err := value.As(&objectValue); err != nil {
+				return value, err
+			}
+
+			copiedObjectValue := maps.Clone(objectValue)
+			copiedObjectValue[string(attributeName)] = replaceWith
+
+			return tftypes.NewValue(value.Type(), copiedObjectValue), nil
+		}
+	}
+
+	return tftypes.Transform(value, func(p *tftypes.AttributePath, v tftypes.Value) (tftypes.Value, error) {
+		if p.Equal(path) {
+			return replaceWith, nil
+		}
+
+		return v, nil
+	})
 }

--- a/internal/fwserver/server_generateresourceconfig.go
+++ b/internal/fwserver/server_generateresourceconfig.go
@@ -58,7 +58,10 @@ func (s *Server) GenerateResourceConfig(ctx context.Context, req *GenerateResour
 	var diags diag.Diagnostics
 	// TODO: make sure all error cases are reflected in diags and not just ignored, maybe some need to be caught?
 
-	resp.GeneratedConfig = stateToConfig(*req.State)
+	resp.GeneratedConfig = &tfsdk.Config{
+		Raw:    req.State.Raw,
+		Schema: req.State.Schema,
+	}
 
 	// smarter algorithm steps:
 	// 1) Set top level properties named id and timeouts to null
@@ -122,14 +125,6 @@ func (s *Server) GenerateResourceConfig(ctx context.Context, req *GenerateResour
 
 	resp.GeneratedConfig.Raw = config
 	resp.Diagnostics = diags
-}
-
-// stateToConfig returns a *tfsdk.Config with a copied value from a tfsdk.State.
-func stateToConfig(state tfsdk.State) *tfsdk.Config {
-	return &tfsdk.Config{
-		Raw:    state.Raw.Copy(),
-		Schema: state.Schema,
-	}
 }
 
 // nullEmptyOptionalValues transforms a config value by replacing empty optional

--- a/internal/fwserver/server_generateresourceconfig.go
+++ b/internal/fwserver/server_generateresourceconfig.go
@@ -215,10 +215,12 @@ func resolveConflictsWithGroups(ctx context.Context, config tftypes.Value, schem
 		members := groups[key]
 		nonNullMembers := nonNullGroupMembers(ctx, config, members)
 
+		// nothing to do if there aren't multiple non-null values that conflict with each other
 		if len(nonNullMembers) <= 1 {
 			continue
 		}
 
+		// null out all but the first non-null value in the group
 		for _, memberPath := range nonNullMembers[1:] {
 			config = nullValueAtPath(config, terraformPathFromPath(ctx, memberPath))
 		}
@@ -240,18 +242,22 @@ func resolveExactlyOneOfGroups(ctx context.Context, config tftypes.Value, schema
 
 		switch len(nonNullMembers) {
 		case 0:
+			// if there are no non-null values, attempt to set the first attribute in alphabetical order with a default value
+			// if there's no default value, try the next
 			for _, memberPath := range members {
-				var applied bool
+				var defaultApplied bool
 
-				config, applied, diags = setDefaultValueAtPath(ctx, config, schema, memberPath, diags)
+				config, defaultApplied, diags = setDefaultValueAtPath(ctx, config, schema, memberPath, diags)
 
-				if applied {
+				if defaultApplied {
 					break
 				}
 			}
 		case 1:
+			// there is exactly one non-null value, do nothing, keep it in place
 			continue
 		default:
+			// if there are multiple non-null values, null out all but the first non-null value in the group
 			for _, memberPath := range nonNullMembers[1:] {
 				config = nullValueAtPath(config, terraformPathFromPath(ctx, memberPath))
 			}
@@ -270,7 +276,7 @@ func resolveAlsoRequiresGroups(ctx context.Context, config tftypes.Value, schema
 	groupKeys := sortedGroupKeys(groups)
 
 	for {
-		changed := false
+		before := config
 
 		for _, key := range groupKeys {
 			members := groups[key]
@@ -283,18 +289,17 @@ func resolveAlsoRequiresGroups(ctx context.Context, config tftypes.Value, schema
 			for _, memberPath := range nonNullMembers {
 				config = nullValueAtPath(config, terraformPathFromPath(ctx, memberPath))
 			}
-
-			changed = true
 		}
 
-		if !changed {
-			break
+		if config.Equal(before) {
+			break // exit loop if there were no changes in the pass
 		}
 	}
 
 	return config, diags
 }
 
+// sortedGroupKeys returns the keys of the given groups mapping sorted alphabetically.
 func sortedGroupKeys(groups map[string]path.Paths) []string {
 	keys := make([]string, 0, len(groups))
 
@@ -307,6 +312,7 @@ func sortedGroupKeys(groups map[string]path.Paths) []string {
 	return keys
 }
 
+// nonNullGroupMembers returns the subset of the given group member paths that have non-null values in the config.
 func nonNullGroupMembers(ctx context.Context, config tftypes.Value, members path.Paths) path.Paths {
 	result := make(path.Paths, 0, len(members))
 
@@ -323,6 +329,7 @@ func nonNullGroupMembers(ctx context.Context, config tftypes.Value, members path
 	return result
 }
 
+// valueAtPath returns the value at the given path in the config. If the path does not exist, a null value and false are returned.
 func valueAtPath(value tftypes.Value, attrPath *tftypes.AttributePath) (tftypes.Value, bool) {
 	rawValue, _, err := tftypes.WalkAttributePath(value, attrPath)
 	if err != nil {

--- a/internal/fwserver/server_generateresourceconfig.go
+++ b/internal/fwserver/server_generateresourceconfig.go
@@ -5,6 +5,7 @@ package fwserver
 
 import (
 	"context"
+	"errors"
 	"maps"
 	"math/big"
 	"sort"
@@ -151,7 +152,15 @@ func nullEmptyOptionalValues(ctx context.Context, config tftypes.Value, schema f
 		}
 
 		attr, err := schema.AttributeAtTerraformPath(ctx, attrPath)
-		if err != nil || !attr.IsOptional() {
+		if err != nil {
+			if errors.Is(err, fwschema.ErrPathInsideAtomicAttribute) || errors.Is(err, fwschema.ErrPathIsBlock) {
+				return value, nil
+			}
+
+			return value, err
+		}
+
+		if !attr.IsOptional() {
 			return value, nil
 		}
 

--- a/internal/fwserver/server_generateresourceconfig.go
+++ b/internal/fwserver/server_generateresourceconfig.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/defaults"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 )
 
@@ -201,7 +200,7 @@ func nullEmptyOptionalValues(ctx context.Context, config tftypes.Value, schema f
 // names are sorted alphabetically and the first non-null value is retained while
 // the others are set to null.
 func resolveConflictsWithGroups(ctx context.Context, config tftypes.Value, schema fwschema.Schema, res resource.Resource, diags diag.Diagnostics) (tftypes.Value, diag.Diagnostics) {
-	groups := buildValidatorGroups(ctx, config, schema, res, getConflictsWithExpressions)
+	groups := buildValidatorGroups(ctx, config, schema, res, getConflictsWithPaths)
 
 	for _, key := range sortedGroupKeys(groups) {
 		members := groups[key]
@@ -224,7 +223,7 @@ func resolveConflictsWithGroups(ctx context.Context, config tftypes.Value, schem
 // retained and the others are set to null. If all values are null, the first
 // attribute in alphabetical order with a default value is set.
 func resolveExactlyOneOfGroups(ctx context.Context, config tftypes.Value, schema fwschema.Schema, res resource.Resource, diags diag.Diagnostics) (tftypes.Value, diag.Diagnostics) {
-	groups := buildValidatorGroups(ctx, config, schema, res, getExactlyOneOfExpressions)
+	groups := buildValidatorGroups(ctx, config, schema, res, getExactlyOneOfPaths)
 
 	for _, key := range sortedGroupKeys(groups) {
 		members := groups[key]
@@ -258,7 +257,7 @@ func resolveExactlyOneOfGroups(ctx context.Context, config tftypes.Value, schema
 // The process is repeated until no group changes so transitive requirements are
 // also cleared.
 func resolveAlsoRequiresGroups(ctx context.Context, config tftypes.Value, schema fwschema.Schema, res resource.Resource, diags diag.Diagnostics) (tftypes.Value, diag.Diagnostics) {
-	groups := buildValidatorGroups(ctx, config, schema, res, getAlsoRequiresExpressions)
+	groups := buildValidatorGroups(ctx, config, schema, res, getAlsoRequiresPaths)
 	groupKeys := sortedGroupKeys(groups)
 
 	for {
@@ -324,240 +323,6 @@ func valueAtPath(value tftypes.Value, attrPath *tftypes.AttributePath) (tftypes.
 	tfValue, ok := rawValue.(tftypes.Value)
 
 	return tfValue, ok
-}
-
-func rootAttributePath(name string) *tftypes.AttributePath {
-	return tftypes.NewAttributePath().WithAttributeName(name)
-}
-
-func setDefaultValueAtPath(ctx context.Context, config tftypes.Value, schema fwschema.Schema, attributePath path.Path, diags diag.Diagnostics) (tftypes.Value, bool, diag.Diagnostics) {
-	tfPath := terraformPathFromPath(ctx, attributePath)
-	if tfPath == nil {
-		return config, false, diags
-	}
-
-	attr, err := schema.AttributeAtTerraformPath(ctx, tfPath)
-	if err != nil {
-		return config, false, diags
-	}
-
-	defaultValue, hasDefault, diags := attributeDefaultValue(ctx, attr, attributePath, diags)
-	if !hasDefault || defaultValue.IsNull() {
-		return config, false, diags
-	}
-
-	config, err = replaceValueAtPath(config, tfPath, defaultValue)
-	if err != nil {
-		diags.AddError(
-			"Generate Resource Config Error",
-			"An unexpected error was encountered setting a default value for attribute "+attributePath.String()+": "+err.Error(),
-		)
-		return config, false, diags
-	}
-
-	return config, true, diags
-}
-
-func attributeDefaultValue(ctx context.Context, attr fwschema.Attribute, fwPath path.Path, diags diag.Diagnostics) (tftypes.Value, bool, diag.Diagnostics) {
-	var (
-		result tftypes.Value
-		err    error
-	)
-
-	switch a := attr.(type) {
-	case fwschema.AttributeWithBoolDefaultValue:
-		defaultValue := a.BoolDefaultValue()
-		if defaultValue == nil {
-			return result, false, diags
-		}
-
-		resp := defaults.BoolResponse{}
-		defaultValue.DefaultBool(ctx, defaults.BoolRequest{Path: fwPath}, &resp)
-		diags.Append(resp.Diagnostics...)
-
-		if resp.Diagnostics.HasError() {
-			return result, false, diags
-		}
-
-		result, err = resp.PlanValue.ToTerraformValue(ctx)
-	case fwschema.AttributeWithFloat32DefaultValue:
-		defaultValue := a.Float32DefaultValue()
-		if defaultValue == nil {
-			return result, false, diags
-		}
-
-		resp := defaults.Float32Response{}
-		defaultValue.DefaultFloat32(ctx, defaults.Float32Request{Path: fwPath}, &resp)
-		diags.Append(resp.Diagnostics...)
-
-		if resp.Diagnostics.HasError() {
-			return result, false, diags
-		}
-
-		result, err = resp.PlanValue.ToTerraformValue(ctx)
-	case fwschema.AttributeWithFloat64DefaultValue:
-		defaultValue := a.Float64DefaultValue()
-		if defaultValue == nil {
-			return result, false, diags
-		}
-
-		resp := defaults.Float64Response{}
-		defaultValue.DefaultFloat64(ctx, defaults.Float64Request{Path: fwPath}, &resp)
-		diags.Append(resp.Diagnostics...)
-
-		if resp.Diagnostics.HasError() {
-			return result, false, diags
-		}
-
-		result, err = resp.PlanValue.ToTerraformValue(ctx)
-	case fwschema.AttributeWithInt32DefaultValue:
-		defaultValue := a.Int32DefaultValue()
-		if defaultValue == nil {
-			return result, false, diags
-		}
-
-		resp := defaults.Int32Response{}
-		defaultValue.DefaultInt32(ctx, defaults.Int32Request{Path: fwPath}, &resp)
-		diags.Append(resp.Diagnostics...)
-
-		if resp.Diagnostics.HasError() {
-			return result, false, diags
-		}
-
-		result, err = resp.PlanValue.ToTerraformValue(ctx)
-	case fwschema.AttributeWithInt64DefaultValue:
-		defaultValue := a.Int64DefaultValue()
-		if defaultValue == nil {
-			return result, false, diags
-		}
-
-		resp := defaults.Int64Response{}
-		defaultValue.DefaultInt64(ctx, defaults.Int64Request{Path: fwPath}, &resp)
-		diags.Append(resp.Diagnostics...)
-
-		if resp.Diagnostics.HasError() {
-			return result, false, diags
-		}
-
-		result, err = resp.PlanValue.ToTerraformValue(ctx)
-	case fwschema.AttributeWithListDefaultValue:
-		defaultValue := a.ListDefaultValue()
-		if defaultValue == nil {
-			return result, false, diags
-		}
-
-		resp := defaults.ListResponse{}
-		defaultValue.DefaultList(ctx, defaults.ListRequest{Path: fwPath}, &resp)
-		diags.Append(resp.Diagnostics...)
-
-		if resp.Diagnostics.HasError() || resp.PlanValue.ElementType(ctx) == nil {
-			return result, false, diags
-		}
-
-		result, err = resp.PlanValue.ToTerraformValue(ctx)
-	case fwschema.AttributeWithMapDefaultValue:
-		defaultValue := a.MapDefaultValue()
-		if defaultValue == nil {
-			return result, false, diags
-		}
-
-		resp := defaults.MapResponse{}
-		defaultValue.DefaultMap(ctx, defaults.MapRequest{Path: fwPath}, &resp)
-		diags.Append(resp.Diagnostics...)
-
-		if resp.Diagnostics.HasError() || resp.PlanValue.ElementType(ctx) == nil {
-			return result, false, diags
-		}
-
-		result, err = resp.PlanValue.ToTerraformValue(ctx)
-	case fwschema.AttributeWithNumberDefaultValue:
-		defaultValue := a.NumberDefaultValue()
-		if defaultValue == nil {
-			return result, false, diags
-		}
-
-		resp := defaults.NumberResponse{}
-		defaultValue.DefaultNumber(ctx, defaults.NumberRequest{Path: fwPath}, &resp)
-		diags.Append(resp.Diagnostics...)
-
-		if resp.Diagnostics.HasError() {
-			return result, false, diags
-		}
-
-		result, err = resp.PlanValue.ToTerraformValue(ctx)
-	case fwschema.AttributeWithObjectDefaultValue:
-		defaultValue := a.ObjectDefaultValue()
-		if defaultValue == nil {
-			return result, false, diags
-		}
-
-		resp := defaults.ObjectResponse{}
-		defaultValue.DefaultObject(ctx, defaults.ObjectRequest{Path: fwPath}, &resp)
-		diags.Append(resp.Diagnostics...)
-
-		if resp.Diagnostics.HasError() {
-			return result, false, diags
-		}
-
-		result, err = resp.PlanValue.ToTerraformValue(ctx)
-	case fwschema.AttributeWithSetDefaultValue:
-		defaultValue := a.SetDefaultValue()
-		if defaultValue == nil {
-			return result, false, diags
-		}
-
-		resp := defaults.SetResponse{}
-		defaultValue.DefaultSet(ctx, defaults.SetRequest{Path: fwPath}, &resp)
-		diags.Append(resp.Diagnostics...)
-
-		if resp.Diagnostics.HasError() || resp.PlanValue.ElementType(ctx) == nil {
-			return result, false, diags
-		}
-
-		result, err = resp.PlanValue.ToTerraformValue(ctx)
-	case fwschema.AttributeWithStringDefaultValue:
-		defaultValue := a.StringDefaultValue()
-		if defaultValue == nil {
-			return result, false, diags
-		}
-
-		resp := defaults.StringResponse{}
-		defaultValue.DefaultString(ctx, defaults.StringRequest{Path: fwPath}, &resp)
-		diags.Append(resp.Diagnostics...)
-
-		if resp.Diagnostics.HasError() {
-			return result, false, diags
-		}
-
-		result, err = resp.PlanValue.ToTerraformValue(ctx)
-	case fwschema.AttributeWithDynamicDefaultValue:
-		defaultValue := a.DynamicDefaultValue()
-		if defaultValue == nil {
-			return result, false, diags
-		}
-
-		resp := defaults.DynamicResponse{}
-		defaultValue.DefaultDynamic(ctx, defaults.DynamicRequest{Path: fwPath}, &resp)
-		diags.Append(resp.Diagnostics...)
-
-		if resp.Diagnostics.HasError() {
-			return result, false, diags
-		}
-
-		result, err = resp.PlanValue.ToTerraformValue(ctx)
-	default:
-		return result, false, diags
-	}
-
-	if err != nil {
-		diags.AddError(
-			"Generate Resource Config Error",
-			"An unexpected error was encountered converting a default value at "+fwPath.String()+": "+err.Error(),
-		)
-		return tftypes.Value{}, false, diags
-	}
-
-	return result, true, diags
 }
 
 // nulls the value at the given path in the value and returns the modified value. If the path does not exist, the original value is returned unmodified.

--- a/internal/fwserver/server_generateresourceconfig.go
+++ b/internal/fwserver/server_generateresourceconfig.go
@@ -6,6 +6,7 @@ package fwserver
 import (
 	"context"
 	"maps"
+	"math/big"
 	"sort"
 
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
@@ -180,11 +181,11 @@ func nullEmptyOptionalValues(ctx context.Context, config tftypes.Value, schema f
 				return null, nil
 			}
 		case tfType.Equal(tftypes.Number):
-			var numVal float64
+			var numVal big.Float
 			if err := value.As(&numVal); err != nil {
 				return value, err
 			}
-			if numVal == 0 {
+			if numVal.Sign() == 0 {
 				return null, nil
 			}
 		}

--- a/internal/fwserver/server_generateresourceconfig.go
+++ b/internal/fwserver/server_generateresourceconfig.go
@@ -56,7 +56,6 @@ func (s *Server) GenerateResourceConfig(ctx context.Context, req *GenerateResour
 	// copy as we'll modify in place
 	config := req.State.Raw.Copy()
 	var diags diag.Diagnostics
-	// TODO: make sure all error cases are reflected in diags and not just ignored, maybe some need to be caught?
 
 	resp.GeneratedConfig = &tfsdk.Config{
 		Raw:    req.State.Raw,
@@ -81,6 +80,13 @@ func (s *Server) GenerateResourceConfig(ctx context.Context, req *GenerateResour
 		}
 		return value, nil
 	})
+	if err != nil {
+		diags.AddError(
+			"Generate Resource Config Error",
+			"An unexpected error was encountered setting the top-level timeouts property to null: "+err.Error()+"\n\n"+
+				"This is always an issue with the provider and should be reported to the provider developers.",
+		)
+	}
 
 	// 2) Set Computed only properties to null
 	config, err = tftypes.Transform(config, func(path *tftypes.AttributePath, value tftypes.Value) (tftypes.Value, error) {
@@ -93,6 +99,13 @@ func (s *Server) GenerateResourceConfig(ctx context.Context, req *GenerateResour
 		}
 		return value, nil
 	})
+	if err != nil {
+		diags.AddError(
+			"Generate Resource Config Error",
+			"An unexpected error was encountered setting computed-only properties to null: "+err.Error()+"\n\n"+
+				"This is always an issue with the provider and should be reported to the provider developers.",
+		)
+	}
 
 	// 3) Set empty Optional properties to null.
 	// Unlike the SDKv2 implementation, we do not set schema-defined default values
@@ -182,7 +195,8 @@ func nullEmptyOptionalValues(ctx context.Context, config tftypes.Value, schema f
 	if err != nil {
 		diags.AddError(
 			"Generate Resource Config Error",
-			"An unexpected error was encountered replacing empty optional values: "+err.Error(),
+			"An unexpected error was encountered replacing empty optional values with null: "+err.Error()+"\n\n"+
+				"This is always an issue with the provider and should be reported to the provider developers.",
 		)
 		return config, diags
 	}

--- a/internal/fwserver/server_generateresourceconfig_steps_test.go
+++ b/internal/fwserver/server_generateresourceconfig_steps_test.go
@@ -1,0 +1,183 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package fwserver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testdefaults"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/defaults"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type testExactlyOneOfStringValidator struct {
+	paths path.Expressions
+}
+
+func (v testExactlyOneOfStringValidator) Description(context.Context) string {
+	return ""
+}
+
+func (v testExactlyOneOfStringValidator) MarkdownDescription(context.Context) string {
+	return ""
+}
+
+func (v testExactlyOneOfStringValidator) ValidateString(context.Context, validator.StringRequest, *validator.StringResponse) {
+}
+
+func (v testExactlyOneOfStringValidator) Paths() path.Expressions {
+	return v.paths
+}
+
+type testAlsoRequiresStringValidator struct {
+	paths path.Expressions
+}
+
+func (v testAlsoRequiresStringValidator) Description(context.Context) string {
+	return ""
+}
+
+func (v testAlsoRequiresStringValidator) MarkdownDescription(context.Context) string {
+	return ""
+}
+
+func (v testAlsoRequiresStringValidator) ValidateString(context.Context, validator.StringRequest, *validator.StringResponse) {
+}
+
+func (v testAlsoRequiresStringValidator) Paths() path.Expressions {
+	return v.paths
+}
+
+func TestResolveExactlyOneOfGroups(t *testing.T) {
+	t.Parallel()
+
+	testType := tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		"alpha": tftypes.String,
+		"beta":  tftypes.String,
+	}}
+
+	testSchema := testschema.Schema{Attributes: map[string]fwschema.Attribute{
+		"alpha": testschema.AttributeWithStringValidators{
+			Computed: true,
+			Optional: true,
+			Validators: []validator.String{
+				testExactlyOneOfStringValidator{paths: path.Expressions{path.MatchRoot("beta")}},
+			},
+		},
+		"beta": testschema.AttributeWithStringDefaultValue{
+			Optional: true,
+			Default: testdefaults.String{
+				DefaultStringMethod: func(_ context.Context, _ defaults.StringRequest, resp *defaults.StringResponse) {
+					resp.PlanValue = types.StringValue("beta-default")
+				},
+			},
+		},
+	}}
+
+	testCases := map[string]struct {
+		config   tftypes.Value
+		expected tftypes.Value
+	}{
+		"sets default when all null": {
+			config: tftypes.NewValue(testType, map[string]tftypes.Value{
+				"alpha": tftypes.NewValue(tftypes.String, nil),
+				"beta":  tftypes.NewValue(tftypes.String, nil),
+			}),
+			expected: tftypes.NewValue(testType, map[string]tftypes.Value{
+				"alpha": tftypes.NewValue(tftypes.String, nil),
+				"beta":  tftypes.NewValue(tftypes.String, "beta-default"),
+			}),
+		},
+		"keeps first non-null and nulls rest": {
+			config: tftypes.NewValue(testType, map[string]tftypes.Value{
+				"alpha": tftypes.NewValue(tftypes.String, "configured-alpha"),
+				"beta":  tftypes.NewValue(tftypes.String, "configured-beta"),
+			}),
+			expected: tftypes.NewValue(testType, map[string]tftypes.Value{
+				"alpha": tftypes.NewValue(tftypes.String, "configured-alpha"),
+				"beta":  tftypes.NewValue(tftypes.String, nil),
+			}),
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, gotDiags := resolveExactlyOneOfGroups(t.Context(), testCase.config, testSchema, diag.Diagnostics{})
+
+			if diff := cmp.Diff(testCase.expected, got); diff != "" {
+				t.Fatalf("unexpected config diff: %s", diff)
+			}
+
+			if len(gotDiags) != 0 {
+				t.Fatalf("unexpected diagnostics: %v", gotDiags)
+			}
+		})
+	}
+}
+
+func TestResolveAlsoRequiresGroups(t *testing.T) {
+	t.Parallel()
+
+	testType := tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		"alpha": tftypes.String,
+		"beta":  tftypes.String,
+		"gamma": tftypes.String,
+	}}
+
+	testSchema := testschema.Schema{Attributes: map[string]fwschema.Attribute{
+		"alpha": testschema.AttributeWithStringValidators{
+			Optional: true,
+			Validators: []validator.String{
+				testAlsoRequiresStringValidator{paths: path.Expressions{path.MatchRoot("beta")}},
+			},
+		},
+		"beta": testschema.AttributeWithStringValidators{
+			Optional: true,
+			Validators: []validator.String{
+				testAlsoRequiresStringValidator{paths: path.Expressions{path.MatchRoot("gamma")}},
+			},
+		},
+		"gamma": testschema.Attribute{Optional: true, Type: types.StringType},
+	}}
+
+	config := tftypes.NewValue(testType, map[string]tftypes.Value{
+		"alpha": tftypes.NewValue(tftypes.String, "configured-alpha"),
+		"beta":  tftypes.NewValue(tftypes.String, "configured-beta"),
+		"gamma": tftypes.NewValue(tftypes.String, nil),
+	})
+
+	expected := tftypes.NewValue(testType, map[string]tftypes.Value{
+		"alpha": tftypes.NewValue(tftypes.String, nil),
+		"beta":  tftypes.NewValue(tftypes.String, nil),
+		"gamma": tftypes.NewValue(tftypes.String, nil),
+	})
+
+	got, gotDiags := resolveAlsoRequiresGroups(t.Context(), config, testSchema, diag.Diagnostics{})
+
+	if diff := cmp.Diff(expected, got); diff != "" {
+		t.Fatalf("unexpected config diff: %s", diff)
+	}
+
+	if len(gotDiags) != 0 {
+		t.Fatalf("unexpected diagnostics: %v", gotDiags)
+	}
+}
+
+var (
+	_ validator.String                = testExactlyOneOfStringValidator{}
+	_ validator.ExactlyOneOfValidator = testExactlyOneOfStringValidator{}
+	_ validator.String                = testAlsoRequiresStringValidator{}
+	_ validator.AlsoRequiresValidator = testAlsoRequiresStringValidator{}
+)

--- a/internal/fwserver/server_generateresourceconfig_steps_test.go
+++ b/internal/fwserver/server_generateresourceconfig_steps_test.go
@@ -13,8 +13,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testdefaults"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testprovider"
 	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/defaults"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -114,7 +117,7 @@ func TestResolveExactlyOneOfGroups(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			got, gotDiags := resolveExactlyOneOfGroups(t.Context(), testCase.config, testSchema, diag.Diagnostics{})
+			got, gotDiags := resolveExactlyOneOfGroups(t.Context(), testCase.config, testSchema, nil, diag.Diagnostics{})
 
 			if diff := cmp.Diff(testCase.expected, got); diff != "" {
 				t.Fatalf("unexpected config diff: %s", diff)
@@ -164,7 +167,310 @@ func TestResolveAlsoRequiresGroups(t *testing.T) {
 		"gamma": tftypes.NewValue(tftypes.String, nil),
 	})
 
-	got, gotDiags := resolveAlsoRequiresGroups(t.Context(), config, testSchema, diag.Diagnostics{})
+	got, gotDiags := resolveAlsoRequiresGroups(t.Context(), config, testSchema, nil, diag.Diagnostics{})
+
+	if diff := cmp.Diff(expected, got); diff != "" {
+		t.Fatalf("unexpected config diff: %s", diff)
+	}
+
+	if len(gotDiags) != 0 {
+		t.Fatalf("unexpected diagnostics: %v", gotDiags)
+	}
+}
+
+func TestResolveConflictsWithGroupsBlockNested(t *testing.T) {
+	t.Parallel()
+
+	testType := tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		"settings": tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+			"alpha": tftypes.String,
+			"beta":  tftypes.String,
+		}},
+	}}
+
+	testSchema := testschema.Schema{Blocks: map[string]fwschema.Block{
+		"settings": testschema.BlockWithObjectValidators{
+			Attributes: map[string]fwschema.Attribute{
+				"alpha": testschema.Attribute{Optional: true, Type: types.StringType},
+				"beta":  testschema.Attribute{Optional: true, Type: types.StringType},
+			},
+			Validators: []validator.Object{
+				testConflictsWithObjectValidator{Object: testvalidator.Object{}, paths: path.Expressions{path.MatchRelative().AtName("beta")}},
+			},
+		},
+	}}
+
+	config := tftypes.NewValue(testType, map[string]tftypes.Value{
+		"settings": tftypes.NewValue(testType.AttributeTypes["settings"], map[string]tftypes.Value{
+			"alpha": tftypes.NewValue(tftypes.String, "configured-alpha"),
+			"beta":  tftypes.NewValue(tftypes.String, "configured-beta"),
+		}),
+	})
+
+	expected := tftypes.NewValue(testType, map[string]tftypes.Value{
+		"settings": tftypes.NewValue(testType.AttributeTypes["settings"], map[string]tftypes.Value{
+			"alpha": tftypes.NewValue(tftypes.String, "configured-alpha"),
+			"beta":  tftypes.NewValue(tftypes.String, nil),
+		}),
+	})
+
+	got, gotDiags := resolveConflictsWithGroups(t.Context(), config, testSchema, nil, diag.Diagnostics{})
+
+	if diff := cmp.Diff(expected, got); diff != "" {
+		t.Fatalf("unexpected config diff: %s", diff)
+	}
+
+	if len(gotDiags) != 0 {
+		t.Fatalf("unexpected diagnostics: %v", gotDiags)
+	}
+}
+
+func TestResolveExactlyOneOfGroupsNestedAttribute(t *testing.T) {
+	t.Parallel()
+
+	testType := tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		"settings": tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+			"alpha": tftypes.String,
+			"beta":  tftypes.String,
+		}},
+	}}
+
+	testSchema := testschema.Schema{Attributes: map[string]fwschema.Attribute{
+		"settings": testschema.NestedAttribute{
+			Optional:    true,
+			NestingMode: fwschema.NestingModeSingle,
+			NestedObject: testschema.NestedAttributeObjectWithValidators{
+				Attributes: map[string]fwschema.Attribute{
+					"alpha": testschema.Attribute{Optional: true, Type: types.StringType},
+					"beta": testschema.AttributeWithStringDefaultValue{
+						Optional: true,
+						Default: testdefaults.String{DefaultStringMethod: func(_ context.Context, _ defaults.StringRequest, resp *defaults.StringResponse) {
+							resp.PlanValue = types.StringValue("beta-default")
+						}},
+					},
+				},
+				Validators: []validator.Object{
+					testExactlyOneOfObjectValidator{Object: testvalidator.Object{}, paths: path.Expressions{
+						path.MatchRelative().AtName("alpha"),
+						path.MatchRelative().AtName("beta"),
+					}},
+				},
+			},
+		},
+	}}
+
+	config := tftypes.NewValue(testType, map[string]tftypes.Value{
+		"settings": tftypes.NewValue(testType.AttributeTypes["settings"], map[string]tftypes.Value{
+			"alpha": tftypes.NewValue(tftypes.String, nil),
+			"beta":  tftypes.NewValue(tftypes.String, nil),
+		}),
+	})
+
+	expected := tftypes.NewValue(testType, map[string]tftypes.Value{
+		"settings": tftypes.NewValue(testType.AttributeTypes["settings"], map[string]tftypes.Value{
+			"alpha": tftypes.NewValue(tftypes.String, nil),
+			"beta":  tftypes.NewValue(tftypes.String, "beta-default"),
+		}),
+	})
+
+	got, gotDiags := resolveExactlyOneOfGroups(t.Context(), config, testSchema, nil, diag.Diagnostics{})
+
+	if diff := cmp.Diff(expected, got); diff != "" {
+		t.Fatalf("unexpected config diff: %s", diff)
+	}
+
+	if len(gotDiags) != 0 {
+		t.Fatalf("unexpected diagnostics: %v", gotDiags)
+	}
+}
+
+func TestResolveAlsoRequiresGroupsNestedListBlock(t *testing.T) {
+	t.Parallel()
+
+	settingsType := tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		"alpha": tftypes.String,
+		"beta":  tftypes.String,
+	}}
+	testType := tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		"settings": tftypes.List{ElementType: settingsType},
+	}}
+
+	testSchema := testschema.Schema{Blocks: map[string]fwschema.Block{
+		"settings": testschema.BlockWithListValidators{
+			Attributes: map[string]fwschema.Attribute{
+				"alpha": testschema.AttributeWithStringValidators{
+					Optional: true,
+					Validators: []validator.String{
+						testAlsoRequiresStringValidator{paths: path.Expressions{path.MatchRelative().AtParent().AtName("beta")}},
+					},
+				},
+				"beta": testschema.Attribute{Optional: true, Type: types.StringType},
+			},
+		},
+	}}
+
+	config := tftypes.NewValue(testType, map[string]tftypes.Value{
+		"settings": tftypes.NewValue(tftypes.List{ElementType: settingsType}, []tftypes.Value{
+			tftypes.NewValue(settingsType, map[string]tftypes.Value{
+				"alpha": tftypes.NewValue(tftypes.String, "configured-alpha"),
+				"beta":  tftypes.NewValue(tftypes.String, nil),
+			}),
+		}),
+	})
+
+	expected := tftypes.NewValue(testType, map[string]tftypes.Value{
+		"settings": tftypes.NewValue(tftypes.List{ElementType: settingsType}, []tftypes.Value{
+			tftypes.NewValue(settingsType, map[string]tftypes.Value{
+				"alpha": tftypes.NewValue(tftypes.String, nil),
+				"beta":  tftypes.NewValue(tftypes.String, nil),
+			}),
+		}),
+	})
+
+	got, gotDiags := resolveAlsoRequiresGroups(t.Context(), config, testSchema, nil, diag.Diagnostics{})
+
+	if diff := cmp.Diff(expected, got); diff != "" {
+		t.Fatalf("unexpected config diff: %s", diff)
+	}
+
+	if len(gotDiags) != 0 {
+		t.Fatalf("unexpected diagnostics: %v", gotDiags)
+	}
+}
+
+func TestResolveConflictsWithGroupsResourceValidator(t *testing.T) {
+	t.Parallel()
+
+	testType := tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		"alpha": tftypes.String,
+		"beta":  tftypes.String,
+	}}
+
+	testSchema := testschema.Schema{Attributes: map[string]fwschema.Attribute{
+		"alpha": testschema.Attribute{Optional: true, Type: types.StringType},
+		"beta":  testschema.Attribute{Optional: true, Type: types.StringType},
+	}}
+
+	res := &testprovider.ResourceWithConfigValidators{
+		Resource: &testprovider.Resource{},
+		ConfigValidatorsMethod: func(context.Context) []resource.ConfigValidator {
+			return []resource.ConfigValidator{
+				&testResourceConflictsWithValidator{testResourceConfigValidator: testResourceConfigValidator{paths: path.Expressions{
+					path.MatchRoot("alpha"),
+					path.MatchRoot("beta"),
+				}}},
+			}
+		},
+	}
+
+	config := tftypes.NewValue(testType, map[string]tftypes.Value{
+		"alpha": tftypes.NewValue(tftypes.String, "configured-alpha"),
+		"beta":  tftypes.NewValue(tftypes.String, "configured-beta"),
+	})
+
+	expected := tftypes.NewValue(testType, map[string]tftypes.Value{
+		"alpha": tftypes.NewValue(tftypes.String, "configured-alpha"),
+		"beta":  tftypes.NewValue(tftypes.String, nil),
+	})
+
+	got, gotDiags := resolveConflictsWithGroups(t.Context(), config, testSchema, res, diag.Diagnostics{})
+
+	if diff := cmp.Diff(expected, got); diff != "" {
+		t.Fatalf("unexpected config diff: %s", diff)
+	}
+
+	if len(gotDiags) != 0 {
+		t.Fatalf("unexpected diagnostics: %v", gotDiags)
+	}
+}
+
+func TestResolveExactlyOneOfGroupsResourceValidator(t *testing.T) {
+	t.Parallel()
+
+	testType := tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		"alpha": tftypes.String,
+		"beta":  tftypes.String,
+	}}
+
+	testSchema := testschema.Schema{Attributes: map[string]fwschema.Attribute{
+		"alpha": testschema.Attribute{Optional: true, Type: types.StringType},
+		"beta": testschema.AttributeWithStringDefaultValue{
+			Optional: true,
+			Default: testdefaults.String{DefaultStringMethod: func(_ context.Context, _ defaults.StringRequest, resp *defaults.StringResponse) {
+				resp.PlanValue = types.StringValue("beta-default")
+			}},
+		},
+	}}
+
+	res := &testprovider.ResourceWithConfigValidators{
+		Resource: &testprovider.Resource{},
+		ConfigValidatorsMethod: func(context.Context) []resource.ConfigValidator {
+			return []resource.ConfigValidator{
+				&testResourceExactlyOneOfValidator{testResourceConfigValidator: testResourceConfigValidator{paths: path.Expressions{
+					path.MatchRoot("alpha"),
+					path.MatchRoot("beta"),
+				}}},
+			}
+		},
+	}
+
+	config := tftypes.NewValue(testType, map[string]tftypes.Value{
+		"alpha": tftypes.NewValue(tftypes.String, nil),
+		"beta":  tftypes.NewValue(tftypes.String, nil),
+	})
+
+	expected := tftypes.NewValue(testType, map[string]tftypes.Value{
+		"alpha": tftypes.NewValue(tftypes.String, nil),
+		"beta":  tftypes.NewValue(tftypes.String, "beta-default"),
+	})
+
+	got, gotDiags := resolveExactlyOneOfGroups(t.Context(), config, testSchema, res, diag.Diagnostics{})
+
+	if diff := cmp.Diff(expected, got); diff != "" {
+		t.Fatalf("unexpected config diff: %s", diff)
+	}
+
+	if len(gotDiags) != 0 {
+		t.Fatalf("unexpected diagnostics: %v", gotDiags)
+	}
+}
+
+func TestResolveAlsoRequiresGroupsResourceValidator(t *testing.T) {
+	t.Parallel()
+
+	testType := tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		"alpha": tftypes.String,
+		"beta":  tftypes.String,
+	}}
+
+	testSchema := testschema.Schema{Attributes: map[string]fwschema.Attribute{
+		"alpha": testschema.Attribute{Optional: true, Type: types.StringType},
+		"beta":  testschema.Attribute{Optional: true, Type: types.StringType},
+	}}
+
+	res := &testprovider.ResourceWithConfigValidators{
+		Resource: &testprovider.Resource{},
+		ConfigValidatorsMethod: func(context.Context) []resource.ConfigValidator {
+			return []resource.ConfigValidator{
+				&testResourceAlsoRequiresValidator{testResourceConfigValidator: testResourceConfigValidator{paths: path.Expressions{
+					path.MatchRoot("alpha"),
+					path.MatchRoot("beta"),
+				}}},
+			}
+		},
+	}
+
+	config := tftypes.NewValue(testType, map[string]tftypes.Value{
+		"alpha": tftypes.NewValue(tftypes.String, "configured-alpha"),
+		"beta":  tftypes.NewValue(tftypes.String, nil),
+	})
+
+	expected := tftypes.NewValue(testType, map[string]tftypes.Value{
+		"alpha": tftypes.NewValue(tftypes.String, nil),
+		"beta":  tftypes.NewValue(tftypes.String, nil),
+	})
+
+	got, gotDiags := resolveAlsoRequiresGroups(t.Context(), config, testSchema, res, diag.Diagnostics{})
 
 	if diff := cmp.Diff(expected, got); diff != "" {
 		t.Fatalf("unexpected config diff: %s", diff)
@@ -181,3 +487,37 @@ var (
 	_ validator.String                = testAlsoRequiresStringValidator{}
 	_ validator.AlsoRequiresValidator = testAlsoRequiresStringValidator{}
 )
+
+type testExactlyOneOfObjectValidator struct {
+	testvalidator.Object
+	paths path.Expressions
+}
+
+func (v testExactlyOneOfObjectValidator) Paths() path.Expressions { return v.paths }
+
+type testConflictsWithObjectValidator struct {
+	testvalidator.Object
+	paths path.Expressions
+}
+
+func (v testConflictsWithObjectValidator) Paths() path.Expressions { return v.paths }
+
+type testResourceConfigValidator struct {
+	testprovider.ResourceConfigValidator
+	paths path.Expressions
+}
+
+func (v *testResourceConfigValidator) Paths() path.Expressions { return v.paths }
+
+type testResourceConflictsWithValidator struct{ testResourceConfigValidator }
+type testResourceExactlyOneOfValidator struct{ testResourceConfigValidator }
+type testResourceAlsoRequiresValidator struct{ testResourceConfigValidator }
+
+var _ validator.Object = testExactlyOneOfObjectValidator{}
+var _ validator.ExactlyOneOfValidator = testExactlyOneOfObjectValidator{}
+var _ validator.Object = testConflictsWithObjectValidator{}
+var _ validator.ConflictsWithValidator = testConflictsWithObjectValidator{}
+var _ resource.ConfigValidator = &testResourceConfigValidator{}
+var _ validator.ConflictsWithValidator = &testResourceConflictsWithValidator{}
+var _ validator.ExactlyOneOfValidator = &testResourceExactlyOneOfValidator{}
+var _ validator.AlsoRequiresValidator = &testResourceAlsoRequiresValidator{}

--- a/internal/fwserver/server_generateresourceconfig_steps_test.go
+++ b/internal/fwserver/server_generateresourceconfig_steps_test.go
@@ -38,7 +38,7 @@ func (v testExactlyOneOfStringValidator) MarkdownDescription(context.Context) st
 func (v testExactlyOneOfStringValidator) ValidateString(context.Context, validator.StringRequest, *validator.StringResponse) {
 }
 
-func (v testExactlyOneOfStringValidator) Paths() path.Expressions {
+func (v testExactlyOneOfStringValidator) ExactlyOneOfPaths() path.Expressions {
 	return v.paths
 }
 
@@ -57,7 +57,7 @@ func (v testAlsoRequiresStringValidator) MarkdownDescription(context.Context) st
 func (v testAlsoRequiresStringValidator) ValidateString(context.Context, validator.StringRequest, *validator.StringResponse) {
 }
 
-func (v testAlsoRequiresStringValidator) Paths() path.Expressions {
+func (v testAlsoRequiresStringValidator) AlsoRequiresPaths() path.Expressions {
 	return v.paths
 }
 
@@ -355,10 +355,10 @@ func TestResolveConflictsWithGroupsResourceValidator(t *testing.T) {
 		Resource: &testprovider.Resource{},
 		ConfigValidatorsMethod: func(context.Context) []resource.ConfigValidator {
 			return []resource.ConfigValidator{
-				&testResourceConflictsWithValidator{testResourceConfigValidator: testResourceConfigValidator{paths: path.Expressions{
+				&testResourceConflictsWithValidator{paths: path.Expressions{
 					path.MatchRoot("alpha"),
 					path.MatchRoot("beta"),
-				}}},
+				}},
 			}
 		},
 	}
@@ -406,10 +406,10 @@ func TestResolveExactlyOneOfGroupsResourceValidator(t *testing.T) {
 		Resource: &testprovider.Resource{},
 		ConfigValidatorsMethod: func(context.Context) []resource.ConfigValidator {
 			return []resource.ConfigValidator{
-				&testResourceExactlyOneOfValidator{testResourceConfigValidator: testResourceConfigValidator{paths: path.Expressions{
+				&testResourceExactlyOneOfValidator{paths: path.Expressions{
 					path.MatchRoot("alpha"),
 					path.MatchRoot("beta"),
-				}}},
+				}},
 			}
 		},
 	}
@@ -452,10 +452,10 @@ func TestResolveAlsoRequiresGroupsResourceValidator(t *testing.T) {
 		Resource: &testprovider.Resource{},
 		ConfigValidatorsMethod: func(context.Context) []resource.ConfigValidator {
 			return []resource.ConfigValidator{
-				&testResourceAlsoRequiresValidator{testResourceConfigValidator: testResourceConfigValidator{paths: path.Expressions{
+				&testResourceAlsoRequiresValidator{paths: path.Expressions{
 					path.MatchRoot("alpha"),
 					path.MatchRoot("beta"),
-				}}},
+				}},
 			}
 		},
 	}
@@ -481,6 +481,90 @@ func TestResolveAlsoRequiresGroupsResourceValidator(t *testing.T) {
 	}
 }
 
+func TestResolveConflictsWithGroupsIgnoresOtherResourceValidatorKinds(t *testing.T) {
+	t.Parallel()
+
+	testType := tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		"alpha": tftypes.String,
+		"beta":  tftypes.String,
+	}}
+
+	testSchema := testschema.Schema{Attributes: map[string]fwschema.Attribute{
+		"alpha": testschema.Attribute{Optional: true, Type: types.StringType},
+		"beta":  testschema.Attribute{Optional: true, Type: types.StringType},
+	}}
+
+	res := &testprovider.ResourceWithConfigValidators{
+		Resource: &testprovider.Resource{},
+		ConfigValidatorsMethod: func(context.Context) []resource.ConfigValidator {
+			return []resource.ConfigValidator{
+				&testResourceExactlyOneOfValidator{paths: path.Expressions{
+					path.MatchRoot("alpha"),
+					path.MatchRoot("beta"),
+				}},
+			}
+		},
+	}
+
+	config := tftypes.NewValue(testType, map[string]tftypes.Value{
+		"alpha": tftypes.NewValue(tftypes.String, "configured-alpha"),
+		"beta":  tftypes.NewValue(tftypes.String, "configured-beta"),
+	})
+
+	got, gotDiags := resolveConflictsWithGroups(t.Context(), config, testSchema, res, diag.Diagnostics{})
+
+	if diff := cmp.Diff(config, got); diff != "" {
+		t.Fatalf("unexpected config diff: %s", diff)
+	}
+
+	if len(gotDiags) != 0 {
+		t.Fatalf("unexpected diagnostics: %v", gotDiags)
+	}
+}
+
+func TestResolveExactlyOneOfGroupsIgnoresOtherBlockValidatorKinds(t *testing.T) {
+	t.Parallel()
+
+	testType := tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		"settings": tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+			"alpha": tftypes.String,
+			"beta":  tftypes.String,
+		}},
+	}}
+
+	testSchema := testschema.Schema{Blocks: map[string]fwschema.Block{
+		"settings": testschema.BlockWithObjectValidators{
+			Attributes: map[string]fwschema.Attribute{
+				"alpha": testschema.Attribute{Optional: true, Type: types.StringType},
+				"beta":  testschema.Attribute{Optional: true, Type: types.StringType},
+			},
+			Validators: []validator.Object{
+				testConflictsWithObjectValidator{Object: testvalidator.Object{}, paths: path.Expressions{
+					path.MatchRelative().AtName("alpha"),
+					path.MatchRelative().AtName("beta"),
+				}},
+			},
+		},
+	}}
+
+	config := tftypes.NewValue(testType, map[string]tftypes.Value{
+		"settings": tftypes.NewValue(testType.AttributeTypes["settings"], map[string]tftypes.Value{
+			"alpha": tftypes.NewValue(tftypes.String, nil),
+			"beta":  tftypes.NewValue(tftypes.String, nil),
+		}),
+	})
+
+	got, gotDiags := resolveExactlyOneOfGroups(t.Context(), config, testSchema, nil, diag.Diagnostics{})
+
+	if diff := cmp.Diff(config, got); diff != "" {
+		t.Fatalf("unexpected config diff: %s", diff)
+	}
+
+	if len(gotDiags) != 0 {
+		t.Fatalf("unexpected diagnostics: %v", gotDiags)
+	}
+}
+
 var (
 	_ validator.String                = testExactlyOneOfStringValidator{}
 	_ validator.ExactlyOneOfValidator = testExactlyOneOfStringValidator{}
@@ -493,31 +577,43 @@ type testExactlyOneOfObjectValidator struct {
 	paths path.Expressions
 }
 
-func (v testExactlyOneOfObjectValidator) Paths() path.Expressions { return v.paths }
+func (v testExactlyOneOfObjectValidator) ExactlyOneOfPaths() path.Expressions { return v.paths }
 
 type testConflictsWithObjectValidator struct {
 	testvalidator.Object
 	paths path.Expressions
 }
 
-func (v testConflictsWithObjectValidator) Paths() path.Expressions { return v.paths }
+func (v testConflictsWithObjectValidator) ConflictsWithPaths() path.Expressions { return v.paths }
 
-type testResourceConfigValidator struct {
+type testResourceConflictsWithValidator struct {
 	testprovider.ResourceConfigValidator
 	paths path.Expressions
 }
 
-func (v *testResourceConfigValidator) Paths() path.Expressions { return v.paths }
+func (v *testResourceConflictsWithValidator) ConflictsWithPaths() path.Expressions { return v.paths }
 
-type testResourceConflictsWithValidator struct{ testResourceConfigValidator }
-type testResourceExactlyOneOfValidator struct{ testResourceConfigValidator }
-type testResourceAlsoRequiresValidator struct{ testResourceConfigValidator }
+type testResourceExactlyOneOfValidator struct {
+	testprovider.ResourceConfigValidator
+	paths path.Expressions
+}
+
+func (v *testResourceExactlyOneOfValidator) ExactlyOneOfPaths() path.Expressions { return v.paths }
+
+type testResourceAlsoRequiresValidator struct {
+	testprovider.ResourceConfigValidator
+	paths path.Expressions
+}
+
+func (v *testResourceAlsoRequiresValidator) AlsoRequiresPaths() path.Expressions { return v.paths }
 
 var _ validator.Object = testExactlyOneOfObjectValidator{}
 var _ validator.ExactlyOneOfValidator = testExactlyOneOfObjectValidator{}
 var _ validator.Object = testConflictsWithObjectValidator{}
 var _ validator.ConflictsWithValidator = testConflictsWithObjectValidator{}
-var _ resource.ConfigValidator = &testResourceConfigValidator{}
+var _ resource.ConfigValidator = &testResourceConflictsWithValidator{}
+var _ resource.ConfigValidator = &testResourceExactlyOneOfValidator{}
+var _ resource.ConfigValidator = &testResourceAlsoRequiresValidator{}
 var _ validator.ConflictsWithValidator = &testResourceConflictsWithValidator{}
 var _ validator.ExactlyOneOfValidator = &testResourceExactlyOneOfValidator{}
 var _ validator.AlsoRequiresValidator = &testResourceAlsoRequiresValidator{}

--- a/internal/fwserver/server_generateresourceconfig_steps_test.go
+++ b/internal/fwserver/server_generateresourceconfig_steps_test.go
@@ -178,6 +178,46 @@ func TestResolveAlsoRequiresGroups(t *testing.T) {
 	}
 }
 
+func TestNullValueAtPathLeavesNullUnchanged(t *testing.T) {
+	t.Parallel()
+
+	testType := tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		"alpha": tftypes.String,
+	}}
+
+	config := tftypes.NewValue(testType, map[string]tftypes.Value{
+		"alpha": tftypes.NewValue(tftypes.String, nil),
+	})
+
+	got := nullValueAtPath(config, tftypes.NewAttributePath().WithAttributeName("alpha"))
+
+	if diff := cmp.Diff(config, got); diff != "" {
+		t.Fatalf("unexpected config diff: %s", diff)
+	}
+}
+
+func TestNullValueAtPathReportsChangeForNonNullValue(t *testing.T) {
+	t.Parallel()
+
+	testType := tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		"alpha": tftypes.String,
+	}}
+
+	config := tftypes.NewValue(testType, map[string]tftypes.Value{
+		"alpha": tftypes.NewValue(tftypes.String, "configured-alpha"),
+	})
+
+	got := nullValueAtPath(config, tftypes.NewAttributePath().WithAttributeName("alpha"))
+
+	expected := tftypes.NewValue(testType, map[string]tftypes.Value{
+		"alpha": tftypes.NewValue(tftypes.String, nil),
+	})
+
+	if diff := cmp.Diff(expected, got); diff != "" {
+		t.Fatalf("unexpected config diff: %s", diff)
+	}
+}
+
 func TestResolveConflictsWithGroupsBlockNested(t *testing.T) {
 	t.Parallel()
 

--- a/internal/fwserver/server_generateresourceconfig_steps_test.go
+++ b/internal/fwserver/server_generateresourceconfig_steps_test.go
@@ -218,6 +218,45 @@ func TestNullValueAtPathReportsChangeForNonNullValue(t *testing.T) {
 	}
 }
 
+func TestSetDefaultValueAtPathAppliesDefault(t *testing.T) {
+	t.Parallel()
+
+	testType := tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		"alpha": tftypes.String,
+	}}
+
+	testSchema := testschema.Schema{Attributes: map[string]fwschema.Attribute{
+		"alpha": testschema.AttributeWithStringDefaultValue{
+			Optional: true,
+			Default: testdefaults.String{DefaultStringMethod: func(_ context.Context, _ defaults.StringRequest, resp *defaults.StringResponse) {
+				resp.PlanValue = types.StringValue("alpha-default")
+			}},
+		},
+	}}
+
+	config := tftypes.NewValue(testType, map[string]tftypes.Value{
+		"alpha": tftypes.NewValue(tftypes.String, nil),
+	})
+
+	got, applied, gotDiags := setDefaultValueAtPath(t.Context(), config, testSchema, path.Root("alpha"), diag.Diagnostics{})
+
+	if !applied {
+		t.Fatal("expected default to be applied")
+	}
+
+	if len(gotDiags) != 0 {
+		t.Fatalf("unexpected diagnostics: %v", gotDiags)
+	}
+
+	expected := tftypes.NewValue(testType, map[string]tftypes.Value{
+		"alpha": tftypes.NewValue(tftypes.String, "alpha-default"),
+	})
+
+	if diff := cmp.Diff(expected, got); diff != "" {
+		t.Fatalf("unexpected config diff: %s", diff)
+	}
+}
+
 func TestResolveConflictsWithGroupsBlockNested(t *testing.T) {
 	t.Parallel()
 
@@ -250,7 +289,7 @@ func TestResolveConflictsWithGroupsBlockNested(t *testing.T) {
 	expected := tftypes.NewValue(testType, map[string]tftypes.Value{
 		"settings": tftypes.NewValue(testType.AttributeTypes["settings"], map[string]tftypes.Value{
 			"alpha": tftypes.NewValue(tftypes.String, "configured-alpha"),
-			"beta":  tftypes.NewValue(tftypes.String, nil),
+			"beta":  tftypes.NewValue(tftypes.String, "configured-beta"),
 		}),
 	})
 

--- a/internal/fwserver/server_generateresourceconfig_test.go
+++ b/internal/fwserver/server_generateresourceconfig_test.go
@@ -144,14 +144,24 @@ func TestServerGenerateResourceConfig(t *testing.T) {
 			expectedResponse: &fwserver.GenerateResourceConfigResponse{
 				GeneratedConfig: &tfsdk.Config{
 					Raw: tftypes.NewValue(testType, map[string]tftypes.Value{
-						"id":                    tftypes.NewValue(tftypes.String, nil),
-						"test_computed":         tftypes.NewValue(tftypes.String, nil),
-						"test_optional":         tftypes.NewValue(tftypes.String, "test-optional-val"),
-						"test_required":         tftypes.NewValue(tftypes.String, "test-config-value"),
-						"test_deprecated":       tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, nil),
-						"test_false_bool":       tftypes.NewValue(tftypes.Bool, false),
-						"test_empty_string":     tftypes.NewValue(tftypes.String, nil),
-						"test_deprecated_block": tftypes.NewValue(tftypes.List{ElementType: testNestedBlockType}, nil),
+						"id":            tftypes.NewValue(tftypes.String, nil),
+						"test_computed": tftypes.NewValue(tftypes.String, nil),
+						"test_optional": tftypes.NewValue(tftypes.String, "test-optional-val"),
+						"test_required": tftypes.NewValue(tftypes.String, "test-config-value"),
+						"test_deprecated": tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, []tftypes.Value{
+							tftypes.NewValue(tftypes.String, "test-deprecated-a"),
+							tftypes.NewValue(tftypes.String, "test-deprecated-b"),
+						}),
+						"test_false_bool":   tftypes.NewValue(tftypes.Bool, false),
+						"test_empty_string": tftypes.NewValue(tftypes.String, nil),
+						"test_deprecated_block": tftypes.NewValue(tftypes.List{ElementType: testNestedBlockType}, []tftypes.Value{
+							tftypes.NewValue(testNestedBlockType, map[string]tftypes.Value{
+								"test_nested_block_attr": tftypes.NewValue(tftypes.String, "test-nested-block-val-a"),
+							}),
+							tftypes.NewValue(testNestedBlockType, map[string]tftypes.Value{
+								"test_nested_block_attr": tftypes.NewValue(tftypes.String, "test-nested-block-val-b"),
+							}),
+						}),
 					}),
 					Schema: testSchema,
 				},

--- a/internal/fwserver/server_generateresourceconfig_test.go
+++ b/internal/fwserver/server_generateresourceconfig_test.go
@@ -4,6 +4,8 @@
 package fwserver_test
 
 import (
+	"context"
+	"math/big"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -12,9 +14,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwserver"
 	"github.com/hashicorp/terraform-plugin-framework/internal/privatestate"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testdefaults"
 	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testprovider"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/defaults"
+	schemavalidator "github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -78,6 +84,93 @@ func TestServerGenerateResourceConfig(t *testing.T) {
 						"test_nested_block_attr": schema.StringAttribute{
 							Optional: true,
 						},
+					},
+				},
+			},
+		},
+	}
+
+	validatorGroupType := tftypes.Object{
+		AttributeTypes: map[string]tftypes.Type{
+			"alpha": tftypes.String,
+			"beta":  tftypes.String,
+		},
+	}
+
+	conflictsWithSchema := schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"alpha": schema.StringAttribute{
+				Optional: true,
+				Validators: []schemavalidator.String{
+					testConflictsWithStringValidator{paths: path.Expressions{path.MatchRoot("beta")}},
+				},
+			},
+			"beta": schema.StringAttribute{
+				Optional: true,
+			},
+		},
+	}
+
+	exactlyOneOfSchema := schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"alpha": schema.StringAttribute{
+				Optional: true,
+				Validators: []schemavalidator.String{
+					testExactlyOneOfStringValidator{paths: path.Expressions{path.MatchRoot("beta")}},
+				},
+			},
+			"beta": schema.StringAttribute{
+				Optional: true,
+				Default: testdefaults.String{
+					DefaultStringMethod: func(_ context.Context, _ defaults.StringRequest, resp *defaults.StringResponse) {
+						resp.PlanValue = types.StringValue("beta-default")
+					},
+				},
+			},
+		},
+	}
+
+	alsoRequiresSchema := schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"alpha": schema.StringAttribute{
+				Optional: true,
+				Validators: []schemavalidator.String{
+					testAlsoRequiresStringValidator{paths: path.Expressions{path.MatchRoot("beta")}},
+				},
+			},
+			"beta": schema.StringAttribute{
+				Optional: true,
+			},
+		},
+	}
+
+	timeoutsType := tftypes.Object{
+		AttributeTypes: map[string]tftypes.Type{
+			"create": tftypes.String,
+		},
+	}
+
+	timeoutsAndNumberType := tftypes.Object{
+		AttributeTypes: map[string]tftypes.Type{
+			"test_optional_number": tftypes.Number,
+			"test_nonzero_number":  tftypes.Number,
+			"timeouts":             timeoutsType,
+		},
+	}
+
+	timeoutsAndNumberSchema := schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"test_optional_number": schema.NumberAttribute{
+				Optional: true,
+			},
+			"test_nonzero_number": schema.NumberAttribute{
+				Optional: true,
+			},
+			"timeouts": schema.SingleNestedAttribute{
+				Optional: true,
+				Attributes: map[string]schema.Attribute{
+					"create": schema.StringAttribute{
+						Optional: true,
 					},
 				},
 			},
@@ -167,6 +260,106 @@ func TestServerGenerateResourceConfig(t *testing.T) {
 				},
 			},
 		},
+		"response-conflicts-with-group": {
+			server: &fwserver.Server{
+				Provider: &testprovider.Provider{},
+			},
+			request: &fwserver.GenerateResourceConfigRequest{
+				ResourceSchema: conflictsWithSchema,
+				State: &tfsdk.State{
+					Raw: tftypes.NewValue(validatorGroupType, map[string]tftypes.Value{
+						"alpha": tftypes.NewValue(tftypes.String, "configured-alpha"),
+						"beta":  tftypes.NewValue(tftypes.String, "configured-beta"),
+					}),
+					Schema: conflictsWithSchema,
+				},
+			},
+			expectedResponse: &fwserver.GenerateResourceConfigResponse{
+				GeneratedConfig: &tfsdk.Config{
+					Raw: tftypes.NewValue(validatorGroupType, map[string]tftypes.Value{
+						"alpha": tftypes.NewValue(tftypes.String, "configured-alpha"),
+						"beta":  tftypes.NewValue(tftypes.String, nil),
+					}),
+					Schema: conflictsWithSchema,
+				},
+			},
+		},
+		"response-exactly-one-of-group-applies-default": {
+			server: &fwserver.Server{
+				Provider: &testprovider.Provider{},
+			},
+			request: &fwserver.GenerateResourceConfigRequest{
+				ResourceSchema: exactlyOneOfSchema,
+				State: &tfsdk.State{
+					Raw: tftypes.NewValue(validatorGroupType, map[string]tftypes.Value{
+						"alpha": tftypes.NewValue(tftypes.String, nil),
+						"beta":  tftypes.NewValue(tftypes.String, nil),
+					}),
+					Schema: exactlyOneOfSchema,
+				},
+			},
+			expectedResponse: &fwserver.GenerateResourceConfigResponse{
+				GeneratedConfig: &tfsdk.Config{
+					Raw: tftypes.NewValue(validatorGroupType, map[string]tftypes.Value{
+						"alpha": tftypes.NewValue(tftypes.String, nil),
+						"beta":  tftypes.NewValue(tftypes.String, "beta-default"),
+					}),
+					Schema: exactlyOneOfSchema,
+				},
+			},
+		},
+		"response-also-requires-group": {
+			server: &fwserver.Server{
+				Provider: &testprovider.Provider{},
+			},
+			request: &fwserver.GenerateResourceConfigRequest{
+				ResourceSchema: alsoRequiresSchema,
+				State: &tfsdk.State{
+					Raw: tftypes.NewValue(validatorGroupType, map[string]tftypes.Value{
+						"alpha": tftypes.NewValue(tftypes.String, "configured-alpha"),
+						"beta":  tftypes.NewValue(tftypes.String, nil),
+					}),
+					Schema: alsoRequiresSchema,
+				},
+			},
+			expectedResponse: &fwserver.GenerateResourceConfigResponse{
+				GeneratedConfig: &tfsdk.Config{
+					Raw: tftypes.NewValue(validatorGroupType, map[string]tftypes.Value{
+						"alpha": tftypes.NewValue(tftypes.String, nil),
+						"beta":  tftypes.NewValue(tftypes.String, nil),
+					}),
+					Schema: alsoRequiresSchema,
+				},
+			},
+		},
+		"response-timeouts-and-optional-number": {
+			server: &fwserver.Server{
+				Provider: &testprovider.Provider{},
+			},
+			request: &fwserver.GenerateResourceConfigRequest{
+				ResourceSchema: timeoutsAndNumberSchema,
+				State: &tfsdk.State{
+					Raw: tftypes.NewValue(timeoutsAndNumberType, map[string]tftypes.Value{
+						"test_optional_number": tftypes.NewValue(tftypes.Number, big.NewFloat(0)),
+						"test_nonzero_number":  tftypes.NewValue(tftypes.Number, big.NewFloat(7)),
+						"timeouts": tftypes.NewValue(timeoutsType, map[string]tftypes.Value{
+							"create": tftypes.NewValue(tftypes.String, "30m"),
+						}),
+					}),
+					Schema: timeoutsAndNumberSchema,
+				},
+			},
+			expectedResponse: &fwserver.GenerateResourceConfigResponse{
+				GeneratedConfig: &tfsdk.Config{
+					Raw: tftypes.NewValue(timeoutsAndNumberType, map[string]tftypes.Value{
+						"test_optional_number": tftypes.NewValue(tftypes.Number, nil),
+						"test_nonzero_number":  tftypes.NewValue(tftypes.Number, big.NewFloat(7)),
+						"timeouts":             tftypes.NewValue(timeoutsType, nil),
+					}),
+					Schema: timeoutsAndNumberSchema,
+				},
+			},
+		},
 	}
 
 	for name, testCase := range testCases {
@@ -182,3 +375,67 @@ func TestServerGenerateResourceConfig(t *testing.T) {
 		})
 	}
 }
+
+type testConflictsWithStringValidator struct {
+	paths path.Expressions
+}
+
+func (v testConflictsWithStringValidator) Description(context.Context) string {
+	return ""
+}
+
+func (v testConflictsWithStringValidator) MarkdownDescription(context.Context) string {
+	return ""
+}
+
+func (v testConflictsWithStringValidator) ValidateString(context.Context, schemavalidator.StringRequest, *schemavalidator.StringResponse) {
+}
+
+func (v testConflictsWithStringValidator) ConflictsWithPaths() path.Expressions {
+	return v.paths
+}
+
+type testExactlyOneOfStringValidator struct {
+	paths path.Expressions
+}
+
+func (v testExactlyOneOfStringValidator) Description(context.Context) string {
+	return ""
+}
+
+func (v testExactlyOneOfStringValidator) MarkdownDescription(context.Context) string {
+	return ""
+}
+
+func (v testExactlyOneOfStringValidator) ValidateString(context.Context, schemavalidator.StringRequest, *schemavalidator.StringResponse) {
+}
+
+func (v testExactlyOneOfStringValidator) ExactlyOneOfPaths() path.Expressions {
+	return v.paths
+}
+
+type testAlsoRequiresStringValidator struct {
+	paths path.Expressions
+}
+
+func (v testAlsoRequiresStringValidator) Description(context.Context) string {
+	return ""
+}
+
+func (v testAlsoRequiresStringValidator) MarkdownDescription(context.Context) string {
+	return ""
+}
+
+func (v testAlsoRequiresStringValidator) ValidateString(context.Context, schemavalidator.StringRequest, *schemavalidator.StringResponse) {
+}
+
+func (v testAlsoRequiresStringValidator) AlsoRequiresPaths() path.Expressions {
+	return v.paths
+}
+
+var _ schemavalidator.String = testConflictsWithStringValidator{}
+var _ schemavalidator.ConflictsWithValidator = testConflictsWithStringValidator{}
+var _ schemavalidator.String = testExactlyOneOfStringValidator{}
+var _ schemavalidator.ExactlyOneOfValidator = testExactlyOneOfStringValidator{}
+var _ schemavalidator.String = testAlsoRequiresStringValidator{}
+var _ schemavalidator.AlsoRequiresValidator = testAlsoRequiresStringValidator{}

--- a/internal/fwserver/validator_groups.go
+++ b/internal/fwserver/validator_groups.go
@@ -1,0 +1,178 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package fwserver
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema/fwxschema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+// buildAttributeValidatorGroups builds deduplicated top-level validator groups.
+// Relative expressions are resolved against the current attribute path and only
+// exact top-level attribute paths are included.
+func buildAttributeValidatorGroups(schema fwschema.Schema, expressionFunc func(fwschema.Attribute) path.Expressions) map[string][]string {
+	groups := map[string][]string{}
+
+	for name, attr := range schema.GetAttributes() {
+		expressions := expressionFunc(attr)
+
+		if len(expressions) == 0 {
+			continue
+		}
+
+		members := []string{name}
+		memberSet := map[string]struct{}{
+			name: {},
+		}
+		currentExpression := path.MatchRoot(name)
+
+		for _, expression := range expressions {
+			memberName, ok := topLevelAttributeName(currentExpression.Merge(expression).Resolve())
+
+			if !ok {
+				continue
+			}
+
+			if _, ok := memberSet[memberName]; ok {
+				continue
+			}
+
+			memberSet[memberName] = struct{}{}
+			members = append(members, memberName)
+		}
+
+		if len(members) <= 1 {
+			continue
+		}
+
+		sort.Strings(members)
+		groups[strings.Join(members, ",")] = members
+	}
+
+	return groups
+}
+
+func topLevelAttributeName(expression path.Expression) (string, bool) {
+	steps := expression.Steps()
+
+	if len(steps) != 1 {
+		return "", false
+	}
+
+	step, ok := steps[0].(path.ExpressionStepAttributeNameExact)
+	if !ok {
+		return "", false
+	}
+
+	return string(step), true
+}
+
+func getExactlyOneOfExpressions(attr fwschema.Attribute) path.Expressions {
+	return getValidatorPathExpressions(attr, func(v interface{}) path.Expressions {
+		if exactlyOneOfValidator, ok := v.(validator.ExactlyOneOfValidator); ok {
+			return exactlyOneOfValidator.Paths()
+		}
+
+		return nil
+	})
+}
+
+func getAlsoRequiresExpressions(attr fwschema.Attribute) path.Expressions {
+	return getValidatorPathExpressions(attr, func(v interface{}) path.Expressions {
+		if alsoRequiresValidator, ok := v.(validator.AlsoRequiresValidator); ok {
+			return alsoRequiresValidator.Paths()
+		}
+
+		return nil
+	})
+}
+
+// getConflictsWithExpressions extracts ConflictsWith path expressions from an attribute's
+// validators. It checks all typed validator interfaces (String, Bool, Int64, etc.) and
+// returns the paths from any validator that implements validator.ConflictsWithValidator.
+func getConflictsWithExpressions(attr fwschema.Attribute) path.Expressions {
+	return getValidatorPathExpressions(attr, func(v interface{}) path.Expressions {
+		if conflictsWithValidator, ok := v.(validator.ConflictsWithValidator); ok {
+			return conflictsWithValidator.Paths()
+		}
+
+		return nil
+	})
+}
+
+func getValidatorPathExpressions(attr fwschema.Attribute, expressionFunc func(interface{}) path.Expressions) path.Expressions {
+	var result path.Expressions
+
+	checkValidator := func(v interface{}) {
+		result = append(result, expressionFunc(v)...)
+	}
+
+	if a, ok := attr.(fwxschema.AttributeWithBoolValidators); ok {
+		for _, v := range a.BoolValidators() {
+			checkValidator(v)
+		}
+	}
+	if a, ok := attr.(fwxschema.AttributeWithFloat32Validators); ok {
+		for _, v := range a.Float32Validators() {
+			checkValidator(v)
+		}
+	}
+	if a, ok := attr.(fwxschema.AttributeWithFloat64Validators); ok {
+		for _, v := range a.Float64Validators() {
+			checkValidator(v)
+		}
+	}
+	if a, ok := attr.(fwxschema.AttributeWithInt32Validators); ok {
+		for _, v := range a.Int32Validators() {
+			checkValidator(v)
+		}
+	}
+	if a, ok := attr.(fwxschema.AttributeWithInt64Validators); ok {
+		for _, v := range a.Int64Validators() {
+			checkValidator(v)
+		}
+	}
+	if a, ok := attr.(fwxschema.AttributeWithListValidators); ok {
+		for _, v := range a.ListValidators() {
+			checkValidator(v)
+		}
+	}
+	if a, ok := attr.(fwxschema.AttributeWithMapValidators); ok {
+		for _, v := range a.MapValidators() {
+			checkValidator(v)
+		}
+	}
+	if a, ok := attr.(fwxschema.AttributeWithNumberValidators); ok {
+		for _, v := range a.NumberValidators() {
+			checkValidator(v)
+		}
+	}
+	if a, ok := attr.(fwxschema.AttributeWithObjectValidators); ok {
+		for _, v := range a.ObjectValidators() {
+			checkValidator(v)
+		}
+	}
+	if a, ok := attr.(fwxschema.AttributeWithSetValidators); ok {
+		for _, v := range a.SetValidators() {
+			checkValidator(v)
+		}
+	}
+	if a, ok := attr.(fwxschema.AttributeWithStringValidators); ok {
+		for _, v := range a.StringValidators() {
+			checkValidator(v)
+		}
+	}
+	if a, ok := attr.(fwxschema.AttributeWithDynamicValidators); ok {
+		for _, v := range a.DynamicValidators() {
+			checkValidator(v)
+		}
+	}
+
+	return result
+}

--- a/internal/fwserver/validator_groups.go
+++ b/internal/fwserver/validator_groups.go
@@ -4,73 +4,76 @@
 package fwserver
 
 import (
+	"context"
 	"sort"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
 	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema/fwxschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/totftypes"
 	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
-// buildAttributeValidatorGroups builds deduplicated top-level validator groups.
-// Relative expressions are resolved against the current attribute path and only
-// exact top-level attribute paths are included.
-func buildAttributeValidatorGroups(schema fwschema.Schema, expressionFunc func(fwschema.Attribute) path.Expressions) map[string][]string {
-	groups := map[string][]string{}
+// buildValidatorGroups builds deduplicated validator groups from schema
+// attributes, blocks, and nested objects. Matching uses the current config so
+// wildcard expressions expand into concrete paths when values are present.
+func buildValidatorGroups(ctx context.Context, config tftypes.Value, schema fwschema.Schema, res resource.Resource, attributeExpressionFunc func(fwschema.Attribute) path.Expressions) map[string]path.Paths {
+	groups := map[string]path.Paths{}
+	configView := tfsdk.Config{Raw: config, Schema: schema}
 
 	for name, attr := range schema.GetAttributes() {
-		expressions := expressionFunc(attr)
+		attributePath := path.Root(name)
+		addAttributeValidatorGroup(ctx, configView, groups, attributePath, attributeExpressionFunc(attr))
 
-		if len(expressions) == 0 {
-			continue
+		collectNestedAttributeValidatorGroups(ctx, configView, attributePath, attr, attributeExpressionFunc, groups)
+	}
+
+	for name, block := range schema.GetBlocks() {
+		blockPath := path.Root(name)
+		addResolvedValidatorGroup(ctx, configView, groups, blockPath.Expression(), getBlockValidatorPathExpressions(block))
+
+		collectNestedBlockValidatorGroups(ctx, configView, blockPath, block, attributeExpressionFunc, groups)
+	}
+
+	if resourceWithConfigValidators, ok := res.(resource.ResourceWithConfigValidators); ok {
+		for _, configValidator := range resourceWithConfigValidators.ConfigValidators(ctx) {
+			addResolvedValidatorGroup(ctx, configView, groups, path.MatchRelative(), getGenericValidatorPathExpressions(configValidator))
 		}
-
-		members := []string{name}
-		memberSet := map[string]struct{}{
-			name: {},
-		}
-		currentExpression := path.MatchRoot(name)
-
-		for _, expression := range expressions {
-			memberName, ok := topLevelAttributeName(currentExpression.Merge(expression).Resolve())
-
-			if !ok {
-				continue
-			}
-
-			if _, ok := memberSet[memberName]; ok {
-				continue
-			}
-
-			memberSet[memberName] = struct{}{}
-			members = append(members, memberName)
-		}
-
-		if len(members) <= 1 {
-			continue
-		}
-
-		sort.Strings(members)
-		groups[strings.Join(members, ",")] = members
 	}
 
 	return groups
 }
 
-func topLevelAttributeName(expression path.Expression) (string, bool) {
-	steps := expression.Steps()
+func addAttributeValidatorGroup(ctx context.Context, config tfsdk.Config, groups map[string]path.Paths, attributePath path.Path, expressions path.Expressions) {
+	members := path.Paths{attributePath}
+	members = appendResolvedMembers(ctx, config, attributePath.Expression(), members, expressions)
+	addValidatorGroup(groups, members)
+}
 
-	if len(steps) != 1 {
-		return "", false
+func addResolvedValidatorGroup(ctx context.Context, config tfsdk.Config, groups map[string]path.Paths, baseExpression path.Expression, expressions path.Expressions) {
+	members := appendResolvedMembers(ctx, config, baseExpression, nil, expressions)
+	addValidatorGroup(groups, members)
+}
+
+func addValidatorGroup(groups map[string]path.Paths, members path.Paths) {
+	if len(members) <= 1 {
+		return
 	}
 
-	step, ok := steps[0].(path.ExpressionStepAttributeNameExact)
-	if !ok {
-		return "", false
+	sort.Slice(members, func(i, j int) bool {
+		return members[i].String() < members[j].String()
+	})
+
+	keyParts := make([]string, 0, len(members))
+	for _, member := range members {
+		keyParts = append(keyParts, member.String())
 	}
 
-	return string(step), true
+	groups[strings.Join(keyParts, ",")] = members
 }
 
 func getExactlyOneOfExpressions(attr fwschema.Attribute) path.Expressions {
@@ -175,4 +178,210 @@ func getValidatorPathExpressions(attr fwschema.Attribute, expressionFunc func(in
 	}
 
 	return result
+}
+
+func getBlockValidatorPathExpressions(block fwschema.Block) path.Expressions {
+	var result path.Expressions
+
+	appendValidatorPaths := func(v interface{}) {
+		switch validatorWithPaths := v.(type) {
+		case validator.List:
+			result = append(result, getGenericValidatorPathExpressions(validatorWithPaths)...)
+		case validator.Object:
+			result = append(result, getGenericValidatorPathExpressions(validatorWithPaths)...)
+		case validator.Set:
+			result = append(result, getGenericValidatorPathExpressions(validatorWithPaths)...)
+		}
+	}
+
+	if b, ok := block.(fwxschema.BlockWithListValidators); ok {
+		for _, v := range b.ListValidators() {
+			appendValidatorPaths(v)
+		}
+	}
+	if b, ok := block.(fwxschema.BlockWithObjectValidators); ok {
+		for _, v := range b.ObjectValidators() {
+			appendValidatorPaths(v)
+		}
+	}
+	if b, ok := block.(fwxschema.BlockWithSetValidators); ok {
+		for _, v := range b.SetValidators() {
+			appendValidatorPaths(v)
+		}
+	}
+
+	return result
+}
+
+func getNestedAttributeObjectValidatorPathExpressions(object fwschema.NestedAttributeObject) path.Expressions {
+	if o, ok := object.(fwxschema.NestedAttributeObjectWithValidators); ok {
+		return getObjectValidatorsPathExpressions(o.ObjectValidators())
+	}
+
+	return nil
+}
+
+func getNestedBlockObjectValidatorPathExpressions(object fwschema.NestedBlockObject) path.Expressions {
+	if o, ok := object.(fwxschema.NestedBlockObjectWithValidators); ok {
+		return getObjectValidatorsPathExpressions(o.ObjectValidators())
+	}
+
+	return nil
+}
+
+func getObjectValidatorsPathExpressions(validators []validator.Object) path.Expressions {
+	var result path.Expressions
+
+	for _, v := range validators {
+		result = append(result, getGenericValidatorPathExpressions(v)...)
+	}
+
+	return result
+}
+
+func getGenericValidatorPathExpressions(v interface{}) path.Expressions {
+	if exactlyOneOfValidator, ok := v.(validator.ExactlyOneOfValidator); ok {
+		return exactlyOneOfValidator.Paths()
+	}
+
+	if alsoRequiresValidator, ok := v.(validator.AlsoRequiresValidator); ok {
+		return alsoRequiresValidator.Paths()
+	}
+
+	if conflictsWithValidator, ok := v.(validator.ConflictsWithValidator); ok {
+		return conflictsWithValidator.Paths()
+	}
+
+	return nil
+}
+
+func collectNestedAttributeValidatorGroups(ctx context.Context, config tfsdk.Config, currentPath path.Path, attr fwschema.Attribute, attributeExpressionFunc func(fwschema.Attribute) path.Expressions, groups map[string]path.Paths) {
+	nestedAttribute, ok := attr.(fwschema.NestedAttribute)
+	if !ok {
+		return
+	}
+
+	for _, instancePath := range nestedInstancePaths(ctx, config, currentPath, nestedAttribute.GetNestingMode()) {
+		collectNestedAttributeObjectValidatorGroups(ctx, config, instancePath, nestedAttribute.GetNestedObject(), attributeExpressionFunc, groups)
+	}
+}
+
+func collectNestedAttributeObjectValidatorGroups(ctx context.Context, config tfsdk.Config, currentPath path.Path, object fwschema.NestedAttributeObject, attributeExpressionFunc func(fwschema.Attribute) path.Expressions, groups map[string]path.Paths) {
+	addResolvedValidatorGroup(ctx, config, groups, currentPath.Expression(), getNestedAttributeObjectValidatorPathExpressions(object))
+
+	for name, attr := range object.GetAttributes() {
+		nextPath := currentPath.AtName(name)
+		addAttributeValidatorGroup(ctx, config, groups, nextPath, attributeExpressionFunc(attr))
+
+		collectNestedAttributeValidatorGroups(ctx, config, nextPath, attr, attributeExpressionFunc, groups)
+	}
+}
+
+func collectNestedBlockValidatorGroups(ctx context.Context, config tfsdk.Config, currentPath path.Path, block fwschema.Block, attributeExpressionFunc func(fwschema.Attribute) path.Expressions, groups map[string]path.Paths) {
+	addResolvedValidatorGroup(ctx, config, groups, currentPath.Expression(), getBlockValidatorPathExpressions(block))
+
+	for _, instancePath := range nestedBlockInstancePaths(ctx, config, currentPath, block.GetNestingMode()) {
+		collectNestedBlockObjectValidatorGroups(ctx, config, instancePath, block.GetNestedObject(), attributeExpressionFunc, groups)
+	}
+}
+
+func collectNestedBlockObjectValidatorGroups(ctx context.Context, config tfsdk.Config, currentPath path.Path, object fwschema.NestedBlockObject, attributeExpressionFunc func(fwschema.Attribute) path.Expressions, groups map[string]path.Paths) {
+	addResolvedValidatorGroup(ctx, config, groups, currentPath.Expression(), getNestedBlockObjectValidatorPathExpressions(object))
+
+	for name, attr := range object.GetAttributes() {
+		nextPath := currentPath.AtName(name)
+		addAttributeValidatorGroup(ctx, config, groups, nextPath, attributeExpressionFunc(attr))
+
+		collectNestedAttributeValidatorGroups(ctx, config, nextPath, attr, attributeExpressionFunc, groups)
+	}
+
+	for name, block := range object.GetBlocks() {
+		nextPath := currentPath.AtName(name)
+		collectNestedBlockValidatorGroups(ctx, config, nextPath, block, attributeExpressionFunc, groups)
+	}
+}
+
+func appendResolvedMembers(ctx context.Context, config tfsdk.Config, baseExpression path.Expression, members path.Paths, expressions path.Expressions) path.Paths {
+	if len(expressions) == 0 {
+		return members
+	}
+
+	memberSet := map[string]struct{}{}
+	for _, member := range members {
+		memberSet[member.String()] = struct{}{}
+	}
+
+	for _, expression := range expressions {
+		resolvedExpression := baseExpression.Merge(expression).Resolve()
+		matchedPaths, diags := config.PathMatches(ctx, resolvedExpression)
+		if diags.HasError() {
+			continue
+		}
+
+		for _, matchedPath := range matchedPaths {
+			if _, ok := memberSet[matchedPath.String()]; ok {
+				continue
+			}
+
+			memberSet[matchedPath.String()] = struct{}{}
+			members = append(members, matchedPath)
+		}
+	}
+
+	return members
+}
+
+func nestedInstancePaths(ctx context.Context, config tfsdk.Config, currentPath path.Path, nestingMode fwschema.NestingMode) path.Paths {
+	switch nestingMode {
+	case fwschema.NestingModeSingle:
+		return path.Paths{currentPath}
+	case fwschema.NestingModeList:
+		return collectionInstancePaths(ctx, config, currentPath.Expression().AtAnyListIndex(), len(currentPath.Steps()))
+	case fwschema.NestingModeMap:
+		return collectionInstancePaths(ctx, config, currentPath.Expression().AtAnyMapKey(), len(currentPath.Steps()))
+	case fwschema.NestingModeSet:
+		return collectionInstancePaths(ctx, config, currentPath.Expression().AtAnySetValue(), len(currentPath.Steps()))
+	default:
+		return nil
+	}
+}
+
+func nestedBlockInstancePaths(ctx context.Context, config tfsdk.Config, currentPath path.Path, nestingMode fwschema.BlockNestingMode) path.Paths {
+	switch nestingMode {
+	case fwschema.BlockNestingModeSingle:
+		return path.Paths{currentPath}
+	case fwschema.BlockNestingModeList:
+		return collectionInstancePaths(ctx, config, currentPath.Expression().AtAnyListIndex(), len(currentPath.Steps()))
+	case fwschema.BlockNestingModeSet:
+		return collectionInstancePaths(ctx, config, currentPath.Expression().AtAnySetValue(), len(currentPath.Steps()))
+	default:
+		return nil
+	}
+}
+
+func collectionInstancePaths(ctx context.Context, config tfsdk.Config, expression path.Expression, parentDepth int) path.Paths {
+	paths, diags := config.PathMatches(ctx, expression)
+	if diags.HasError() {
+		return nil
+	}
+
+	var result path.Paths
+	for _, matchedPath := range paths {
+		if len(matchedPath.Steps()) <= parentDepth {
+			continue
+		}
+
+		result = append(result, matchedPath)
+	}
+
+	return result
+}
+
+func terraformPathFromPath(ctx context.Context, fwPath path.Path) *tftypes.AttributePath {
+	tfPath, diags := totftypes.AttributePath(ctx, fwPath)
+	if diags.HasError() {
+		return nil
+	}
+
+	return tfPath
 }

--- a/internal/fwserver/validator_groups.go
+++ b/internal/fwserver/validator_groups.go
@@ -21,27 +21,27 @@ import (
 // buildValidatorGroups builds deduplicated validator groups from schema
 // attributes, blocks, and nested objects. Matching uses the current config so
 // wildcard expressions expand into concrete paths when values are present.
-func buildValidatorGroups(ctx context.Context, config tftypes.Value, schema fwschema.Schema, res resource.Resource, attributeExpressionFunc func(fwschema.Attribute) path.Expressions) map[string]path.Paths {
+func buildValidatorGroups(ctx context.Context, config tftypes.Value, schema fwschema.Schema, res resource.Resource, expressionFunc func(interface{}) path.Expressions) map[string]path.Paths {
 	groups := map[string]path.Paths{}
 	configView := tfsdk.Config{Raw: config, Schema: schema}
 
 	for name, attr := range schema.GetAttributes() {
 		attributePath := path.Root(name)
-		addAttributeValidatorGroup(ctx, configView, groups, attributePath, attributeExpressionFunc(attr))
+		addAttributeValidatorGroup(ctx, configView, groups, attributePath, getValidatorPathExpressions(attr, expressionFunc))
 
-		collectNestedAttributeValidatorGroups(ctx, configView, attributePath, attr, attributeExpressionFunc, groups)
+		collectNestedAttributeValidatorGroups(ctx, configView, attributePath, attr, expressionFunc, groups)
 	}
 
 	for name, block := range schema.GetBlocks() {
 		blockPath := path.Root(name)
-		addResolvedValidatorGroup(ctx, configView, groups, blockPath.Expression(), getBlockValidatorPathExpressions(block))
+		addResolvedValidatorGroup(ctx, configView, groups, blockPath.Expression(), getBlockValidatorPathExpressions(block, expressionFunc))
 
-		collectNestedBlockValidatorGroups(ctx, configView, blockPath, block, attributeExpressionFunc, groups)
+		collectNestedBlockValidatorGroups(ctx, configView, blockPath, block, expressionFunc, groups)
 	}
 
 	if resourceWithConfigValidators, ok := res.(resource.ResourceWithConfigValidators); ok {
 		for _, configValidator := range resourceWithConfigValidators.ConfigValidators(ctx) {
-			addResolvedValidatorGroup(ctx, configView, groups, path.MatchRelative(), getGenericValidatorPathExpressions(configValidator))
+			addResolvedValidatorGroup(ctx, configView, groups, path.MatchRelative(), expressionFunc(configValidator))
 		}
 	}
 
@@ -76,37 +76,28 @@ func addValidatorGroup(groups map[string]path.Paths, members path.Paths) {
 	groups[strings.Join(keyParts, ",")] = members
 }
 
-func getExactlyOneOfExpressions(attr fwschema.Attribute) path.Expressions {
-	return getValidatorPathExpressions(attr, func(v interface{}) path.Expressions {
-		if exactlyOneOfValidator, ok := v.(validator.ExactlyOneOfValidator); ok {
-			return exactlyOneOfValidator.Paths()
-		}
+func getExactlyOneOfPaths(v interface{}) path.Expressions {
+	if exactlyOneOfValidator, ok := v.(validator.ExactlyOneOfValidator); ok {
+		return exactlyOneOfValidator.ExactlyOneOfPaths()
+	}
 
-		return nil
-	})
+	return nil
 }
 
-func getAlsoRequiresExpressions(attr fwschema.Attribute) path.Expressions {
-	return getValidatorPathExpressions(attr, func(v interface{}) path.Expressions {
-		if alsoRequiresValidator, ok := v.(validator.AlsoRequiresValidator); ok {
-			return alsoRequiresValidator.Paths()
-		}
+func getAlsoRequiresPaths(v interface{}) path.Expressions {
+	if alsoRequiresValidator, ok := v.(validator.AlsoRequiresValidator); ok {
+		return alsoRequiresValidator.AlsoRequiresPaths()
+	}
 
-		return nil
-	})
+	return nil
 }
 
-// getConflictsWithExpressions extracts ConflictsWith path expressions from an attribute's
-// validators. It checks all typed validator interfaces (String, Bool, Int64, etc.) and
-// returns the paths from any validator that implements validator.ConflictsWithValidator.
-func getConflictsWithExpressions(attr fwschema.Attribute) path.Expressions {
-	return getValidatorPathExpressions(attr, func(v interface{}) path.Expressions {
-		if conflictsWithValidator, ok := v.(validator.ConflictsWithValidator); ok {
-			return conflictsWithValidator.Paths()
-		}
+func getConflictsWithPaths(v interface{}) path.Expressions {
+	if conflictsWithValidator, ok := v.(validator.ConflictsWithValidator); ok {
+		return conflictsWithValidator.ConflictsWithPaths()
+	}
 
-		return nil
-	})
+	return nil
 }
 
 func getValidatorPathExpressions(attr fwschema.Attribute, expressionFunc func(interface{}) path.Expressions) path.Expressions {
@@ -180,18 +171,11 @@ func getValidatorPathExpressions(attr fwschema.Attribute, expressionFunc func(in
 	return result
 }
 
-func getBlockValidatorPathExpressions(block fwschema.Block) path.Expressions {
+func getBlockValidatorPathExpressions(block fwschema.Block, expressionFunc func(interface{}) path.Expressions) path.Expressions {
 	var result path.Expressions
 
 	appendValidatorPaths := func(v interface{}) {
-		switch validatorWithPaths := v.(type) {
-		case validator.List:
-			result = append(result, getGenericValidatorPathExpressions(validatorWithPaths)...)
-		case validator.Object:
-			result = append(result, getGenericValidatorPathExpressions(validatorWithPaths)...)
-		case validator.Set:
-			result = append(result, getGenericValidatorPathExpressions(validatorWithPaths)...)
-		}
+		result = append(result, expressionFunc(v)...)
 	}
 
 	if b, ok := block.(fwxschema.BlockWithListValidators); ok {
@@ -213,91 +197,75 @@ func getBlockValidatorPathExpressions(block fwschema.Block) path.Expressions {
 	return result
 }
 
-func getNestedAttributeObjectValidatorPathExpressions(object fwschema.NestedAttributeObject) path.Expressions {
+func getNestedAttributeObjectValidatorPathExpressions(object fwschema.NestedAttributeObject, expressionFunc func(interface{}) path.Expressions) path.Expressions {
 	if o, ok := object.(fwxschema.NestedAttributeObjectWithValidators); ok {
-		return getObjectValidatorsPathExpressions(o.ObjectValidators())
+		return getObjectValidatorsPathExpressions(o.ObjectValidators(), expressionFunc)
 	}
 
 	return nil
 }
 
-func getNestedBlockObjectValidatorPathExpressions(object fwschema.NestedBlockObject) path.Expressions {
+func getNestedBlockObjectValidatorPathExpressions(object fwschema.NestedBlockObject, expressionFunc func(interface{}) path.Expressions) path.Expressions {
 	if o, ok := object.(fwxschema.NestedBlockObjectWithValidators); ok {
-		return getObjectValidatorsPathExpressions(o.ObjectValidators())
+		return getObjectValidatorsPathExpressions(o.ObjectValidators(), expressionFunc)
 	}
 
 	return nil
 }
 
-func getObjectValidatorsPathExpressions(validators []validator.Object) path.Expressions {
+func getObjectValidatorsPathExpressions(validators []validator.Object, expressionFunc func(interface{}) path.Expressions) path.Expressions {
 	var result path.Expressions
 
 	for _, v := range validators {
-		result = append(result, getGenericValidatorPathExpressions(v)...)
+		result = append(result, expressionFunc(v)...)
 	}
 
 	return result
 }
 
-func getGenericValidatorPathExpressions(v interface{}) path.Expressions {
-	if exactlyOneOfValidator, ok := v.(validator.ExactlyOneOfValidator); ok {
-		return exactlyOneOfValidator.Paths()
-	}
-
-	if alsoRequiresValidator, ok := v.(validator.AlsoRequiresValidator); ok {
-		return alsoRequiresValidator.Paths()
-	}
-
-	if conflictsWithValidator, ok := v.(validator.ConflictsWithValidator); ok {
-		return conflictsWithValidator.Paths()
-	}
-
-	return nil
-}
-
-func collectNestedAttributeValidatorGroups(ctx context.Context, config tfsdk.Config, currentPath path.Path, attr fwschema.Attribute, attributeExpressionFunc func(fwschema.Attribute) path.Expressions, groups map[string]path.Paths) {
+func collectNestedAttributeValidatorGroups(ctx context.Context, config tfsdk.Config, currentPath path.Path, attr fwschema.Attribute, expressionFunc func(interface{}) path.Expressions, groups map[string]path.Paths) {
 	nestedAttribute, ok := attr.(fwschema.NestedAttribute)
 	if !ok {
 		return
 	}
 
 	for _, instancePath := range nestedInstancePaths(ctx, config, currentPath, nestedAttribute.GetNestingMode()) {
-		collectNestedAttributeObjectValidatorGroups(ctx, config, instancePath, nestedAttribute.GetNestedObject(), attributeExpressionFunc, groups)
+		collectNestedAttributeObjectValidatorGroups(ctx, config, instancePath, nestedAttribute.GetNestedObject(), expressionFunc, groups)
 	}
 }
 
-func collectNestedAttributeObjectValidatorGroups(ctx context.Context, config tfsdk.Config, currentPath path.Path, object fwschema.NestedAttributeObject, attributeExpressionFunc func(fwschema.Attribute) path.Expressions, groups map[string]path.Paths) {
-	addResolvedValidatorGroup(ctx, config, groups, currentPath.Expression(), getNestedAttributeObjectValidatorPathExpressions(object))
+func collectNestedAttributeObjectValidatorGroups(ctx context.Context, config tfsdk.Config, currentPath path.Path, object fwschema.NestedAttributeObject, expressionFunc func(interface{}) path.Expressions, groups map[string]path.Paths) {
+	addResolvedValidatorGroup(ctx, config, groups, currentPath.Expression(), getNestedAttributeObjectValidatorPathExpressions(object, expressionFunc))
 
 	for name, attr := range object.GetAttributes() {
 		nextPath := currentPath.AtName(name)
-		addAttributeValidatorGroup(ctx, config, groups, nextPath, attributeExpressionFunc(attr))
+		addAttributeValidatorGroup(ctx, config, groups, nextPath, getValidatorPathExpressions(attr, expressionFunc))
 
-		collectNestedAttributeValidatorGroups(ctx, config, nextPath, attr, attributeExpressionFunc, groups)
+		collectNestedAttributeValidatorGroups(ctx, config, nextPath, attr, expressionFunc, groups)
 	}
 }
 
-func collectNestedBlockValidatorGroups(ctx context.Context, config tfsdk.Config, currentPath path.Path, block fwschema.Block, attributeExpressionFunc func(fwschema.Attribute) path.Expressions, groups map[string]path.Paths) {
-	addResolvedValidatorGroup(ctx, config, groups, currentPath.Expression(), getBlockValidatorPathExpressions(block))
+func collectNestedBlockValidatorGroups(ctx context.Context, config tfsdk.Config, currentPath path.Path, block fwschema.Block, expressionFunc func(interface{}) path.Expressions, groups map[string]path.Paths) {
+	addResolvedValidatorGroup(ctx, config, groups, currentPath.Expression(), getBlockValidatorPathExpressions(block, expressionFunc))
 
 	for _, instancePath := range nestedBlockInstancePaths(ctx, config, currentPath, block.GetNestingMode()) {
-		collectNestedBlockObjectValidatorGroups(ctx, config, instancePath, block.GetNestedObject(), attributeExpressionFunc, groups)
+		collectNestedBlockObjectValidatorGroups(ctx, config, instancePath, block.GetNestedObject(), expressionFunc, groups)
 	}
 }
 
-func collectNestedBlockObjectValidatorGroups(ctx context.Context, config tfsdk.Config, currentPath path.Path, object fwschema.NestedBlockObject, attributeExpressionFunc func(fwschema.Attribute) path.Expressions, groups map[string]path.Paths) {
-	addResolvedValidatorGroup(ctx, config, groups, currentPath.Expression(), getNestedBlockObjectValidatorPathExpressions(object))
+func collectNestedBlockObjectValidatorGroups(ctx context.Context, config tfsdk.Config, currentPath path.Path, object fwschema.NestedBlockObject, expressionFunc func(interface{}) path.Expressions, groups map[string]path.Paths) {
+	addResolvedValidatorGroup(ctx, config, groups, currentPath.Expression(), getNestedBlockObjectValidatorPathExpressions(object, expressionFunc))
 
 	for name, attr := range object.GetAttributes() {
 		nextPath := currentPath.AtName(name)
-		addAttributeValidatorGroup(ctx, config, groups, nextPath, attributeExpressionFunc(attr))
+		addAttributeValidatorGroup(ctx, config, groups, nextPath, getValidatorPathExpressions(attr, expressionFunc))
 
-		collectNestedAttributeValidatorGroups(ctx, config, nextPath, attr, attributeExpressionFunc, groups)
+		collectNestedAttributeValidatorGroups(ctx, config, nextPath, attr, expressionFunc, groups)
 	}
 
 	for name, block := range object.GetBlocks() {
 		nextPath := currentPath.AtName(name)
-		collectNestedBlockValidatorGroups(ctx, config, nextPath, block, attributeExpressionFunc, groups)
+		collectNestedBlockValidatorGroups(ctx, config, nextPath, block, expressionFunc, groups)
 	}
 }
 

--- a/internal/fwserver/validator_groups.go
+++ b/internal/fwserver/validator_groups.go
@@ -21,7 +21,7 @@ import (
 // buildValidatorGroups builds deduplicated validator groups from schema
 // attributes, blocks, and nested objects. Matching uses the current config so
 // wildcard expressions expand into concrete paths when values are present.
-func buildValidatorGroups(ctx context.Context, config tftypes.Value, schema fwschema.Schema, res resource.Resource, expressionFunc func(interface{}) path.Expressions) map[string]path.Paths {
+func buildValidatorGroups(ctx context.Context, config tftypes.Value, schema fwschema.Schema, res resource.Resource, expressionFunc func(any) path.Expressions) map[string]path.Paths {
 	groups := map[string]path.Paths{}
 	configView := tfsdk.Config{Raw: config, Schema: schema}
 
@@ -76,7 +76,9 @@ func addValidatorGroup(groups map[string]path.Paths, members path.Paths) {
 	groups[strings.Join(keyParts, ",")] = members
 }
 
-func getExactlyOneOfPaths(v interface{}) path.Expressions {
+// getExactlyOneOfPaths returns the paths from the given validator if it is an
+// ExactlyOneOfValidator, or nil if it is not.
+func getExactlyOneOfPaths(v any) path.Expressions {
 	if exactlyOneOfValidator, ok := v.(validator.ExactlyOneOfValidator); ok {
 		return exactlyOneOfValidator.ExactlyOneOfPaths()
 	}
@@ -84,7 +86,9 @@ func getExactlyOneOfPaths(v interface{}) path.Expressions {
 	return nil
 }
 
-func getAlsoRequiresPaths(v interface{}) path.Expressions {
+// getRequiredPaths returns the paths from the given validator if it is a
+// RequiredValidator, or nil if it is not.
+func getAlsoRequiresPaths(v any) path.Expressions {
 	if alsoRequiresValidator, ok := v.(validator.AlsoRequiresValidator); ok {
 		return alsoRequiresValidator.AlsoRequiresPaths()
 	}
@@ -92,7 +96,9 @@ func getAlsoRequiresPaths(v interface{}) path.Expressions {
 	return nil
 }
 
-func getConflictsWithPaths(v interface{}) path.Expressions {
+// getConflictsWithPaths returns the paths from the given validator if it is a
+// ConflictsWithValidator, or nil if it is not.
+func getConflictsWithPaths(v any) path.Expressions {
 	if conflictsWithValidator, ok := v.(validator.ConflictsWithValidator); ok {
 		return conflictsWithValidator.ConflictsWithPaths()
 	}
@@ -100,10 +106,10 @@ func getConflictsWithPaths(v interface{}) path.Expressions {
 	return nil
 }
 
-func getValidatorPathExpressions(attr fwschema.Attribute, expressionFunc func(interface{}) path.Expressions) path.Expressions {
+func getValidatorPathExpressions(attr fwschema.Attribute, expressionFunc func(any) path.Expressions) path.Expressions {
 	var result path.Expressions
 
-	checkValidator := func(v interface{}) {
+	checkValidator := func(v any) {
 		result = append(result, expressionFunc(v)...)
 	}
 
@@ -171,10 +177,10 @@ func getValidatorPathExpressions(attr fwschema.Attribute, expressionFunc func(in
 	return result
 }
 
-func getBlockValidatorPathExpressions(block fwschema.Block, expressionFunc func(interface{}) path.Expressions) path.Expressions {
+func getBlockValidatorPathExpressions(block fwschema.Block, expressionFunc func(any) path.Expressions) path.Expressions {
 	var result path.Expressions
 
-	appendValidatorPaths := func(v interface{}) {
+	appendValidatorPaths := func(v any) {
 		result = append(result, expressionFunc(v)...)
 	}
 
@@ -197,7 +203,7 @@ func getBlockValidatorPathExpressions(block fwschema.Block, expressionFunc func(
 	return result
 }
 
-func getNestedAttributeObjectValidatorPathExpressions(object fwschema.NestedAttributeObject, expressionFunc func(interface{}) path.Expressions) path.Expressions {
+func getNestedAttributeObjectValidatorPathExpressions(object fwschema.NestedAttributeObject, expressionFunc func(any) path.Expressions) path.Expressions {
 	if o, ok := object.(fwxschema.NestedAttributeObjectWithValidators); ok {
 		return getObjectValidatorsPathExpressions(o.ObjectValidators(), expressionFunc)
 	}
@@ -205,7 +211,7 @@ func getNestedAttributeObjectValidatorPathExpressions(object fwschema.NestedAttr
 	return nil
 }
 
-func getNestedBlockObjectValidatorPathExpressions(object fwschema.NestedBlockObject, expressionFunc func(interface{}) path.Expressions) path.Expressions {
+func getNestedBlockObjectValidatorPathExpressions(object fwschema.NestedBlockObject, expressionFunc func(any) path.Expressions) path.Expressions {
 	if o, ok := object.(fwxschema.NestedBlockObjectWithValidators); ok {
 		return getObjectValidatorsPathExpressions(o.ObjectValidators(), expressionFunc)
 	}
@@ -213,7 +219,7 @@ func getNestedBlockObjectValidatorPathExpressions(object fwschema.NestedBlockObj
 	return nil
 }
 
-func getObjectValidatorsPathExpressions(validators []validator.Object, expressionFunc func(interface{}) path.Expressions) path.Expressions {
+func getObjectValidatorsPathExpressions(validators []validator.Object, expressionFunc func(any) path.Expressions) path.Expressions {
 	var result path.Expressions
 
 	for _, v := range validators {
@@ -223,7 +229,7 @@ func getObjectValidatorsPathExpressions(validators []validator.Object, expressio
 	return result
 }
 
-func collectNestedAttributeValidatorGroups(ctx context.Context, config tfsdk.Config, currentPath path.Path, attr fwschema.Attribute, expressionFunc func(interface{}) path.Expressions, groups map[string]path.Paths) {
+func collectNestedAttributeValidatorGroups(ctx context.Context, config tfsdk.Config, currentPath path.Path, attr fwschema.Attribute, expressionFunc func(any) path.Expressions, groups map[string]path.Paths) {
 	nestedAttribute, ok := attr.(fwschema.NestedAttribute)
 	if !ok {
 		return
@@ -234,7 +240,7 @@ func collectNestedAttributeValidatorGroups(ctx context.Context, config tfsdk.Con
 	}
 }
 
-func collectNestedAttributeObjectValidatorGroups(ctx context.Context, config tfsdk.Config, currentPath path.Path, object fwschema.NestedAttributeObject, expressionFunc func(interface{}) path.Expressions, groups map[string]path.Paths) {
+func collectNestedAttributeObjectValidatorGroups(ctx context.Context, config tfsdk.Config, currentPath path.Path, object fwschema.NestedAttributeObject, expressionFunc func(any) path.Expressions, groups map[string]path.Paths) {
 	addResolvedValidatorGroup(ctx, config, groups, currentPath.Expression(), getNestedAttributeObjectValidatorPathExpressions(object, expressionFunc))
 
 	for name, attr := range object.GetAttributes() {
@@ -245,7 +251,7 @@ func collectNestedAttributeObjectValidatorGroups(ctx context.Context, config tfs
 	}
 }
 
-func collectNestedBlockValidatorGroups(ctx context.Context, config tfsdk.Config, currentPath path.Path, block fwschema.Block, expressionFunc func(interface{}) path.Expressions, groups map[string]path.Paths) {
+func collectNestedBlockValidatorGroups(ctx context.Context, config tfsdk.Config, currentPath path.Path, block fwschema.Block, expressionFunc func(any) path.Expressions, groups map[string]path.Paths) {
 	addResolvedValidatorGroup(ctx, config, groups, currentPath.Expression(), getBlockValidatorPathExpressions(block, expressionFunc))
 
 	for _, instancePath := range nestedBlockInstancePaths(ctx, config, currentPath, block.GetNestingMode()) {
@@ -253,7 +259,7 @@ func collectNestedBlockValidatorGroups(ctx context.Context, config tfsdk.Config,
 	}
 }
 
-func collectNestedBlockObjectValidatorGroups(ctx context.Context, config tfsdk.Config, currentPath path.Path, object fwschema.NestedBlockObject, expressionFunc func(interface{}) path.Expressions, groups map[string]path.Paths) {
+func collectNestedBlockObjectValidatorGroups(ctx context.Context, config tfsdk.Config, currentPath path.Path, object fwschema.NestedBlockObject, expressionFunc func(any) path.Expressions, groups map[string]path.Paths) {
 	addResolvedValidatorGroup(ctx, config, groups, currentPath.Expression(), getNestedBlockObjectValidatorPathExpressions(object, expressionFunc))
 
 	for name, attr := range object.GetAttributes() {

--- a/internal/fwserver/validator_groups_test.go
+++ b/internal/fwserver/validator_groups_test.go
@@ -1,0 +1,102 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package fwserver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testprovider"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testschema"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestBuildValidatorGroupsIncludesNestedBlockMembers(t *testing.T) {
+	t.Parallel()
+
+	testType := tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		"settings": tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+			"alpha": tftypes.String,
+			"beta":  tftypes.String,
+		}},
+	}}
+
+	testSchema := testschema.Schema{Blocks: map[string]fwschema.Block{
+		"settings": testschema.BlockWithObjectValidators{
+			Attributes: map[string]fwschema.Attribute{
+				"alpha": testschema.Attribute{Optional: true, Type: types.StringType},
+				"beta":  testschema.Attribute{Optional: true, Type: types.StringType},
+			},
+			Validators: []validator.Object{
+				testConflictsWithObjectValidator{Object: testvalidator.Object{}, paths: path.Expressions{
+					path.MatchRelative().AtName("alpha"),
+					path.MatchRelative().AtName("beta"),
+				}},
+			},
+		},
+	}}
+
+	config := tftypes.NewValue(testType, map[string]tftypes.Value{
+		"settings": tftypes.NewValue(testType.AttributeTypes["settings"], map[string]tftypes.Value{
+			"alpha": tftypes.NewValue(tftypes.String, "configured-alpha"),
+			"beta":  tftypes.NewValue(tftypes.String, "configured-beta"),
+		}),
+	})
+
+	groups := buildValidatorGroups(context.Background(), config, testSchema, nil, getConflictsWithPaths)
+	if len(groups) != 1 {
+		t.Fatalf("expected one group, got %d", len(groups))
+	}
+
+	for _, members := range groups {
+		expected := path.Paths{path.Root("settings").AtName("alpha"), path.Root("settings").AtName("beta")}
+		if diff := cmp.Diff(expected, members); diff != "" {
+			t.Fatalf("unexpected members diff: %s", diff)
+		}
+	}
+}
+
+func TestBuildValidatorGroupsIgnoresNonConfigValidators(t *testing.T) {
+	t.Parallel()
+
+	testType := tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		"alpha": tftypes.String,
+		"beta":  tftypes.String,
+	}}
+
+	testSchema := testschema.Schema{Attributes: map[string]fwschema.Attribute{
+		"alpha": testschema.Attribute{Optional: true, Type: types.StringType},
+		"beta":  testschema.Attribute{Optional: true, Type: types.StringType},
+	}}
+
+	res := &testprovider.ResourceWithConfigValidators{
+		Resource: &testprovider.Resource{},
+		ConfigValidatorsMethod: func(context.Context) []resource.ConfigValidator {
+			return []resource.ConfigValidator{
+				&testResourceExactlyOneOfValidator{paths: path.Expressions{
+					path.MatchRoot("alpha"),
+					path.MatchRoot("beta"),
+				}},
+			}
+		},
+	}
+
+	config := tftypes.NewValue(testType, map[string]tftypes.Value{
+		"alpha": tftypes.NewValue(tftypes.String, "configured-alpha"),
+		"beta":  tftypes.NewValue(tftypes.String, "configured-beta"),
+	})
+
+	groups := buildValidatorGroups(context.Background(), config, testSchema, res, getConflictsWithPaths)
+	if len(groups) != 0 {
+		t.Fatalf("expected no groups, got %d", len(groups))
+	}
+}

--- a/internal/proto5server/server_generateresourceconfig.go
+++ b/internal/proto5server/server_generateresourceconfig.go
@@ -21,6 +21,13 @@ func (s *Server) GenerateResourceConfig(ctx context.Context, proto5Req *tfprotov
 
 	fwResp := &fwserver.GenerateResourceConfigResponse{}
 
+	resource, diags := s.FrameworkServer.Resource(ctx, proto5Req.TypeName)
+	fwResp.Diagnostics.Append(diags...)
+
+	if fwResp.Diagnostics.HasError() {
+		return toproto5.GenerateResourceConfigResponse(ctx, fwResp), nil
+	}
+
 	resourceSchema, diags := s.FrameworkServer.ResourceSchema(ctx, proto5Req.TypeName)
 	fwResp.Diagnostics.Append(diags...)
 
@@ -28,7 +35,7 @@ func (s *Server) GenerateResourceConfig(ctx context.Context, proto5Req *tfprotov
 		return toproto5.GenerateResourceConfigResponse(ctx, fwResp), nil
 	}
 
-	fwReq, diags := fromproto5.GenerateResourceConfigRequest(ctx, proto5Req, resourceSchema)
+	fwReq, diags := fromproto5.GenerateResourceConfigRequest(ctx, proto5Req, resource, resourceSchema)
 	fwResp.Diagnostics.Append(diags...)
 
 	if fwResp.Diagnostics.HasError() {

--- a/internal/proto6server/server_generateresourceconfig.go
+++ b/internal/proto6server/server_generateresourceconfig.go
@@ -21,6 +21,13 @@ func (s *Server) GenerateResourceConfig(ctx context.Context, proto6Req *tfprotov
 
 	fwResp := &fwserver.GenerateResourceConfigResponse{}
 
+	resource, diags := s.FrameworkServer.Resource(ctx, proto6Req.TypeName)
+	fwResp.Diagnostics.Append(diags...)
+
+	if fwResp.Diagnostics.HasError() {
+		return toproto6.GenerateResourceConfigResponse(ctx, fwResp), nil
+	}
+
 	resourceSchema, diags := s.FrameworkServer.ResourceSchema(ctx, proto6Req.TypeName)
 	fwResp.Diagnostics.Append(diags...)
 
@@ -28,7 +35,7 @@ func (s *Server) GenerateResourceConfig(ctx context.Context, proto6Req *tfprotov
 		return toproto6.GenerateResourceConfigResponse(ctx, fwResp), nil
 	}
 
-	fwReq, diags := fromproto6.GenerateResourceConfigRequest(ctx, proto6Req, resourceSchema)
+	fwReq, diags := fromproto6.GenerateResourceConfigRequest(ctx, proto6Req, resource, resourceSchema)
 	fwResp.Diagnostics.Append(diags...)
 
 	if fwResp.Diagnostics.HasError() {

--- a/schema/validator/also_requires.go
+++ b/schema/validator/also_requires.go
@@ -1,0 +1,11 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package validator
+
+import "github.com/hashicorp/terraform-plugin-framework/path"
+
+type AlsoRequiresValidator interface {
+	// Paths returns attribute paths that this validator applies to
+	Paths() path.Expressions
+}

--- a/schema/validator/also_requires.go
+++ b/schema/validator/also_requires.go
@@ -6,6 +6,6 @@ package validator
 import "github.com/hashicorp/terraform-plugin-framework/path"
 
 type AlsoRequiresValidator interface {
-	// Paths returns attribute paths that this validator applies to
-	Paths() path.Expressions
+	// AlsoRequiresPaths returns attribute paths that this validator applies to.
+	AlsoRequiresPaths() path.Expressions
 }

--- a/schema/validator/conflicts_with.go
+++ b/schema/validator/conflicts_with.go
@@ -1,0 +1,11 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package validator
+
+import "github.com/hashicorp/terraform-plugin-framework/path"
+
+type ConflictsWithValidator interface {
+	// Paths returns attribute paths that this validator applies to
+	Paths() path.Expressions
+}

--- a/schema/validator/conflicts_with.go
+++ b/schema/validator/conflicts_with.go
@@ -6,6 +6,6 @@ package validator
 import "github.com/hashicorp/terraform-plugin-framework/path"
 
 type ConflictsWithValidator interface {
-	// Paths returns attribute paths that this validator applies to
-	Paths() path.Expressions
+	// ConflictsWithPaths returns attribute paths that this validator applies to.
+	ConflictsWithPaths() path.Expressions
 }

--- a/schema/validator/doc.go
+++ b/schema/validator/doc.go
@@ -19,7 +19,7 @@
 // If the value was associated with a custom type and using the custom value
 // type is desired, the developer must use the type's ValueFrom{TYPE} method.
 //
-// In the custom type model, the developer must always convert to a concreate
+// In the custom type model, the developer must always convert to a concrete
 // type before using the value unless checking for null or unknown. Since any
 // custom type may be passed due to the schema, it is possible, if not likely,
 // that unknown concrete types will be passed to the validator.

--- a/schema/validator/exactly_one_of.go
+++ b/schema/validator/exactly_one_of.go
@@ -1,0 +1,11 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package validator
+
+import "github.com/hashicorp/terraform-plugin-framework/path"
+
+type ExactlyOneOfValidator interface {
+	// Paths returns attribute paths that this validator applies to
+	Paths() path.Expressions
+}

--- a/schema/validator/exactly_one_of.go
+++ b/schema/validator/exactly_one_of.go
@@ -6,6 +6,6 @@ package validator
 import "github.com/hashicorp/terraform-plugin-framework/path"
 
 type ExactlyOneOfValidator interface {
-	// Paths returns attribute paths that this validator applies to
-	Paths() path.Expressions
+	// ExactlyOneOfPaths returns attribute paths that this validator applies to.
+	ExactlyOneOfPaths() path.Expressions
 }


### PR DESCRIPTION
## What this does

This improves the quality of generated resource config.

It now:
- clears top-level `id` and `timeouts`
- clears computed-only values
- clears empty optional values
- handles validator groups better for `ConflictsWith`, `ExactlyOneOf`, and `AlsoRequires`

For the validator group handling to work, validators need to implement the three new interfaces that expose the paths they validate. The `terraform-plugin-framework-validators` package will be updated to support that, so updating that package will be one way to pick this up.

## Why

The old behavior was what Terraform Core can do on its own.

This change improves the generated config using schema information that the provider has, but Terraform Core does not. That gives us better output during import and makes the generated config closer to something a user can actually keep instead of having to clean up by hand.

## Notes

I kept the normal Framework default behavior instead of writing defaults straight into generated config across the board.

The one special case is `ExactlyOneOf`, where using a default can help generate config that makes sense.

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.