### PR TITLE
fwserver: set AttributePathExpression when modifying schema plans

### DIFF
--- a/.changes/unreleased/BUG FIXES-20260706-161441.yaml
+++ b/.changes/unreleased/BUG FIXES-20260706-161441.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'fwserver: Fixed plan modifiers of nested attributes and nested blocks receiving a request `PathExpression` that was missing the root attribute or block step'
+time: 2026-07-06T16:14:41+03:00
+custom:
+    Issue: "1219"

--- a/internal/fwserver/schema_plan_modification.go
+++ b/internal/fwserver/schema_plan_modification.go
@@ -83,12 +83,13 @@ func SchemaModifyPlan(ctx context.Context, s fwschema.Schema, req ModifySchemaPl
 
 	for name, attribute := range s.GetAttributes() {
 		attrReq := ModifyAttributePlanRequest{
-			AttributePath: path.Root(name),
-			Config:        req.Config,
-			State:         req.State,
-			Plan:          req.Plan,
-			ProviderMeta:  req.ProviderMeta,
-			Private:       req.Private,
+			AttributePath:           path.Root(name),
+			AttributePathExpression: path.MatchRoot(name),
+			Config:                  req.Config,
+			State:                   req.State,
+			Plan:                    req.Plan,
+			ProviderMeta:            req.ProviderMeta,
+			Private:                 req.Private,
 		}
 
 		attrReq.AttributeConfig, diags = configData.ValueAtPath(ctx, attrReq.AttributePath)
@@ -140,12 +141,13 @@ func SchemaModifyPlan(ctx context.Context, s fwschema.Schema, req ModifySchemaPl
 
 	for name, block := range s.GetBlocks() {
 		blockReq := ModifyAttributePlanRequest{
-			AttributePath: path.Root(name),
-			Config:        req.Config,
-			State:         req.State,
-			Plan:          req.Plan,
-			ProviderMeta:  req.ProviderMeta,
-			Private:       req.Private,
+			AttributePath:           path.Root(name),
+			AttributePathExpression: path.MatchRoot(name),
+			Config:                  req.Config,
+			State:                   req.State,
+			Plan:                    req.Plan,
+			ProviderMeta:            req.ProviderMeta,
+			Private:                 req.Private,
 		}
 
 		blockReq.AttributeConfig, diags = configData.ValueAtPath(ctx, blockReq.AttributePath)

--- a/internal/fwserver/schema_plan_modification_test.go
+++ b/internal/fwserver/schema_plan_modification_test.go
@@ -489,6 +489,289 @@ func TestSchemaModifyPlan(t *testing.T) {
 				},
 			},
 		},
+		"attribute-plan-nested-single-path-expression": {
+			// Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/1219
+			req: ModifySchemaPlanRequest{
+				Config: tfsdk.Config{
+					Raw: tftypes.NewValue(tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"nested": tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"double_nested": tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"str_a": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+					}, map[string]tftypes.Value{
+						"nested": tftypes.NewValue(tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"double_nested": tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"str_a": tftypes.String,
+									},
+								},
+							},
+						}, map[string]tftypes.Value{
+							"double_nested": tftypes.NewValue(tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"str_a": tftypes.String,
+								},
+							}, map[string]tftypes.Value{
+								"str_a": tftypes.NewValue(tftypes.String, "testvalue"),
+							}),
+						}),
+					}),
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"nested": testschema.NestedAttribute{
+								Required:    true,
+								NestingMode: fwschema.NestingModeSingle,
+								NestedObject: testschema.NestedAttributeObject{
+									Attributes: map[string]fwschema.Attribute{
+										"double_nested": testschema.NestedAttribute{
+											Required:    true,
+											NestingMode: fwschema.NestingModeSingle,
+											NestedObject: testschema.NestedAttributeObject{
+												Attributes: map[string]fwschema.Attribute{
+													"str_a": testschema.AttributeWithStringPlanModifiers{
+														Required: true,
+														PlanModifiers: []planmodifier.String{
+															testplanmodifier.String{
+																PlanModifyStringMethod: func(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+																	expected := "nested.double_nested.str_a"
+																	if req.PathExpression.String() != expected {
+																		resp.Diagnostics.AddError(
+																			"Unexpected req.PathExpression",
+																			"expected: "+expected+", got: "+req.PathExpression.String(),
+																		)
+																	}
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Plan: tfsdk.Plan{
+					Raw: tftypes.NewValue(tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"nested": tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"double_nested": tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"str_a": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+					}, map[string]tftypes.Value{
+						"nested": tftypes.NewValue(tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"double_nested": tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"str_a": tftypes.String,
+									},
+								},
+							},
+						}, map[string]tftypes.Value{
+							"double_nested": tftypes.NewValue(tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"str_a": tftypes.String,
+								},
+							}, map[string]tftypes.Value{
+								"str_a": tftypes.NewValue(tftypes.String, "testvalue"),
+							}),
+						}),
+					}),
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"nested": testschema.NestedAttribute{
+								Required:    true,
+								NestingMode: fwschema.NestingModeSingle,
+								NestedObject: testschema.NestedAttributeObject{
+									Attributes: map[string]fwschema.Attribute{
+										"double_nested": testschema.NestedAttribute{
+											Required:    true,
+											NestingMode: fwschema.NestingModeSingle,
+											NestedObject: testschema.NestedAttributeObject{
+												Attributes: map[string]fwschema.Attribute{
+													"str_a": testschema.AttributeWithStringPlanModifiers{
+														Required: true,
+														PlanModifiers: []planmodifier.String{
+															testplanmodifier.String{
+																PlanModifyStringMethod: func(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+																	expected := "nested.double_nested.str_a"
+																	if req.PathExpression.String() != expected {
+																		resp.Diagnostics.AddError(
+																			"Unexpected req.PathExpression",
+																			"expected: "+expected+", got: "+req.PathExpression.String(),
+																		)
+																	}
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				State: tfsdk.State{
+					Raw: tftypes.NewValue(tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"nested": tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"double_nested": tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"str_a": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+					}, map[string]tftypes.Value{
+						"nested": tftypes.NewValue(tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"double_nested": tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"str_a": tftypes.String,
+									},
+								},
+							},
+						}, map[string]tftypes.Value{
+							"double_nested": tftypes.NewValue(tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"str_a": tftypes.String,
+								},
+							}, map[string]tftypes.Value{
+								"str_a": tftypes.NewValue(tftypes.String, "testvalue"),
+							}),
+						}),
+					}),
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"nested": testschema.NestedAttribute{
+								Required:    true,
+								NestingMode: fwschema.NestingModeSingle,
+								NestedObject: testschema.NestedAttributeObject{
+									Attributes: map[string]fwschema.Attribute{
+										"double_nested": testschema.NestedAttribute{
+											Required:    true,
+											NestingMode: fwschema.NestingModeSingle,
+											NestedObject: testschema.NestedAttributeObject{
+												Attributes: map[string]fwschema.Attribute{
+													"str_a": testschema.AttributeWithStringPlanModifiers{
+														Required: true,
+														PlanModifiers: []planmodifier.String{
+															testplanmodifier.String{
+																PlanModifyStringMethod: func(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+																	expected := "nested.double_nested.str_a"
+																	if req.PathExpression.String() != expected {
+																		resp.Diagnostics.AddError(
+																			"Unexpected req.PathExpression",
+																			"expected: "+expected+", got: "+req.PathExpression.String(),
+																		)
+																	}
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedResp: ModifySchemaPlanResponse{
+				Plan: tfsdk.Plan{
+					Raw: tftypes.NewValue(tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"nested": tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"double_nested": tftypes.Object{
+										AttributeTypes: map[string]tftypes.Type{
+											"str_a": tftypes.String,
+										},
+									},
+								},
+							},
+						},
+					}, map[string]tftypes.Value{
+						"nested": tftypes.NewValue(tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"double_nested": tftypes.Object{
+									AttributeTypes: map[string]tftypes.Type{
+										"str_a": tftypes.String,
+									},
+								},
+							},
+						}, map[string]tftypes.Value{
+							"double_nested": tftypes.NewValue(tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"str_a": tftypes.String,
+								},
+							}, map[string]tftypes.Value{
+								"str_a": tftypes.NewValue(tftypes.String, "testvalue"),
+							}),
+						}),
+					}),
+					Schema: testschema.Schema{
+						Attributes: map[string]fwschema.Attribute{
+							"nested": testschema.NestedAttribute{
+								Required:    true,
+								NestingMode: fwschema.NestingModeSingle,
+								NestedObject: testschema.NestedAttributeObject{
+									Attributes: map[string]fwschema.Attribute{
+										"double_nested": testschema.NestedAttribute{
+											Required:    true,
+											NestingMode: fwschema.NestingModeSingle,
+											NestedObject: testschema.NestedAttributeObject{
+												Attributes: map[string]fwschema.Attribute{
+													"str_a": testschema.AttributeWithStringPlanModifiers{
+														Required: true,
+														PlanModifiers: []planmodifier.String{
+															testplanmodifier.String{
+																PlanModifyStringMethod: func(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+																	expected := "nested.double_nested.str_a"
+																	if req.PathExpression.String() != expected {
+																		resp.Diagnostics.AddError(
+																			"Unexpected req.PathExpression",
+																			"expected: "+expected+", got: "+req.PathExpression.String(),
+																		)
+																	}
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 		"attribute-request-private": {
 			req: ModifySchemaPlanRequest{
 				Config: tfsdk.Config{


### PR DESCRIPTION
## Related Issue

Fixes #1219

## Description

`SchemaModifyPlan` built the top-level `ModifyAttributePlanRequest` with `AttributePath` set but `AttributePathExpression` left as the zero value. Every nested level then derived its expression from that empty root with `AtName(...)`, so plan modifiers received expressions missing the root step. With the schema from the issue, the modifier on `nested.double_nested.str_a` saw `double_nested.str_a`, and a modifier on a first-level nested attribute saw a single bare step.

The fix sets `AttributePathExpression: path.MatchRoot(name)` in both the attributes and blocks loops, which is exactly how `SchemaValidate` already constructs its requests. The blocks loop had the same omission, and since both child-request sites in `block_plan_modification.go` and `attribute_plan_modification.go` derive from the parent expression, fixing the root repairs expressions at every nesting depth for attributes and blocks alike.

The new test runs the issue's two-level `SingleNestedAttribute` shape through `SchemaModifyPlan` and asserts the leaf modifier's `req.PathExpression`. Without the fix it fails with the exact output from the report (`got: double_nested.str_a`). The test covers the attribute path from the report; the block loop is the same one-line fix by symmetry, and I can add a block-shaped test if you would like one.

One behavior note: providers that observed the truncated expression and matched against it will now see the corrected full expression.

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No changes to security controls.