### PR TITLE
types: Add `ObjectAsOptions` type alias for `basetypes.ObjectAsOptions`

### DIFF
--- a/.changes/unreleased/ENHANCEMENTS-20260806-174555.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20260806-174555.yaml
@@ -1,0 +1,5 @@
+kind: ENHANCEMENTS
+body: 'types: Added `ObjectAsOptions` type alias for `basetypes.ObjectAsOptions`'
+time: 2026-08-06T17:45:55.206779-05:00
+custom:
+    Issue: "723"

--- a/types/object_as_options.go
+++ b/types/object_as_options.go
@@ -1,0 +1,12 @@
+// Copyright IBM Corp. 2021, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package types
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+// ObjectAsOptions is a collection of toggles to control the behavior of
+// Object.As.
+type ObjectAsOptions = basetypes.ObjectAsOptions


### PR DESCRIPTION
## Related Issue

Fixes #723

## Description

See title -- minimal change.

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No. This change adds a type alias and makes no functional changes.
