### PR TITLE
Skip element semantic-equality walk when no element type implements semantic equality (fixes O(n²) on large sets)

### DIFF
--- a/.changelog/1315.txt
+++ b/.changelog/1315.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+framework: Skipped the element semantic-equality reconciliation walk for collection attributes and blocks whose element type does not implement semantic equality, fixing O(n^2) plan/refresh time on large sets
+```

--- a/internal/fwschemadata/value_semantic_equality_benchmark_test.go
+++ b/internal/fwschemadata/value_semantic_equality_benchmark_test.go
@@ -1,0 +1,182 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package fwschemadata_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/internal/fwschemadata"
+	"github.com/hashicorp/terraform-plugin-framework/internal/testing/testtypes"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+// buildSetNested constructs a prior and proposed SetNested value of n object
+// elements. When semanticEquals is false the object fields are plain string and
+// int64 attributes (no semantic equality anywhere in the type tree). When true,
+// the "name" field is a custom string type that always reports semantic
+// equality, exercising the per-element reconciliation path.
+func buildSetNested(ctx context.Context, tb testing.TB, n int, semanticEquals bool) (basetypes.SetValue, basetypes.SetValue) {
+	tb.Helper()
+
+	var nameType attr.Type = basetypes.StringType{}
+	if semanticEquals {
+		nameType = testtypes.StringTypeWithSemanticEquals{SemanticEquals: true}
+	}
+
+	attrTypes := map[string]attr.Type{
+		"name": nameType,
+		"num":  basetypes.Int64Type{},
+	}
+	objType := basetypes.ObjectType{AttrTypes: attrTypes}
+
+	newName := func(s string) attr.Value {
+		if semanticEquals {
+			return testtypes.StringValueWithSemanticEquals{
+				StringValue:    basetypes.NewStringValue(s),
+				SemanticEquals: true,
+			}
+		}
+		return basetypes.NewStringValue(s)
+	}
+
+	priorElements := make([]attr.Value, n)
+	proposedElements := make([]attr.Value, n)
+
+	for i := 0; i < n; i++ {
+		priorObj, diags := basetypes.NewObjectValue(attrTypes, map[string]attr.Value{
+			"name": newName(fmt.Sprintf("prior-%d", i)),
+			"num":  basetypes.NewInt64Value(int64(i)),
+		})
+		if diags.HasError() {
+			tb.Fatalf("prior object %d: %v", i, diags)
+		}
+
+		proposedObj, diags := basetypes.NewObjectValue(attrTypes, map[string]attr.Value{
+			"name": newName(fmt.Sprintf("proposed-%d", i)),
+			"num":  basetypes.NewInt64Value(int64(i)),
+		})
+		if diags.HasError() {
+			tb.Fatalf("proposed object %d: %v", i, diags)
+		}
+
+		priorElements[i] = priorObj
+		proposedElements[i] = proposedObj
+	}
+
+	prior, diags := basetypes.NewSetValue(objType, priorElements)
+	if diags.HasError() {
+		tb.Fatalf("prior set: %v", diags)
+	}
+
+	proposed, diags := basetypes.NewSetValue(objType, proposedElements)
+	if diags.HasError() {
+		tb.Fatalf("proposed set: %v", diags)
+	}
+
+	return prior, proposed
+}
+
+func benchmarkSetNested(b *testing.B, n int, semanticEquals bool) {
+	ctx := context.Background()
+	prior, proposed := buildSetNested(ctx, b, n, semanticEquals)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		req := fwschemadata.ValueSemanticEqualityRequest{
+			Path:             path.Root("test"),
+			PriorValue:       prior,
+			ProposedNewValue: proposed,
+		}
+		resp := &fwschemadata.ValueSemanticEqualityResponse{
+			NewValue: req.ProposedNewValue,
+		}
+
+		fwschemadata.ValueSemanticEquality(ctx, req, resp)
+
+		if resp.Diagnostics.HasError() {
+			b.Fatalf("unexpected diagnostics: %v", resp.Diagnostics)
+		}
+	}
+}
+
+// No semantic equality anywhere in the type tree: this is the pathological case
+// from the real-world report (e.g. a large cloudflare_list). The pre-fix code
+// walks all N^2 element pairs here even though every recursive call is a no-op.
+func BenchmarkSetNestedNoSemanticEquals100(b *testing.B)  { benchmarkSetNested(b, 100, false) }
+func BenchmarkSetNestedNoSemanticEquals1000(b *testing.B) { benchmarkSetNested(b, 1000, false) }
+func BenchmarkSetNestedNoSemanticEquals3251(b *testing.B) { benchmarkSetNested(b, 3251, false) }
+
+// An element type implements semantic equality: the per-element walk must still
+// run. Kept as a correctness/perf guard for the path the fix must preserve.
+func BenchmarkSetNestedWithSemanticEquals100(b *testing.B) { benchmarkSetNested(b, 100, true) }
+
+// TestBenchmarkSetNestedSemanticEqualsStillApplies proves the element-level
+// semantic equality path still runs after the short-circuit was added: with a
+// field type that always reports semantic equality, every proposed element must
+// be swapped back to its prior counterpart, so the reconciled value differs
+// from the proposed value and equals the prior value.
+func TestBenchmarkSetNestedSemanticEqualsStillApplies(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	prior, proposed := buildSetNested(ctx, t, 10, true)
+
+	req := fwschemadata.ValueSemanticEqualityRequest{
+		Path:             path.Root("test"),
+		PriorValue:       prior,
+		ProposedNewValue: proposed,
+	}
+	resp := &fwschemadata.ValueSemanticEqualityResponse{
+		NewValue: req.ProposedNewValue,
+	}
+
+	fwschemadata.ValueSemanticEquality(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", resp.Diagnostics)
+	}
+
+	if resp.NewValue.Equal(proposed) {
+		t.Fatalf("expected reconciled value to differ from proposed value (semantic equality path did not run)")
+	}
+
+	if !resp.NewValue.Equal(prior) {
+		t.Fatalf("expected reconciled value to equal prior value after semantic equality swap")
+	}
+}
+
+// TestBenchmarkSetNestedNoSemanticEqualsUnchanged proves the short-circuit is
+// behavior-preserving for the no-semantic-equality case: the reconciled value
+// is byte-identical to the proposed value.
+func TestBenchmarkSetNestedNoSemanticEqualsUnchanged(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	prior, proposed := buildSetNested(ctx, t, 10, false)
+
+	req := fwschemadata.ValueSemanticEqualityRequest{
+		Path:             path.Root("test"),
+		PriorValue:       prior,
+		ProposedNewValue: proposed,
+	}
+	resp := &fwschemadata.ValueSemanticEqualityResponse{
+		NewValue: req.ProposedNewValue,
+	}
+
+	fwschemadata.ValueSemanticEquality(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", resp.Diagnostics)
+	}
+
+	if !resp.NewValue.Equal(proposed) {
+		t.Fatalf("expected reconciled value to equal proposed value when no element implements semantic equality")
+	}
+}

--- a/internal/fwschemadata/value_semantic_equality_list.go
+++ b/internal/fwschemadata/value_semantic_equality_list.go
@@ -119,6 +119,13 @@ func ValueSemanticEqualityListElements(ctx context.Context, req ValueSemanticEqu
 		return
 	}
 
+	// If no element type anywhere in the tree implements semantic equality,
+	// the per-element walk below is guaranteed to be a no-op. Skip it to
+	// avoid the O(n^2) prior/proposed element comparison on large collections.
+	if !typeMightHaveSemanticEquals(ctx, proposedNewValue.ElementType(ctx)) {
+		return
+	}
+
 	proposedNewValueElements := proposedNewValue.Elements()
 
 	// Create a new element value slice, which will be used to create the final

--- a/internal/fwschemadata/value_semantic_equality_map.go
+++ b/internal/fwschemadata/value_semantic_equality_map.go
@@ -119,6 +119,13 @@ func ValueSemanticEqualityMapElements(ctx context.Context, req ValueSemanticEqua
 		return
 	}
 
+	// If no element type anywhere in the tree implements semantic equality,
+	// the per-element walk below is guaranteed to be a no-op. Skip it to
+	// avoid the O(n^2) prior/proposed element comparison on large collections.
+	if !typeMightHaveSemanticEquals(ctx, proposedNewValue.ElementType(ctx)) {
+		return
+	}
+
 	proposedNewValueElements := proposedNewValue.Elements()
 
 	// Create a new element value map, which will be used to create the final

--- a/internal/fwschemadata/value_semantic_equality_set.go
+++ b/internal/fwschemadata/value_semantic_equality_set.go
@@ -119,6 +119,13 @@ func ValueSemanticEqualitySetElements(ctx context.Context, req ValueSemanticEqua
 		return
 	}
 
+	// If no element type anywhere in the tree implements semantic equality,
+	// the per-element walk below is guaranteed to be a no-op. Skip it to
+	// avoid the O(n^2) prior/proposed element comparison on large collections.
+	if !typeMightHaveSemanticEquals(ctx, proposedNewValue.ElementType(ctx)) {
+		return
+	}
+
 	proposedNewValueElements := proposedNewValue.Elements()
 
 	// Create a new element value slice, which will be used to create the final

--- a/internal/fwschemadata/value_semantic_equality_type.go
+++ b/internal/fwschemadata/value_semantic_equality_type.go
@@ -1,0 +1,73 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package fwschemadata
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+// typeMightHaveSemanticEquals reports whether a value of the given type, or any
+// value nested anywhere within its type tree, could implement one of the
+// basetypes semantic equality interfaces.
+//
+// It is a conservative, static pre-check used to skip the recursive per-element
+// semantic equality walk performed by the collection reconciliation functions.
+// When it returns false, no value the collection can contain implements
+// semantic equality, so the walk is guaranteed to be a no-op and can be
+// skipped. It only returns false when the entire type tree is concrete and
+// provably free of semantic-equality implementers; anything uncertain (most
+// importantly dynamic types, whose concrete type is only known at runtime)
+// returns true so the normal walk still runs.
+func typeMightHaveSemanticEquals(ctx context.Context, t attr.Type) bool {
+	if t == nil {
+		return false
+	}
+
+	// A representative value of the type reveals whether the value type
+	// implements any semantic equality interface.
+	switch t.ValueType(ctx).(type) {
+	case basetypes.BoolValuableWithSemanticEquals,
+		basetypes.Float32ValuableWithSemanticEquals,
+		basetypes.Float64ValuableWithSemanticEquals,
+		basetypes.Int32ValuableWithSemanticEquals,
+		basetypes.Int64ValuableWithSemanticEquals,
+		basetypes.ListValuableWithSemanticEquals,
+		basetypes.MapValuableWithSemanticEquals,
+		basetypes.NumberValuableWithSemanticEquals,
+		basetypes.ObjectValuableWithSemanticEquals,
+		basetypes.SetValuableWithSemanticEquals,
+		basetypes.StringValuableWithSemanticEquals,
+		basetypes.DynamicValuableWithSemanticEquals:
+		return true
+	case basetypes.DynamicValuable:
+		// The concrete underlying type of a dynamic value is only known at
+		// runtime and may itself implement semantic equality, so be
+		// conservative and assume it might.
+		return true
+	}
+
+	// Recurse into nested element/attribute types. Terraform type trees are
+	// always finite, so no explicit cycle guard is required.
+	switch nested := t.(type) {
+	case attr.TypeWithElementType:
+		return typeMightHaveSemanticEquals(ctx, nested.ElementType())
+	case attr.TypeWithElementTypes:
+		for _, elementType := range nested.ElementTypes() {
+			if typeMightHaveSemanticEquals(ctx, elementType) {
+				return true
+			}
+		}
+	case attr.TypeWithAttributeTypes:
+		for _, attributeType := range nested.AttributeTypes() {
+			if typeMightHaveSemanticEquals(ctx, attributeType) {
+				return true
+			}
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
### Problem
`ValueSemanticEqualitySetElements` (and the List/Map equivalents) walk collection elements to run recursive semantic-equality reconciliation on every `ReadResource`. For sets, the walk introduced in #1064 (v1.14.0, fixing order-sensitivity from #1061) compares every proposed element against every remaining prior element: O(n²). It runs even when no element type implements any `*ValuableWithSemanticEquals` interface, in which case every recursive call is a guaranteed no-op and the entire pass is dead work. (List is index-matched and Map is key-matched, so those are O(n), but they still make N no-op calls in the same case.)

Real impact: a `cloudflare_list` with ~3,251 items (no field implements semantic equality) takes 10m+ per plan/create with the provider pegged above 100% CPU. This is the underlying cause behind the broad slowdown symptom in #775 (there mis-attributed to allocations/logging).

### Fix
Add `typeMightHaveSemanticEquals(ctx, attr.Type)`: it takes a representative `t.ValueType(ctx)`, type-asserts against every `basetypes.*ValuableWithSemanticEquals` interface, and recurses into element types (list/set/map/tuple) and attribute types (object). It returns `false` only when the entire type tree is concrete and provably free of semantic-equals implementers, and is conservative on dynamic types (returns `true`). Each of the Set/List/Map element functions returns early when the element type cannot contain a semantic-equals implementer, leaving the proposed value unchanged.

### Behavior preservation
- The collection-level path (a type implementing `SetValuableWithSemanticEquals` etc.) runs before `*Elements` and is untouched.
- When no element implements semantic equality, the old walk always ended with `updatedElements == false` and returned the proposed value unchanged, byte-identical to the early return.
- Dynamic types and any custom type implementing a semantic-equals interface still take the full walk.

### Benchmarks
New `internal/fwschemadata/value_semantic_equality_benchmark_test.go`. SetNested, plain string/int64 fields, no semantic equality:

| N | before | after | speedup |
|---|---|---|---|
| 100 | 82.6 ms | 17.6 µs | ~4,700x |
| 1,000 | 8.96 s | 149 µs | ~60,000x |
| 3,251 | 98.9 s | 0.53 ms | ~185,000x |

Allocations at N=3,251: 990,666,514 → 18 (~46 GB → ~116 KB). A guard benchmark/test with an element type that does implement semantic equality confirms the reconciliation path still runs and still swaps proposed→prior.

### Tests
Existing `internal/fwschemadata` tests pass. `go build ./...`, `go vet`, and `gofmt -l` are clean. Added `TestBenchmarkSetNestedSemanticEqualsStillApplies` (element-level semantic-equals path still applies) and `TestBenchmarkSetNestedNoSemanticEqualsUnchanged` (no-equality output unchanged).

Refs #775, #1064, #1061.

Fixes #1314
